### PR TITLE
docs(dsv4): preserve container packages during MCore sync

### DIFF
--- a/examples/models/deepseek_v4/README.md
+++ b/examples/models/deepseek_v4/README.md
@@ -8,12 +8,35 @@ The bridge supports four published variants out of the same code path. The on-di
 
 The pretraining recipes were tested with Megatron-LM `dev` commit `35f36c7c9dba` plus PR [#4839](https://github.com/NVIDIA/Megatron-LM/pull/4839) (`f04b762406f0` in the OCI test checkout). The Megatron-LM copy inside the current NeMo FW container is not expected to work for these recipes.
 
+The NeMo Framework container uses one shared `/opt/venv` for several source
+projects. A plain `uv sync` is exact by default and removes packages that are
+not in the Megatron Bridge dependency graph, including container-provided
+packages such as NeMo Run. When switching MCore in this container, preserve
+those packages and then restore the aggregate container pins:
+
 ```bash
 ./scripts/switch_mcore.sh dev
-uv sync
+uv sync --inexact
+(cd /opt/NeMo-FW && uv sync --locked --all-groups --inexact)
+export UV_NO_SYNC=1
 ```
 
-Use `./scripts/switch_mcore.sh main` and `uv sync --locked` to return to the pinned main-branch submodule.
+Keep `UV_NO_SYNC=1` set while running the examples. It makes `uv run` calls,
+including those inside the example wrapper scripts, skip the implicit exact
+sync. The unlocked dev sync updates `uv.lock`; do not commit that generated
+change. From a clean checkout, return to the pinned main-branch submodule with:
+
+```bash
+./scripts/switch_mcore.sh main
+git restore uv.lock
+uv sync --locked --inexact
+(cd /opt/NeMo-FW && uv sync --locked --all-groups --inexact)
+export UV_NO_SYNC=1
+```
+
+In a standalone Megatron Bridge environment with its own virtual environment,
+exact sync is appropriate: use `uv sync` after switching to dev and restore the
+tracked lock file followed by `uv sync --locked` when switching back to main.
 
 The full-scale `deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config` performance
 recipe preserves the stack validated by Megatron Bridge PR
@@ -142,11 +165,6 @@ DSv4 currently requires **TP=1** because MLA tensor parallelism is not supported
 
 - **Fused mHC: use the unfused path for SFT.** The fused cuTile mHC kernel needs sm_100 (not H100) and is on by default in the bridge config; it works for import/inference on Blackwell, but **NaNs in SFT training** (see SFT Blockers). The SFT recipes therefore force `use_fused_mhc=False` — the validated unfused/reference path, which also runs on Hopper.
 
-- **`fast_hadamard_transform` is required by the DSA attention variant.** `csa.py` and `dsa.py` import `hadamard_transform` from this package and hard-assert availability — there is no in-tree PyTorch fallback. Install from the Dao-AILab git repo (the PyPI source distribution is incomplete; see the sibling GLM-5 [README](../glm/glm5/README.md#pre-requisites) for the same dependency):
-
-  ```bash
-  pip install --no-build-isolation \
-      git+https://github.com/Dao-AILab/fast-hadamard-transform.git
-  ```
+- **`fast_hadamard_transform` is required by the DSA attention variant.** `csa.py` and `dsa.py` import `hadamard_transform` from this package and hard-assert availability — there is no in-tree PyTorch fallback. It is a required Megatron Bridge dependency, pinned to the complete Dao-AILab git source because the PyPI source distribution is incomplete, and is installed by the `uv sync` commands above.
 
 - **Logit parity is verified for Flash and Flash-Base** against the official inference stack at last-real-token logits. The remaining gap is structural, from different attention/HC kernel decompositions and accumulation precisions between MCore and official inference.

--- a/examples/models/deepseek_v4/slurm_pretrain.sh
+++ b/examples/models/deepseek_v4/slurm_pretrain.sh
@@ -90,7 +90,8 @@ export NCCL_PXN_DISABLE=1
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
-# Pre-sync once before submitting jobs: UV_CACHE_DIR=/path/to/cache uv sync
+# Before submitting, follow README.md's MCore Checkout instructions. In a NeMo
+# Framework container, use its two-stage inexact sync; do not run plain `uv sync`.
 # export UV_CACHE_DIR="/path/to/shared/uv_cache"
 # export HF_HOME="/path/to/shared/HF_HOME"
 # export HF_TOKEN="hf_your_token_here"


### PR DESCRIPTION
# What does this PR do?

Document a safe MCore-switch workflow for DeepSeek V4 when Megatron Bridge runs inside the NeMo Framework container's shared virtual environment.

Fixes NVBug 6589319

# Changelog

- Use a two-stage inexact sync for the shared NeMo Framework environment.
- Retain exact sync for standalone Megatron Bridge virtual environments.
- Require `uv run --no-sync` after setup and document restoring the tracked lock file when switching back to main.
- Remove the obsolete manual FHT installation instruction now that FHT is a required Bridge dependency.
- Point the DeepSeek V4 pretraining launcher to the corrected setup instructions.

# Root cause

`uv sync` is exact by default. In the NeMo Framework release container, Megatron Bridge shares `/opt/venv` with other source projects, so syncing only the Bridge dependency graph removes container-provided packages outside that graph. Switching MCore changes the resolved Bridge graph but does not use a different `uv` executable.

The documented sequence now updates the Bridge/MCore layer with `--inexact`, then reapplies the aggregate NeMo Framework lock with `--inexact`. This preserves packages owned by the other image layers while restoring the container's cross-project version pins.

# Validation

- Before: plain Bridge sync in a stock NeMo 26.08 release-candidate container pruned 161 distribution names, including NeMo Framework and NeMo Run packages.
- After: the documented two-stage inexact sequence lost zero distribution names, restored the aggregate locked versions, preserved the selected development MCore checkout, and passed the required import and conversion-CLI oracles.
- `UV_NO_SYNC=1 uv run ...` with the container's `uv 0.7.2` — started without a resolve/install/uninstall step.
- `uv run pre-commit run --all-files` with the container's `uv 0.7.2` — passed.
- `bash -n examples/models/deepseek_v4/slurm_pretrain.sh` — passed.
- `git diff --check` — passed.
- Independent review of exact commit `25177213c8e13b67d2fa937060f429e5557a4d8d` — no findings.

No code regression test is added because this is a documentation-only correction backed by the release-container before/after reproducer.

# AI assistance

This investigation, documentation update, and validation summary were prepared with OpenAI Codex assistance and independently reviewed and validated by the author.
