### PR TITLE
[ckpt] fix: Save Energon state through MSC

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1765,7 +1765,11 @@ def maybe_save_dataloader_state(
 
     dataloader_save_dict = {}
     dataloader_save_dict["dataloader_state_dict"] = train_dataloader_state_dict
-    torch.save(dataloader_save_dict, data_state_save_path)
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        msc.torch.save(dataloader_save_dict, data_state_save_path)
+    else:
+        torch.save(dataloader_save_dict, data_state_save_path)
 
 
 def maybe_load_dataloader_state(

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5340,3 +5340,34 @@ class TestMaybeSaveDataloaderState:
         assert msc.torch.load(state_path, weights_only=True) == {
             "dataloader_state_dict": {"dummy_energon_state": "xyz"}
         }
+
+    @patch("megatron.bridge.training.checkpointing.torch.save")
+    @patch("megatron.bridge.training.checkpointing.ensure_directory_exists")
+    @patch("megatron.bridge.training.checkpointing.get_checkpoint_name")
+    def test_writes_nondefault_msc_uri_through_remote_adapter(
+        self, mock_get_checkpoint_name, mock_ensure_directory, mock_torch_save
+    ):
+        """A named MSC profile must not be passed to PyTorch's local-path serializer."""
+        mock_get_checkpoint_name.return_value = "msc://named/checkpoints/energon/iter_0000010"
+        msc = Mock()
+        train_iterator = self._iterator()
+
+        with (
+            patch.object(MultiStorageClientFeature, "is_enabled", return_value=True),
+            patch.object(MultiStorageClientFeature, "import_package", return_value=msc),
+            patch("megatron.bridge.training.checkpointing.torch.distributed.barrier"),
+        ):
+            maybe_save_dataloader_state(
+                Mock(),
+                train_iterator,
+                10,
+                "msc://named/checkpoints/energon",
+                pg_collection=self._pg(),
+            )
+
+        expected_path = "msc://named/checkpoints/energon/iter_0000010/train_dataloader_dprank000.pt"
+        mock_ensure_directory.assert_called_once_with(expected_path)
+        msc.torch.save.assert_called_once_with(
+            {"dataloader_state_dict": {"dummy_energon_state": "xyz"}}, expected_path
+        )
+        mock_torch_save.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Route Energon dataloader-state serialization through Multi-Storage Client when MSC is enabled.

## User impact and root cause

Training with a savable Energon iterator and a named remote `msc://<profile>/...` checkpoint root could not create checkpoints. Bridge correctly created the remote dataloader-state directory through MSC, but then passed the retained MSC URI to plain `torch.save`, which treats it as a local path and raises before the native model checkpoint is written or asynchronously scheduled.

The default `msc://default/...` profile canonicalizes to a local path, so the existing MSC save test did not exercise this failure.

The fix uses `msc.torch.save` whenever MSC is enabled, matching the existing remote restore path, while preserving plain `torch.save` for local filesystems.

## Verification

Fail before, using the base revision's exact helper with a named MSC URI:

```text
python reproduce_msc_energon_save.py
RuntimeError: Parent directory msc://named/checkpoints/energon/iter_0000010 does not exist.
```

The unchanged reproducer passes after the fix.

Focused and adjacent unit coverage in the project container:

```text
uv run python -m pytest \
  tests/unit_tests/training/test_checkpointing.py::TestMaybeSaveDataloaderState \
  tests/unit_tests/training/test_checkpointing.py::TestMaybeLoadDataloaderState \
  -q --tb=short
20 passed
```

Quality gates:

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This changes only Energon dataloader-state serialization when MSC is enabled and adds a focused CPU unit regression. It does not change public APIs, dependencies, CI workflows, Megatron-Core, checkpoint formats, retention behavior, or model state serialization. No full-suite, GPU/distributed, model-quality, convergence, or performance validation is claimed.
