### PR TITLE
test(recipe): align Gemma 4 vocabulary assertion with checkpoint vocab

### DIFF
--- a/tests/unit_tests/recipes/test_gemma4_recipe.py
+++ b/tests/unit_tests/recipes/test_gemma4_recipe.py
@@ -196,7 +196,7 @@ class TestGemma4RecipeOverrides:
     def test_recipe_runtime_overrides(self, recipe_config):
         assert recipe_config.tokenizer.tokenizer_type == "NullTokenizer"
         assert recipe_config.tokenizer.tokenizer_model is None
-        assert recipe_config.tokenizer.vocab_size == 32000
+        assert recipe_config.tokenizer.vocab_size == 262143
         assert recipe_config.dataset.blend is None
         assert recipe_config.dataset.seq_length == 4096
         assert recipe_config.model.seq_length == 4096


### PR DESCRIPTION
# What does this PR do ?

Unblocks CI. `test_gemma4_recipe.py` still asserts the pre-#5531 Gemma 4 tokenizer vocabulary, so `Launch_Unit_Tests_Core` fails on every PR built on top of #5531.

# Changelog

- `tests/unit_tests/recipes/test_gemma4_recipe.py`: assert the tokenizer vocabulary is the converted checkpoint vocabulary (262143) instead of the old `NullTokenizer` default of 32000.

# Context

#5531 ("[recipe] fix: preserve Gemma 4 checkpoint vocabulary", 492446d) changed `recipes/gemma/h100/gemma4.py`:

```diff
-    cfg.tokenizer.vocab_size = DEFAULT_NULL_TOKENIZER_VOCAB_SIZE   # 32000
+    cfg.tokenizer.vocab_size = cfg.model.vocab_size                # 262143
```

It added `test_gemma4_checkpoint_vocab.py` covering the new behaviour, but the pre-existing assertion in `test_gemma4_recipe.py` still encoded the old behaviour. That test reaches the changed code through the compatibility alias `recipes/gemma/gemma4.py`, which re-exports `gemma4_e4b_pretrain_2gpu_h100_bf16_config`.

Resulting failure:

```
FAILED tests/unit_tests/recipes/test_gemma4_recipe.py::TestGemma4RecipeOverrides::test_recipe_runtime_overrides
AssertionError: assert 262143 == 32000
```

Observed on five PRs, none of which touch Gemma 4 — it is the only failure in each (e.g. #5367: `1 failed, 9178 passed`):

| PR | Failing job |
| --- | --- |
| #5394 | https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31626439277/job/94220966103 |
| #5367 | https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31622800804/job/94219068386 |
| #5519 | https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31623276080/job/94207614106 |
| #5354 | https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31612053562/job/94173567977 |
| #5479 | https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31613627243/job/94179540374 |

`Launch_Unit_Tests_Core` failing also fails the `Nemo_CICD_Test` aggregate, which is what blocks the merge.

# Note for the reviewer

The recipe no longer imports `tokenizer_utils`, so the `DEFAULT_NULL_TOKENIZER_VOCAB_SIZE = 32000` stub injected by the test's `_load_gemma4_recipe_module` helper is now dead scaffolding. Left in place to keep this change minimal; happy to remove it here or in a follow-up.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — test-only change; behaviour is already covered by `test_gemma4_checkpoint_vocab.py` from #5531
- [x] Did you add or update any necessary documentation? — n/a
- [ ] Does the PR affect components that are optional to install? — no

# Additional Information

- Follow-up to #5531

🤖 Generated with [Claude Code](https://claude.com/claude-code)