### PR TITLE
docs: update performance summary for 26.08

### DIFF
--- a/docs/performance-summary-archive.md
+++ b/docs/performance-summary-archive.md
@@ -39,6 +39,56 @@ The performance data includes:
 
 ---
 
+## 26.06.01 NeMo Container
+
+### Pre-Training Performance
+
+#### Model: DeepSeekV3
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 2 | 1 | 8 | 32 | 6304 | 1640 |
+| DGX-GB200 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 4 | 1 | 4 | 64 | 4928 | 1280 |
+
+#### Model: GPT OSS 120B
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 64 | MXFP8 | 1280 | 4 | 4096 | 1 | 1 | 1 | n/a | 16 | 20288 | 661[^gpt-oss-note] |
+| DGX-GB200 | 64 | MXFP8 | 1280 | 4 | 4096 | 1 | 1 | 1 | n/a | 64 | 18304 | 597[^gpt-oss-note] |
+
+#### Model: Qwen3_30B_a3B
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 8 | MXFP8 | 512 | 8 | 4096 | 1 | 1 | 1 | n/a | 8 | 44544 | 1029 |
+| DGX-GB200 | 8 | MXFP8 | 512 | 4 | 4096 | 1 | 1 | 1 | n/a | 8 | 40960 | 937 |
+
+#### Model: Qwen3_235B_a22B
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 256 | MXFP8 | 8192 | 2 | 4096 | 1 | 4 | 1 | 12 | 32 | 9008 | 1333 |
+| DGX-GB200 | 256 | MXFP8 | 8192 | 1 | 4096 | 1 | 8 | 1 | 3 | 32 | 7360 | 1089 |
+
+#### Model: Nemotron_3_Nano
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 8 | MXFP8 | 512 | 4 | 8192 | 1 | 1 | 1 | n/a | 8 | 40960 | 905 |
+| DGX-GB200 | 8 | MXFP8 | 512 | 2 | 8192 | 1 | 1 | 1 | n/a | 8 | 34816 | 776 |
+
+#### Model: Nemotron_3_Super
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 64 | MXFP8 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 9728 | 827 |
+| DGX-GB300 | 64 | NVFP4 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 9984 | 845 |
+| DGX-GB200 | 64 | MXFP8 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 7040 | 598 |
+| DGX-GB200 | 64 | NVFP4 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 7040 | 598 |
+
+[^gpt-oss-note]: Performance regression in GPT-OSS 120B pre-training is a [known issue](https://github.com/NVIDIA/cudnn-frontend/issues/256). It will be resolved with the next container release.
+
 ## 26.06 NeMo Container
 
 ### Pre-Training Performance

--- a/docs/performance-summary.md
+++ b/docs/performance-summary.md
@@ -98,10 +98,8 @@ The performance data includes:
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
-| DGX-GB300 | 256 | MXFP8 | 256 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 3552 | n/a |
-| DGX-GB300 | 256 | NVFP4 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | n/a | n/a |
+| DGX-GB300 | 256 | MXFP8 | 256 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 3552 | 1281 |
 | DGX-GB200 | 256 | MXFP8 | 256 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 2528 | 923 |
-| DGX-GB200 | 256 | NVFP4 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | n/a | n/a |
 
 [^moe-training-note]: In MoE training benchmarks, we force-balance the token distribution among experts and all benchmarks are token-dropless.
 

--- a/docs/performance-summary.md
+++ b/docs/performance-summary.md
@@ -34,7 +34,7 @@ The performance data includes:
 
 ---
 
-## 26.06.01 NeMo Container
+## 26.08 NeMo Container
 
 ### Pre-Training Performance
 
@@ -42,48 +42,78 @@ The performance data includes:
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
-| DGX-GB300 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 2 | 1 | 8 | 32 | 6304 | 1640 |
-| DGX-GB200 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 4 | 1 | 4 | 64 | 4928 | 1280 |
+| DGX-GB300 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 2 | 1 | 8 | 32 | 6288 | 1635 |
+| DGX-GB200 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 4 | 1 | 4 | 64 | 4912 | 1276 |
+
+#### Model: DeepSeekV4 Pro
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 256 | MXFP8 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | n/a | n/a |
+| DGX-GB300 | 256 | NVFP4 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | n/a | n/a |
+| DGX-GB200 | 256 | MXFP8 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | n/a | n/a |
+| DGX-GB200 | 256 | NVFP4 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | n/a | n/a |
+
+#### Model: DeepSeekV4 Flash
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 128 | MXFP8 | 2048 | 1 | 4096 | 1 | 1 | 1 | n/a | 64 | 8224 | 748 |
+| DGX-GB200 | 128 | MXFP8 | 2048 | 1 | 4096 | 1 | 1 | 1 | n/a | 64 | 7776 | 706 |
 
 #### Model: GPT OSS 120B
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
-| DGX-GB300 | 64 | MXFP8 | 1280 | 4 | 4096 | 1 | 1 | 1 | n/a | 16 | 20288 | 661[^gpt-oss-note] |
-| DGX-GB200 | 64 | MXFP8 | 1280 | 4 | 4096 | 1 | 1 | 1 | n/a | 64 | 18304 | 597[^gpt-oss-note] |
+| DGX-GB300 | 64 | MXFP8 | 1280 | 4 | 4096 | 1 | 1 | 1 | n/a | 16 | 33024 | 1077 |
+| DGX-GB200 | 64 | MXFP8 | 1280 | 4 | 4096 | 1 | 1 | 1 | n/a | 64 | 28672 | 934 |
 
 #### Model: Qwen3_30B_a3B
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
 | DGX-GB300 | 8 | MXFP8 | 512 | 8 | 4096 | 1 | 1 | 1 | n/a | 8 | 44544 | 1029 |
-| DGX-GB200 | 8 | MXFP8 | 512 | 4 | 4096 | 1 | 1 | 1 | n/a | 8 | 40960 | 937 |
+| DGX-GB200 | 8 | MXFP8 | 512 | 4 | 4096 | 1 | 1 | 1 | n/a | 8 | 39936 | 923 |
 
 #### Model: Qwen3_235B_a22B
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
-| DGX-GB300 | 256 | MXFP8 | 8192 | 2 | 4096 | 1 | 4 | 1 | 12 | 32 | 9008 | 1333 |
-| DGX-GB200 | 256 | MXFP8 | 8192 | 1 | 4096 | 1 | 8 | 1 | 3 | 32 | 7360 | 1089 |
+| DGX-GB300 | 256 | MXFP8 | 8192 | 2 | 4096 | 1 | 4 | 1 | 12 | 32 | 8816 | 1306 |
+| DGX-GB200 | 256 | MXFP8 | 8192 | 1 | 4096 | 1 | 8 | 1 | 3 | 32 | 7280 | 1077 |
 
 #### Model: Nemotron_3_Nano
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
-| DGX-GB300 | 8 | MXFP8 | 512 | 4 | 8192 | 1 | 1 | 1 | n/a | 8 | 40960 | 905 |
-| DGX-GB200 | 8 | MXFP8 | 512 | 2 | 8192 | 1 | 1 | 1 | n/a | 8 | 34816 | 776 |
+| DGX-GB300 | 8 | MXFP8 | 512 | 4 | 8192 | 1 | 1 | 1 | n/a | 8 | 39936 | 901 |
+| DGX-GB200 | 8 | MXFP8 | 512 | 2 | 8192 | 1 | 1 | 1 | n/a | 8 | 34816 | 781 |
+
+#### Model: Nemotron_3_5_Lightning
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB200 | 8 | MXFP8 | 512 | 2 | 8192 | 1 | 1 | 1 | n/a | 8 | 28672 | 807 |
 
 #### Model: Nemotron_3_Super
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
-| DGX-GB300 | 64 | MXFP8 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 9728 | 827 |
-| DGX-GB300 | 64 | NVFP4 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 9984 | 845 |
-| DGX-GB200 | 64 | MXFP8 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 7040 | 598 |
-| DGX-GB200 | 64 | NVFP4 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 7040 | 598 |
+| DGX-GB300 | 64 | MXFP8 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 9856 | 831 |
+| DGX-GB300 | 64 | NVFP4 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 10240 | 864 |
+| DGX-GB200 | 64 | MXFP8 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 7040 | 600 |
+| DGX-GB200 | 64 | NVFP4 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 7168 | 610 |
+
+#### Model: Nemotron_3_Ultra
+
+| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
+|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
+| DGX-GB300 | 256 | MXFP8 | 256 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | 3552 | n/a |
+| DGX-GB300 | 256 | NVFP4 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | n/a | n/a |
+| DGX-GB200 | 256 | MXFP8 | 256 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | 2528 | 923 |
+| DGX-GB200 | 256 | NVFP4 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | n/a | n/a |
 
 [^moe-training-note]: In MoE training benchmarks, we force-balance the token distribution among experts and all benchmarks are token-dropless.
-[^gpt-oss-note]: Performance regression in GPT-OSS 120B pre-training is a [known issue](https://github.com/NVIDIA/cudnn-frontend/issues/256). It will be resolved with the next container release.
 
 ## Archive
 

--- a/docs/performance-summary.md
+++ b/docs/performance-summary.md
@@ -45,15 +45,6 @@ The performance data includes:
 | DGX-GB300 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 2 | 1 | 8 | 32 | 6288 | 1635 |
 | DGX-GB200 | 256 | MXFP8 | 4096 | 1 | 4096 | 1 | 4 | 1 | 4 | 64 | 4912 | 1276 |
 
-#### Model: DeepSeekV4 Pro
-
-| System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
-|--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
-| DGX-GB300 | 256 | MXFP8 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | n/a | n/a |
-| DGX-GB300 | 256 | NVFP4 | 512 | 1 | 8192 | 1 | 1 | 1 | n/a | 64 | n/a | n/a |
-| DGX-GB200 | 256 | MXFP8 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | n/a | n/a |
-| DGX-GB200 | 256 | NVFP4 | 512 | 1 | 8192 | 2 | 1 | 1 | n/a | 64 | n/a | n/a |
-
 #### Model: DeepSeekV4 Flash
 
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
@@ -87,7 +78,6 @@ The performance data includes:
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
 | DGX-GB300 | 8 | MXFP8 | 512 | 4 | 8192 | 1 | 1 | 1 | n/a | 8 | 39936 | 901 |
-| DGX-GB200 | 8 | MXFP8 | 512 | 2 | 8192 | 1 | 1 | 1 | n/a | 8 | 34816 | 781 |
 
 #### Model: Nemotron_3_5_Lightning
 


### PR DESCRIPTION
# What does this PR do?

Updates the latest Megatron Bridge performance summary with the 26.08 E2E benchmark data and moves the previous 26.06.01 results into the archive.

# Changelog

- Filter the 26.08 source data to rows owned by E2E.
- Preserve the existing performance-summary table schema and precision compatibility rules.
- Add eligible DeepSeekV4 Flash, Nemotron 3.5 Lightning, and Nemotron 3 Ultra benchmarks.
- Exclude DeepSeekV4 Pro, llama3_8b, qwen3.5_vl, and large-scale proxy benchmarks, and omit the GB200 Nemotron 3 Nano row.
- Limit Nemotron 3 Ultra results to MXFP8 and record 1281 TFLOP/sec/GPU for GB300.
- Archive the former 26.06.01 performance summary.

# GitHub Actions CI

This is a documentation-only change.

Local validation:
- `uv run --no-sync pre-commit run --all-files`
- CSV-to-Markdown reconciliation for all 18 included rows
- Table-schema, exclusion, archive-equivalence, and footnote checks
- `git diff --check`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Tests are not required for this documentation-only update.
- [x] Updated the necessary documentation.
- [x] No optional-install components are affected.

# Additional Information

No related issue.
