### PR TITLE
fix(model): preserve Parakeet audio lengths

### DIFF
--- a/examples/models/nemotron/nemotron_3_omni/hf_to_megatron_generate_nemotron_omni.py
+++ b/examples/models/nemotron/nemotron_3_omni/hf_to_megatron_generate_nemotron_omni.py
@@ -89,6 +89,7 @@ from megatron.bridge.models.nemotron_omni.nemotron_omni_utils import (
     patchify_temporal_frame,
     select_inference_next_token,
     temporal_model_frames,
+    valid_audio_feature_lengths,
 )
 from megatron.bridge.models.nemotron_vl.nemotron_vl_utils import adjust_image_tokens
 from megatron.bridge.utils.common_utils import get_last_rank, print_rank_0
@@ -149,10 +150,9 @@ def _fastconformer_output_length(mel_length: int, subsampling_factor: int = 8) -
 def _align_sound_tokens(input_ids: torch.Tensor, sound_token_id: int, desired_count: int) -> torch.Tensor:
     """Rewrite ``input_ids`` so the contiguous run of sound tokens has ``desired_count`` entries.
 
-    The HF processor estimates sound-token count from ``len(waveform) // hop_length``, but
-    ``ParakeetFeatureExtractor`` (STFT with ``center=True``) produces one extra mel frame,
-    so ``BridgeSoundEncoder``'s output length can exceed the HF-inserted count by 1. We
-    realign here using the true encoder output length computed from ``sound_length``.
+    The HF processor estimates the sound-token count from the waveform length. Bridge
+    recomputes it from Parakeet's semantic feature-mask length so padding and boundary
+    frames remain invalid, then defensively realigns any differing processor token run.
     """
     assert input_ids.dim() == 2 and input_ids.size(0) == 1, "Expected a single-sample batch"
     mask = input_ids[0] == sound_token_id
@@ -508,9 +508,17 @@ def process_audio_inputs(tokenizer, processor, audio_path: str, prompt: str, sys
 
     # Extract mel spectrogram features (Megatron BridgeSoundEncoder expects mel, not raw waveform)
     feature_extractor = ParakeetFeatureExtractor(sampling_rate=16000, feature_size=128)
-    audio_features = feature_extractor(raw_sound_clips, sampling_rate=16000, return_tensors="pt")
+    audio_features = feature_extractor(
+        raw_sound_clips,
+        sampling_rate=16000,
+        return_tensors="pt",
+        return_attention_mask=True,
+    )
     sound_clips = audio_features.input_features  # [batch, frames, mel_bins]
-    sound_length = torch.tensor([sound_clips.shape[1]], dtype=torch.long)
+    sound_length = valid_audio_feature_lengths(
+        audio_features.attention_mask,
+        num_frames=sound_clips.shape[1],
+    )
 
     # Realign <so_embedding> tokens in the prompt to match the encoder's actual output
     # length (see _align_sound_tokens docstring for why this can differ from the HF count).
@@ -587,9 +595,17 @@ def process_video_audio_inputs(
     # Extract raw sound clips and convert to mel spectrogram for BridgeSoundEncoder
     raw_sound_clips = proc_output.pop("sound_clips", None)
     feature_extractor = ParakeetFeatureExtractor(sampling_rate=16000, feature_size=128)
-    audio_features = feature_extractor(raw_sound_clips, sampling_rate=16000, return_tensors="pt")
+    audio_features = feature_extractor(
+        raw_sound_clips,
+        sampling_rate=16000,
+        return_tensors="pt",
+        return_attention_mask=True,
+    )
     sound_clips = audio_features.input_features
-    sound_length = torch.tensor([sound_clips.shape[1]], dtype=torch.long)
+    sound_length = valid_audio_feature_lengths(
+        audio_features.attention_mask,
+        num_frames=sound_clips.shape[1],
+    )
 
     sound_token_id = tokenizer.convert_tokens_to_ids(audio_token)
     expected_sound_tokens = _fastconformer_output_length(int(sound_length.item()))

--- a/examples/models/nemotron/nemotron_3_omni/valor32k_avqa_inference.py
+++ b/examples/models/nemotron/nemotron_3_omni/valor32k_avqa_inference.py
@@ -49,6 +49,7 @@ from megatron.bridge.models.nemotron_omni.nemotron_omni_utils import (
     patchify_temporal_frame,
     select_inference_next_token,
     temporal_model_frames,
+    valid_audio_feature_lengths,
 )
 from megatron.bridge.models.nemotron_vl.nemotron_vl_utils import (
     adjust_image_tokens,
@@ -310,12 +311,20 @@ def process_sample(
             waveform = librosa.resample(waveform, orig_sr=sr, target_sr=16000)
         waveform = waveform[: int(10.0 * 16000)]  # max 10s
 
-        audio_features = feature_extractor([waveform], sampling_rate=16000, return_tensors="pt")
+        audio_features = feature_extractor(
+            [waveform],
+            sampling_rate=16000,
+            return_tensors="pt",
+            return_attention_mask=True,
+        )
         sound_clips = audio_features.input_features.bfloat16()
-        sound_length = torch.tensor([sound_clips.shape[1]], dtype=torch.long)
+        sound_length = valid_audio_feature_lengths(
+            audio_features.attention_mask,
+            num_frames=sound_clips.shape[1],
+        )
 
         # Compute audio token count and insert into input_ids
-        mel_len = sound_clips.shape[1]
+        mel_len = int(sound_length.item())
         token_len = float(mel_len)
         for _ in range(3):
             token_len = math.floor((token_len + 2 - 3) / 2 + 1)

--- a/src/megatron/bridge/models/nemotron_omni/data/collate_fn.py
+++ b/src/megatron/bridge/models/nemotron_omni/data/collate_fn.py
@@ -461,7 +461,7 @@ def _add_audio_inputs(
     num_mel_bins: int,
 ) -> None:
     """Extract audio features and align each row's sound placeholder count."""
-    from megatron.bridge.models.nemotron_omni.nemotron_omni_utils import compute_mel_features
+    from megatron.bridge.models.nemotron_omni.nemotron_omni_utils import compute_mel_features_with_length
 
     waveforms = [_audio_waveform(example) for example in examples]
     if not any(waveform is not None for waveform in waveforms):
@@ -470,14 +470,20 @@ def _add_audio_inputs(
         raise ValueError("Nemotron Omni collation does not support mixing audio and no-audio samples.")
 
     mel_features: list[torch.Tensor] = []
+    valid_lengths: list[int] = []
     token_counts: list[int] = []
     for example, waveform in zip(examples, waveforms, strict=True):
         assert waveform is not None
         duration = float(example.get("max_audio_duration", max_audio_duration))
         waveform = waveform[: int(duration * 16000)]
-        mel = compute_mel_features(waveform, sampling_rate=16000, num_mel_bins=num_mel_bins)
+        mel, valid_length = compute_mel_features_with_length(
+            waveform,
+            sampling_rate=16000,
+            num_mel_bins=num_mel_bins,
+        )
         mel_features.append(mel)
-        token_length = int(mel.shape[0])
+        valid_lengths.append(valid_length)
+        token_length = valid_length
         for _ in range(3):
             token_length = (token_length + 1) // 2
         token_counts.append(max(1, token_length))
@@ -533,7 +539,7 @@ def _add_audio_inputs(
     for row_index, mel in enumerate(mel_features):
         sound_clips[row_index, : mel.shape[0]] = mel
     batch["sound_clips"] = sound_clips
-    batch["sound_length"] = torch.tensor([mel.shape[0] for mel in mel_features], dtype=torch.long)
+    batch["sound_length"] = torch.tensor(valid_lengths, dtype=torch.long)
 
 
 def _adjust_image_placeholders(

--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_sound.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_sound.py
@@ -60,8 +60,32 @@ class BridgeSoundEncoder(MegatronModule):
         """Dummy for pipeline parallel set_input_tensor hook."""
         self.input_tensor = input_tensor
 
-    def forward(self, sound_clips, sound_length):
+    def forward(self, sound_clips: torch.Tensor, sound_length: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Encode padded mel features using one valid prefix length per sample."""
+        if sound_clips.ndim != 3:
+            raise ValueError(f"sound_clips must have shape [batch, frames, mel_bins], got {tuple(sound_clips.shape)}.")
+        if sound_length.ndim != 1 or sound_length.numel() != sound_clips.shape[0]:
+            raise ValueError(
+                "sound_length must contain one value per sound_clips batch item; "
+                f"got shape {tuple(sound_length.shape)} for batch size {sound_clips.shape[0]}."
+            )
+        integral_dtypes = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+        if sound_length.dtype not in integral_dtypes:
+            raise ValueError(f"sound_length must use an integral dtype, got {sound_length.dtype}.")
+        if sound_length.device != sound_clips.device:
+            raise ValueError(
+                "sound_length and sound_clips must be on the same device; "
+                f"got {sound_length.device} and {sound_clips.device}."
+            )
         max_frames = sound_clips.size(1)
+        lengths_in_bounds = torch.all((sound_length > 0) & (sound_length <= max_frames))
+        bounds_message = (
+            f"sound_length values must satisfy 0 < length <= the physical sound_clips width ({max_frames})"
+        )
+        if sound_length.is_cuda:
+            torch._assert_async(lengths_in_bounds, f"{bounds_message}.")
+        elif not bool(lengths_in_bounds):
+            raise ValueError(f"{bounds_message}, got {sound_length.tolist()}.")
         attention_mask = torch.arange(max_frames, device=sound_clips.device)[None, :] < sound_length[:, None]
         output = self.encoder(
             input_features=sound_clips,

--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_utils.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_utils.py
@@ -297,6 +297,80 @@ def _parakeet_feature_extractor(num_mel_bins: int, sampling_rate: int) -> Any:
     )
 
 
+def valid_audio_feature_lengths(attention_mask: torch.Tensor, *, num_frames: int) -> torch.Tensor:
+    """Convert Parakeet feature masks to contiguous-prefix frame lengths.
+
+    Parakeet retains a padded boundary frame in ``input_features`` while its
+    feature-level attention mask records the semantic frame count. Bridge's
+    sound encoder accepts that mask in compressed form as ``sound_length``.
+
+    Args:
+        attention_mask: Binary mask with shape ``(batch, frames)``.
+        num_frames: Physical frame width of the corresponding feature tensor.
+
+    Returns:
+        Long tensor containing one valid frame length per batch item.
+
+    Raises:
+        ValueError: If the mask is empty, non-binary, has the wrong shape, or
+            is not a non-empty contiguous prefix for every batch item.
+    """
+    mask = torch.as_tensor(attention_mask)
+    if mask.ndim != 2:
+        raise ValueError(f"Parakeet feature attention_mask must be 2-D, got shape {tuple(mask.shape)}.")
+    if num_frames < 1 or mask.shape[1] != num_frames:
+        raise ValueError(
+            "Parakeet feature attention_mask width must match the physical feature width; "
+            f"got mask shape {tuple(mask.shape)} and num_frames={num_frames}."
+        )
+    if not bool(torch.all((mask == 0) | (mask == 1))):
+        raise ValueError("Parakeet feature attention_mask must contain only binary values.")
+
+    prefix_mask = mask.to(dtype=torch.bool)
+    lengths = prefix_mask.sum(dim=1, dtype=torch.long)
+    if bool(torch.any(lengths == 0)):
+        raise ValueError("Parakeet feature attention_mask must contain at least one valid frame per sample.")
+    expected_mask = torch.arange(num_frames, device=mask.device)[None, :] < lengths[:, None]
+    if not torch.equal(prefix_mask, expected_mask):
+        raise ValueError("Parakeet feature attention_mask must contain one contiguous valid prefix per sample.")
+    return lengths
+
+
+def compute_mel_features_with_length(
+    waveform: Union[np.ndarray, list],
+    sampling_rate: int = 16000,
+    num_mel_bins: int = 128,
+) -> tuple[torch.Tensor, int]:
+    """Convert one waveform to physical mel features and its valid frame length.
+
+    Args:
+        waveform: 1-D float32 numpy array (or list) of the mono waveform.
+        sampling_rate: Sampling rate of *waveform* (must match the extractor).
+        num_mel_bins: Number of mel frequency bins.
+
+    Returns:
+        A ``(mel, valid_length)`` pair. ``mel`` has physical shape
+        ``(frames, num_mel_bins)`` and may include padded boundary rows;
+        ``valid_length`` is derived from Parakeet's feature attention mask.
+    """
+    extractor = _parakeet_feature_extractor(num_mel_bins, sampling_rate)
+    features = extractor(
+        waveform,
+        sampling_rate=sampling_rate,
+        return_tensors="pt",
+        return_attention_mask=True,
+    )
+    input_features = torch.as_tensor(features["input_features"])
+    if input_features.ndim != 3 or input_features.shape[0] != 1:
+        raise ValueError(
+            "compute_mel_features_with_length expects one waveform and Parakeet features with shape "
+            f"(1, frames, mel_bins), got {tuple(input_features.shape)}."
+        )
+    mel = input_features.squeeze(0)
+    lengths = valid_audio_feature_lengths(features["attention_mask"], num_frames=mel.shape[0])
+    return mel, int(lengths[0].item())
+
+
 def compute_mel_features(
     waveform: Union[np.ndarray, list],
     sampling_rate: int = 16000,
@@ -315,14 +389,15 @@ def compute_mel_features(
     Returns:
         Float tensor of shape ``(frames, num_mel_bins)`` -- a single clip
         ready to be batched and passed as ``sound_clips`` to the model.
+
+        Call :func:`compute_mel_features_with_length` when the corresponding
+        semantic frame length is also required.
     """
-    extractor = _parakeet_feature_extractor(num_mel_bins, sampling_rate)
-    features = extractor(
+    mel, _ = compute_mel_features_with_length(
         waveform,
         sampling_rate=sampling_rate,
-        return_tensors="pt",
+        num_mel_bins=num_mel_bins,
     )
-    mel = features["input_features"].squeeze(0)
     return mel
 
 

--- a/tests/unit_tests/data/collators/test_model_collators.py
+++ b/tests/unit_tests/data/collators/test_model_collators.py
@@ -2177,14 +2177,15 @@ def test_nemotron_omni_llava_collate_fixed_packing_rejects_misaligned_sequence_l
         )
 
 
-def test_nemotron_omni_collate_replaces_audio_placeholder_with_computed_token_count(monkeypatch):
+@pytest.mark.parametrize("collate_fn_name", ["nemotron_omni_expanded_collate_fn", "nemotron_omni_llava_collate_fn"])
+def test_nemotron_omni_collators_use_mask_length_for_audio_placeholders(monkeypatch, collate_fn_name):
     import megatron.bridge.models.nemotron_omni.nemotron_omni_utils as omni_utils
 
     monkeypatch.setattr(nemotron_omni_collate, "build_assistant_loss_mask", _zero_assistant_loss_mask)
     monkeypatch.setattr(
         omni_utils,
-        "compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=128: torch.ones(9, num_mel_bins),
+        "compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=128: (torch.ones(9, num_mel_bins), 8),
     )
 
     proc = _NemotronOmniProcessor(tokenized_rows=[[5, NEMO_SO_TOKEN_ID, 6, 7]])
@@ -2198,15 +2199,48 @@ def test_nemotron_omni_collate_replaces_audio_placeholder_with_computed_token_co
         }
     ]
 
-    batch = collate.nemotron_omni_collate_fn(examples, proc)
+    collate_fn = getattr(collate, collate_fn_name)
+    if collate_fn_name == "nemotron_omni_llava_collate_fn":
+        with pytest.warns(FutureWarning, match="deprecated"):
+            batch = collate_fn(examples, proc)
+    else:
+        batch = collate_fn(examples, proc)
 
     assert "<so_embedding>" in proc.tokenizer.tokenized_texts[0]
-    assert batch["input_ids"].tolist() == [
-        [5, NEMO_SO_START_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_END_TOKEN_ID, 6, 7]
-    ]
+    assert batch["input_ids"].tolist() == [[5, NEMO_SO_START_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_END_TOKEN_ID, 6, 7]]
     assert batch["sound_clips"].shape == (1, 9, 128)
-    assert batch["sound_length"].tolist() == [9]
+    assert batch["sound_length"].tolist() == [8]
     assert batch["visual_inputs"] is None
+
+
+def test_nemotron_omni_collate_pads_physical_audio_independently_from_valid_lengths(monkeypatch):
+    import megatron.bridge.models.nemotron_omni.nemotron_omni_utils as omni_utils
+
+    def _features(waveform, sampling_rate=16000, num_mel_bins=4):
+        del sampling_rate
+        physical_length, valid_length = (9, 8) if len(waveform) == 3 else (17, 16)
+        return torch.ones(physical_length, num_mel_bins), valid_length
+
+    monkeypatch.setattr(nemotron_omni_collate, "build_assistant_loss_mask", _zero_assistant_loss_mask)
+    monkeypatch.setattr(omni_utils, "compute_mel_features_with_length", _features)
+    proc = _NemotronOmniProcessor(tokenized_rows=[[5, NEMO_SO_TOKEN_ID, 6], [7, NEMO_SO_TOKEN_ID, 8]])
+    examples = [
+        {"conversation": [{"role": "user", "content": "short"}], "audio": ([0.0, 0.1, -0.1], 16000)},
+        {
+            "conversation": [{"role": "user", "content": "long"}],
+            "audio": ([0.0, 0.1, -0.1, 0.2], 16000),
+        },
+    ]
+
+    batch = collate.nemotron_omni_expanded_collate_fn(examples, proc, num_mel_bins=4)
+
+    assert batch["input_ids"].tolist() == [
+        [5, NEMO_SO_START_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_END_TOKEN_ID, 6, 0],
+        [7, NEMO_SO_START_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_END_TOKEN_ID, 8],
+    ]
+    assert batch["sound_clips"].shape == (2, 17, 4)
+    assert torch.all(batch["sound_clips"][0, 9:] == 0)
+    assert batch["sound_length"].tolist() == [8, 16]
 
 
 def test_nemotron_omni_collate_does_not_duplicate_existing_audio_framing(monkeypatch):
@@ -2215,8 +2249,8 @@ def test_nemotron_omni_collate_does_not_duplicate_existing_audio_framing(monkeyp
     monkeypatch.setattr(nemotron_omni_collate, "build_assistant_loss_mask", _zero_assistant_loss_mask)
     monkeypatch.setattr(
         omni_utils,
-        "compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=128: torch.ones(9, num_mel_bins),
+        "compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=128: (torch.ones(9, num_mel_bins), 8),
     )
     proc = _NemotronOmniProcessor(
         tokenized_rows=[[5, NEMO_SO_START_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_END_TOKEN_ID, 6, 7]]
@@ -2230,9 +2264,7 @@ def test_nemotron_omni_collate_does_not_duplicate_existing_audio_framing(monkeyp
 
     batch = collate.nemotron_omni_collate_fn(examples, proc)
 
-    assert batch["input_ids"].tolist() == [
-        [5, NEMO_SO_START_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_END_TOKEN_ID, 6, 7]
-    ]
+    assert batch["input_ids"].tolist() == [[5, NEMO_SO_START_TOKEN_ID, NEMO_SO_TOKEN_ID, NEMO_SO_END_TOKEN_ID, 6, 7]]
 
 
 @pytest.mark.parametrize(
@@ -2248,8 +2280,8 @@ def test_nemotron_omni_collate_rejects_partially_framed_audio_placeholder(monkey
     monkeypatch.setattr(nemotron_omni_collate, "build_assistant_loss_mask", _zero_assistant_loss_mask)
     monkeypatch.setattr(
         omni_utils,
-        "compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=128: torch.ones(9, num_mel_bins),
+        "compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=128: (torch.ones(9, num_mel_bins), 8),
     )
     proc = _NemotronOmniProcessor(tokenized_rows=[tokenized_row])
     examples = [
@@ -2269,8 +2301,8 @@ def test_nemotron_omni_collate_rejects_disjoint_audio_placeholder_runs(monkeypat
     monkeypatch.setattr(nemotron_omni_collate, "build_assistant_loss_mask", _zero_assistant_loss_mask)
     monkeypatch.setattr(
         omni_utils,
-        "compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=128: torch.ones(9, num_mel_bins),
+        "compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=128: (torch.ones(9, num_mel_bins), 8),
     )
     proc = _NemotronOmniProcessor(tokenized_rows=[[5, NEMO_SO_TOKEN_ID, 6, NEMO_SO_TOKEN_ID, 7]])
     examples = [
@@ -2310,8 +2342,8 @@ def test_nemotron_omni_collate_loads_audio_path_when_no_placeholder_exists(monke
     )
     monkeypatch.setattr(
         omni_utils,
-        "compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=128: torch.ones(1, num_mel_bins),
+        "compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=128: (torch.ones(1, num_mel_bins), 1),
     )
 
     proc = _NemotronOmniProcessor(tokenized_rows=[[5, 6, 7]])

--- a/tests/unit_tests/data/energon/test_nemotron_omni_task_encoder.py
+++ b/tests/unit_tests/data/energon/test_nemotron_omni_task_encoder.py
@@ -221,8 +221,8 @@ def test_energon_batch_preserves_real_tokens_when_pad_id_equals_turn_end(monkeyp
 def test_energon_audio_uses_shared_collator_token_expansion(monkeypatch):
     monkeypatch.setattr(omni_collate, "build_assistant_loss_mask", _mask_all_tokens)
     monkeypatch.setattr(
-        "megatron.bridge.models.nemotron_omni.nemotron_omni_utils.compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=4: torch.ones(9, num_mel_bins),
+        "megatron.bridge.models.nemotron_omni.nemotron_omni_utils.compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=4: (torch.ones(9, num_mel_bins), 8),
     )
     processor = _Processor([[1, IMG_END_ID, 21, PAD_AND_END_ID]])
     encoder = NemotronOmniTaskEncoder(
@@ -240,18 +240,16 @@ def test_energon_audio_uses_shared_collator_token_expansion(monkeypatch):
 
     batch = encoder.batch([encoded])
 
-    assert batch.input_ids.tolist() == [
-        [1, IMG_END_ID, SO_START_ID, SO_EMBEDDING_ID, SO_EMBEDDING_ID, SO_END_ID, 21, PAD_AND_END_ID]
-    ]
+    assert batch.input_ids.tolist() == [[1, IMG_END_ID, SO_START_ID, SO_EMBEDDING_ID, SO_END_ID, 21, PAD_AND_END_ID]]
     assert batch.sound_clips.shape == (1, 9, 4)
-    assert batch.sound_length.tolist() == [9]
+    assert batch.sound_length.tolist() == [8]
 
 
 def test_energon_audio_placeholder_uses_framed_shared_expansion(monkeypatch):
     monkeypatch.setattr(omni_collate, "build_assistant_loss_mask", _mask_all_tokens)
     monkeypatch.setattr(
-        "megatron.bridge.models.nemotron_omni.nemotron_omni_utils.compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=4: torch.ones(9, num_mel_bins),
+        "megatron.bridge.models.nemotron_omni.nemotron_omni_utils.compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=4: (torch.ones(9, num_mel_bins), 8),
     )
     processor = _Processor([[1, SO_EMBEDDING_ID, 21, PAD_AND_END_ID]])
     encoder = NemotronOmniTaskEncoder(
@@ -269,9 +267,7 @@ def test_energon_audio_placeholder_uses_framed_shared_expansion(monkeypatch):
 
     batch = encoder.batch([encoded])
 
-    assert batch.input_ids.tolist() == [
-        [1, SO_START_ID, SO_EMBEDDING_ID, SO_EMBEDDING_ID, SO_END_ID, 21, PAD_AND_END_ID]
-    ]
+    assert batch.input_ids.tolist() == [[1, SO_START_ID, SO_EMBEDDING_ID, SO_END_ID, 21, PAD_AND_END_ID]]
 
 
 def test_energon_temporal_video_is_processed_in_shared_collator(monkeypatch):
@@ -525,8 +521,8 @@ def test_hf_and_energon_packing_are_identical_for_image_video_audio(monkeypatch,
         lambda frame, *, height, width, patch_dim: torch.ones(2, 3),
     )
     monkeypatch.setattr(
-        "megatron.bridge.models.nemotron_omni.nemotron_omni_utils.compute_mel_features",
-        lambda waveform, sampling_rate=16000, num_mel_bins=4: torch.ones(9, num_mel_bins),
+        "megatron.bridge.models.nemotron_omni.nemotron_omni_utils.compute_mel_features_with_length",
+        lambda waveform, sampling_rate=16000, num_mel_bins=4: (torch.ones(9, num_mel_bins), 8),
     )
     rows = [
         [1, IMG_START_ID, IMAGE_TOKEN_ID, IMG_END_ID, 21, PAD_AND_END_ID],
@@ -611,12 +607,12 @@ def test_hf_and_energon_packing_are_identical_for_image_video_audio(monkeypatch,
     for key in tensor_keys:
         assert torch.equal(hf_batch[key], energon_batch[key]), key
     assert hf_batch["attention_mask"] is energon_batch["attention_mask"] is None
-    assert hf_batch["total_tokens"] == energon_batch["total_tokens"] == 800
-    assert hf_batch["cu_seqlens_q"].tolist() == [0, 265, 789]
-    assert hf_batch["cu_seqlens_q_padded"].tolist() == [0, 272, 800]
+    assert hf_batch["total_tokens"] == energon_batch["total_tokens"] == 792
+    assert hf_batch["cu_seqlens_q"].tolist() == [0, 264, 787]
+    assert hf_batch["cu_seqlens_q_padded"].tolist() == [0, 264, 792]
     if not collapse_image_tokens:
-        assert hf_batch["input_ids"].shape == (1, 800)
-        assert hf_batch["padding_mask"].sum().item() == 11
+        assert hf_batch["input_ids"].shape == (1, 792)
+        assert hf_batch["padding_mask"].sum().item() == 5
         assert torch.equal(hf_batch["padding_mask"], energon_batch["padding_mask"])
     assert torch.equal(
         hf_batch["visual_inputs"].pixel_values,

--- a/tests/unit_tests/examples/test_nemotron_omni_inference.py
+++ b/tests/unit_tests/examples/test_nemotron_omni_inference.py
@@ -14,6 +14,7 @@
 
 import runpy
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -104,3 +105,62 @@ def test_generic_inference_processes_heterogeneous_source_images(monkeypatch):
     assert packed.shape == (1, 4, 3 * 16 * 16)
     assert torch.equal(num_patches, torch.tensor([1, 1]))
     assert torch.equal(imgs_sizes, torch.tensor([[32, 16], [16, 32]]))
+
+
+@pytest.mark.unit
+def test_generic_audio_inference_uses_parakeet_feature_mask_length(monkeypatch):
+    script_globals = runpy.run_path(_EXAMPLE_ROOT / "hf_to_megatron_generate_nemotron_omni.py")
+    process_inputs = script_globals["process_audio_inputs"]
+
+    class _Tokenizer:
+        audio_token = "<so_embedding>"
+
+        def apply_chat_template(self, messages, **kwargs):
+            del kwargs
+            assert messages[-1]["content"].startswith("<so_embedding>")
+            return "rendered prompt"
+
+        def convert_tokens_to_ids(self, token):
+            assert token == "<so_embedding>"
+            return 90
+
+    class _Inputs(dict):
+        @property
+        def input_ids(self):
+            return self["input_ids"]
+
+    class _Processor:
+        def __call__(self, *, text, audio, return_tensors):
+            assert text == ["rendered prompt"]
+            assert audio == ["clip.wav"]
+            assert return_tensors == "pt"
+            return _Inputs(
+                input_ids=torch.tensor([[5, 90, 90, 6]]),
+                sound_clips=torch.zeros(1, 1280),
+            )
+
+    class _FeatureExtractor:
+        def __init__(self, *, sampling_rate, feature_size):
+            assert sampling_rate == 16000
+            assert feature_size == 128
+
+        def __call__(self, raw_sound_clips, **kwargs):
+            assert raw_sound_clips.shape == (1, 1280)
+            assert kwargs["return_attention_mask"] is True
+            return SimpleNamespace(
+                input_features=torch.ones(1, 9, 128),
+                attention_mask=torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0]]),
+            )
+
+    monkeypatch.setattr("transformers.ParakeetFeatureExtractor", _FeatureExtractor)
+
+    input_ids, sound_clips, sound_length = process_inputs(
+        _Tokenizer(),
+        _Processor(),
+        "clip.wav",
+        "transcribe",
+    )
+
+    assert input_ids.tolist() == [[5, 90, 6]]
+    assert sound_clips.shape == (1, 9, 128)
+    assert sound_length.tolist() == [8]

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
@@ -373,6 +373,112 @@ def test_sound_encoder_drops_padded_rows_and_preserves_sample_order():
     )
 
 
+def test_bridge_sound_encoder_reconstructs_parakeet_feature_mask_from_valid_length():
+    from megatron.bridge.models.nemotron_omni.nemotron_omni_sound import BridgeSoundEncoder
+
+    class _RecordingEncoder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attention_mask = None
+
+        def forward(self, *, input_features, attention_mask):
+            self.attention_mask = attention_mask
+            return SimpleNamespace(last_hidden_state=input_features)
+
+        def _get_subsampling_output_length(self, lengths):
+            for _ in range(3):
+                lengths = (lengths + 1) // 2
+            return lengths
+
+    config = SimpleNamespace(
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        intermediate_size=64,
+        num_mel_bins=8,
+        subsampling_factor=8,
+        conv_kernel_size=9,
+        use_bias=False,
+    )
+    model = BridgeSoundEncoder(config)
+    recording_encoder = _RecordingEncoder()
+    model.encoder = recording_encoder
+
+    _, embedding_lengths = model(torch.ones(1, 9, config.num_mel_bins), torch.tensor([8]))
+
+    assert recording_encoder.attention_mask.tolist() == [[True] * 8 + [False]]
+    assert embedding_lengths.tolist() == [1]
+
+
+@pytest.mark.parametrize(
+    ("sound_length", "match"),
+    [
+        (torch.tensor([0]), "0 < length"),
+        (torch.tensor([10]), "physical sound_clips width"),
+        (torch.tensor([8.0]), "integral dtype"),
+    ],
+)
+def test_bridge_sound_encoder_rejects_invalid_valid_lengths(sound_length, match):
+    from megatron.bridge.models.nemotron_omni.nemotron_omni_sound import BridgeSoundEncoder
+
+    config = SimpleNamespace(
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        intermediate_size=64,
+        num_mel_bins=8,
+        subsampling_factor=8,
+        conv_kernel_size=9,
+        use_bias=False,
+    )
+    model = BridgeSoundEncoder(config)
+
+    with pytest.raises(ValueError, match=match):
+        model(torch.ones(1, 9, config.num_mel_bins), sound_length)
+
+
+@pytest.mark.run_only_on("GPU")
+def test_bridge_sound_encoder_validates_cuda_lengths_asynchronously(monkeypatch):
+    from megatron.bridge.models.nemotron_omni.nemotron_omni_sound import BridgeSoundEncoder
+
+    class _RecordingEncoder(nn.Module):
+        def forward(self, *, input_features, attention_mask):
+            del attention_mask
+            return SimpleNamespace(last_hidden_state=input_features)
+
+        def _get_subsampling_output_length(self, lengths):
+            return lengths
+
+    config = SimpleNamespace(
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        intermediate_size=64,
+        num_mel_bins=8,
+        subsampling_factor=8,
+        conv_kernel_size=9,
+        use_bias=False,
+    )
+    model = BridgeSoundEncoder(config)
+    model.encoder = _RecordingEncoder()
+    assertions = []
+    original_assert_async = torch._assert_async
+
+    def _record_assertion(condition, message):
+        assertions.append(condition)
+        original_assert_async(condition, message)
+
+    monkeypatch.setattr(torch, "_assert_async", _record_assertion)
+
+    model(
+        torch.ones(1, 9, config.num_mel_bins, device="cuda"),
+        torch.tensor([8], device="cuda"),
+    )
+
+    assert len(assertions) == 1
+    assert assertions[0].is_cuda
+
+
 def test_real_parakeet_sound_encoder_matches_subsampled_placeholder_count():
     from megatron.bridge.models.nemotron_omni.nemotron_omni_sound import BridgeSoundEncoder
 

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_utils.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_utils.py
@@ -12,17 +12,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import pytest
 import torch
 
+import megatron.bridge.models.nemotron_omni.nemotron_omni_utils as omni_utils
 from megatron.bridge.models.nemotron_omni.nemotron_omni_utils import (
+    compute_mel_features,
+    compute_mel_features_with_length,
     inference_expanded_image_token_counts,
     inference_merged_sequence_length,
     inference_num_image_tiles,
     select_inference_next_token,
     temporal_model_frames,
+    valid_audio_feature_lengths,
 )
 from megatron.bridge.models.nemotron_vl.nemotron_vl_utils import adjust_image_tokens
+
+
+def test_compute_mel_features_preserves_physical_rows_and_mask_length(monkeypatch):
+    extractor_kwargs = {}
+
+    class _Extractor:
+        def __call__(self, waveform, **kwargs):
+            del waveform
+            extractor_kwargs.update(kwargs)
+            return {
+                "input_features": torch.ones(1, 9, 4),
+                "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0]]),
+            }
+
+    monkeypatch.setattr(omni_utils, "_parakeet_feature_extractor", lambda num_mel_bins, sampling_rate: _Extractor())
+
+    mel, valid_length = compute_mel_features_with_length([0.0] * 1280, num_mel_bins=4)
+
+    assert mel.shape == (9, 4)
+    assert valid_length == 8
+    assert extractor_kwargs["return_attention_mask"] is True
+    assert compute_mel_features([0.0] * 1280, num_mel_bins=4).shape == (9, 4)
+
+
+@pytest.mark.parametrize(
+    ("attention_mask", "match"),
+    [
+        (torch.tensor([[1, 0, 1]]), "contiguous valid prefix"),
+        (torch.tensor([[0, 0, 0]]), "at least one valid frame"),
+        (torch.tensor([[1.0, 0.5, 0.0]]), "binary values"),
+    ],
+)
+def test_valid_audio_feature_lengths_rejects_invalid_masks(attention_mask, match):
+    with pytest.raises(ValueError, match=match):
+        valid_audio_feature_lengths(attention_mask, num_frames=3)
+
+
+def test_real_parakeet_extractor_marks_centered_stft_boundary_frame_invalid():
+    mel, valid_length = compute_mel_features_with_length(np.zeros(1280, dtype=np.float32))
+
+    assert mel.shape == (9, 128)
+    assert valid_length == 8
 
 
 def test_temporal_model_frames_duplicates_single_frame_for_temporal_embedder():


### PR DESCRIPTION
## Summary

- preserve Parakeet's feature-mask-derived valid frame length alongside the physical mel tensor
- derive audio placeholders and `sound_length` from valid frames in the shared canonical/legacy collator
- reconstruct the feature attention mask in `BridgeSoundEncoder` and align both inference examples to the same contract
- add boundary, batching, inference, and CUDA validation regressions

## Root cause

Parakeet can retain a physical boundary mel row while marking that row invalid in its feature-level attention mask. Bridge previously discarded the mask and used the physical tensor width as `sound_length`. For a 1,280-sample waveform, that changes the semantic length from 8 valid frames to 9 physical rows and changes the three-stage subsampled output from one audio token to two.

## Compatibility

The existing `sound_clips` / `sound_length` model contract and tensor-only mel helper remain available. Checkpoint weights and model forward keys are unchanged. Sequence lengths change only where the corrected valid length crosses a Parakeet subsampling boundary.

## Validation

- 156 focused tests passed across Nemotron Omni utilities, model integration, shared collators, Energon, and inference examples on one H100
- real Parakeet boundary extraction, real RADIO paths, packed optimizer step, canonical and legacy contracts, mixed-width batching, and the CUDA asynchronous validation path are covered
- all configured pre-commit hooks passed
- `git diff --check` passed
