### PR TITLE
[model] fix: preserve Step3.7 MTP export config

### DIFF
--- a/src/megatron/bridge/models/stepfun/step37_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step37_bridge.py
@@ -112,6 +112,15 @@ class Step37Bridge(MegatronModelBridge):
     # uses the identical HF schema.
     CONFIG_MAPPING = Step35Bridge.CONFIG_MAPPING
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider: Step37ModelProvider) -> dict:
+        """Convert a Step3.7 provider into its nested Hugging Face config."""
+        hf_config = super().megatron_to_hf_config(provider)
+        mtp_num_layers = hf_config.pop("num_nextn_predict_layers", None)
+        if mtp_num_layers is not None:
+            hf_config["text_config"] = {"num_nextn_predict_layers": mtp_num_layers}
+        return hf_config
+
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Step37ModelProvider:
         """Convert a HuggingFace Step3.7 config into a :class:`Step37ModelProvider`.
 

--- a/tests/unit_tests/models/stepfun/test_step37_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step37_bridge.py
@@ -17,7 +17,9 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.stepfun import step37_bridge as _step37_bridge_mod
+from megatron.bridge.models.stepfun.configuration_step37 import Step37Config
 from megatron.bridge.models.stepfun.modelling_step37 import transformer_block as _step37_block_mod
 from megatron.bridge.models.stepfun.modelling_step37.transformer_block import get_step37_text_layer_spec
 from megatron.bridge.models.stepfun.step35_bridge import build_step35_layer_spec
@@ -81,6 +83,18 @@ class TestStep37BridgeProviderBridge:
         spec = p.transformer_layer_spec
         target = f"{spec.__module__}.{spec.__qualname__}"
         _validate_target_prefix(target=target, full_key="transformer_layer_spec")
+
+
+class TestStep37BridgeReverseConfig:
+    def test_checkpoint_mtp_override_is_nested_in_exported_config(self):
+        reference_config = Step37Config(text_config={"num_nextn_predict_layers": 3})
+        provider = SimpleNamespace(mtp_num_layers=0)
+
+        checkpoint_config = Step37Bridge.megatron_to_hf_config(provider)
+        exported_config = conform_config_to_reference(checkpoint_config, reference_config.to_dict())
+        synthesized_config = Step37Config(**exported_config)
+
+        assert synthesized_config.text_config.num_nextn_predict_layers == 0
 
 
 class TestGetStep37TextLayerSpec:


### PR DESCRIPTION
## Summary

Step3.7 native-checkpoint export now preserves the checkpoint-derived MTP layer count in the nested Hugging Face `text_config`.

The maintained 4-GPU smoke recipe disables MTP with `model.mtp_num_layers = 0`. Before this change, export could write MTP-less weights while retaining the reference checkpoints nested value of three MTP layers, leaving the saved model configuration inconsistent with its tensors.

## Root cause

The generic `MegatronModelBridge.megatron_to_hf_config()` reverse mapping emits `num_nextn_predict_layers` as a top-level key. Step3.7 stores that field under `text_config`. During `conform_config_to_reference()`, the shape mismatch drops the checkpoint-derived top-level value and preserves the stale nested reference value.

## Fix

Add a Step3.7 family-local reverse-config override that moves only `num_nextn_predict_layers` into `text_config` before reference conformance. The `is not None` check deliberately preserves the supported zero-layer override.

Related: #5153

## Validation

Fail-before on the unmodified base:

```text
PYTHONPATH=/workspace/src:/workspace/3rdparty/Megatron-LM uv run --no-sync python -m pytest tests/unit_tests/models/stepfun/test_step37_bridge.py::TestStep37BridgeReverseConfig::test_checkpoint_mtp_override_is_nested_in_exported_config -q
1 failed: expected 0, got the stale reference value 3
```

Pass-after with the unchanged regression test:

```text
PYTHONPATH=/workspace/src:/workspace/3rdparty/Megatron-LM uv run --no-sync python -m pytest tests/unit_tests/models/stepfun/test_step37_bridge.py::TestStep37BridgeReverseConfig::test_checkpoint_mtp_override_is_nested_in_exported_config -q
1 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/stepfun/test_step37_bridge.py tests/unit_tests/models/stepfun/test_configuration_step37.py tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_from_auto_config_happy_path tests/unit_tests/models/qwen3_asr/test_qwen3_asr_config.py::test_qwen3_asr_config_conforming_preserves_reference_audio_subconfig
9 passed
```

`git diff --check` and `uv run --no-sync pre-commit run --all-files` also pass.

## Scope

This is limited to Step3.7 reverse config synthesis. It does not change dependencies, workflows, lockfiles, submodules, or public API signatures. No full-suite, model-quality, convergence, or performance validation is claimed.