### PR TITLE
fix(data): reject unsafe partial distributed batches

### DIFF
--- a/src/megatron/bridge/data/samplers.py
+++ b/src/megatron/bridge/data/samplers.py
@@ -152,6 +152,7 @@ class MegatronPretrainingSampler:
         self.consumed_samples = consumed_samples
         self.micro_batch_size = micro_batch_size
         self.data_parallel_rank = data_parallel_rank
+        self.data_parallel_size = data_parallel_size
         self.micro_batch_times_data_parallel_size = self.micro_batch_size * data_parallel_size
         self.drop_last = drop_last
 
@@ -180,6 +181,18 @@ class MegatronPretrainingSampler:
 
     def __iter__(self) -> Iterator[list[int]]:
         """Yields lists of indices for each microbatch assigned to this rank."""
+        remaining_samples = self.total_samples - self.consumed_samples
+        if (
+            not self.drop_last
+            and self.data_parallel_size > 1
+            and remaining_samples % self.micro_batch_times_data_parallel_size != 0
+        ):
+            raise ValueError(
+                "drop_last=False is unsupported for a partial distributed batch with "
+                f"dataloader_type='single': {remaining_samples} remaining samples are not divisible by "
+                f"micro_batch_size ({self.micro_batch_size}) x data_parallel_size ({self.data_parallel_size})."
+            )
+
         batch = []
         # Last batch will be dropped if drop_last is not set False
         for idx in range(self.consumed_samples, self.total_samples):

--- a/tests/unit_tests/data/test_samplers.py
+++ b/tests/unit_tests/data/test_samplers.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+
+from megatron.bridge.data.samplers import MegatronPretrainingSampler
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_single_sampler_rejects_unsafe_partial_distributed_batch() -> None:
+    """A partial sequential tail must not desynchronize data-parallel ranks."""
+    sampler = MegatronPretrainingSampler(
+        total_samples=5,
+        consumed_samples=0,
+        micro_batch_size=2,
+        data_parallel_rank=1,
+        data_parallel_size=2,
+        drop_last=False,
+    )
+
+    with pytest.raises(ValueError, match="drop_last=False"):
+        list(sampler)
+
+
+def test_single_sampler_keeps_partial_batch_without_data_parallelism() -> None:
+    """Single-rank users can safely retain a smaller final batch."""
+    sampler = MegatronPretrainingSampler(
+        total_samples=5,
+        consumed_samples=0,
+        micro_batch_size=2,
+        data_parallel_rank=0,
+        data_parallel_size=1,
+        drop_last=False,
+    )
+
+    assert list(sampler) == [[0, 1], [2, 3], [4]]
+
+
+@pytest.mark.parametrize(
+    ("data_parallel_rank", "expected_batches"),
+    [(0, [[0, 1], [4, 5]]), (1, [[2, 3], [6, 7]])],
+)
+def test_single_sampler_distributes_complete_batches_across_ranks(
+    data_parallel_rank: int, expected_batches: list[list[int]]
+) -> None:
+    """Complete distributed batches retain their rank-local ownership."""
+    sampler = MegatronPretrainingSampler(
+        total_samples=8,
+        consumed_samples=0,
+        micro_batch_size=2,
+        data_parallel_rank=data_parallel_rank,
+        data_parallel_size=2,
+        drop_last=False,
+    )
+
+    assert list(sampler) == expected_batches
+
+
+def test_single_sampler_drops_partial_distributed_batch() -> None:
+    """The existing drop-last path remains valid for distributed tails."""
+    sampler = MegatronPretrainingSampler(
+        total_samples=5,
+        consumed_samples=0,
+        micro_batch_size=2,
+        data_parallel_rank=1,
+        data_parallel_size=2,
+        drop_last=True,
+    )
+
+    assert list(sampler) == [[2, 3]]


### PR DESCRIPTION
## What

A standard sequential data loader with `drop_last=False` could emit an empty batch on higher data-parallel ranks when the dataset tail did not fill a complete distributed micro-batch.

For five samples, micro-batch size two, and DP size two, rank 0 received `[[0, 1], [4]]` while rank 1 received `[[2, 3], []]`. PyTorch successfully loaded rank 0's tail but raised `IndexError` while collating rank 1's empty batch. In distributed training this can fail asymmetrically after one rank has advanced into the step.

## Root cause

`MegatronPretrainingSampler` collects a global micro-batch and slices a fixed rank-local window. Its `drop_last=False` tail path yielded that slice unconditionally, even when the remainder did not reach a higher rank. The public loader exposes this combination and forwards actual DP geometry and checkpoint-restored consumption without a divisibility guard.

## Fix

Reject only non-divisible partial `single` batches when `drop_last=False` and DP size is greater than one. The check runs during sampler iteration on every rank, before any rank yields the unsafe tail. Single-rank partial batches, complete distributed batches, and the existing `drop_last=True` behavior are unchanged.

## Validation

- Unmodified base regression: `1 failed, 1 passed`; the distributed partial-tail contract did not raise, while the single-rank control passed.
- Same unchanged regression after the fix: `2 passed`.
- Focused regression plus complete two-rank ownership and drop-last controls: `5 passed`.
- `git diff --check`: passed.
- `uv run pre-commit run --all-files`: passed.

Focused command:

```bash
uv run python -m pytest tests/unit_tests/data/test_samplers.py -q --tb=short
```

The workstation command used an import-only private test harness to bypass an unrelated optional package that requires CUDA during eager import; the committed tests use the normal public Bridge sampler import and contain no harness dependency.

## Scope

This changes only unsafe partial sequential batches across multiple data-parallel ranks. It does not change batch/cyclic/external loaders, padding semantics, complete batches, dependencies, public signatures, CI configuration, or Megatron-Core. No full-suite, GPU-training, convergence, model-quality, or performance validation was run.
