### PR TITLE
[docs] fix: align Gemma 3 programmatic recipe examples

### DIFF
--- a/docs/models/gemma/gemma3.md
+++ b/docs/models/gemma/gemma3.md
@@ -109,13 +109,11 @@ See: [bridge.recipes.gemma](../../apidocs/bridge/bridge.recipes.gemma.md)
 ```python
 from megatron.bridge.recipes.gemma import gemma3_1b_pretrain_config
 
-config = gemma3_1b_pretrain_config(
-    name="gemma3_1b_pretrain",
-    data_paths=["path/to/data"],
-    train_iters=100000,
-    global_batch_size=256,
-    # Uses TP=1, PP=1 (8 GPUs) automatically
-)
+config = gemma3_1b_pretrain_config()
+config.dataset.blend = [["path/to/data"], None]
+config.train.train_iters = 100000
+config.train.global_batch_size = 256
+# Uses TP=1, PP=1; additional GPUs become data parallel
 ```
 
 ### Finetuning Examples
@@ -125,14 +123,13 @@ config = gemma3_1b_pretrain_config(
 ```python
 from megatron.bridge.recipes.gemma import gemma3_1b_sft_config
 
-config = gemma3_1b_sft_config(
-    name="gemma3_1b_full_finetune",
-    pretrained_checkpoint="/models/gemma-3-1b-it",
-    train_iters=1000,
-    global_batch_size=64,
-    finetune_lr=5e-6,
-    # Uses TP=1, PP=1 (8 GPUs) automatically
-)
+config = gemma3_1b_sft_config()
+config.checkpoint.pretrained_checkpoint = "/models/gemma-3-1b-it"
+config.train.train_iters = 1000
+config.train.global_batch_size = 64
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 5e-6
+# Uses TP=1, PP=1; additional GPUs become data parallel
 ```
 
 #### LoRA Finetuning
@@ -140,15 +137,13 @@ config = gemma3_1b_sft_config(
 ```python
 from megatron.bridge.recipes.gemma import gemma3_1b_peft_config
 
-config = gemma3_1b_peft_config(
-    name="gemma3_1b_lora_finetune",
-    pretrained_checkpoint="/models/gemma-3-1b-it",
-    peft_scheme="lora",  # or "dora"
-    train_iters=1000,
-    global_batch_size=128,
-    finetune_lr=1e-4,
-    # Uses TP=1, PP=1 (8 GPUs) automatically
-)
+config = gemma3_1b_peft_config(peft_scheme="lora")  # or "dora"
+config.checkpoint.pretrained_checkpoint = "/models/gemma-3-1b-it"
+config.train.train_iters = 1000
+config.train.global_batch_size = 128
+config.scheduler.lr_decay_iters = 1000
+config.optimizer.lr = 1e-4
+# Uses TP=1, PP=1; additional GPUs become data parallel
 ```
 
 ### Command-Line Training

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -42,6 +42,9 @@ RL_INTEGRATION_DOCS = (
 MODEL_PROVIDER = REPO_ROOT / "src" / "megatron" / "bridge" / "models" / "model_provider.py"
 GEMMA3_VL_README = REPO_ROOT / "examples" / "models" / "gemma" / "gemma3_vl" / "README.md"
 GEMMA3_VL_RECIPES = RECIPES_DIR / "gemma3_vl" / "gemma3_vl.py"
+GEMMA3_DOCS = REPO_ROOT / "docs" / "models" / "gemma" / "gemma3.md"
+GEMMA3_ALIASES = RECIPES_DIR / "gemma" / "gemma3.py"
+GEMMA3_H100_RECIPES = RECIPES_DIR / "gemma" / "h100" / "gemma3.py"
 RUN_RECIPE = REPO_ROOT / "scripts" / "training" / "run_recipe.py"
 MODEL_EXAMPLES = REPO_ROOT / "examples" / "models"
 TRAINING_CONFIG = REPO_ROOT / "src" / "megatron" / "bridge" / "training" / "config.py"
@@ -371,6 +374,51 @@ def test_multimodal_model_docs_use_current_launchers_and_conversion_flags():
     assert "--megatron-path /checkpoints/nemotron_omni" in valor
     assert "--hf_path" not in valor
     assert "--output_dir /checkpoints/nemotron_omni" not in valor
+
+
+def test_gemma3_recipe_examples_match_source_signatures():
+    """Gemma 3 examples must pass only keywords accepted by public recipe factories."""
+    recipe_names = {
+        "gemma3_1b_pretrain_config",
+        "gemma3_1b_sft_config",
+        "gemma3_1b_peft_config",
+    }
+    alias_targets: dict[str, str] = {}
+    for node in ast.parse(_read(GEMMA3_ALIASES), filename=str(GEMMA3_ALIASES)).body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for imported_name in node.names:
+            if imported_name.asname in recipe_names:
+                alias_targets[imported_name.asname] = imported_name.name
+    assert set(alias_targets) == recipe_names
+
+    accepted_keywords: dict[str, set[str]] = {}
+    for node in ast.parse(_read(GEMMA3_H100_RECIPES), filename=str(GEMMA3_H100_RECIPES)).body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in alias_targets.values():
+            continue
+        assert node.args.kwarg is None
+        accepted_keywords[node.name] = {
+            argument.arg for argument in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
+        }
+    assert set(accepted_keywords) == set(alias_targets.values())
+
+    examples = _read(GEMMA3_DOCS).split("### Pre-training Example", 1)[1].split("### Command-Line Training", 1)[0]
+    calls: dict[str, list[set[str | None]]] = {name: [] for name in recipe_names}
+    for code in re.findall(r"```python\n(.*?)```", examples, re.DOTALL):
+        tree = ast.parse(code, filename=str(GEMMA3_DOCS))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in calls:
+                calls[node.func.id].append({keyword.arg for keyword in node.keywords})
+
+    unsupported_by_recipe: dict[str, list[str | None]] = {}
+    for recipe_name in recipe_names:
+        assert len(calls[recipe_name]) == 1, (
+            f"Gemma 3 docs should call {recipe_name} exactly once: {calls[recipe_name]}"
+        )
+        unsupported = calls[recipe_name][0] - accepted_keywords[alias_targets[recipe_name]]
+        if unsupported:
+            unsupported_by_recipe[recipe_name] = sorted(unsupported)
+    assert not unsupported_by_recipe, f"Gemma 3 docs use unsupported recipe keywords: {unsupported_by_recipe}"
 
 
 def test_qwen3_recipe_examples_use_current_factory_api():


### PR DESCRIPTION
## Problem

The maintained Gemma 3 page advertises direct-Python pretrain, SFT, and PEFT examples that pass removed flat keyword arguments to the public recipe aliases. Copying any example raises `TypeError` during Python argument binding, before configuration construction or training starts.

## Root cause

`gemma3_1b_pretrain_config` and `gemma3_1b_sft_config` directly alias parameterless H100 builders. `gemma3_1b_peft_config` directly aliases a builder whose only supported keyword is `peft_scheme`. The docs still pass legacy fields such as `name`, `data_paths`, `pretrained_checkpoint`, `train_iters`, `global_batch_size`, and `finetune_lr` into those builders.

## Fix

- Construct pretrain and SFT recipes without arguments.
- Pass only `peft_scheme` to the PEFT builder.
- Apply dataset, checkpoint, training, scheduler, and optimizer customizations through their current nested `ConfigContainer` fields.
- Add a dependency-free documentation contract that follows the public aliases and compares documented call keywords with the canonical builder signatures.

## Validation

Exact regression on the unmodified docs with only the new test present:

```bash
uv run --no-sync python -c 'import runpy; ns = runpy.run_path("tests/unit_tests/doc_consistency/test_readme_consistency.py"); ns["test_gemma3_recipe_examples_match_source_signatures"]()'
```

- Before: exit 1; reported unsupported keyword sets for all three examples.
- After: exit 0 with the unchanged contract.

Adjacent documentation contracts:

```bash
uv run --no-sync python - <<'PY'
import inspect
import runpy

namespace = runpy.run_path("tests/unit_tests/doc_consistency/test_readme_consistency.py")
checks = sorted(
    value
    for name, value in namespace.items()
    if name.startswith("test_") and callable(value) and not inspect.signature(value).parameters
)
for check in checks:
    check()
print(f"{len(checks)} documentation consistency contracts passed")
PY
```

- Result: 20 documentation consistency contracts passed.

Additional checks:

```bash
git diff --check
uv run --no-sync pre-commit run --all-files
```

- Result: passed; all hooks passed.

## Scope

This changes only the maintained Gemma 3 model page and its static documentation contract. It does not change recipe signatures, runtime code, dependencies, workflows, lockfiles, conversion APIs, or the Megatron-LM submodule. GPU, convergence, and performance behavior were not tested or changed.
