### PR TITLE
fix(docs): include recipe index in toctree

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -58,6 +58,7 @@ skills/nemo-mbridge-perf-activation-recompute/SKILL
 ```{toctree}
 :hidden:
 
+skills/nemo-mbridge-recipe-recommender/references/recipe-index
 skills/nemo-mbridge-perf-nsys-analysis/references/pitfalls
 skills/nemo-mbridge-perf-nsys-analysis/references/sql-recipes
 ```


### PR DESCRIPTION
## Summary

- Register the recipe recommender reference index in the hidden skills toctree.
- Keep the reference page linkable without adding another visible navigation entry.
- Restore warning-as-error Sphinx builds on `main` and downstream PRs.

## Root cause

`docs/conf.py` copies every file under `skills/` into the Sphinx source tree. When the recipe tables were split into `skills/nemo-mbridge-recipe-recommender/references/recipe-index.md`, the new page was linked from the parent skill but was not registered in a toctree. Sphinx therefore emitted `toc.not_included`, which is fatal under `--fail-on-warning`.

The same warning failed both PR run 31465999883 and the latest `main` run 31493952223.

## Validation

- `uv run --only-group docs sphinx-build --fail-on-warning --builder html . _build/html` — passed.
- `uv run --no-project --with pre-commit pre-commit run --all-files` — passed.
- `git diff --check` — passed.

AI assistance disclosure: This CI diagnosis and fix were prepared with Codex assistance and reviewed by the author.