### PR TITLE
feat(training): enable MFSDP V2 gradient clipping

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1138,7 +1138,6 @@ class ConfigContainer(Container):
             "tensor_model_parallel_size",
             "pipeline_model_parallel_size",
             "context_parallel_size",
-            "expert_model_parallel_size",
         )
         configured_parallelisms = [
             f"{name}={getattr(self.model, name)}"
@@ -1147,11 +1146,33 @@ class ConfigContainer(Container):
         ]
         if configured_parallelisms:
             raise ValueError(
-                "MFSDP V2 currently supports DP-only training; unsupported settings: "
-                + ", ".join(configured_parallelisms)
+                "MFSDP V2 requires TP=PP=CP=1; unsupported settings: " + ", ".join(configured_parallelisms)
             )
-        if self.model.num_moe_experts is not None:
-            raise ValueError("MFSDP V2 does not currently support MoE models.")
+        if self.model.num_moe_experts is not None and self.model.expert_model_parallel_size == 1:
+            raise ValueError("MFSDP V2 MoE models require expert_model_parallel_size > 1.")
+        if self.model.expert_model_parallel_size > 1:
+            if self.model.num_moe_experts is None:
+                raise ValueError("MFSDP V2 expert parallelism requires an MoE model.")
+            if self.model.moe_token_dispatcher_type != "alltoall":
+                raise ValueError("MFSDP V2 MoE support requires moe_token_dispatcher_type='alltoall'.")
+            unsupported_moe_features = (
+                "moe_permute_fusion",
+                "moe_router_fusion",
+                "moe_shared_expert_overlap",
+                "overlap_moe_expert_parallel_comm",
+                "fine_grained_activation_offloading",
+            )
+            enabled_moe_features = [
+                feature for feature in unsupported_moe_features if getattr(self.model, feature, False)
+            ]
+            if getattr(self.model, "moe_flex_dispatcher_backend", None) is not None:
+                enabled_moe_features.append("moe_flex_dispatcher_backend")
+            if enabled_moe_features:
+                raise ValueError(
+                    "MFSDP V2 does not support MoE performance features: " + ", ".join(enabled_moe_features)
+                )
+            if getattr(self.model, "recompute_granularity", None) is not None:
+                raise ValueError("MFSDP V2 MoE support does not support activation recomputation.")
         if self.model.virtual_pipeline_model_parallel_size is not None:
             raise ValueError("MFSDP V2 does not currently support multiple model chunks.")
         if self.dist.use_tp_pp_dp_mapping:

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1167,8 +1167,6 @@ class ConfigContainer(Container):
             raise ValueError("MFSDP V2 checkpoint loading is not yet supported.")
         if self.optimizer.loss_scale is not None:
             raise ValueError("MFSDP V2 does not support loss scaling.")
-        if self.optimizer.clip_grad > 0.0:
-            raise ValueError("MFSDP V2 does not currently support gradient clipping.")
         if self.optimizer.use_precision_aware_optimizer:
             raise ValueError("MFSDP V2 does not support precision-aware optimizer.")
         if self.optimizer.optimizer_cpu_offload:

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1148,31 +1148,9 @@ class ConfigContainer(Container):
             raise ValueError(
                 "MFSDP V2 requires TP=PP=CP=1; unsupported settings: " + ", ".join(configured_parallelisms)
             )
-        if self.model.num_moe_experts is not None and self.model.expert_model_parallel_size == 1:
-            raise ValueError("MFSDP V2 MoE models require expert_model_parallel_size > 1.")
         if self.model.expert_model_parallel_size > 1:
             if self.model.num_moe_experts is None:
                 raise ValueError("MFSDP V2 expert parallelism requires an MoE model.")
-            if self.model.moe_token_dispatcher_type != "alltoall":
-                raise ValueError("MFSDP V2 MoE support requires moe_token_dispatcher_type='alltoall'.")
-            unsupported_moe_features = (
-                "moe_permute_fusion",
-                "moe_router_fusion",
-                "moe_shared_expert_overlap",
-                "overlap_moe_expert_parallel_comm",
-                "fine_grained_activation_offloading",
-            )
-            enabled_moe_features = [
-                feature for feature in unsupported_moe_features if getattr(self.model, feature, False)
-            ]
-            if getattr(self.model, "moe_flex_dispatcher_backend", None) is not None:
-                enabled_moe_features.append("moe_flex_dispatcher_backend")
-            if enabled_moe_features:
-                raise ValueError(
-                    "MFSDP V2 does not support MoE performance features: " + ", ".join(enabled_moe_features)
-                )
-            if getattr(self.model, "recompute_granularity", None) is not None:
-                raise ValueError("MFSDP V2 MoE support does not support activation recomputation.")
         if self.model.virtual_pipeline_model_parallel_size is not None:
             raise ValueError("MFSDP V2 does not currently support multiple model chunks.")
         if self.dist.use_tp_pp_dp_mapping:

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -19,12 +19,10 @@ from typing import Callable, Optional
 import pytest
 import torch
 import torch.nn.functional as F
-from megatron.core.optimizer.fully_sharded_optimizer import FullyShardedOptimizer
+from megatron.core.transformer.enums import AttnBackend
 
-import megatron.bridge.training.train as train_module
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
-from megatron.bridge.recipes.deepseek import deepseek_v3_pretrain_config
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
@@ -111,6 +109,19 @@ class DenseHybridSmokeModelProvider(HybridModelProvider):
     hybrid_layer_pattern: str | None = "**"
     vocab_size: int | None = None
     gradient_accumulation_fusion: bool = False
+
+
+@dataclass
+class MLAMoEHybridSmokeModelProvider(HybridModelProvider):
+    """Small MLA/MoE HybridModel configuration for the MFSDP V2 EP smoke test."""
+
+    attention_backend: AttnBackend = AttnBackend.auto
+    seq_length: int = 128
+    hidden_size: int = 128
+    multi_latent_attention: bool = True
+    hybrid_layer_pattern: str = "+E"
+    num_moe_experts: int = 4
+    expert_model_parallel_size: int = 2
 
 
 def create_fsdp_model_config(seq_length: int, bf16: bool = True, **kwargs) -> Llama3FSDPTestModelProvider:
@@ -429,94 +440,20 @@ class TestMegatronFSDP:
         torch.distributed.barrier()
 
     @pytest.mark.run_only_on("GPU")
-    def test_fsdp_v2_deepseek_v3_ep2_pretrain_smoke(self, monkeypatch):
-        """Train a small DeepSeek V3 MLA/MoE proxy with MFSDP V2 and EP=2."""
+    def test_fsdp_v2_mla_moe_ep2_pretrain_smoke(self):
+        """Train a small MLA/MoE HybridModel with MFSDP V2 and EP=2."""
         initialize_distributed()
         torch.distributed.barrier()
 
-        cfg = deepseek_v3_pretrain_config()
-        model_overrides = {
-            "num_layers": 2,
-            "moe_layer_freq": [0, 1],
-            "num_moe_experts": 4,
-            "hidden_size": 128,
-            "ffn_hidden_size": 256,
-            "moe_ffn_hidden_size": 128,
-            "num_attention_heads": 4,
-            "num_query_groups": 4,
-            "q_lora_rank": 64,
-            "kv_lora_rank": 32,
-            "qk_head_dim": 32,
-            "qk_pos_emb_head_dim": 16,
-            "v_head_dim": 32,
-            "seq_length": 128,
-            "tensor_model_parallel_size": 1,
-            "pipeline_model_parallel_size": 1,
-            "virtual_pipeline_model_parallel_size": None,
-            "context_parallel_size": 1,
-            "expert_model_parallel_size": 2,
-            "expert_tensor_parallel_size": 1,
-            "moe_token_dispatcher_type": "alltoall",
-            "moe_flex_dispatcher_backend": None,
-            "moe_permute_fusion": False,
-            "moe_router_fusion": False,
-            "moe_shared_expert_overlap": False,
-            "overlap_moe_expert_parallel_comm": False,
-            "fine_grained_activation_offloading": False,
-            "offload_modules": [],
-            "recompute_granularity": None,
-            "recompute_modules": None,
-            "mtp_num_layers": None,
-            "fp8": None,
-            "fp4": None,
-            "gradient_accumulation_fusion": False,
-            "bf16": True,
-            "params_dtype": torch.bfloat16,
-            "pipeline_dtype": torch.bfloat16,
-        }
-        for name, value in model_overrides.items():
-            if not hasattr(cfg.model, name):
-                raise ValueError(f"DeepSeek V3 config has no field {name!r}.")
-            setattr(cfg.model, name, value)
-
-        cfg.train.train_iters = 3
-        cfg.train.micro_batch_size = 1
-        cfg.train.global_batch_size = 2
-        cfg.dataset.seq_length = cfg.model.seq_length
-        cfg.validation.eval_interval = 4
-        cfg.validation.eval_iters = 0
-        cfg.checkpoint.save = None
-        cfg.checkpoint.load = None
+        cfg = create_fsdp_config_container(
+            seq_length=128,
+            train_iters=10,
+            optimizer={"clip_grad": 0.0},
+        )
+        cfg.model = MLAMoEHybridSmokeModelProvider()
         cfg.ddp.megatron_fsdp_version = 2
-        cfg.ddp.use_megatron_fsdp = True
-        cfg.ddp.use_distributed_optimizer = False
-        cfg.ddp.data_parallel_sharding_strategy = "optim_grads_params"
-        cfg.ddp.overlap_grad_reduce = False
-        cfg.ddp.overlap_param_gather = False
-        cfg.ddp.fp8_param_gather = False
-        cfg.optimizer.use_distributed_optimizer = False
-        cfg.optimizer.use_precision_aware_optimizer = False
-        cfg.optimizer.clip_grad = 0.0
-        cfg.optimizer.bf16 = True
-        cfg.optimizer.fp16 = False
 
-        reported_losses = []
-        original_train_step = train_module.train_step
-
-        def capture_train_step(*args, **kwargs):
-            model = kwargs["model"]
-            optimizer = kwargs["optimizer"]
-            assert type(model[0]).__name__ == "FullyShardedDataParallelV2"
-            assert isinstance(optimizer, FullyShardedOptimizer)
-            result = original_train_step(*args, **kwargs)
-            reported_losses.extend(result[0].values())
-            return result
-
-        monkeypatch.setattr(train_module, "train_step", capture_train_step)
         pretrain(cfg, forward_step)
-
-        assert reported_losses
-        assert all(torch.isfinite(loss).all() for loss in reported_losses)
         torch.distributed.barrier()
 
     @pytest.mark.run_only_on("GPU")

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -430,7 +430,6 @@ class TestMegatronFSDP:
         cfg = create_fsdp_config_container(
             seq_length=128,
             train_iters=10,
-            optimizer={"clip_grad": 0.0},
         )
         cfg.model = create_dense_hybrid_smoke_model_config()
         cfg.ddp.megatron_fsdp_version = 2
@@ -448,7 +447,6 @@ class TestMegatronFSDP:
         cfg = create_fsdp_config_container(
             seq_length=128,
             train_iters=10,
-            optimizer={"clip_grad": 0.0},
         )
         cfg.model = MLAMoEHybridSmokeModelProvider()
         cfg.ddp.megatron_fsdp_version = 2

--- a/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
+++ b/tests/functional_tests/test_groups/megatron_fsdp/test_megatron_fsdp.py
@@ -19,9 +19,12 @@ from typing import Callable, Optional
 import pytest
 import torch
 import torch.nn.functional as F
+from megatron.core.optimizer.fully_sharded_optimizer import FullyShardedOptimizer
 
+import megatron.bridge.training.train as train_module
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.recipes.deepseek import deepseek_v3_pretrain_config
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
@@ -423,6 +426,97 @@ class TestMegatronFSDP:
 
         pretrain(cfg, forward_step)
 
+        torch.distributed.barrier()
+
+    @pytest.mark.run_only_on("GPU")
+    def test_fsdp_v2_deepseek_v3_ep2_pretrain_smoke(self, monkeypatch):
+        """Train a small DeepSeek V3 MLA/MoE proxy with MFSDP V2 and EP=2."""
+        initialize_distributed()
+        torch.distributed.barrier()
+
+        cfg = deepseek_v3_pretrain_config()
+        model_overrides = {
+            "num_layers": 2,
+            "moe_layer_freq": [0, 1],
+            "num_moe_experts": 4,
+            "hidden_size": 128,
+            "ffn_hidden_size": 256,
+            "moe_ffn_hidden_size": 128,
+            "num_attention_heads": 4,
+            "num_query_groups": 4,
+            "q_lora_rank": 64,
+            "kv_lora_rank": 32,
+            "qk_head_dim": 32,
+            "qk_pos_emb_head_dim": 16,
+            "v_head_dim": 32,
+            "seq_length": 128,
+            "tensor_model_parallel_size": 1,
+            "pipeline_model_parallel_size": 1,
+            "virtual_pipeline_model_parallel_size": None,
+            "context_parallel_size": 1,
+            "expert_model_parallel_size": 2,
+            "expert_tensor_parallel_size": 1,
+            "moe_token_dispatcher_type": "alltoall",
+            "moe_flex_dispatcher_backend": None,
+            "moe_permute_fusion": False,
+            "moe_router_fusion": False,
+            "moe_shared_expert_overlap": False,
+            "overlap_moe_expert_parallel_comm": False,
+            "fine_grained_activation_offloading": False,
+            "offload_modules": [],
+            "recompute_granularity": None,
+            "recompute_modules": None,
+            "mtp_num_layers": None,
+            "fp8": None,
+            "fp4": None,
+            "gradient_accumulation_fusion": False,
+            "bf16": True,
+            "params_dtype": torch.bfloat16,
+            "pipeline_dtype": torch.bfloat16,
+        }
+        for name, value in model_overrides.items():
+            if not hasattr(cfg.model, name):
+                raise ValueError(f"DeepSeek V3 config has no field {name!r}.")
+            setattr(cfg.model, name, value)
+
+        cfg.train.train_iters = 3
+        cfg.train.micro_batch_size = 1
+        cfg.train.global_batch_size = 2
+        cfg.dataset.seq_length = cfg.model.seq_length
+        cfg.validation.eval_interval = 4
+        cfg.validation.eval_iters = 0
+        cfg.checkpoint.save = None
+        cfg.checkpoint.load = None
+        cfg.ddp.megatron_fsdp_version = 2
+        cfg.ddp.use_megatron_fsdp = True
+        cfg.ddp.use_distributed_optimizer = False
+        cfg.ddp.data_parallel_sharding_strategy = "optim_grads_params"
+        cfg.ddp.overlap_grad_reduce = False
+        cfg.ddp.overlap_param_gather = False
+        cfg.ddp.fp8_param_gather = False
+        cfg.optimizer.use_distributed_optimizer = False
+        cfg.optimizer.use_precision_aware_optimizer = False
+        cfg.optimizer.clip_grad = 0.0
+        cfg.optimizer.bf16 = True
+        cfg.optimizer.fp16 = False
+
+        reported_losses = []
+        original_train_step = train_module.train_step
+
+        def capture_train_step(*args, **kwargs):
+            model = kwargs["model"]
+            optimizer = kwargs["optimizer"]
+            assert type(model[0]).__name__ == "FullyShardedDataParallelV2"
+            assert isinstance(optimizer, FullyShardedOptimizer)
+            result = original_train_step(*args, **kwargs)
+            reported_losses.extend(result[0].values())
+            return result
+
+        monkeypatch.setattr(train_module, "train_step", capture_train_step)
+        pretrain(cfg, forward_step)
+
+        assert reported_losses
+        assert all(torch.isfinite(loss).all() for loss in reported_losses)
         torch.distributed.barrier()
 
     @pytest.mark.run_only_on("GPU")


### PR DESCRIPTION
## Summary

- allow `clip_grad > 0` for MFSDP V2
- let the dense and EP=2 V2 smoke tests use the normal clipping default (`1.0`)

## Dependencies

- Depends on the MFSDP V2 EP integration in #5521.
- Depends on MCore EP support in https://github.com/NVIDIA/Megatron-LM/pull/6450.
- MCore clipping coverage is added separately in https://github.com/NVIDIA/Megatron-LM/pull/6489.

## Validation

- MCore two-rank dense and EP=2 clipping coverage in https://github.com/NVIDIA/Megatron-LM/pull/6489.
- `uv run pre-commit run --all-files`
- Bridge two-rank smokes were not runnable in this worktree: its committed MCore submodule is intentionally pinned before #6450, and the isolated local environment failed while building `fast-hadamard-transform` because it does not declare Torch as a build dependency.