### PR TITLE
fix(recipe): prevent Qwen3.5-VL FSDP SFT OOM

### DIFF
--- a/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
@@ -1190,7 +1190,9 @@ def qwen35_vl_35b_a3b_sft_2gpu_h100_bf16_fsdp_config() -> ConfigContainer:
     cfg.model.attention_backend = "auto"
     cfg.model.gradient_accumulation_fusion = True
     cfg.model.cross_entropy_loss_fusion = True
-    cfg.model.cross_entropy_fusion_impl = "native"
+    # Native fused cross entropy materializes a full FP32 vocabulary-sized
+    # softmax buffer. Use the TE kernel to keep the 248K-token loss bounded.
+    cfg.model.cross_entropy_fusion_impl = "te"
 
     # MoE settings
     cfg.model.moe_token_dispatcher_type = "alltoall"
@@ -1204,10 +1206,12 @@ def qwen35_vl_35b_a3b_sft_2gpu_h100_bf16_fsdp_config() -> ConfigContainer:
     cfg.model.moe_router_padding_for_fp8 = False
 
     # Memory saving
-    cfg.model.recompute_granularity = None
+    # Full SFT retains FP32 optimizer state alongside the FSDP communication
+    # pools, so recompute each transformer layer to bound live activations.
+    cfg.model.recompute_granularity = "full"
     cfg.model.recompute_modules = None
-    cfg.model.recompute_method = None
-    cfg.model.recompute_num_layers = None
+    cfg.model.recompute_method = "uniform"
+    cfg.model.recompute_num_layers = 1
     cfg.model.fine_grained_activation_offloading = False
     cfg.model.offload_modules = None
 

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -561,6 +561,12 @@ def test_qwen35_vl_35b_a3b_fsdp_sft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.sequence_parallel is False
     assert cfg.model.moe_token_dispatcher_type == "alltoall"
     assert cfg.model.moe_router_fusion is True
+    assert cfg.model.cross_entropy_loss_fusion is True
+    assert cfg.model.cross_entropy_fusion_impl == "te"
+    assert cfg.model.recompute_granularity == "full"
+    assert cfg.model.recompute_modules is None
+    assert cfg.model.recompute_method == "uniform"
+    assert cfg.model.recompute_num_layers == 1
     assert cfg.ddp.use_megatron_fsdp is True
     assert cfg.ddp.fsdp_double_buffer is True
     assert cfg.ddp.megatron_fsdp_max_pool_double_buffer is True


### PR DESCRIPTION
# What does this PR do?

Prevent Qwen3.5/Qwen3.6-VL 35B-A3B full SFT with Megatron FSDP from exhausting H100 memory before the first optimizer iteration.

Fixes NVBug 6588641

# Changelog

- Use Transformer Engine fused cross entropy for the 248K-token language head instead of materializing the native FP32 vocabulary-sized buffer.
- Enable full uniform activation recompute in one-layer chunks to bound live activations alongside FSDP communication pools and FP32 optimizer state.
- Add focused assertions for the memory-safe FSDP SFT defaults.
- Preserve the existing FSDP max-pool double buffering and persistent allocation fallback.

# Root cause

The original defaults combined unrecomputed transformer activations with native fused cross entropy. The native loss path creates an approximately 3.79 GiB FP32 buffer for a `[4096, 1, 248320]` tensor, while the unrecomputed MoE forward also reaches the device memory limit. Controlled runs showed that either mitigation alone still exhausted memory in the following iteration; both are required for this workload.

# Validation

- Before: a generated FSDP checkpoint loaded on all 16 H100 ranks, then the checkpoint-backed SFT workload exhausted memory before completing iteration 1.
- After: the same checkpoint-backed workload completed two finite optimizer iterations with zero skipped or NaN iterations, saved an FSDP checkpoint, and completed validation and test evaluation.
- Patched-source verification repeated the successful run without command-line overrides for the changed recipe fields.
- `uv run python -m pytest tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py -q` — 122 passed.
- `uv run pre-commit run --all-files` — passed.
- `git diff --check` — passed.

Full-layer recompute has a throughput cost, but controlled selective-recompute and loss-only alternatives did not provide enough memory headroom for the reported full-SFT workload.

Developed with OpenAI Codex assistance; the author reviewed and validated the changes.
