### PR TITLE
feat(data): scalable canonical-grid reads for MegatronMIMO data loading

### DIFF
--- a/examples/megatron_mimo/qwen35_vl/finetune_qwen35_vl.py
+++ b/examples/megatron_mimo/qwen35_vl/finetune_qwen35_vl.py
@@ -58,6 +58,7 @@ from megatron.bridge.data.conversation_processing import (
     chat_template_kwargs_from_example,
 )
 from megatron.bridge.data.datasets.utils import IGNORE_INDEX
+from megatron.bridge.data.megatron_mimo.canonical_sampler import build_canonical_mimo_data_loader
 from megatron.bridge.data.megatron_mimo.dp_utils import get_megatron_mimo_sampling_info
 from megatron.bridge.data.samplers import build_pretraining_data_loader
 from megatron.bridge.data.sources.hf import hf_dataset_supports_split
@@ -416,6 +417,7 @@ def _build_dataset_config(args: argparse.Namespace) -> DirectHFSFTDatasetConfig:
         # MegatronMIMO packs in the step, after the module-DP slice (deferred packing).
         enable_in_batch_packing=args.pack_sequences_in_batch,
         defer_in_batch_packing_to_step=True,
+        megatron_mimo_scalable_dp=args.scalable_dp,
         do_validation=do_validation,
         do_test=False,
         trust_remote_code=args.trust_remote_code,
@@ -857,9 +859,11 @@ def _make_build_data_iterators(spec: Qwen35MIMOHFSpec, args: argparse.Namespace)
         if cfg.model._grids is None:
             raise ValueError("MegatronMIMOProvider._grids is None. Model must be built before data iterators.")
 
+        scalable_dp = bool(getattr(cfg.dataset, "megatron_mimo_scalable_dp", False))
         sampler_dp_rank, sampler_dp_size, needs_data = get_megatron_mimo_sampling_info(
             cfg.model.megatron_mimo_parallelism_config,
             cfg.model._grids,
+            scalable_dp=scalable_dp,
         )
         if not needs_data:
             return None, None
@@ -909,20 +913,42 @@ def _make_build_data_iterators(spec: Qwen35MIMOHFSpec, args: argparse.Namespace)
                 batch_spec=batch_spec,
             )
 
-        train_loader = build_pretraining_data_loader(
-            dataset=train_ds,
-            consumed_samples=train_state.consumed_train_samples,
-            dataloader_type=cfg.dataset.dataloader_type,
-            micro_batch_size=cfg.train.micro_batch_size,
-            num_workers=cfg.dataset.num_workers,
-            data_sharding=cfg.dataset.data_sharding,
-            collate_fn=collate_fn,
-            pin_memory=cfg.dataset.pin_memory,
-            persistent_workers=cfg.dataset.persistent_workers,
-            data_parallel_rank=sampler_dp_rank,
-            data_parallel_size=sampler_dp_size,
-            drop_last=cfg.dataset.drop_last,
-        )
+        if scalable_dp:
+            # Shard reads on the canonical grid (LCM of the module DP sizes) so every
+            # module materializes the same ordered global micro-batch under any sampler.
+            module_dps = [
+                p.data_parallel_size for p in cfg.model.megatron_mimo_parallelism_config.module_parallelisms.values()
+            ]
+            train_loader = build_canonical_mimo_data_loader(
+                train_ds,
+                consumed_samples=train_state.consumed_train_samples,
+                dataloader_type=cfg.dataset.dataloader_type,
+                micro_batch_size=cfg.train.micro_batch_size,
+                module_dp_sizes=module_dps,
+                dp_rank=sampler_dp_rank,
+                dp_size=sampler_dp_size,
+                data_sharding=cfg.dataset.data_sharding,
+                drop_last=cfg.dataset.drop_last,
+                num_workers=cfg.dataset.num_workers,
+                pin_memory=cfg.dataset.pin_memory,
+                collate_fn=collate_fn,
+                persistent_workers=cfg.dataset.persistent_workers,
+            )
+        else:
+            train_loader = build_pretraining_data_loader(
+                dataset=train_ds,
+                consumed_samples=train_state.consumed_train_samples,
+                dataloader_type=cfg.dataset.dataloader_type,
+                micro_batch_size=cfg.train.micro_batch_size,
+                num_workers=cfg.dataset.num_workers,
+                data_sharding=cfg.dataset.data_sharding,
+                collate_fn=collate_fn,
+                pin_memory=cfg.dataset.pin_memory,
+                persistent_workers=cfg.dataset.persistent_workers,
+                data_parallel_rank=sampler_dp_rank,
+                data_parallel_size=sampler_dp_size,
+                drop_last=cfg.dataset.drop_last,
+            )
 
         # `pretrain_megatron_mimo` calls `next(data_iterator)` per microbatch, so
         # return an iterator (DataLoader is iterable but not itself an iterator).
@@ -1229,6 +1255,14 @@ def _parse_args() -> argparse.Namespace:
         help="Enable MegatronMIMO in-batch sequence packing: pack each language DP shard's real "
         "tokens into one [1, T] THD sequence so the language model skips padding compute "
         "(block-diagonal attention comes from cu_seqlens).",
+    )
+    parser.add_argument(
+        "--scalable-dp",
+        action="store_true",
+        help="Scalable data parallelism: each rank reads only its disjoint 1/dp shard of the global "
+        "micro-batch instead of every rank reading the full batch and slicing locally (IO scales with "
+        "DP). Each rank processes its natural, unbalanced shard. Uses the same DP loss reduction as "
+        "non-scalable runs.",
     )
     parser.add_argument("--profile", choices=("none", "nsys", "pytorch"), default="none")
     parser.add_argument("--profile-step-start", type=int, default=1)

--- a/src/megatron/bridge/data/builders/direct_hf_sft.py
+++ b/src/megatron/bridge/data/builders/direct_hf_sft.py
@@ -93,6 +93,7 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
     pad_to_max_length: bool = False
     pad_to_multiple_of: int = 128
     in_batch_packing_pad_to_multiple_of: int = 1
+    megatron_mimo_scalable_dp: bool = False
 
     def validate(self) -> None:
         """Validate declarative source and dataset settings."""
@@ -112,6 +113,18 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
             self.test_source.validate()
         if self.hf_processor_path is not None and not self.hf_processor_path.strip():
             raise ValueError("hf_processor_path must be a non-empty string when set.")
+        if self.megatron_mimo_scalable_dp:
+            if self.dataloader_type not in ("single", "cyclic"):
+                raise ValueError(
+                    "megatron_mimo_scalable_dp requires dataloader_type 'single' or 'cyclic' "
+                    f"(got {self.dataloader_type!r}); other samplers have no cross-module-consistent "
+                    "shard assignment."
+                )
+            if not self.drop_last:
+                raise ValueError(
+                    "megatron_mimo_scalable_dp requires drop_last=True; a partial final micro-batch "
+                    "gives modules unequal shares and misaligns the modality routing."
+                )
         validate_declarative_mapping(self.hf_processor_kwargs, field_name="hf_processor_kwargs")
         if self.hf_processor_kwargs is not None and "trust_remote_code" in self.hf_processor_kwargs:
             raise ValueError(

--- a/src/megatron/bridge/data/megatron_mimo/canonical_sampler.py
+++ b/src/megatron/bridge/data/megatron_mimo/canonical_sampler.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical-grid batch sampling for MegatronMIMO scalable data-parallel reads.
+
+With ``megatron_mimo_scalable_dp`` every module's loaders must materialize the same
+ordered global micro-batch, because the ``BridgeCommunicator`` routes modality
+embeddings to language ranks by contiguous position along the batch dim. A sampler's
+shard assignment depends on its ``(data_parallel_rank, data_parallel_size,
+micro_batch_size)``, so modules with different DP sizes cannot shard by their own DP:
+a shuffling sampler would hand them different sample sets. Instead, all loaders shard
+on one shared **canonical grid** — the least common multiple of the module DP sizes.
+A rank whose module has DP size ``d`` covers ``grid // d`` consecutive canonical
+groups and concatenates their windows, so concatenating any module's rank batches
+reproduces the identical ordered global micro-batch under any deterministic sampler
+(``single`` and ``cyclic`` included; the shuffle seed derives from the epoch alone).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Iterator
+
+from torch.utils.data import DataLoader, Dataset
+
+from megatron.bridge.data.samplers import MegatronPretrainingRandomSampler, MegatronPretrainingSampler
+
+
+def canonical_grid_size(module_dp_sizes: list[int]) -> int:
+    """Return the shared sampler grid size: the LCM of every module's DP size."""
+    if not module_dp_sizes or any(dp is None or dp < 1 for dp in module_dp_sizes):
+        raise ValueError(f"module DP sizes must be positive integers (got {module_dp_sizes}).")
+    return math.lcm(*module_dp_sizes)
+
+
+def covered_canonical_groups(dp_rank: int, dp_size: int, grid_size: int) -> list[int]:
+    """Return the canonical groups this rank reads.
+
+    The groups are the ``grid_size // dp_size`` consecutive slots matching the
+    contiguous batch-dim chunk the ``BridgeCommunicator`` routes to this DP rank.
+    """
+    if grid_size % dp_size != 0:
+        raise ValueError(
+            f"canonical grid size ({grid_size}) is not divisible by the module DP size ({dp_size}); "
+            "module DP sizes must divide their least common multiple."
+        )
+    span = grid_size // dp_size
+    return list(range(dp_rank * span, (dp_rank + 1) * span))
+
+
+class CanonicalGroupBatchSampler:
+    """Concatenate per-canonical-group Megatron samplers into one batch sampler.
+
+    Holds one flat sampler per covered canonical group, all built with the same
+    ``(micro_batch // grid, grid)`` geometry and the same global ``consumed_samples``.
+    Each yield emits the groups' current windows concatenated in group order. Group
+    streams are functions of ``(group, grid, micro_batch, consumed, epoch seed)`` only,
+    so every rank covering group ``g`` — in any module — sees the identical stream.
+    """
+
+    def __init__(self, samplers: list) -> None:
+        if not samplers:
+            raise ValueError("CanonicalGroupBatchSampler needs at least one group sampler.")
+        self.samplers = samplers
+
+    def __len__(self) -> int:
+        """Match the flat Megatron samplers' convention of reporting total samples."""
+        return min(len(sampler) for sampler in self.samplers)
+
+    def __iter__(self) -> Iterator[list[int]]:
+        """Yield one concatenated index window per micro-batch."""
+        iterators = [iter(sampler) for sampler in self.samplers]
+        while True:
+            window: list[int] = []
+            for iterator in iterators:
+                group_batch = next(iterator, None)
+                if group_batch is None:
+                    # Groups share one truncated geometry, so they exhaust on the same window.
+                    return
+                window.extend(group_batch)
+            yield window
+
+
+def build_canonical_group_batch_sampler(
+    *,
+    dataloader_type: str,
+    dataset: Dataset,
+    consumed_samples: int,
+    micro_batch_size: int,
+    grid_size: int,
+    groups: list[int],
+    data_sharding: bool,
+    drop_last: bool = True,
+) -> CanonicalGroupBatchSampler:
+    """Build this rank's canonical-group batch sampler for scalable MIMO reads.
+
+    Args:
+        dataloader_type: ``"single"`` or ``"cyclic"``; other types have no shard
+            assignment that is consistent across modules and are rejected.
+        dataset: The dataset the loader reads.
+        consumed_samples: Global consumed-sample count, exactly as the flat samplers
+            expect (used for resume / epoch derivation).
+        micro_batch_size: The global micro-batch size (not the per-rank share).
+        grid_size: Canonical grid size from :func:`canonical_grid_size`.
+        groups: This rank's groups from :func:`covered_canonical_groups`.
+        data_sharding: Passed through to the cyclic sampler.
+        drop_last: Must stay ``True``: a partial final window gives the groups
+            unequal shares and breaks the positional routing.
+
+    Returns:
+        The merged batch sampler for ``torch.utils.data.DataLoader(batch_sampler=...)``.
+    """
+    if not drop_last:
+        raise ValueError("megatron_mimo_scalable_dp requires drop_last=True (partial windows misalign modules).")
+    if micro_batch_size % grid_size != 0:
+        raise ValueError(
+            f"micro_batch_size ({micro_batch_size}) must be divisible by the canonical grid size ({grid_size})."
+        )
+    group_micro_batch_size = micro_batch_size // grid_size
+    # Truncate to whole global micro-batches: the flat samplers round their active range at
+    # per-group granularity, which diverges per group for a non-multiple dataset size (the
+    # cyclic data_sharding=False stride would give groups unequal window counts).
+    total_samples = (len(dataset) // micro_batch_size) * micro_batch_size
+    if total_samples <= 0:
+        raise ValueError(f"dataset ({len(dataset)} samples) is smaller than one micro-batch ({micro_batch_size}).")
+
+    samplers = []
+    for group in groups:
+        if dataloader_type == "single":
+            samplers.append(
+                MegatronPretrainingSampler(
+                    total_samples=total_samples,
+                    consumed_samples=consumed_samples,
+                    micro_batch_size=group_micro_batch_size,
+                    data_parallel_rank=group,
+                    data_parallel_size=grid_size,
+                    drop_last=True,
+                )
+            )
+        elif dataloader_type == "cyclic":
+            samplers.append(
+                MegatronPretrainingRandomSampler(
+                    dataset,
+                    total_samples=total_samples,
+                    consumed_samples=consumed_samples,
+                    micro_batch_size=group_micro_batch_size,
+                    data_parallel_rank=group,
+                    data_parallel_size=grid_size,
+                    data_sharding=data_sharding,
+                )
+            )
+        else:
+            raise ValueError(
+                f"megatron_mimo_scalable_dp supports dataloader_type 'single' or 'cyclic' (got {dataloader_type!r})."
+            )
+    return CanonicalGroupBatchSampler(samplers)
+
+
+def build_canonical_mimo_data_loader(
+    dataset: Dataset | None,
+    *,
+    consumed_samples: int,
+    dataloader_type: str,
+    micro_batch_size: int,
+    module_dp_sizes: list[int],
+    dp_rank: int,
+    dp_size: int,
+    data_sharding: bool,
+    drop_last: bool,
+    num_workers: int,
+    pin_memory: bool,
+    collate_fn: Callable | None,
+    persistent_workers: bool,
+) -> DataLoader | None:
+    """Build this rank's read-sharded DataLoader for scalable MegatronMIMO reads.
+
+    Computes the canonical grid from ``module_dp_sizes``, derives this rank's covered
+    groups from its module-local ``(dp_rank, dp_size)``, and wraps the merged batch
+    sampler in a ``DataLoader``. Returns ``None`` when ``dataset`` is ``None``.
+    """
+    if dataset is None:
+        return None
+    grid = canonical_grid_size(module_dp_sizes)
+    groups = covered_canonical_groups(dp_rank, dp_size, grid)
+    batch_sampler = build_canonical_group_batch_sampler(
+        dataloader_type=dataloader_type,
+        dataset=dataset,
+        consumed_samples=consumed_samples,
+        micro_batch_size=micro_batch_size,
+        grid_size=grid,
+        groups=groups,
+        data_sharding=data_sharding,
+        drop_last=drop_last,
+    )
+    return DataLoader(
+        dataset,
+        batch_sampler=batch_sampler,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+        collate_fn=collate_fn,
+        persistent_workers=persistent_workers,
+    )

--- a/src/megatron/bridge/data/megatron_mimo/dp_utils.py
+++ b/src/megatron/bridge/data/megatron_mimo/dp_utils.py
@@ -172,22 +172,29 @@ def get_megatron_mimo_dp_info(
 def get_megatron_mimo_sampling_info(
     megatron_mimo_cfg: "MegatronMIMOParallelismConfig",
     grids: Dict[str, "HyperCommGrid"],
+    *,
+    scalable_dp: bool = False,
 ) -> Tuple[int, int, bool]:
     """Get sampler DP rank, size, and data-loading flag for MegatronMIMO.
 
-    In heterogeneous MegatronMIMO, modules may have different DP sizes.  The data
-    loader must give every data-loading rank the **same global micro-batch**
-    so that :func:`slice_batch_for_megatron_mimo` (called in the forward step) can
-    sub-shard it consistently with the :class:`BridgeCommunicator` fan-in /
-    fan-out routing.
+    In heterogeneous MegatronMIMO, modules may have different DP sizes.
 
-    This function therefore returns ``dp_size=1, dp_rank=0`` for all ranks,
-    disabling DP sharding at the sampler level.  Per-module DP sharding is
-    deferred to :func:`slice_batch_for_megatron_mimo`.
+    **Default (full-batch reads).** Returns ``dp_size=1, dp_rank=0`` for all ranks, so the data
+    loader gives every data-loading rank the **same global micro-batch**; per-module DP sharding
+    is deferred to :func:`slice_batch_for_megatron_mimo` in the forward step, consistent with the
+    :class:`BridgeCommunicator` fan-in / fan-out routing.
+
+    **Scalable data parallelism (``scalable_dp=True``).** Returns this rank's **module-local**
+    ``(dp_rank, dp_size)``, from which the caller derives its canonical groups and builds the
+    read-sharded loader (see
+    :func:`megatron.bridge.data.megatron_mimo.canonical_sampler.build_canonical_group_batch_sampler`);
+    the forward step does **not** slice again. Each rank then processes its natural, unbalanced
+    ``1/dp`` shard: this is the read-sharding win on its own, with no cross-rank exchange.
 
     Args:
         megatron_mimo_cfg: MegatronMIMO parallelism configuration.
         grids: Module name to HyperCommGrid mapping.
+        scalable_dp: When ``True``, shard reads at the sampler (module-local DP).
 
     Returns:
         Tuple of (sampler_dp_rank, sampler_dp_size, needs_data).
@@ -197,9 +204,24 @@ def get_megatron_mimo_sampling_info(
         return 0, 1, False
 
     needs_data = _needs_data_for_module(my_grid, my_module)
-    # All data-loading ranks use the same sampler settings so they load
-    # identical global micro-batches.  Module-local DP slicing happens later
-    # in forward_step via slice_batch_for_megatron_mimo.
+    if scalable_dp:
+        module_parallelism = megatron_mimo_cfg.module_parallelisms[my_module]
+        if module_parallelism.expert_tensor_parallel_size != 1:
+            raise NotImplementedError(
+                "MegatronMIMO scalable_dp currently requires expert_tensor_parallel_size=1. "
+                "Sharding sampler reads across the module DP group with ETP > 1 is an "
+                "unvalidated combination, so it is conservatively rejected."
+            )
+        # Disjoint reads: each rank's sampler emits only its module-local DP shard.
+        dp_pg = my_grid.get_pg(["dp"])
+        if dp_pg.size() != module_parallelism.data_parallel_size:
+            raise RuntimeError(
+                f"MegatronMIMO scalable_dp expected module {my_module!r} data-parallel size "
+                f"{module_parallelism.data_parallel_size}, but its base DP group has size {dp_pg.size()}."
+            )
+        return dp_pg.rank(), dp_pg.size(), needs_data
+    # All data-loading ranks use the same sampler settings so they load identical global
+    # micro-batches; module-local DP slicing happens later in forward_step.
     return 0, 1, needs_data
 
 
@@ -210,11 +232,13 @@ def slice_batch_for_megatron_mimo(
 ) -> Dict[str, Any]:
     """Slice a global micro-batch for this rank's module-local DP shard.
 
-    All data-loading ranks receive the same global micro-batch (the sampler
-    uses ``dp_size=1``).  This function contiguously slices it so that each
-    module-local DP replica processes the correct subset.  The slicing is
-    contiguous to match the :class:`BridgeCommunicator`'s batch-dimension
-    split / concatenate logic for fan-out and fan-in routing.
+    In the default (non-scalable) mode all data-loading ranks receive the same
+    global micro-batch (the sampler uses ``dp_size=1``) and this function
+    contiguously slices it so that each module-local DP replica processes the
+    correct subset.  The slicing is contiguous to match the
+    :class:`BridgeCommunicator`'s batch-dimension split / concatenate logic for
+    fan-out and fan-in routing.  With ``megatron_mimo_scalable_dp`` the loader
+    already delivers the shard and ``forward_step`` skips this call.
 
     Handles nested dicts (e.g. ``modality_inputs``) by recursing.
 

--- a/src/megatron/bridge/data/megatron_mimo/loaders.py
+++ b/src/megatron/bridge/data/megatron_mimo/loaders.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 from torch.utils.data import DataLoader
 
 from megatron.bridge.data.base import DatasetBuildContext, DatasetProvider
+from megatron.bridge.data.megatron_mimo.canonical_sampler import build_canonical_mimo_data_loader
 from megatron.bridge.data.megatron_mimo.dp_utils import get_megatron_mimo_sampling_info
 from megatron.bridge.data.samplers import build_pretraining_data_loader
 from megatron.bridge.utils.common_utils import print_rank_0
@@ -28,11 +29,13 @@ def build_megatron_mimo_data_loaders(
 ) -> Tuple[Optional[DataLoader], Optional[DataLoader], Optional[DataLoader]]:
     """Build MegatronMIMO data loaders with globally consistent sampling.
 
-    All data-loading ranks receive identical global micro-batches (the sampler
-    uses dp_size=1).  Per-module DP sub-sharding is deferred to
+    By default all data-loading ranks receive identical global micro-batches (the
+    sampler uses dp_size=1) and per-module DP sub-sharding is deferred to
     ``slice_batch_for_megatron_mimo`` in the forward step, ensuring consistency with
     the BridgeCommunicator's fan-in/fan-out routing for asymmetric DP configs.
-    Only ranks that need data (first/last PP stage) will get non-None loaders.
+    With ``dataset.megatron_mimo_scalable_dp`` each rank instead reads only its
+    canonical-grid shard (see ``canonical_sampler``) and the forward step does not
+    slice. Only ranks that need data (first/last PP stage) will get non-None loaders.
 
     Args:
         cfg: Configuration container with MegatronMIMOProvider as cfg.model.
@@ -105,8 +108,9 @@ def build_megatron_mimo_data_loaders(
     # Use cached grids from build_model()
     grids = cfg.model._grids
 
+    scalable_dp = bool(getattr(getattr(cfg, "dataset", None), "megatron_mimo_scalable_dp", False))
     sampler_dp_rank, sampler_dp_size, needs_data = get_megatron_mimo_sampling_info(
-        cfg.model.megatron_mimo_parallelism_config, grids
+        cfg.model.megatron_mimo_parallelism_config, grids, scalable_dp=scalable_dp
     )
 
     if not needs_data:
@@ -127,15 +131,37 @@ def build_megatron_mimo_data_loaders(
         f"test={len(test_ds) if test_ds else 0}"
     )
 
-    # Build data loaders via the shared standard-path helper so MegatronMIMO picks up
-    # the same sampler selection logic (driven by ``dataloader_type``) and automatic
-    # consumed_samples handling on checkpoint resume. sampler_dp_size=1 means all
+    # Default mode builds via the shared standard-path helper (sampler_dp_size=1: all
     # data-loading ranks see the same global batches; per-module DP sub-sharding is
-    # deferred to slice_batch_for_megatron_mimo in the forward step.
+    # deferred to slice_batch_for_megatron_mimo in the forward step). Scalable mode
+    # shards reads on the canonical grid instead and skips the forward-step slice.
     collate_fn = megatron_mimo_provider.get_collate_fn()
     micro_batch_size = cfg.train.micro_batch_size
 
     def _make_loader(dataset, consumed_samples: int, split_micro_batch_size: int) -> Optional[DataLoader]:
+        if dataset is None:
+            return None
+        if scalable_dp:
+            # Shard reads on the canonical grid (LCM of the module DP sizes) so every
+            # module materializes the same ordered global micro-batch under any sampler.
+            module_dps = [
+                p.data_parallel_size for p in cfg.model.megatron_mimo_parallelism_config.module_parallelisms.values()
+            ]
+            return build_canonical_mimo_data_loader(
+                dataset,
+                consumed_samples=consumed_samples,
+                dataloader_type=megatron_mimo_provider.dataloader_type,
+                micro_batch_size=split_micro_batch_size,
+                module_dp_sizes=module_dps,
+                dp_rank=sampler_dp_rank,
+                dp_size=sampler_dp_size,
+                data_sharding=megatron_mimo_provider.data_sharding,
+                drop_last=megatron_mimo_provider.drop_last,
+                num_workers=megatron_mimo_provider.num_workers,
+                pin_memory=megatron_mimo_provider.pin_memory,
+                collate_fn=collate_fn,
+                persistent_workers=megatron_mimo_provider.persistent_workers,
+            )
         return build_pretraining_data_loader(
             dataset=dataset,
             consumed_samples=consumed_samples,

--- a/src/megatron/bridge/training/megatron_mimo_step.py
+++ b/src/megatron/bridge/training/megatron_mimo_step.py
@@ -196,8 +196,9 @@ def forward_step(
             modality_modules = megatron_mimo_model.role.modality_module_names
             needs_data = any(megatron_mimo_model.role.is_first_stage(mod) for mod in modality_modules)
 
-    # MegatronMIMO in-batch sequence packing, read from the dataset config (absent -> off).
+    # MegatronMIMO data-efficiency settings, read from the dataset config (absent -> off).
     pack_sequences_enabled = resolve_step_packing(state.cfg.dataset)
+    scalable_dp = bool(getattr(state.cfg.dataset, "megatron_mimo_scalable_dp", False))
 
     if needs_data:
         data_batch = get_batch(data_iterator)
@@ -207,7 +208,6 @@ def forward_step(
                 "This indicates a data-loading or parallelism misconfiguration."
             )
         # Slice the global micro-batch for this module's DP shard.
-        # All data-loading ranks receive identical batches (sampler dp_size=1).
         # slice_batch_for_megatron_mimo contiguously sub-shards to match the
         # BridgeCommunicator's fan-in/fan-out batch-dimension routing.
         if (
@@ -221,7 +221,9 @@ def forward_step(
             # sample batch.
             data_batch["modality_inputs"] = None
         dp_rank, dp_size = _get_module_dp_info(megatron_mimo_model)
-        data_batch = slice_batch_for_megatron_mimo(data_batch, dp_rank, dp_size)
+        if not scalable_dp:
+            # With megatron_mimo_scalable_dp the sampler already delivered this rank's shard.
+            data_batch = slice_batch_for_megatron_mimo(data_batch, dp_rank, dp_size)
         pack_lengths = None
         if megatron_mimo_model.role is not None and megatron_mimo_model.role.has_language_module:
             # Lengths come from the batch's attention_mask; it must cover modality placeholder tokens.

--- a/tests/unit_tests/data/megatron_mimo/test_canonical_sampler.py
+++ b/tests/unit_tests/data/megatron_mimo/test_canonical_sampler.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for canonical-grid batch sampling (MegatronMIMO scalable reads)."""
+
+import pytest
+
+from megatron.bridge.data.megatron_mimo.canonical_sampler import (
+    build_canonical_group_batch_sampler,
+    canonical_grid_size,
+    covered_canonical_groups,
+)
+
+
+class _FakeDataset:
+    def __init__(self, n: int):
+        self.n = n
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, idx: int) -> int:
+        return idx
+
+
+def _windows(sampler, count: int):
+    it = iter(sampler)
+    return [next(it) for _ in range(count)]
+
+
+class TestGridHelpers:
+    def test_grid_size_is_lcm(self):
+        assert canonical_grid_size([1, 2]) == 2
+        assert canonical_grid_size([2, 4]) == 4
+        assert canonical_grid_size([2, 3]) == 6
+
+    def test_grid_size_rejects_invalid(self):
+        with pytest.raises(ValueError, match="positive"):
+            canonical_grid_size([2, 0])
+
+    def test_covered_groups_are_contiguous(self):
+        assert covered_canonical_groups(0, 1, 2) == [0, 1]
+        assert covered_canonical_groups(1, 2, 2) == [1]
+        assert covered_canonical_groups(1, 2, 4) == [2, 3]
+
+    def test_covered_groups_rejects_non_divisor(self):
+        with pytest.raises(ValueError, match="not divisible"):
+            covered_canonical_groups(0, 3, 4)
+
+
+class TestFactoryValidation:
+    def test_rejects_drop_last_false(self):
+        with pytest.raises(ValueError, match="drop_last"):
+            build_canonical_group_batch_sampler(
+                dataloader_type="single",
+                dataset=_FakeDataset(16),
+                consumed_samples=0,
+                micro_batch_size=4,
+                grid_size=2,
+                groups=[0],
+                data_sharding=True,
+                drop_last=False,
+            )
+
+    def test_rejects_indivisible_micro_batch(self):
+        with pytest.raises(ValueError, match="divisible"):
+            build_canonical_group_batch_sampler(
+                dataloader_type="single",
+                dataset=_FakeDataset(16),
+                consumed_samples=0,
+                micro_batch_size=5,
+                grid_size=2,
+                groups=[0],
+                data_sharding=True,
+            )
+
+    def test_rejects_unsupported_dataloader_type(self):
+        with pytest.raises(ValueError, match="single.*cyclic"):
+            build_canonical_group_batch_sampler(
+                dataloader_type="batch",
+                dataset=_FakeDataset(16),
+                consumed_samples=0,
+                micro_batch_size=4,
+                grid_size=2,
+                groups=[0],
+                data_sharding=True,
+            )
+
+
+def _build(groups, *, dataloader_type, total=48, consumed=0, mbs=4, grid=2, data_sharding=True):
+    return build_canonical_group_batch_sampler(
+        dataloader_type=dataloader_type,
+        dataset=_FakeDataset(total),
+        consumed_samples=consumed,
+        micro_batch_size=mbs,
+        grid_size=grid,
+        groups=groups,
+        data_sharding=data_sharding,
+    )
+
+
+class TestCrossGeometryAlignment:
+    """The core invariant: a rank covering groups {0, 1} reads, per window, exactly the
+    concatenation of what single-group ranks read — for shuffling samplers included."""
+
+    @pytest.mark.parametrize("data_sharding", [True, False])
+    def test_cyclic_merged_equals_concat_of_group_streams(self, data_sharding):
+        merged = _build([0, 1], dataloader_type="cyclic", data_sharding=data_sharding)
+        group0 = _build([0], dataloader_type="cyclic", data_sharding=data_sharding)
+        group1 = _build([1], dataloader_type="cyclic", data_sharding=data_sharding)
+
+        merged_windows = _windows(merged, 6)
+        g0_windows = _windows(group0, 6)
+        g1_windows = _windows(group1, 6)
+
+        for m, g0, g1 in zip(merged_windows, g0_windows, g1_windows):
+            assert m == g0 + g1
+            assert len(m) == 4
+
+    def test_cyclic_group_streams_are_disjoint(self):
+        group0 = _build([0], dataloader_type="cyclic")
+        group1 = _build([1], dataloader_type="cyclic")
+        seen0 = {i for w in _windows(group0, 6) for i in w}
+        seen1 = {i for w in _windows(group1, 6) for i in w}
+        assert seen0.isdisjoint(seen1)
+
+    def test_single_merged_reproduces_contiguous_windows(self):
+        merged = _build([0, 1], dataloader_type="single")
+        assert _windows(merged, 3) == [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
+
+    def test_single_group_streams_match_slice_semantics(self):
+        # Group g's stream equals the [g*2, (g+1)*2) slice of each contiguous window,
+        # i.e. exactly what slice_batch_for_megatron_mimo would keep for dp rank g.
+        group1 = _build([1], dataloader_type="single")
+        assert _windows(group1, 3) == [[2, 3], [6, 7], [10, 11]]
+
+    def test_heterogeneous_grid_four_groups(self):
+        # language dp=4 (one group per rank) with vision dp=2 (two groups per rank).
+        vision_rank0 = _build([0, 1], dataloader_type="cyclic", grid=4, mbs=8)
+        lang_rank0 = _build([0], dataloader_type="cyclic", grid=4, mbs=8)
+        lang_rank1 = _build([1], dataloader_type="cyclic", grid=4, mbs=8)
+        for m, g0, g1 in zip(_windows(vision_rank0, 4), _windows(lang_rank0, 4), _windows(lang_rank1, 4)):
+            assert m == g0 + g1
+
+
+class TestResume:
+    @pytest.mark.parametrize("dataloader_type", ["single", "cyclic"])
+    def test_resume_continues_the_stream(self, dataloader_type):
+        full = _build([0, 1], dataloader_type=dataloader_type)
+        full_windows = _windows(full, 6)
+
+        # Two windows consumed -> global consumed = 2 * micro_batch_size.
+        resumed = _build([0, 1], dataloader_type=dataloader_type, consumed=8)
+        resumed_windows = _windows(resumed, 4)
+
+        assert resumed_windows == full_windows[2:]
+
+    def test_resume_across_epoch_boundary(self):
+        # total=8, window=4 -> 2 windows per epoch. consumed=12 resumes at the
+        # second window of epoch 1.
+        merged = _build([0, 1], dataloader_type="cyclic", total=8)
+        epoch0 = list(iter(merged))
+        epoch1 = list(iter(merged))
+        full_seq = epoch0 + epoch1
+
+        resumed = _build([0, 1], dataloader_type="cyclic", total=8, consumed=12)
+        assert next(iter(resumed)) == full_seq[3]
+
+
+class TestEpochBoundary:
+    def test_cyclic_reiterates_with_new_epoch(self):
+        # total=8, window=4 -> 2 windows per epoch; sub-samplers advance their own
+        # consumed_samples, so re-iterating the wrapper enters the next epoch.
+        merged = _build([0, 1], dataloader_type="cyclic", total=8)
+        epoch0 = list(iter(merged))
+        assert len(epoch0) == 2
+        epoch1 = list(iter(merged))
+        assert len(epoch1) == 2
+        assert {i for w in epoch0 for i in w} == set(range(8))
+        assert {i for w in epoch1 for i in w} == set(range(8))
+        # The sub-samplers must have advanced (a replayed epoch 0 would pass the
+        # set checks above): consumed grew and the epoch-1 order is a new shuffle.
+        assert merged.samplers[0].consumed_samples == 16
+        assert epoch1 != epoch0
+
+
+class TestNonMultipleDatasetSize:
+    @pytest.mark.parametrize("data_sharding", [True, False])
+    def test_groups_stay_aligned_when_total_is_not_a_multiple(self, data_sharding):
+        # 54 % 8 != 0: without truncation the cyclic data_sharding=False stride gives
+        # groups unequal window counts ([7, 7, 6, 6]) and desyncs the modules.
+        groups = [
+            _build([g], dataloader_type="cyclic", total=54, mbs=8, grid=4, data_sharding=data_sharding)
+            for g in range(4)
+        ]
+        counts = [len(list(iter(g))) for g in groups]
+        assert counts == [6, 6, 6, 6]
+
+        merged = _build([0, 1, 2, 3], dataloader_type="cyclic", total=54, mbs=8, grid=4, data_sharding=data_sharding)
+        windows = list(iter(merged))
+        assert len(windows) == 6
+        assert all(len(w) == 8 for w in windows)

--- a/tests/unit_tests/data/megatron_mimo/test_dp_utils.py
+++ b/tests/unit_tests/data/megatron_mimo/test_dp_utils.py
@@ -157,6 +157,50 @@ def test_get_megatron_mimo_sampling_info_llm_intermediate_pp(monkeypatch):
     assert needs_data is True
 
 
+def test_get_megatron_mimo_sampling_info_scalable_dp_uses_configured_dp(monkeypatch):
+    """Scalable sampling uses the configured sample-DP group when ETP is one."""
+    megatron_mimo_cfg = _make_megatron_mimo_cfg()
+    monkeypatch.setattr(dist, "get_rank", lambda: 5)
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
+        "language": FakeGrid(4, 4, dp_rank=1, dp_size=4, pp_rank=1, pp_size=3),
+    }
+
+    sampler_dp_rank, sampler_dp_size, needs_data = get_megatron_mimo_sampling_info(
+        megatron_mimo_cfg, grids, scalable_dp=True
+    )
+
+    assert (sampler_dp_rank, sampler_dp_size, needs_data) == (1, 4, True)
+
+
+def test_get_megatron_mimo_sampling_info_scalable_dp_rejects_etp(monkeypatch):
+    """ETP ranks must not be mistaken for independent sample-DP replicas."""
+    megatron_mimo_cfg = _make_megatron_mimo_cfg()
+    megatron_mimo_cfg.module_parallelisms["vision"].expert_tensor_parallel_size = 2
+    monkeypatch.setattr(dist, "get_rank", lambda: 0)
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+        "language": FakeGrid(4, 4, dp_rank=0, dp_size=4, pp_rank=0, pp_size=1),
+    }
+
+    with pytest.raises(NotImplementedError, match="expert_tensor_parallel_size=1"):
+        get_megatron_mimo_sampling_info(megatron_mimo_cfg, grids, scalable_dp=True)
+
+
+def test_get_megatron_mimo_sampling_info_scalable_dp_rejects_grid_mismatch(monkeypatch):
+    """A grid DP group that disagrees with the configured DP size must not shard reads silently."""
+    megatron_mimo_cfg = _make_megatron_mimo_cfg()
+    monkeypatch.setattr(dist, "get_rank", lambda: 5)
+    grids = {
+        "vision": FakeGrid(0, 4, dp_rank=0, dp_size=2, pp_rank=0, pp_size=1),
+        # language is configured with data_parallel_size=4 but its grid group reports 2
+        "language": FakeGrid(4, 4, dp_rank=1, dp_size=2, pp_rank=0, pp_size=1),
+    }
+
+    with pytest.raises(RuntimeError, match="data-parallel size"):
+        get_megatron_mimo_sampling_info(megatron_mimo_cfg, grids, scalable_dp=True)
+
+
 def test_get_megatron_mimo_dp_info_non_participating_rank(monkeypatch):
     """Test heterogeneous mode, rank not in any module."""
     megatron_mimo_cfg = _make_megatron_mimo_cfg()

--- a/tests/unit_tests/data/megatron_mimo/test_loaders.py
+++ b/tests/unit_tests/data/megatron_mimo/test_loaders.py
@@ -100,7 +100,7 @@ def _patch_happy_path_dependencies(monkeypatch):
 
     monkeypatch.setattr(
         "megatron.bridge.data.megatron_mimo.loaders.get_megatron_mimo_sampling_info",
-        lambda megatron_mimo_cfg, grids: (1, 4, True),
+        lambda megatron_mimo_cfg, grids, **kwargs: (1, 4, True),
     )
     monkeypatch.setattr(
         "megatron.bridge.data.megatron_mimo.loaders.print_rank_0",
@@ -254,7 +254,7 @@ def _make_real_loader_cfg(monkeypatch, *, micro_batch_size: int, sampler_dp_rank
     _patch_megatron_mimo_provider_class(monkeypatch)
     monkeypatch.setattr(
         "megatron.bridge.data.megatron_mimo.loaders.get_megatron_mimo_sampling_info",
-        lambda megatron_mimo_cfg, grids: (sampler_dp_rank, sampler_dp_size, True),
+        lambda megatron_mimo_cfg, grids, **kwargs: (sampler_dp_rank, sampler_dp_size, True),
     )
     monkeypatch.setattr(
         "megatron.bridge.data.megatron_mimo.loaders.print_rank_0",
@@ -361,7 +361,7 @@ def test_build_megatron_mimo_data_loaders_skips_non_data_ranks(monkeypatch):
     provider = FakeProvider()
     monkeypatch.setattr(
         "megatron.bridge.data.megatron_mimo.loaders.get_megatron_mimo_sampling_info",
-        lambda megatron_mimo_cfg, grids: (0, 1, False),
+        lambda megatron_mimo_cfg, grids, **kwargs: (0, 1, False),
     )
 
     monkeypatch.setattr(
@@ -380,3 +380,53 @@ def test_build_megatron_mimo_data_loaders_skips_non_data_ranks(monkeypatch):
 
     assert (train_loader, valid_loader, test_loader) == (None, None, None)
     assert provider.built is False
+
+
+def test_scalable_dp_loader_shards_on_canonical_grid_end_to_end(monkeypatch):
+    """With megatron_mimo_scalable_dp the loader must shard on the canonical grid
+    (LCM of module DP sizes, not this module's dp or the max), under the real
+    cyclic sampler."""
+    from megatron.bridge.data.megatron_mimo.canonical_sampler import (
+        CanonicalGroupBatchSampler,
+        build_canonical_group_batch_sampler,
+    )
+
+    micro_batch_size = 12
+    train_size = 48
+    # This rank: module-local dp rank 1 of 3; modules have dps {2, 3} -> grid = lcm = 6.
+    cfg = _make_real_loader_cfg(monkeypatch, micro_batch_size=micro_batch_size, sampler_dp_rank=1, sampler_dp_size=3)
+    cfg.model.megatron_mimo_parallelism_config = SimpleNamespace(
+        module_parallelisms={
+            "vision": SimpleNamespace(data_parallel_size=2),
+            "llm": SimpleNamespace(data_parallel_size=3),
+        }
+    )
+    cfg.dataset = SimpleNamespace(megatron_mimo_scalable_dp=True)
+    provider = IndexDatasetProvider(train_size=train_size)
+    provider.dataloader_type = "cyclic"
+    provider.data_sharding = True
+    train_state = SimpleNamespace(consumed_train_samples=0)
+
+    train_loader, _, _ = build_megatron_mimo_data_loaders(
+        cfg,
+        train_state=train_state,
+        megatron_mimo_provider=provider,
+        train_samples=train_size,
+        valid_samples=0,
+        test_samples=0,
+    )
+
+    assert isinstance(train_loader.batch_sampler, CanonicalGroupBatchSampler)
+    first_batch = next(iter(train_loader))
+    # Rank 1 of 3 covers canonical groups [2, 3] of grid 6 -> mbs // dp = 4 samples.
+    assert len(first_batch) == micro_batch_size // 3
+    reference = build_canonical_group_batch_sampler(
+        dataloader_type="cyclic",
+        dataset=FakeDataset(train_size),
+        consumed_samples=0,
+        micro_batch_size=micro_batch_size,
+        grid_size=6,
+        groups=[2, 3],
+        data_sharding=True,
+    )
+    assert first_batch == next(iter(reference))

--- a/tests/unit_tests/examples/test_qwen35_vl_mimo_finetune.py
+++ b/tests/unit_tests/examples/test_qwen35_vl_mimo_finetune.py
@@ -158,6 +158,8 @@ def test_dataset_config_enables_only_requested_or_known_validation_splits(
                 dataloader_type="single",
                 trust_remote_code=False,
                 do_validation=do_validation,
+                pack_sequences_in_batch=False,
+                scalable_dp=False,
             )
         )
         config.validate()

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_step.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_step.py
@@ -97,6 +97,7 @@ class TestForwardStep:
         # Create mock state
         mock_state = MagicMock()
         mock_state.cfg.dataset.enable_in_batch_packing = False
+        mock_state.cfg.dataset.megatron_mimo_scalable_dp = False
 
         # Create mock model with role=None (indicates last stage)
         mock_model = MagicMock()
@@ -125,6 +126,7 @@ class TestForwardStep:
 
         mock_state = MagicMock()
         mock_state.cfg.dataset.enable_in_batch_packing = False
+        mock_state.cfg.dataset.megatron_mimo_scalable_dp = False
         mock_model = MagicMock()
         # Configure role to indicate intermediate stage (not last stage)
         mock_role = MagicMock()
@@ -153,6 +155,7 @@ class TestForwardStep:
 
         mock_state = MagicMock()
         mock_state.cfg.dataset.enable_in_batch_packing = False
+        mock_state.cfg.dataset.megatron_mimo_scalable_dp = False
         mock_model = MagicMock()
         mock_role = MagicMock()
         mock_role.has_language_module = True
@@ -191,6 +194,7 @@ class TestForwardStep:
 
         mock_state = MagicMock()
         mock_state.cfg.dataset.enable_in_batch_packing = False
+        mock_state.cfg.dataset.megatron_mimo_scalable_dp = False
         mock_model = MagicMock()
         mock_model.role = None  # role=None means is_last_stage=True
         # Return dict (incorrect for last stage)
@@ -255,6 +259,122 @@ class TestForwardStep:
         assert call_kwargs["packing_kwargs"]["cu_seqlens_q"].tolist() == [0, 3, 5]
         assert call_kwargs["position_ids"].tolist() == [[0, 1, 2, 0, 1]]
         assert call_kwargs["attention_mask"] is None
+
+    @patch("megatron.bridge.training.megatron_mimo_step._get_module_dp_info")
+    @patch("megatron.bridge.training.megatron_mimo_step.get_batch")
+    @patch("megatron.bridge.training.megatron_mimo_step.unwrap_megatron_mimo_model")
+    def test_forward_step_scalable_dp_skips_batch_slicing(self, mock_unwrap, mock_get_batch, mock_dp_info):
+        """megatron_mimo_scalable_dp: the sampler already delivered this rank's shard, so the
+        batch must reach the model unsliced."""
+        from megatron.bridge.training.megatron_mimo_step import forward_step
+
+        mock_state = MagicMock()
+        mock_state.cfg.dataset = SimpleNamespace(
+            enable_in_batch_packing=False,
+            defer_in_batch_packing_to_step=False,
+            megatron_mimo_scalable_dp=True,
+        )
+        mock_model = MagicMock()
+        mock_role = MagicMock()
+        mock_role.has_language_module = True
+        mock_role.has_modality_modules = False
+        mock_role.is_first_stage.return_value = True
+        mock_role.is_last_stage.return_value = False
+        mock_model.role = mock_role
+        mock_model.return_value = (torch.tensor([1.0]), None)
+        mock_unwrap.return_value = mock_model
+        mock_dp_info.return_value = (0, 2)
+
+        mock_get_batch.return_value = {
+            "input_ids": torch.arange(16).reshape(4, 4),
+            "position_ids": torch.arange(4).repeat(4, 1),
+            "attention_mask": None,
+            "labels": torch.arange(16).reshape(4, 4),
+            "loss_mask": torch.ones(4, 4),
+            "modality_inputs": None,
+        }
+
+        forward_step(mock_state, iter([]), mock_model)
+
+        # Slicing with dp=2 would have kept only rows 0-1 ([2, 4]); the shard must stay [4, 4].
+        assert mock_model.call_args.kwargs["input_ids"].shape[0] == 4
+
+    @patch("megatron.bridge.training.megatron_mimo_step._get_module_dp_info")
+    @patch("megatron.bridge.training.megatron_mimo_step.get_batch")
+    @patch("megatron.bridge.training.megatron_mimo_step.unwrap_megatron_mimo_model")
+    def test_forward_step_default_still_slices_batch(self, mock_unwrap, mock_get_batch, mock_dp_info):
+        """Without megatron_mimo_scalable_dp the full-batch read must still be sliced."""
+        from megatron.bridge.training.megatron_mimo_step import forward_step
+
+        mock_state = MagicMock()
+        mock_state.cfg.dataset = SimpleNamespace(
+            enable_in_batch_packing=False,
+            defer_in_batch_packing_to_step=False,
+            megatron_mimo_scalable_dp=False,
+        )
+        mock_model = MagicMock()
+        mock_role = MagicMock()
+        mock_role.has_language_module = True
+        mock_role.has_modality_modules = False
+        mock_role.is_first_stage.return_value = True
+        mock_role.is_last_stage.return_value = False
+        mock_model.role = mock_role
+        mock_model.return_value = (torch.tensor([1.0]), None)
+        mock_unwrap.return_value = mock_model
+        mock_dp_info.return_value = (0, 2)
+
+        mock_get_batch.return_value = {
+            "input_ids": torch.arange(16).reshape(4, 4),
+            "position_ids": torch.arange(4).repeat(4, 1),
+            "attention_mask": None,
+            "labels": torch.arange(16).reshape(4, 4),
+            "loss_mask": torch.ones(4, 4),
+            "modality_inputs": None,
+        }
+
+        forward_step(mock_state, iter([]), mock_model)
+
+        # dp rank 0 of 2 keeps rows 0-1 of the full 4-row read.
+        assert mock_model.call_args.kwargs["input_ids"].shape[0] == 2
+
+    @patch("megatron.bridge.training.megatron_mimo_step._get_module_dp_info")
+    @patch("megatron.bridge.training.megatron_mimo_step.get_batch")
+    @patch("megatron.bridge.training.megatron_mimo_step.unwrap_megatron_mimo_model")
+    def test_scalable_dp_binds_to_real_dataset_config_field(self, mock_unwrap, mock_get_batch, mock_dp_info):
+        """The step's getattr key must match the real DirectHFSFTDatasetConfig field name."""
+        from megatron.bridge.data.builders import DirectHFSFTDatasetConfig, HFDatasetSourceConfig
+        from megatron.bridge.training.megatron_mimo_step import forward_step
+
+        mock_state = MagicMock()
+        mock_state.cfg.dataset = DirectHFSFTDatasetConfig(
+            seq_length=16,
+            source=HFDatasetSourceConfig(path_or_dataset="org/chat"),
+            megatron_mimo_scalable_dp=True,
+        )
+        mock_model = MagicMock()
+        mock_role = MagicMock()
+        mock_role.has_language_module = True
+        mock_role.has_modality_modules = False
+        mock_role.is_first_stage.return_value = True
+        mock_role.is_last_stage.return_value = False
+        mock_model.role = mock_role
+        mock_model.return_value = (torch.tensor([1.0]), None)
+        mock_unwrap.return_value = mock_model
+        mock_dp_info.return_value = (0, 2)
+
+        mock_get_batch.return_value = {
+            "input_ids": torch.arange(16).reshape(4, 4),
+            "position_ids": torch.arange(4).repeat(4, 1),
+            "attention_mask": None,
+            "labels": torch.arange(16).reshape(4, 4),
+            "loss_mask": torch.ones(4, 4),
+            "modality_inputs": None,
+        }
+
+        forward_step(mock_state, iter([]), mock_model)
+
+        # A one-sided field rename would silently revert to slicing ([2, 4]).
+        assert mock_model.call_args.kwargs["input_ids"].shape[0] == 4
 
     @patch("megatron.bridge.training.megatron_mimo_step.get_batch")
     @patch("megatron.bridge.training.megatron_mimo_step.unwrap_megatron_mimo_model")


### PR DESCRIPTION
## What

Adds opt-in **scalable data-parallel reads** to MegatronMIMO. By default every data-loading
rank reads the full global micro-batch and `forward_step` slices out its module-DP shard, so
per-rank read and preprocessing cost scales with the DP degree. With
`dataset.megatron_mimo_scalable_dp` each rank's sampler reads only its shard and the slice is
skipped:

```text
default            scalable
read    [4, S]     read    [2, S]      (per language rank, dp=2)
slice   [4]->[2]   slice   skipped
forward [2, S]     forward [2, S]      (same shard geometry, identical routing)
```

Second of three PRs splitting #4608 (original work by **@sailor1493**, credited
as co-author and signer), per the maintainers' [split request in #4609](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/4609#issuecomment-4926364154).
Part 1 merged as #5131.

## Why a canonical grid (mechanism deviation from #4608)

#4608 sharded each module's loader by its own module-DP `(rank, size)`. A sampler's shard
assignment is a function of `(micro_batch_size, data_parallel_size)`, so under `"cyclic"` —
the direct-HF-SFT default since #5048 — modules with different DP sizes read **different
sample sets**, while the `BridgeCommunicator` routes modality embeddings positionally along
the batch dim. We hit this live as an embedding-count crash in
`align_embeddings_by_token_positions`; with uniform image sizes it would silently train on
mispaired image-text.

Here all loaders shard on one **canonical grid** — the LCM of the module DP sizes. Every
group sampler uses the identical `(micro_batch // grid, grid)` geometry and global
`consumed_samples`; a rank whose module has DP size `d` concatenates the windows of its
`grid // d` consecutive groups (`CanonicalGroupBatchSampler`). Group streams are
module-independent, so every module materializes the identical ordered micro-batch under
`"single"` **and** `"cyclic"`; for `"single"` the stream is bit-identical to the default
path's slice. Geometries are truncated to whole micro-batches so ragged dataset sizes cannot
desynchronize the groups. ("Canonical group" is the vocabulary of #4608's reordering
machinery, which ③ will port.)

## Configuration

```python
cfg.dataset.megatron_mimo_scalable_dp = True   # DirectHFSFTDatasetConfig; example: --scalable-dp
```

`"single"` and `"cyclic"` are supported; `"batch"`/`"external"` and `drop_last=False` are
rejected in `validate()` and again at loader build. Off by default — with the switch unset, the
sampler parameters, loader arguments and slicing behavior are identical to main.

## Notes for reviewers

- Scalable reads reject `expert_tensor_parallel_size > 1` (unvalidated combination). The
  default slicing path shares the same assumption — happy to hoist the guard into
  `MegatronMIMOParallelismConfig` validation if preferred.
- No train-loop changes: the provider forces `variable_seq_lengths=True`, so the schedule's
  `micro_batch_size` is shape-inert and the LR/consumed accounting already uses the full
  micro-batch in both modes (#4608's schedule/LR adjustment is unnecessary here).
- Under `"cyclic"`, scalable on/off are two different valid epoch shuffles (per-iteration
  losses not comparable); `"single"` is order-identical.

## Testing

258 unit tests passing locally, including the cross-geometry alignment invariant (a rank
covering groups {0,1} reads exactly the concatenation of the single-group ranks' windows, for
`"cyclic"` in both `data_sharding` modes) and a library-path end-to-end test with DP {2,3}
(grid = 6). Live PP=2 runs (5 GPUs of an 8xA100 node, `language=tp1,pp2,dp2` + `images=dp1`, Qwen3.5-0.8B random
init, cord_v2, mbs 4, 10 iters): `cyclic`+scalable completes 10/10 where module-DP sharding
crashes; `single` scalable matches the default losses within bf16 noise (max |diff| 0.0043);
the default path matches prior losses within run-to-run noise (max |diff| 0.0024); packing on/off parity under scalable ~0.001.
(One drive-by repair: the example-config test's arg namespace was already failing on main —
#5131 added `pack_sequences_in_batch` to `_build_dataset_config` without updating it — so this
PR adds both missing kwargs there.)

## Known limitations

ETP > 1 and `"batch"`/`"external"` loaders are rejected for scalable reads; MegatronMIMO still
cannot run CP (pre-existing); checkpoint resume is unit-tested but not yet exercised in a live
run, and multi-node validation is pending, as with #4608.

Signed-off-by: kayeon.song <kayeon.song@navercorp.com>
Signed-off-by: Yoonsik Kim <yoonsik.kim90@navercorp.com>
Signed-off-by: Chanwoo Park <chanwoo.park98@navercorp.com>