### PR TITLE
[ci] fix: set explicit CA bundle for lint checkout

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -239,6 +239,9 @@ jobs:
     name: Lint check
     runs-on: ubuntu-latest
     needs: [pre-flight, configure]
+    env:
+      # Keep checkout independent of hosted-runner Git CA auto-detection.
+      GIT_SSL_CAINFO: /etc/ssl/certs/ca-certificates.crt
     if: |
       needs.pre-flight.outputs.is_deployment_workflow == 'false'
       || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## What\n\nSet `GIT_SSL_CAINFO` for the GitHub-hosted lint job so `actions/checkout` and its recursive submodule fetch use Ubuntu’s system CA bundle instead of relying on runner Git CA auto-detection. TLS verification remains enabled.\n\n## Why\n\nMain run [31538728024](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31538728024), job [93936091264](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31538728024/job/93936091264), failed before lint. All three checkout attempts reported `server certificate verification failed. CAfile: none CRLfile: none`; other jobs checked out the same SHA successfully, isolating the failure to one hosted runner rather than repository contents.\n\n## Validation\n\n- Exact system-CA `git ls-remote` against this repository: pass\n- Workflow YAML parse and expected lint-job env assertion: pass\n- `git diff --check`: pass\n- `uv run --active --no-sync pre-commit run --all-files`: pass\n\nThe fresh worktree could not resolve the newly pinned `nvidia-resiliency-ext` wheel on the host glibc, so pre-commit used the repository’s existing validated development environment without syncing or changing dependencies.