### PR TITLE
feat(training): support MFSDP V2 expert parallelism

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1140,7 +1140,6 @@ class ConfigContainer(Container):
             "tensor_model_parallel_size",
             "pipeline_model_parallel_size",
             "context_parallel_size",
-            "expert_model_parallel_size",
         )
         configured_parallelisms = [
             f"{name}={getattr(self.model, name)}"
@@ -1149,11 +1148,11 @@ class ConfigContainer(Container):
         ]
         if configured_parallelisms:
             raise ValueError(
-                "MFSDP V2 currently supports DP-only training; unsupported settings: "
-                + ", ".join(configured_parallelisms)
+                "MFSDP V2 requires TP=PP=CP=1; unsupported settings: " + ", ".join(configured_parallelisms)
             )
-        if self.model.num_moe_experts is not None:
-            raise ValueError("MFSDP V2 does not currently support MoE models.")
+        if self.model.expert_model_parallel_size > 1:
+            if self.model.num_moe_experts is None:
+                raise ValueError("MFSDP V2 expert parallelism requires an MoE model.")
         if self.model.virtual_pipeline_model_parallel_size is not None:
             raise ValueError("MFSDP V2 does not currently support multiple model chunks.")
         if self.dist.use_tp_pp_dp_mapping:

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -23,6 +23,7 @@ from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.transformer_config import MLATransformerConfig
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
@@ -113,7 +114,7 @@ class DenseHybridSmokeModelProvider(HybridModelProvider):
 
 
 @dataclass
-class MLAMoEHybridSmokeModelProvider(HybridModelProvider):
+class MLAMoEHybridSmokeModelProvider(MLATransformerConfig, HybridModelProvider):
     """Small MLA/MoE HybridModel configuration for the MFSDP V2 EP smoke test."""
 
     attention_backend: AttnBackend = AttnBackend.auto

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -23,7 +23,6 @@ from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
-from megatron.bridge.models.transformer_config import MLATransformerConfig
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
@@ -114,14 +113,13 @@ class DenseHybridSmokeModelProvider(HybridModelProvider):
 
 
 @dataclass
-class MLAMoEHybridSmokeModelProvider(MLATransformerConfig, HybridModelProvider):
-    """Small MLA/MoE HybridModel configuration for the MFSDP V2 EP smoke test."""
+class MoEHybridSmokeModelProvider(HybridModelProvider):
+    """Small HybridModel configuration for the MFSDP V2 EP smoke test."""
 
     attention_backend: AttnBackend = AttnBackend.auto
     seq_length: int = 128
     hidden_size: int = 128
-    multi_latent_attention: bool = True
-    hybrid_layer_pattern: str = "+E"
+    hybrid_layer_pattern: str = "*E"
     num_moe_experts: int = 4
     expert_model_parallel_size: int = 2
 
@@ -443,8 +441,8 @@ class TestMegatronFSDP:
         torch.distributed.barrier()
 
     @pytest.mark.run_only_on("GPU")
-    def test_fsdp_v2_mla_moe_ep2_pretrain_smoke(self):
-        """Train a small MLA/MoE HybridModel with MFSDP V2 and EP=2."""
+    def test_fsdp_v2_moe_ep2_pretrain_smoke(self):
+        """Train a small MoE HybridModel with MFSDP V2 and EP=2."""
         initialize_distributed()
         torch.distributed.barrier()
 
@@ -453,7 +451,7 @@ class TestMegatronFSDP:
             train_iters=10,
             optimizer={"clip_grad": 0.0},
         )
-        cfg.model = MLAMoEHybridSmokeModelProvider()
+        cfg.model = MoEHybridSmokeModelProvider()
         cfg.ddp.megatron_fsdp_version = 2
 
         pretrain(cfg, forward_step)

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -19,6 +19,7 @@ from typing import Callable, Optional
 import pytest
 import torch
 import torch.nn.functional as F
+from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
@@ -109,6 +110,19 @@ class DenseHybridSmokeModelProvider(HybridModelProvider):
     hybrid_layer_pattern: str | None = "**"
     vocab_size: int | None = None
     gradient_accumulation_fusion: bool = False
+
+
+@dataclass
+class MLAMoEHybridSmokeModelProvider(HybridModelProvider):
+    """Small MLA/MoE HybridModel configuration for the MFSDP V2 EP smoke test."""
+
+    attention_backend: AttnBackend = AttnBackend.auto
+    seq_length: int = 128
+    hidden_size: int = 128
+    multi_latent_attention: bool = True
+    hybrid_layer_pattern: str = "+E"
+    num_moe_experts: int = 4
+    expert_model_parallel_size: int = 2
 
 
 def create_fsdp_model_config(seq_length: int, bf16: bool = True, **kwargs) -> Llama3FSDPTestModelProvider:
@@ -425,6 +439,23 @@ class TestMegatronFSDP:
 
         pretrain(cfg, forward_step)
 
+        torch.distributed.barrier()
+
+    @pytest.mark.run_only_on("GPU")
+    def test_fsdp_v2_mla_moe_ep2_pretrain_smoke(self):
+        """Train a small MLA/MoE HybridModel with MFSDP V2 and EP=2."""
+        initialize_distributed()
+        torch.distributed.barrier()
+
+        cfg = create_fsdp_config_container(
+            seq_length=128,
+            train_iters=10,
+            optimizer={"clip_grad": 0.0},
+        )
+        cfg.model = MLAMoEHybridSmokeModelProvider()
+        cfg.ddp.megatron_fsdp_version = 2
+
+        pretrain(cfg, forward_step)
         torch.distributed.barrier()
 
     @pytest.mark.run_only_on("GPU")


### PR DESCRIPTION
## Summary
- enable the guarded MFSDP V2 MoE path for TP=PP=CP=1 with EP>1
- add a small, two-GPU generic MoE EP=2 smoke exercising MFSDP V2 training

## Upstream dependency
This PR depends on the MCore adapter changes in https://github.com/NVIDIA/Megatron-LM/pull/6450.

## Tracking
- https://github.com/NVIDIA/Megatron-LM/issues/5656 — MFSDP v2 composability with expert parallelism
- https://github.com/NVIDIA/Megatron-LM/issues/6325 — Integrate MFSDP v2 with Megatron Bridge

## Validation
- `uv run pre-commit run --all-files`
- focused two-GPU `test_fsdp_v2_moe_ep2_pretrain_smoke`