### PR TITLE
fix(misc): surface failed async inference requests

### DIFF
--- a/scripts/inference/async_text_generation.py
+++ b/scripts/inference/async_text_generation.py
@@ -116,6 +116,10 @@ async def _generate(
     ) as llm:
         if llm.is_primary_rank:
             results = await asyncio.gather(*(llm.generate(prompt, sampling_params) for prompt in prompts))
+            failed_results = [result for result in results if result.failed()]
+            if failed_results:
+                details = ", ".join(f"request {result.request_id}={result.status.name}" for result in failed_results)
+                raise RuntimeError(f"Async inference failed: {details}")
             print_rank_0("======== ASYNC GENERATED TEXT OUTPUT ========")
             for idx, result in enumerate(results):
                 print_rank_0(f"[{idx}] Prompt: {prompts[idx]}")

--- a/tests/unit_tests/scripts/test_async_text_generation_entrypoint.py
+++ b/tests/unit_tests/scripts/test_async_text_generation_entrypoint.py
@@ -60,6 +60,7 @@ class _AsyncLLM:
             generated_log_probs=[-0.3],
             prompt_top_n_logprobs=[{"prompt-token": -0.1}],
             generated_top_n_logprobs=[{"generated-token": -0.3}],
+            failed=lambda: False,
         )
 
 
@@ -151,3 +152,44 @@ def test_generate_prints_requested_log_probabilities(
     assert "Generated log probs: [-0.3]" in rendered
     assert "Prompt top-n logprobs: [{'prompt-token': -0.1}]" in rendered
     assert "Generated top-n logprobs: [{'generated-token': -0.3}]" in rendered
+
+
+@pytest.mark.unit
+def test_generate_rejects_failed_inference_requests(
+    async_text_generation_entrypoint: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _failed_generate(_self, _prompt, _sampling_params):
+        return types.SimpleNamespace(
+            request_id=7,
+            status=types.SimpleNamespace(name="FAILED"),
+            generated_text="",
+            failed=lambda: True,
+        )
+
+    monkeypatch.setattr(_AsyncLLM, "generate", _failed_generate)
+    args = types.SimpleNamespace(
+        max_seq_length=32,
+        max_new_tokens=2,
+        max_batch_size=None,
+        tp=1,
+        block_size_tokens=8,
+        kv_cache_buffer_size_gb=1.0,
+        max_tokens=None,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+        coordinator_host=None,
+        coordinator_port=None,
+    )
+    tokenizer = types.SimpleNamespace(tokenize=lambda prompt: [1, 2])
+
+    with pytest.raises(RuntimeError, match="request 7.*FAILED"):
+        asyncio.run(
+            async_text_generation_entrypoint._generate(
+                args,
+                model=object(),
+                tokenizer=tokenizer,
+                prompts=["prompt"],
+                sampling_params=object(),
+            )
+        )


### PR DESCRIPTION
# What does this PR do ?

Make the standalone async text-generation CLI exit nonzero when MCore returns a failed inference request.

MCore represents request-admission failures as completed request values rather than exceptions. For example, a prompt that exceeds the configured active-token limit while chunked prefill is disabled is returned with `Status.FAILED`. The Bridge CLI previously rendered that value as an empty generation and exited successfully, so shell and scheduler automation could not distinguish a rejected request from successful inference.

After gathering the batch, the CLI now checks MCore's public `failed()` contract and raises with the failed request IDs and statuses before printing successful output. Async-context cleanup and process-group teardown remain unchanged.

# Changelog

- Surface failed async inference requests as a process failure.
- Add a regression covering a failed MCore request value.
- Keep successful text and log-probability rendering unchanged.

# Validation

Fail-before:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_async_text_generation_entrypoint.py -q
1 failed, 1 passed
Failed: DID NOT RAISE <class 'RuntimeError'>
```

Pass-after and adjacent coverage:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_async_text_generation_entrypoint.py \
  tests/unit_tests/scripts/test_openai_server_entrypoint.py \
  tests/unit_tests/scripts/test_text_generation_entrypoint.py \
  tests/unit_tests/scripts/inference/test_setup_inference.py -q
41 passed
```

```text
uv run --no-sync pre-commit run --all-files
Passed

uv run --no-sync mypy --strict scripts/inference/async_text_generation.py
Passed

git diff --check
Passed
```

The verification reused an already synchronized development environment because the pinned resiliency package has no wheel for this workstation's glibc. No dependency or lockfile changes are included.

# Scope

This change only affects the standalone async text-generation CLI's handling of completed failed requests. It does not change MCore request semantics, the OpenAI server, synchronous generation, model loading, or distributed cleanup. No GPU functional test, full test suite, convergence, quality, or performance validation was run.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added the necessary regression test.
- [x] No documentation update is needed; the documented CLI now reports failures accurately.
- [x] No optional-install component is affected.

# Additional Information

No existing issue or open pull request was found for this root cause.
