### PR TITLE
docs: remove duplicate skills toctree entry

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -61,7 +61,6 @@ skills/nemo-mbridge-perf-activation-recompute/SKILL
 skills/nemo-mbridge-recipe-recommender/references/recipe-index
 skills/nemo-mbridge-perf-nsys-analysis/references/pitfalls
 skills/nemo-mbridge-perf-nsys-analysis/references/sql-recipes
-skills/nemo-mbridge-recipe-recommender/references/recipe-index
 ```
 
 ```{toctree}


### PR DESCRIPTION
# What does this PR do?

Remove a duplicated hidden Sphinx toctree entry from the skills index so the documentation build no longer emits `toc.duplicate_entry` for the recipe reference index.

# Changelog

- Keep the recipe reference index in its intended position before the Nsight Systems references.
- Remove only the redundant trailing occurrence.

# GitHub Actions CI

The commit is GPG-signed for automatic CI trust.

Focused validation completed:

- `git diff --check`
- `uv run --only-group docs sphinx-build -b dummy -n -W --keep-going docs <temporary-output> docs/skills-index.md`
- `uv run --no-sync pre-commit run --all-files`

The focused Sphinx build passed with warnings treated as errors and emitted no duplicate-entry warning. A fresh independent review of the exact signed-off commit returned no findings.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] No new test is needed for this one-line documentation correction; the focused warning-as-error Sphinx build exercises the reported failure.
- [x] Updated the affected documentation index.
- [x] The change does not affect optional components.

# Additional Information

No related issue.
