### PR TITLE
fix(deepseek-v4): use full-prefix inference

### DIFF
--- a/examples/models/deepseek_v4/inference.sh
+++ b/examples/models/deepseek_v4/inference.sh
@@ -46,6 +46,7 @@ if [[ -z "${PP:-}" ]]; then
 fi
 TP=1
 
+# DSv4 hybrid attention does not support inference contexts yet, so use full-prefix generation.
 # Inference directly from the HF checkpoint (Bridge dequantises in-flight).
 uv run python -m torch.distributed.run --nproc_per_node=$((PP * EP)) \
     examples/conversion/hf_to_megatron_generate_text.py \
@@ -53,6 +54,7 @@ uv run python -m torch.distributed.run --nproc_per_node=$((PP * EP)) \
     --prompt "${PROMPT}" \
     --max_new_tokens 100 \
     --tp ${TP} --pp ${PP} --ep ${EP} \
+    --legacy-full-prefix \
     --trust-remote-code
 
 # Inference from a previously-imported Megatron checkpoint (faster cold start).
@@ -65,5 +67,6 @@ if [[ -d "${MEGATRON_DIR}/iter_0000000" ]]; then
         --prompt "${PROMPT}" \
         --max_new_tokens 100 \
         --tp ${TP} --pp ${PP} --ep ${EP} \
+        --legacy-full-prefix \
         --trust-remote-code
 fi


### PR DESCRIPTION
# What does this PR do?

Use the supported full-prefix compatibility path for DeepSeek V4 text generation.

Fixes NVBug 6589320

# Changelog

- Pass `--legacy-full-prefix` when generating directly from a Hugging Face checkpoint.
- Pass the same option when generating from an imported Megatron checkpoint.
- Document why cached inference is not selected for DSv4 hybrid attention yet.

# Root cause

The generation entry point creates an inference context by default, but the current DSv4 hybrid-attention implementation explicitly rejects inference contexts. The model therefore fails before generation begins. Selecting legacy full-prefix generation keeps the inference context unset and uses the supported compatibility path.

# Validation

- Before: the documented TP1/PP1/EP16 H100 workflow on the latest NeMo 26.08 RC failed across all 16 ranks with the DSv4 unsupported-inference-context assertion.
- After: an otherwise identical run adding only `--legacy-full-prefix` completed all 100 requested generation steps and emitted generated text.
- The no-flag failure also reproduced against current Megatron Core `dev`, confirming that this is not only a stale-pin issue.
- `bash -n examples/models/deepseek_v4/inference.sh` — passed.
- `uv run --no-sync pre-commit run --all-files` — passed in the release container.
- `git diff --check` — passed.
- Independent exact-commit review — no findings.

No script unit test is added per maintainer direction; the full-model before/after run is the regression oracle.

# AI assistance

This fix, investigation, and validation summary were prepared with OpenAI Codex assistance and independently reviewed and validated by the author.
