### PR TITLE
[ckpt] fix: support multi-layer MTP export filtering

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -174,9 +174,10 @@ def _mtp_source_key_prefixes(source: Any, *configs: Any) -> tuple[str, ...]:
     differently:
 
     * DeepSeek-style: a dedicated ``mtp.*`` prefix.
-    * GLM-4.x ``glm4_moe_lite``: the nextn layer is stored as a regular decoder
-      layer at index ``num_hidden_layers`` (i.e. one past the last real layer),
-      so its tensors live under ``model.layers.{num_hidden_layers}.*``.
+    * GLM-4.x ``glm4_moe_lite`` and Step3.7: nextn layers are stored as regular
+      decoder layers starting at index ``num_hidden_layers`` (i.e. one past the
+      last real layer), so their tensors live under consecutive
+      ``model.layers.{layer_index}.*`` prefixes.
 
     When the megatron model is built without an MTP head the generator never
     yields these tensors. If they remain in the source sharding map, the shards
@@ -212,9 +213,20 @@ def _mtp_source_key_prefixes(source: Any, *configs: Any) -> tuple[str, ...]:
             break
 
     if num_hidden_layers is not _MISSING:
-        nextn_prefix = f"model.layers.{num_hidden_layers}."
-        if source.has_glob(f"{nextn_prefix}*"):
-            prefixes.append(nextn_prefix)
+        num_nextn_layers = 1
+        for config in configs:
+            text_config = _get_config_field(config, "text_config")
+            config_candidates = (config,) if text_config is _MISSING else (config, text_config)
+            for config_candidate in config_candidates:
+                for field in MTP_CONFIG_FIELDS:
+                    value = _get_config_field(config_candidate, field)
+                    if value is not _MISSING and value is not None:
+                        num_nextn_layers = max(num_nextn_layers, int(value))
+
+        for layer_index in range(num_hidden_layers, num_hidden_layers + num_nextn_layers):
+            nextn_prefix = f"model.layers.{layer_index}."
+            if source.has_glob(f"{nextn_prefix}*"):
+                prefixes.append(nextn_prefix)
 
     return tuple(prefixes)
 

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -311,6 +311,15 @@ class TestAutoBridge:
         # Nested text_config carries num_hidden_layers.
         assert _mtp_source_key_prefixes(glm_src, {"text_config": {"num_hidden_layers": 47}}) == ("model.layers.47.",)
 
+        # Step3.7 stores multiple MTP layers after the regular decoder layers.
+        step37_src = src("model.layers.45.*", "model.layers.46.*", "model.layers.47.*")
+        step37_config = {"text_config": {"num_hidden_layers": 45, "num_nextn_predict_layers": 3}}
+        assert _mtp_source_key_prefixes(step37_src, step37_config) == (
+            "model.layers.45.",
+            "model.layers.46.",
+            "model.layers.47.",
+        )
+
         # No matching source keys -> nothing to strip.
         assert _mtp_source_key_prefixes(src(), {"num_hidden_layers": 47}) == ()
 


### PR DESCRIPTION
## Summary

Step3.7 checkpoints can intentionally disable MTP for training, while the released Hugging Face reference contains three MTP layers after the 45 regular decoder layers. During strict GPU export, Bridge detected that the Megatron model omitted MTP but removed only `model.layers.45.*` from the reference state map. The layer-46 and layer-47 keys remained expected, so the streaming save could not complete their shard and raised for unwritten tensors.

This change reads the configured MTP layer count and filters every consecutive regular-index MTP prefix. It retains the existing one-layer fallback for models such as GLM whose reference does not expose an MTP count.

Related architecture-authority tracking: #5153.

## Root cause

`AutoBridge.save_hf_weights()` correctly enters the MTP-omitted path, but `_mtp_source_key_prefixes()` assumed that architectures storing MTP as decoder layers always had exactly one such layer. Step3.7 stores three at indices 45, 46, and 47.

## Regression evidence

The focused test uses a nested Step3.7-shaped config (`num_hidden_layers=45`, `num_nextn_predict_layers=3`) and a source exposing all three prefixes.

Before the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_mtp_source_key_prefixes -q
1 failed: returned only ('model.layers.45.',)
```

After the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_mtp_source_key_prefixes -q
1 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest <five focused AutoBridge MTP tests> <two strict/non-strict state-save tests> -q
7 passed

uv run --no-sync pre-commit run --all-files
passed

git diff --check
passed
```

The broader `test_auto_bridge.py` run reached 88 passed and 1 skipped; three unrelated Qwen3.5 token-classification tests fail in the validation image because it has Transformers 5.8.1 while those tests require 5.9.

## Scope

- No public API, dependency, workflow, lockfile, or Megatron-LM changes.
- No full-suite, convergence, performance, or full-model Step3.7 export claim.
