### PR TITLE
fix(ckpt): restore Energon state from MSC checkpoints

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -79,6 +79,7 @@ from megatron.bridge.training.utils.checkpoint_utils import (
     get_checkpoint_train_state_filename,
     is_checkpoint_iteration_directory,
     is_hf_checkpoint_dir,
+    join_paths,
     read_run_config,
     read_train_state,
 )
@@ -1814,15 +1815,24 @@ def maybe_load_dataloader_state(
     if iterable is None or not hasattr(iterable, "restore_state"):
         return
 
-    if not os.path.isdir(dataloader_load_path):
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        is_dir = msc.os.path.isdir
+        is_file = msc.os.path.isfile
+    else:
+        msc = None
+        is_dir = os.path.isdir
+        is_file = os.path.isfile
+
+    if not is_dir(dataloader_load_path):
         # No dataloader state dir at all: the checkpoint predates this feature. Start from scratch.
         print_rank_0(f"no dataloader state under {dataloader_load_path}; dataloader starts from the beginning")
         return
 
     dp_rank = get_pg_rank(pg_collection.dp)
     iter_dir = get_checkpoint_name(dataloader_load_path, iteration)
-    data_state_load_path = os.path.join(iter_dir, f"train_dataloader_dprank{dp_rank:03d}.pt")
-    if not os.path.isfile(data_state_load_path):
+    data_state_load_path = join_paths(iter_dir, f"train_dataloader_dprank{dp_rank:03d}.pt")
+    if not is_file(data_state_load_path):
         raise RuntimeError(
             f"Dataloader state directory {dataloader_load_path} exists but {data_state_load_path} is "
             f"missing. The data-parallel size likely changed since the checkpoint was saved (expected "
@@ -1831,7 +1841,11 @@ def maybe_load_dataloader_state(
         )
 
     print_rank_0(f"restoring dataloader state at iteration {iteration} from {data_state_load_path}")
-    loaded = energon_torch_load(data_state_load_path)
+    if msc is not None:
+        with msc.open(data_state_load_path, "rb") as state_file:
+            loaded = energon_torch_load(state_file)
+    else:
+        loaded = energon_torch_load(data_state_load_path)
     iterable.restore_state(loaded["dataloader_state_dict"])
 
 
@@ -3563,7 +3577,8 @@ def _load_base_checkpoint(
         checkpoint_path = load_dir
         # load_dir is the iter_N dir itself, so the checkpoint root (holding the energon/ sibling) is
         # one level up.
-        _record_dataloader_state_dir(checkpointing_context, os.path.dirname(os.path.normpath(load_dir)))
+        checkpoint_root = os.path.dirname(load_dir.rstrip(os.sep))
+        _record_dataloader_state_dir(checkpointing_context, checkpoint_root)
         ckpt_format = _get_checkpoint_format(checkpoint_path)
         if not rank0:
             print_rank_0(f" loading {ckpt_format} checkpoint directly from {checkpoint_path}")

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -21,7 +21,7 @@ import zipfile
 from collections import OrderedDict
 from dataclasses import fields
 from types import MappingProxyType, ModuleType
-from typing import cast
+from typing import BinaryIO, cast
 
 
 _BUILTIN_SAFE_TYPES = frozenset(
@@ -316,7 +316,7 @@ class _EnergonUnpickler(_NumpyRestrictedUnpickler):
         )
 
 
-def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
+def energon_torch_load(path: str | BinaryIO, *, map_location: str = "cpu") -> object:
     """Load an Energon dataloader state ``.pt`` file through a restricted unpickler.
 
     Parses the torch zip format directly without calling ``torch.load``.  Security is enforced
@@ -335,7 +335,7 @@ def energon_torch_load(path: str, *, map_location: str = "cpu") -> object:
     that tensors sharing a storage (views, slices) remain aliased after restore.
 
     Args:
-        path: Path to the ``.pt`` file written by
+        path: Path to or binary stream for the ``.pt`` file written by
             :func:`~megatron.bridge.training.checkpointing.maybe_save_dataloader_state`.
         map_location: Device to map tensor storages to; defaults to ``"cpu"`` to avoid GPU
             allocation during restore.

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -2439,6 +2439,38 @@ class TestLoadBaseCheckpoint:
 
         assert ctx["dataloader_state_dir"] == os.path.join("/ckpt", DATALOADER_STATE_SUBDIR)
 
+    @patch("megatron.bridge.training.checkpointing._load_global_dist_base_checkpoint")
+    @patch("megatron.bridge.training.checkpointing._get_checkpoint_format")
+    @patch("megatron.bridge.training.checkpointing._resolve_checkpoint_iteration")
+    def test_records_msc_dataloader_state_dir_one_level_up_for_direct_iteration(
+        self,
+        mock_resolve,
+        mock_get_format,
+        mock_load_global,
+        base_config,
+        mock_pg_collection,
+    ):
+        """A direct MSC iter_N path preserves its URI when recording the Energon sibling."""
+        MultiStorageClientFeature.enable()
+        mock_resolve.return_value = (_DIRECT_ITERATION_DIR_SENTINEL, False)
+        mock_get_format.return_value = "torch_dist"
+        mock_load_global.return_value = (
+            {"model": "x"},
+            "msc://default/ckpt/iter_0001000",
+            False,
+            CheckpointType.GLOBAL,
+        )
+
+        ctx = {}
+        _load_base_checkpoint(
+            "msc://default/ckpt/iter_0001000",
+            base_config,
+            checkpointing_context=ctx,
+            pg_collection=mock_pg_collection,
+        )
+
+        assert ctx["dataloader_state_dir"] == "msc://default/ckpt/energon"
+
     @patch("megatron.bridge.training.checkpointing.file_exists")
     @patch("megatron.bridge.training.checkpointing._get_non_persistent_iteration")
     @patch("megatron.bridge.training.checkpointing._resolve_checkpoint_iteration")
@@ -5040,6 +5072,21 @@ class TestMaybeLoadDataloaderState:
 
         train_iterator.iterable.restore_state.assert_called_once_with({"dummy_energon_state": "xyz"})
 
+    def test_restores_from_msc_file(self, tmp_path):
+        """An Energon state colocated with an MSC checkpoint restores through the remote adapter."""
+        MultiStorageClientFeature.enable()
+        msc = MultiStorageClientFeature.import_package()
+        state_root = f"msc://default{tmp_path}/energon"
+        iter_dir = get_checkpoint_name(state_root, 10)
+        msc.os.makedirs(iter_dir, exist_ok=True)
+        state_path = os.path.join(iter_dir, "train_dataloader_dprank000.pt")
+        msc.torch.save({"dataloader_state_dict": {"dummy_energon_state": "xyz"}}, state_path)
+        train_iterator = Mock()
+
+        maybe_load_dataloader_state(train_iterator, 10, state_root, pg_collection=self._pg())
+
+        train_iterator.iterable.restore_state.assert_called_once_with({"dummy_energon_state": "xyz"})
+
     def test_restores_energon_state_via_restricted_unpickler(self, tmp_path):
         """Energon dataclass and NumPy state round-trips correctly through the restricted zip loader."""
         from megatron.energon.flavors.webdataset.sample_loader import SliceState
@@ -5274,3 +5321,22 @@ class TestMaybeSaveDataloaderState:
         train_iterator.iterable.save_state.assert_called_once_with()
         _, saved_path = mock_save.call_args[0]
         assert saved_path.endswith("train_dataloader_dprank002.pt")
+
+    def test_writes_to_msc_path(self, tmp_path):
+        """An Energon state colocated with an MSC checkpoint is written through the remote adapter."""
+        MultiStorageClientFeature.enable()
+        msc = MultiStorageClientFeature.import_package()
+        state_root = f"msc://default{tmp_path}/energon"
+        train_iterator = self._iterator()
+
+        with patch("megatron.bridge.training.checkpointing.torch.distributed.barrier"):
+            maybe_save_dataloader_state(Mock(), train_iterator, 10, state_root, pg_collection=self._pg())
+
+        state_path = os.path.join(
+            get_checkpoint_name(state_root, 10),
+            "train_dataloader_dprank000.pt",
+        )
+        assert msc.os.path.isfile(state_path)
+        assert msc.torch.load(state_path, weights_only=True) == {
+            "dataloader_state_dict": {"dummy_energon_state": "xyz"}
+        }


### PR DESCRIPTION
## What changed

Energon resume now restores its per-DP-rank state when the checkpoint root is an enabled Multi-Storage Client (MSC) URI. The direct `iter_N` load path also preserves the `msc://` scheme when deriving the sibling `energon` directory.

## User impact and root cause

With MSC enabled, a supported training run can use an `msc://` checkpoint root and an Energon iterator. Model state resumes through MSC-aware readers, but the Energon sidecar restore previously used local `os.path.isdir` / `os.path.isfile` checks and passed the URI directly to `zipfile.ZipFile`. A present sidecar was therefore treated as absent, silently restarting the data stream. Loading a specific remote `iter_N` directory also passed the URI through `os.path.normpath`, changing `msc://` to `msc:/`.

The fix uses MSC-aware existence checks and `msc.open`, while retaining the restricted Energon unpickler. It uses the existing MSC-aware path join helper and avoids URI-destructive normalization.

## Validation

Regression command:

```shell
uv run --project /opt/Megatron-Bridge --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py -q --tb=short -k 'restores_from_msc_file or writes_to_msc_path or records_msc_dataloader_state_dir_one_level_up_for_direct_iteration'
```

- Before: 2 failed, 1 passed. Restore skipped a present MSC state, and direct iteration derived `msc:/...`; the save-side negative control passed.
- After: 3 passed.

Adjacent validation:

```shell
uv run --project /opt/Megatron-Bridge --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py -q --tb=short -k 'MaybeLoadDataloaderState or MaybeSaveDataloaderState or records_dataloader_state_dir'
```

- 22 passed.
- `git diff --check` passed.
- `uv run pre-commit run --all-files` passed.

## Scope

This is limited to Energon dataloader-state resume and direct-iteration path derivation with MSC enabled. It does not change model checkpoint formats, dataloader save semantics, parallelism behavior, or public configuration APIs. Validation used the configured MSC filesystem adapter; no model-quality, convergence, performance, GPU, or object-store end-to-end claim is made.
