### PR TITLE
fix(training): clean up failed MegatronMIMO pretraining

### DIFF
--- a/src/megatron/bridge/training/pretrain_megatron_mimo.py
+++ b/src/megatron/bridge/training/pretrain_megatron_mimo.py
@@ -30,7 +30,7 @@ from typing import Callable, Optional
 import torch.distributed as dist
 
 from megatron.bridge.training.config import ConfigContainer, megatron_mimo_runtime_config_update
-from megatron.bridge.training.pretrain import _maybe_destroy_process_group
+from megatron.bridge.training.pretrain import _cleanup_after_pretrain_failure, _maybe_destroy_process_group
 from megatron.bridge.training.setup_megatron_mimo import setup_megatron_mimo
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.train import _finish_train
@@ -75,33 +75,37 @@ def pretrain_megatron_mimo(
     state = global_state if global_state is not None else GlobalState()
     state.cfg = cfg
 
-    # Setup: model, optimizer, schedulers, MPU bridging, checkpoint load, data iterators.
-    setup_output = setup_megatron_mimo(
-        state=state,
-        build_data_iterators_fn=build_data_iterators_fn,
-    )
+    try:
+        # Setup: model, optimizer, schedulers, MPU bridging, checkpoint load, data iterators.
+        setup_output = setup_megatron_mimo(
+            state=state,
+            build_data_iterators_fn=build_data_iterators_fn,
+        )
 
-    logger.info(f"Rank {dist.get_rank()}: Starting training loop")
+        logger.info(f"Rank {dist.get_rank()}: Starting training loop")
 
-    # Run training loop
-    train_megatron_mimo(
-        forward_step_func=forward_step_func,
-        model=setup_output.model,
-        optimizer=setup_output.optimizer,
-        schedulers=setup_output.schedulers,
-        train_data_iterator=setup_output.train_data_iterator,
-        valid_data_iterator=setup_output.valid_data_iterator,
-        global_state=setup_output.global_state,
-        megatron_mimo_infra=setup_output.megatron_mimo_infra,
-        multimodule_communicator=setup_output.multimodule_communicator,
-        checkpoint_manager=setup_output.checkpoint_manager,
-        multimodule_pg_collection=setup_output.multimodule_pg_collection,
-        module_to_grid_tuple=setup_output.module_to_grid_tuple,
-    )
+        # Run training loop
+        train_megatron_mimo(
+            forward_step_func=forward_step_func,
+            model=setup_output.model,
+            optimizer=setup_output.optimizer,
+            schedulers=setup_output.schedulers,
+            train_data_iterator=setup_output.train_data_iterator,
+            valid_data_iterator=setup_output.valid_data_iterator,
+            global_state=setup_output.global_state,
+            megatron_mimo_infra=setup_output.megatron_mimo_infra,
+            multimodule_communicator=setup_output.multimodule_communicator,
+            checkpoint_manager=setup_output.checkpoint_manager,
+            multimodule_pg_collection=setup_output.multimodule_pg_collection,
+            module_to_grid_tuple=setup_output.module_to_grid_tuple,
+        )
 
-    # Post-training cleanup: finalize async saves, shut down NVRx/FT, flush
-    # loggers, destroy GlobalState (which calls destroy_model_parallel internally).
-    _finish_train(setup_output.global_state, setup_output.checkpoint_manager)
+        # Post-training cleanup: finalize async saves, shut down NVRx/FT, flush
+        # loggers, destroy GlobalState (which calls destroy_model_parallel internally).
+        _finish_train(setup_output.global_state, setup_output.checkpoint_manager)
+    except BaseException:
+        _cleanup_after_pretrain_failure(state, should_destroy_process_group)
+        raise
 
     _maybe_destroy_process_group(should_destroy_process_group)
 

--- a/tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py
+++ b/tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py
@@ -258,6 +258,45 @@ def test_pretrain_megatron_mimo_calls_setup_and_train(
     mock_finish.assert_called_once()
 
 
+def test_pretrain_megatron_mimo_aborts_async_state_after_training_failure():
+    """MegatronMIMO should abort initialized async state after training fails."""
+    from megatron.bridge.training.pretrain_megatron_mimo import pretrain_megatron_mimo
+
+    cfg = _make_cfg()
+    state = MagicMock()
+    async_calls_queue = MagicMock()
+    state._async_calls_queue = async_calls_queue
+    failure = RuntimeError("training failed")
+    setup_output = _make_setup_output(module_to_grid_map={"language": MagicMock()})
+    setup_output.global_state = state
+
+    with (
+        patch("megatron.bridge.training.pretrain_megatron_mimo.dist") as mock_dist,
+        patch("megatron.bridge.training.pretrain_megatron_mimo.megatron_mimo_runtime_config_update"),
+        patch(
+            "megatron.bridge.training.pretrain_megatron_mimo.setup_megatron_mimo",
+            return_value=setup_output,
+        ),
+        patch("megatron.bridge.training.pretrain_megatron_mimo.train_megatron_mimo", side_effect=failure),
+        patch("megatron.bridge.training.pretrain.destroy_global_state") as mock_destroy_global_state,
+        patch("megatron.core.dist_checkpointing.strategies.filesystem_async._results_queue", None),
+        pytest.raises(RuntimeError, match="training failed") as exc_info,
+    ):
+        mock_dist.is_initialized.return_value = True
+        pretrain_megatron_mimo(
+            cfg=cfg,
+            forward_step_func=MagicMock(),
+            build_data_iterators_fn=MagicMock(),
+            global_state=state,
+        )
+
+    assert exc_info.value is failure
+    async_calls_queue.close.assert_called_once_with(abort=True)
+    assert state._async_calls_queue is None
+    mock_destroy_global_state.assert_called_once()
+    mock_dist.destroy_process_group.assert_not_called()
+
+
 def test_finish_train_calls_cleanup():
     """_finish_train should finalize async saves, shut down NVRx/FT, and flush loggers."""
     from megatron.bridge.training.train import _finish_train


### PR DESCRIPTION
## Summary

MegatronMIMO pretraining can leave an outstanding persistent async-checkpoint request and Megatron global state alive when training raises. A same-process retry can then reuse request index zero and finalize the retry from the abandoned session's completion, potentially publishing an incomplete checkpoint.

This wraps MIMO setup, training, and normal finalization in the established Bridge failure-cleanup path. The original exception is re-raised, framework-owned async/global state is aborted, and the caller-owned default process group remains intact.

This supersedes the unmerged, author-closed #5136 with current-base reproduction and validation.

## Root cause

`pretrain_megatron_mimo()` only finalized resources on success. Pinned MCore keeps the persistent completion queue process-wide while a new `AsyncCallsQueue` restarts request indices at zero. Without exceptional cleanup, an abandoned completion can therefore alias the retry's first request.

## Validation

- `uv run python -m pytest tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py::test_pretrain_megatron_mimo_aborts_async_state_after_training_failure -q`
  - Before: failed because `close(abort=True)` was never called.
  - After: passed (`1 passed`).
- `uv run python -m pytest tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py tests/unit_tests/training/test_pretrain.py::TestPretrainProcessGroupOwnership -q`
  - Passed (`13 passed`).
- `uv run python -m torch.distributed.run --standalone --nproc_per_node=2 reproduce_mimo_async_retry_stale_completion.py <output-dir>`
  - Before: failed after the retry finalized request zero from the abandoned session's completion.
  - After: passed with the unchanged reproducer.
- `uv run pre-commit run --all-files`: passed.
- `git diff --check`: passed.

## Scope

The regression covers failure during training after setup has returned initialized async state. It does not claim full-suite, convergence, model-quality, performance, or persistent-worker warmup-before-first-request validation.
