### PR TITLE
fix: tolerate missing llama2_70b_peft_config in older Megatron-Bridge

### DIFF
--- a/scripts/performance/configs/llama/__init__.py
+++ b/scripts/performance/configs/llama/__init__.py
@@ -5,11 +5,21 @@ try:
 except ModuleNotFoundError:
     HAVE_MEGATRON_BRIDGE = False
 
+HAVE_LLAMA2_LORA_CONFIGS = False
+
 if HAVE_MEGATRON_BRIDGE:
-    from .llama2_llm_finetune import (
-        llama2_70b_lora_config_gb200,
-        llama2_70b_lora_config_gb300,
-    )
+    try:
+        from .llama2_llm_finetune import (
+            llama2_70b_lora_config_gb200,
+            llama2_70b_lora_config_gb300,
+        )
+
+        HAVE_LLAMA2_LORA_CONFIGS = True
+    except ImportError:
+        # llama2_70b_peft_config landed in Megatron-Bridge after v0.5.1, which is
+        # what nemo:26.06.01 ships. The llama3 configs below do not depend on it.
+        pass
+
     from .llama3_llm_finetune import (
         llama3_8b_sft_config_gb200,
         llama3_8b_sft_config_h100,
@@ -362,11 +372,17 @@ __all__ = [
     "LLAMA2_70B_LORA_CONFIG_GB300_FP8_DS_V4",
 ]
 
-if HAVE_MEGATRON_BRIDGE:
+if HAVE_LLAMA2_LORA_CONFIGS:
     __all__.extend(
         [
             "llama2_70b_lora_config_gb200",
             "llama2_70b_lora_config_gb300",
+        ]
+    )
+
+if HAVE_MEGATRON_BRIDGE:
+    __all__.extend(
+        [
             "llama3_8b_pretrain_config_gb300",
             "llama3_8b_pretrain_config_gb200",
             "llama3_8b_pretrain_config_b300",


### PR DESCRIPTION
Resolved llama3.1 pretrain + finetune  issues in nvbug: https://nvbugspro.nvidia.com/bug/6582466 for GB200/B200/H100 chips.

**What was the issue:**

On chips GB200/B200/H100, llama3.1 pretrain was seeing the following error when run: 

```
 File ".../workloads/pretrain_llama3.1/Megatron-Bridge/scripts/performance/configs/llama/llama2_llm_finetune.py", line 22
    from megatron.bridge.recipes.llama import (
    ImportError: cannot import name 'llama2_70b_peft_config' from
      'megatron.bridge.recipes.llama' (/opt/Megatron-Bridge/src/megatron/bridge/recipes/llama/__init__.py).
    Did you mean: 'llama3_70b_peft_config'?
```

The recipe pins Megatron-Bridge to **a555c47d6** (tip of branch llmb-r0.5.1) and mounts only its
scripts/performance directory into the **nvcr.io/nvidia/nemo:26.06.01** container. The **megatron.bridge**
library itself is not mounted, so it resolves to the older  copy baked into that image.

One of the mounted scripts, **configs/llama/llama2_llm_finetune.py**, needs the function
**llama2_70b_peft_config**, which was added to the library in the same commit as the script (#4849)
and so is absent from v0.5.1. Because **configs/llama/__init__.py** imports that script eagerly, the
**ImportError** fires as soon as the **configs.llama** package loads, taking down every llama-family run,
including llama3 pretrain and llama3 70B LoRA, neither of which uses llama2.

**What was the fix.**

Wrapped the llama2 LoRA import in **configs/llama/__init__.py** in a **try/except ImportError**, and gated
its two **__all__** entries behind a new **HAVE_LLAMA2_LORA_CONFIGS** flag.
