### PR TITLE
docs(ckpt): document roundtrip scaling limits

### DIFF
--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -203,7 +203,14 @@ def _roundtrip_weights_match(name: str, exported: torch.Tensor, original: torch.
 
 
 def _verify_roundtrip_weights(bridge: AutoBridge, megatron_model: list[torch.nn.Module]) -> None:
-    """Verify exported Megatron weights against the original Hugging Face state."""
+    """Exhaustively verify exported Megatron weights against the original Hugging Face state.
+
+    Every rank participates in the collective Megatron-to-Hugging-Face export, but only rank 0 lazily reads each
+    original Hugging Face tensor and compares it serially. This does not materialize a complete Hugging Face model
+    on every rank. For very large checkpoints, the rank-0 work can create prolonged rank skew before the result
+    broadcast, exceed the process-group collective timeout, and incur substantial transient tensor memory and
+    storage I/O.
+    """
     is_rank_0 = torch.distributed.get_rank() == 0
     all_match = True
     verified_count = 0
@@ -423,6 +430,13 @@ def roundtrip_checkpoint(
     distributed_timeout_minutes: int | None,
 ) -> None:
     """Validate a Hugging Face to Megatron to Hugging Face round trip.
+
+    This workflow performs exhaustive equality validation and is not intended as the scalable conversion path for
+    very large checkpoints. When the goal is conversion rather than exhaustive validation, prefer separate
+    ``convert.sh import`` and ``convert.sh export --distributed-save`` workflows. If a full round trip is required,
+    provision sufficient time and memory and choose an appropriate ``--distributed-timeout-minutes`` value. A
+    longer timeout can accommodate expected rank skew, but does not reduce serial verification cost or memory and
+    I/O pressure.
 
     Args:
         hf_model: Hugging Face model ID or local path.


### PR DESCRIPTION
# What does this PR do ?

Documents the operational limits of the maintained distributed roundtrip verifier for very large Hugging Face checkpoints.

# Changelog

- Clarifies that every rank participates in collective Megatron-to-Hugging-Face export while rank 0 lazily reads and compares original Hugging Face tensors serially.
- Notes that this does not materialize a complete Hugging Face model on every rank, but can still cause long rank skew, collective timeout, and substantial transient tensor memory and storage I/O.
- Recommends separate `convert.sh import` and `convert.sh export --distributed-save` workflows when scalable conversion, rather than exhaustive equality validation, is the goal.
- Explains that exhaustive roundtrip users must provision enough time and memory and select an appropriate distributed timeout; a longer timeout does not reduce serial verification cost.

# GitHub Actions CI

Documentation-only checks:

- targeted Ruff format/check — passed
- Python syntax compilation — passed
- `uv run pre-commit run --all-files` — passed

No behavioral tests were needed because production code and test behavior exactly match the PR base.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests? (not needed; documentation-only)
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (no)

# Additional Information

The final diff changes docstrings only in `scripts/conversion/gpu_backend.py`; it does not change runtime behavior, tests, model cards, timeout defaults, or public APIs.