### PR TITLE
fix(recipe): reduce qwen3.5-vl gb200 bf16 microbatch size

### DIFF
--- a/src/megatron/bridge/perf_recipes/qwen_vl/gb200/qwen35_vl.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/gb200/qwen35_vl.py
@@ -41,11 +41,11 @@ def qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.expert_model_parallel_size = 8
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = False
-    # MBS4 exhausts 184-GiB GB200 HBM before the second optimizer step in
-    # NeMo 26.06. MBS3 retains most of its compute intensity with headroom for
-    # the optimizer step; GBS480 gives 20 microbatches at dense DP8.
+    # BF16 MBS3 exhausts 184-GiB GB200 HBM in the second-iteration output
+    # projection. MBS2 leaves enough headroom; GBS480 gives 30 microbatches at
+    # dense DP8.
     cfg.train.global_batch_size = 480
-    cfg.train.micro_batch_size = 3
+    cfg.train.micro_batch_size = 2
 
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
     cfg.model.moe_token_dispatcher_type = "flex"
@@ -87,6 +87,7 @@ def qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8cs_config() -> ConfigContainer:
     """Qwen3.5/Qwen3.6-VL 35B-A3B pretrain: 8× GB200, FP8 current-scaling."""
     cfg = qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config()
     cfg.mixed_precision = _perf_precision("fp8_cs")
+    cfg.train.micro_batch_size = 3
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -116,6 +117,7 @@ def qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Qwen3.5/Qwen3.6-VL 35B-A3B pretrain: 8× GB200, MXFP8."""
     cfg = qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config()
     cfg.mixed_precision = _perf_precision("fp8_mx")
+    cfg.train.micro_batch_size = 3
     # This fixed-shape synthetic MXFP8 path has been measured successfully with
     # Transformer Engine graphs for the Qwen35-VL router and preprocessing scopes.
     cfg.model.cuda_graph_impl = "transformer_engine"

--- a/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
+++ b/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
@@ -146,33 +146,37 @@ def test_qwen35_vl_35b_h100_measured_performance_defaults(monkeypatch: pytest.Mo
 
 
 @pytest.mark.parametrize(
-    ("recipe_fn", "expected_graph_modules"),
+    ("recipe_fn", "expected_micro_batch_size", "expected_graph_modules"),
     [
         (
             qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config,
+            2,
             [],
         ),
         (
             qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8cs_config,
+            3,
             [],
         ),
         (
             qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8mx_config,
+            3,
             ["moe_router", "moe_preprocess"],
         ),
     ],
 )
 def test_qwen35_vl_35b_gb200_measured_performance_defaults(
     recipe_fn: Callable,
+    expected_micro_batch_size: int,
     expected_graph_modules: list[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The real GB200 factories should retain their measured batch and graph defaults."""
+    """The real GB200 factories should retain their precision-specific defaults."""
     patch_recipe_construction_dependencies(monkeypatch)
 
     config = recipe_fn()
 
-    assert config.train.micro_batch_size == 3
+    assert config.train.micro_batch_size == expected_micro_batch_size
     assert config.train.global_batch_size == 480
     assert config.model.moe_router_force_load_balancing is True
     assert config.model.moe_flex_dispatcher_backend == "hybridep"


### PR DESCRIPTION
# What does this PR do ?

Reduce the Qwen3.5/Qwen3.6-VL 35B-A3B GB200 BF16 microbatch size from 3 to 2 so the recipe completes without exhausting GPU memory.

The BF16 recipe still OOMed with MBS3 during the second-iteration output projection. The projection required a 5.68-GiB allocation while only 5.36-5.56 GiB remained free. The existing GB200 verification covered MXFP8 at MBS3/GBS480, not BF16.

# Changelog

- Use MBS2/GBS480 for the 8-GPU GB200 BF16 recipe.
- Preserve MBS3/GBS480 for FP8 current-scaling and MXFP8 recipes.
- Test the precision-specific microbatch defaults.

# Validation

- NeMo 26.08 RC5, 2 nodes x 4 GB200, BF16, TP1/PP1/CP1/EP8, MBS2/GBS480: completed 10/10 training steps with finite losses and no skipped or NaN iterations.
- `uv run --no-sync python -m pytest tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py -q`: 6 passed.
- `uv run --no-project --with pre-commit==3.6.0 pre-commit run --all-files`: passed.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing guide.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary focused test coverage.
- [x] Confirmed that no documentation update is needed for this recipe-default correction.
- [x] Confirmed that this change does not affect optional dependency import guards.

# Additional Information

This follows up on the GB200 recipe introduced with the Qwen3.6 verification card and narrows only the BF16 batch default.
