### PR TITLE
fix(deepseek): default DeepSeek V4 to HybridEP

### DIFF
--- a/examples/models/deepseek_v4/README.md
+++ b/examples/models/deepseek_v4/README.md
@@ -61,6 +61,17 @@ performance features, so it is not a supported runtime for that recipe.
 - `slurm_pretrain.sh` runs the DeepSeek-V4-Flash pretraining recipes.
 - `slurm_sft.sh` runs DeepSeek-V4-Flash full SFT end to end (import, then fine-tune) on Hopper or Blackwell, with MTP on or off.
 
+Bridge-created DeepSeek-V4 providers default to the `flex`/HybridEP MoE
+dispatcher with 16 dispatcher SMs and unfused HybridEP permutation. Native
+Megatron checkpoints retain the dispatcher configuration with which they were
+saved, so older checkpoints may still use `alltoall`. HybridEP requires a
+runtime containing the HybridEP package. It auto-detects accessible ranks and
+fabric support when its topology environment variables are unset. To override
+detection, set
+`NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN`, `NVLINK_DOMAIN_SIZE`, and
+`USE_MNNVL` to values that describe the actual deployment. Hardware recipes
+retain their independently qualified dispatcher overrides.
+
 Run `bash conversion.sh` after setting `WORKSPACE` and `MODEL_VARIANT`. See each script's header comments for the expected environment variables and `#SBATCH` directives to edit before submitting.
 
 ## Pretraining Recipes

--- a/examples/models/deepseek_v4/inference.sh
+++ b/examples/models/deepseek_v4/inference.sh
@@ -22,8 +22,13 @@
 #   EP: expert-parallel size (default: 4 for Flash, 8 for Pro)
 #   PP: pipeline-parallel size (default: 1 for Flash, 4 for Pro)
 #   PROMPT: prompt string (default: "Explain hyper-connections in transformer models.")
+#   NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: optional HybridEP topology override
+#   NVLINK_DOMAIN_SIZE: optional physical NVLink-domain size override
+#   USE_MNNVL: optional HybridEP fabric override (0 or 1)
 #
 # Defaults below are for GB200 (192 GB). For H100 (80 GB) configs, see README.md.
+# HybridEP auto-detects accessible ranks and fabric support when the topology
+# overrides are unset. If set, the values must describe the actual deployment.
 
 set -xeuo pipefail
 

--- a/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_bridge.py
@@ -481,7 +481,10 @@ class DeepSeekV4Bridge(MegatronModelBridge):
         provider.gated_linear_unit = True
         provider.moe_grouped_gemm = True
         provider.moe_router_pre_softmax = False  # V4 uses post-topk normalisation
-        provider.moe_token_dispatcher_type = "alltoall"
+        provider.moe_token_dispatcher_type = "flex"
+        provider.moe_flex_dispatcher_backend = "hybridep"
+        provider.moe_flex_dispatcher_num_sms = 16
+        provider.moe_permute_fusion_into_hybridep = False
         provider.moe_router_load_balancing_type = "noaux_tc"
         provider.moe_shared_expert_overlap = True
         provider.moe_router_score_function = hf_config.scoring_func  # "sqrtsoftplus"

--- a/src/megatron/bridge/perf_recipes/deepseek/gb200/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb200/deepseek_v4.py
@@ -44,7 +44,6 @@ def deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
     cfg.model.moe_token_dispatcher_type = "flex"
     cfg.model.moe_shared_expert_overlap = False
-    cfg.model.moe_hybridep_num_sms = 32
     cfg.model.moe_hybridep_num_sms_preprocessing = 108
     cfg.model.moe_router_fusion = True
     cfg.model.moe_router_force_load_balancing = True
@@ -60,6 +59,8 @@ def deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.fine_grained_offloading_max_inflight_offloads = None
 
     _benchmark_common(cfg, cross_entropy_impl="native")
+    cfg.model.moe_flex_dispatcher_num_sms = 32
+    cfg.model.moe_hybridep_num_sms = None
 
     set_full_iteration_cuda_graph(cfg.model)
     cfg.model.cuda_graph_warmup_steps = 3

--- a/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/gb300/deepseek_v4.py
@@ -72,6 +72,8 @@ def deepseek_v4_pro_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.model.recompute_modules = ["mla_up_proj", "mhc"]
 
     _benchmark_common(cfg, cross_entropy_impl="native")
+    cfg.model.moe_flex_dispatcher_num_sms = 32
+    cfg.model.moe_hybridep_num_sms = None
 
     cfg.model.cuda_graph_impl = "full_iteration"
     cfg.model.cuda_graph_scope = []

--- a/src/megatron/bridge/recipes/deepseek/gb200/deepseek_v4.py
+++ b/src/megatron/bridge/recipes/deepseek/gb200/deepseek_v4.py
@@ -80,7 +80,8 @@ def deepseek_v4_flash_pretrain_64gpu_gb200_bf16_config() -> ConfigContainer:
 
     cfg.model.moe_token_dispatcher_type = "flex"
     cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_hybridep_num_sms = 16
+    cfg.model.moe_flex_dispatcher_num_sms = 16
+    cfg.model.moe_hybridep_num_sms = None
     cfg.model.moe_grouped_gemm = True
     cfg.model.moe_permute_fusion = True
     cfg.model.moe_aux_loss_coeff = 0.0

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_bridge.py
@@ -427,6 +427,24 @@ class TestDeepSeekV4RotaryPercent:
         assert out.csa_compress_rotary_base == 160000
 
 
+class TestDeepSeekV4MoEDispatcher:
+    """DeepSeek-V4 providers use the inference-validated HybridEP path."""
+
+    def test_provider_bridge_uses_hybridep(self):
+        hf_pretrained = MagicMock()
+        hf_pretrained.config = _deepseek_v4_hf_config()
+        provider = MagicMock()
+
+        bridge = DeepSeekV4Bridge.__new__(DeepSeekV4Bridge)
+        with patch.object(MegatronModelBridge, "provider_bridge", return_value=provider):
+            out = bridge.provider_bridge(hf_pretrained)
+
+        assert out.moe_token_dispatcher_type == "flex"
+        assert out.moe_flex_dispatcher_backend == "hybridep"
+        assert out.moe_flex_dispatcher_num_sms == 16
+        assert out.moe_permute_fusion_into_hybridep is False
+
+
 class TestDeepSeekV4HardwareDefaults:
     """DSv4 Blackwell-only fused kernels must not default on for Hopper."""
 

--- a/tests/unit_tests/recipes/test_deepseek_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_recipes.py
@@ -459,6 +459,33 @@ def test_deepseek_v4_base_recipe_uses_blackwell_defaults(monkeypatch: pytest.Mon
 
 
 @pytest.mark.parametrize(
+    ("recipe_name", "expected_dispatcher"),
+    [
+        ("deepseek_v4_flash_pretrain_config", "alltoall"),
+        ("deepseek_v4_flash_pretrain_mxfp8_config", "alltoall"),
+        ("deepseek_v4_flash_pretrain_muon_config", "alltoall"),
+        ("deepseek_v4_flash_sft_config", "alltoall"),
+        ("deepseek_v4_flash_no_mtp_sft_config", "alltoall"),
+        ("deepseek_v4_pro_pretrain_config", "alltoall"),
+        ("deepseek_v4_pro_pretrain_mxfp8_config", "alltoall"),
+        ("deepseek_v4_flash_pretrain_gb200_config", "flex"),
+        ("deepseek_v4_flash_pretrain_mxfp8_gb200_config", "flex"),
+        ("deepseek_v4_flash_pretrain_muon_gb200_config", "flex"),
+    ],
+)
+def test_deepseek_v4_recipes_keep_hardware_qualified_dispatcher(
+    recipe_name: str, expected_dispatcher: str, monkeypatch: pytest.MonkeyPatch
+):
+    cfg = _build_deepseek_v4_recipe(recipe_name, monkeypatch)
+
+    assert cfg.model.moe_token_dispatcher_type == expected_dispatcher
+    if expected_dispatcher == "flex":
+        assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+        assert cfg.model.moe_flex_dispatcher_num_sms == 16
+        assert cfg.model.moe_hybridep_num_sms is None
+
+
+@pytest.mark.parametrize(
     "recipe_name",
     [
         "deepseek_v4_flash_pretrain_config",

--- a/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
@@ -50,7 +50,8 @@ def test_deepseek_v4_flash_128gpu_gb200_fp8mx_config() -> None:
     assert cfg.model.moe_token_dispatcher_type == "flex"
     assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
     assert cfg.model.moe_router_force_load_balancing is True
-    assert cfg.model.moe_hybridep_num_sms == 32
+    assert cfg.model.moe_flex_dispatcher_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms is None
     assert cfg.model.moe_hybridep_num_sms_preprocessing == 108
     assert cfg.model.recompute_granularity == "selective"
     assert cfg.model.recompute_modules == ["mla_up_proj"]
@@ -121,4 +122,6 @@ def test_deepseek_v4_flash_128gpu_gb300_fp8mx_config() -> None:
     assert cfg.train.global_batch_size == 2048
     assert cfg.train.micro_batch_size == 1
     assert cfg.model.recompute_modules == ["mla_up_proj"]
+    assert cfg.model.moe_flex_dispatcher_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms is None
     assert is_full_iteration_cuda_graph(cfg.model)

--- a/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
+++ b/tests/unit_tests/recipes/test_r050_perf_recipe_ports.py
@@ -178,6 +178,8 @@ def test_deepseek_v4_pro_gb300_matches_r050_performance_config() -> None:
     assert cfg.model.recompute_modules == ["mla_up_proj", "mhc"]
     assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
     assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms is None
     assert cfg.model.moe_shared_expert_overlap is False
 
     assert cfg.model.cuda_graph_impl == "full_iteration"


### PR DESCRIPTION
# What does this PR do?

Default Bridge-created DeepSeek-V4 providers to the `flex`/HybridEP MoE dispatcher with 16 dispatcher SMs and unfused HybridEP permutation. This avoids the standard unequal-split all-to-all path that produced non-finite logits and degenerate token-0 generation in the affected multi-node Hopper inference configuration.

Fixes NVBug 6595026.

Related to #5462.

# Changelog

- Set the DeepSeek-V4 provider's dispatcher defaults to `flex`/HybridEP, 16 dispatcher SMs, and unfused HybridEP permutation.
- Move DeepSeek-V4 GB200/GB300 recipe SM overrides to the current unified field so their independently tuned 16/32-SM values retain precedence.
- Document HybridEP runtime and topology auto-detection/override behavior in the DeepSeek-V4 example.
- Add focused assertions for the provider defaults and final hardware/performance recipe configurations.

# Scope

The provider default applies to newly constructed Bridge DeepSeek-V4 providers, including the direct-HF inference path. Native Megatron checkpoints retain their serialized dispatcher configuration. Library recipes also retain their explicit, independently qualified overrides: H100 and GB300 library recipes remain on `alltoall`, while GB200 library recipes remain on HybridEP. Existing GB200/GB300 HybridEP performance recipes retain their tuned 32-SM setting.

The generic text-generation utility is unchanged. The repository still contains intentional `alltoall` configurations because token dropping and MoE Multi-LoRA require the standard dispatcher, and because dispatcher support and performance depend on the installed runtime, hardware, and topology.

# Validation

- Full DeepSeek-V4-Flash-Base inference, 2 nodes / 16 H100 GPUs, TP1/PP1/EP16/ETP1, 20 generated tokens, using the provider default without dispatcher CLI overrides and with `NCCL_NET` and all three optional HybridEP topology overrides unset:
  - runtime resolved `flex`/HybridEP, 16 dispatcher SMs, and unfused HybridEP permutation;
  - first-five variances were `25.2412, 26.2589, 27.4498, 28.1335, 28.3474`, token IDs were `1730, 696, 851, 1346, 538`, and the completion was coherent and matched the known-good control.
- Focused DeepSeek-V4 provider, library-recipe, and performance-recipe tests: 86 passed.
- `uv run --no-sync pre-commit run --all-files`: passed locally and in the exact candidate container.
- `git diff --check`, Python compile checks, and `bash -n examples/models/deepseek_v4/inference.sh`: passed.

The controlled end-to-end validation covers full-model inference only; this PR does not make a training convergence or performance claim.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression tests.
- [x] Updated the DeepSeek-V4 example documentation.
- [x] The change selects the container-provided HybridEP runtime but adds no direct optional-package import or dependency.

This change was developed with assistance from OpenAI Codex.
