### PR TITLE
[model] fix: preserve Step3.7 projector bias

### DIFF
--- a/src/megatron/bridge/models/stepfun/step37_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step37_bridge.py
@@ -119,6 +119,9 @@ class Step37Bridge(MegatronModelBridge):
         mtp_num_layers = hf_config.pop("num_nextn_predict_layers", None)
         if mtp_num_layers is not None:
             hf_config["text_config"] = {"num_nextn_predict_layers": mtp_num_layers}
+        projector_bias = getattr(provider, "projector_bias", None)
+        if projector_bias is not None:
+            hf_config["projector_bias"] = projector_bias
         return hf_config
 
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> Step37ModelProvider:
@@ -535,6 +538,7 @@ class Step37Bridge(MegatronModelBridge):
             # inside ``image_insert_embedding.align_projector``; on the HF side
             # it is the top-level ``vit_large_projector`` linear.
             "image_insert_embedding.align_projector.weight": "vit_large_projector.weight",
+            "image_insert_embedding.align_projector.bias": "vit_large_projector.bias",
         }
         for megatron_param, hf_param in vision_replicated_param_mappings.items():
             mapping_list.append(ReplicatedMapping(megatron_param=megatron_param, hf_param=hf_param))

--- a/tests/unit_tests/models/stepfun/test_step37_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step37_bridge.py
@@ -17,10 +17,13 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from torch import nn
+
 from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.stepfun import step37_bridge as _step37_bridge_mod
 from megatron.bridge.models.stepfun.configuration_step37 import Step37Config
 from megatron.bridge.models.stepfun.modelling_step37 import transformer_block as _step37_block_mod
+from megatron.bridge.models.stepfun.modelling_step37.image_insert_embedding import ImageInsertEmbedding
 from megatron.bridge.models.stepfun.modelling_step37.transformer_block import get_step37_text_layer_spec
 from megatron.bridge.models.stepfun.step35_bridge import build_step35_layer_spec
 from megatron.bridge.models.stepfun.step37_bridge import Step37Bridge
@@ -95,6 +98,27 @@ class TestStep37BridgeReverseConfig:
         synthesized_config = Step37Config(**exported_config)
 
         assert synthesized_config.text_config.num_nextn_predict_layers == 0
+
+    def test_projector_bias_schema_roundtrips(self):
+        reference_config = Step37Config(projector_bias=False)
+        provider = SimpleNamespace(projector_bias=True)
+
+        biased_projector = ImageInsertEmbedding(nn.Identity(), 4, 2, projector_bias=provider.projector_bias)
+        unbiased_projector = ImageInsertEmbedding(nn.Identity(), 4, 2, projector_bias=False)
+        assert biased_projector.align_projector.bias is not None
+        assert unbiased_projector.align_projector.bias is None
+
+        mapping = (
+            Step37Bridge().mapping_registry().megatron_to_hf_lookup("image_insert_embedding.align_projector.bias")
+        )
+        checkpoint_config = Step37Bridge.megatron_to_hf_config(provider)
+        exported_config = conform_config_to_reference(checkpoint_config, reference_config.to_dict())
+        synthesized_config = Step37Config(**exported_config)
+
+        assert (
+            mapping.hf_param if mapping is not None else None,
+            synthesized_config.projector_bias,
+        ) == ("vit_large_projector.bias", True)
 
 
 class TestGetStep37TextLayerSpec:


### PR DESCRIPTION
## Summary

Step3.7 conversion now preserves the optional vision-to-language projector bias in both the parameter mapping and exported Hugging Face configuration.

## Supported trigger and impact

`projector_bias` is an explicit Step3.7 architecture option implemented by the Hugging Face config/model and by Bridge's config, provider, and runtime model. Setting it to `true` creates `image_insert_embedding.align_projector.bias` in Megatron and `vit_large_projector.bias` in Hugging Face.

Before this change, the Step3.7 mapping registry had no entry for that parameter. Ordinary HF-to-Megatron and Megatron-to-HF conversion therefore built an unmapped conversion-task slot and failed when the standard path dereferenced it. Checkpoint-derived HF config synthesis also omitted `projector_bias`, so reference conformance could restore the published reference value `false` and construct the wrong state schema.

The published Step3.7 checkpoint uses `projector_bias=false` and is unaffected.

## Fix

- Add a replicated `image_insert_embedding.align_projector.bias` to `vit_large_projector.bias` mapping.
- Preserve checkpoint-derived `projector_bias` in Step3.7 reverse config synthesis.

This is family-local and does not change dependencies, workflows, public API signatures, or the pinned Megatron-Core submodule.

## Regression evidence

The focused regression first verifies that `projector_bias=true` creates a runtime parameter while the false negative-control does not. It then asserts both the parameter mapping and checkpoint-derived exported schema.

Fail-before on the unmodified base:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/stepfun/test_step37_bridge.py::TestStep37BridgeReverseConfig::test_projector_bias_schema_roundtrips -q
1 failed: assert (None, False) == ("vit_large_projector.bias", True)
```

Pass-after with the unchanged regression:

```text
1 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest \
  tests/unit_tests/models/stepfun/test_step37_bridge.py \
  tests/unit_tests/models/stepfun/test_configuration_step37.py \
  tests/unit_tests/models/test_model_bridge.py::test_modelopt_plan_skips_unmapped_task_slot_and_keeps_later_task -q
9 passed
```

`git diff --check` and `uv run --no-sync pre-commit run --all-files` also pass.

## Scope

No full-suite, GPU, model-quality, convergence, or performance validation is claimed. The regression and adjacent checks are CPU config/mapping unit tests.
