### PR TITLE
[recipe] fix: preserve Gemma 4 checkpoint vocabulary

### DIFF
--- a/src/megatron/bridge/recipes/gemma/h100/gemma4.py
+++ b/src/megatron/bridge/recipes/gemma/h100/gemma4.py
@@ -22,7 +22,6 @@ import torch
 from megatron.bridge import AutoBridge
 from megatron.bridge.recipes.common import _pretrain_common
 from megatron.bridge.recipes.utils.environment_utils import COMMON_RECIPE_ENV_VARS
-from megatron.bridge.recipes.utils.tokenizer_utils import DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
 from megatron.bridge.training.config import ConfigContainer
 
 
@@ -72,7 +71,7 @@ def gemma4_e4b_pretrain_2gpu_h100_bf16_config() -> ConfigContainer:
     # Tokenizer — NullTokenizer for mock pre-training; override for real data
     cfg.tokenizer.tokenizer_type = "NullTokenizer"
     cfg.tokenizer.tokenizer_model = None
-    cfg.tokenizer.vocab_size = DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+    cfg.tokenizer.vocab_size = cfg.model.vocab_size
 
     # Dataset — mock data by default; override dataset.blend for real data
     cfg.dataset.blend = None

--- a/tests/unit_tests/recipes/test_gemma4_checkpoint_vocab.py
+++ b/tests/unit_tests/recipes/test_gemma4_checkpoint_vocab.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression coverage for Gemma 4 recipe checkpoint vocabulary ownership."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from megatron.bridge.models.gemma.gemma4_provider import Gemma4DenseProvider
+from megatron.bridge.recipes.gemma.h100 import gemma4 as gemma4_recipe
+from megatron.bridge.training.setup import _validate_and_set_vocab_size
+
+
+@pytest.mark.unit
+def test_gemma4_mock_recipe_preserves_checkpoint_embedding_rows() -> None:
+    """The mock-data recipe must allocate the converted checkpoint vocabulary."""
+    provider = Gemma4DenseProvider(vocab_size=262143, make_vocab_size_divisible_by=128)
+    bridge = Mock()
+    bridge.to_megatron_provider.return_value = provider
+
+    with patch.object(gemma4_recipe.AutoBridge, "from_hf_pretrained", return_value=bridge):
+        config = gemma4_recipe.gemma4_e4b_pretrain_2gpu_h100_bf16_config()
+
+    runtime_vocab_size, _ = _validate_and_set_vocab_size(
+        model_vocab_size=config.model.vocab_size,
+        tokenizer_vocab_size=config.tokenizer.vocab_size,
+        use_tokenizer_vocab_size=config.tokenizer.use_tokenizer_vocab_size,
+    )
+    checkpoint_rows = 262144
+    runtime_rows = (
+        (runtime_vocab_size + config.model.make_vocab_size_divisible_by - 1)
+        // config.model.make_vocab_size_divisible_by
+        * config.model.make_vocab_size_divisible_by
+    )
+
+    assert runtime_rows == checkpoint_rows


### PR DESCRIPTION
## Summary

Fix the Gemma 4 E4B mock-data recipe so its NullTokenizer preserves the bridge-derived model vocabulary required by converted checkpoints.

## Supported trigger and impact

The documented Gemma 4 pretraining script allows `TRAIN_DATA_PATH` to remain unset, selects mock data, and still initializes from the converted text checkpoint. The recipe inherited `use_tokenizer_vocab_size=True` but configured a 32K NullTokenizer, so setup replaced the provider's 262143 logical vocabulary before model construction. That allocated 32000 embedding/output rows for a checkpoint containing 262144 padded rows, preventing checkpoint-backed training from starting.

## Root cause and fix

`_pretrain_common()` intentionally lets from-scratch pretraining derive model vocabulary from the runtime tokenizer. Gemma 4's fixed checkpoint architecture therefore needs its mock tokenizer to describe the provider vocabulary. Set `tokenizer.vocab_size` from `cfg.model.vocab_size`; setup then retains the general tokenizer policy and pads to the checkpoint-compatible 262144 rows. Real Hugging Face tokenizer overrides remain runtime-derived.

## Validation

- Fail before: `uv run python -m pytest tests/unit_tests/recipes/test_gemma4_checkpoint_vocab.py -q` — `1 failed` (`32000 != 262144`).
- Pass after: same command — `1 passed`.
- Adjacent vocabulary setup/provider checks — `7 passed`.
- Common pretraining tokenizer policy check — `1 passed`.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed.

## Scope

This changes only the Gemma 4 E4B NullTokenizer default and adds a CPU contract regression. It does not alter tokenizer setup globally, conversion APIs, checkpoint formats, real-data tokenizer selection, or Megatron-Core.
