### PR TITLE
fix(ci): run tests after queue bypass

### DIFF
--- a/.github/scripts/test_queue_bypass.sh
+++ b/.github/scripts/test_queue_bypass.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow="${1:-.github/workflows/cicd-main.yml}"
+
+awk '
+  function check_job() {
+    if (!in_queue_chain || !has_success) {
+      return
+    }
+
+    checked++
+    if (!allows_queue_bypass) {
+      print job " uses success() but does not allow the intentional queue skip" > "/dev/stderr"
+      failed = 1
+    }
+  }
+
+  /^  [[:alnum:]_-]+:$/ {
+    check_job()
+    job = $1
+    sub(/:$/, "", job)
+    in_queue_chain = (in_queue_chain || job == "cicd-compute-build-matrix")
+    if (job == "Nemo_CICD_Test") {
+      in_queue_chain = 0
+    }
+    has_success = 0
+    allows_queue_bypass = 0
+    next
+  }
+
+  in_queue_chain && /success\(\)/ {
+    has_success = 1
+  }
+
+  in_queue_chain && /needs\.configure\.outputs\.skip_queue == '\''true'\'' && !failure\(\)/ {
+    allows_queue_bypass = 1
+  }
+
+  END {
+    check_job()
+    if (checked == 0) {
+      print "No queue-dependent success() conditions found" > "/dev/stderr"
+      exit 1
+    }
+    exit failed
+  }
+' "$workflow"

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -287,6 +287,7 @@ jobs:
         run: |
           .github/scripts/test_cache_keys.sh
           .github/scripts/test_docker_dependency_layers.sh
+          .github/scripts/test_queue_bypass.sh
 
       - name: Check lint
         run: |
@@ -317,7 +318,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
-        || needs.configure.outputs.skip_queue == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -358,6 +359,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -537,6 +539,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -568,6 +571,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -609,6 +613,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -657,6 +662,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -719,6 +725,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -766,6 +773,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -814,6 +822,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -901,6 +910,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -963,6 +973,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -1018,6 +1029,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )
@@ -1074,6 +1086,7 @@ jobs:
       (
         success()
         || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || (needs.configure.outputs.skip_queue == 'true' && !failure())
         || needs.pre-flight.outputs.force_run_all == 'true'
         || github.event_name == 'merge_group'
       )


### PR DESCRIPTION
## Background

PR #5550 intentionally skips `cicd-wait-in-queue` for automated MCore bump PRs. The skipped job remains a transitive dependency, so every downstream job-level `success()` evaluated false. In run `31681436301`, the build matrix succeeded, but the container build, unit tests, and functional matrices/jobs were skipped.

## What changed

Propagate the intentional `skip_queue` exception through each downstream status gate. Pair the exception with `!failure()` so a real ancestor failure still blocks downstream work.

Add a workflow invariant test that scans the queue-dependent job chain and fails if a `success()` gate omits the guarded queue-bypass condition.

## Details

```mermaid
flowchart LR
  A[Configure skip_queue] --> B[Queue job skipped]
  B --> C[Compute build matrix]
  C --> D[Container builds]
  D --> E[Import and unit tests]
  D --> F[H100 and GB200 matrices]
  E --> G[Functional tests]
  F --> G
```

Each queue-dependent gate accepts either ordinary success or `skip_queue == 'true' && !failure()`. Existing tier, event, cancellation, membership, and performance-only conditions remain unchanged.

## Tested

- Live regression evidence: workflow run `31681436301` had `skip_queue=true`; queue skipped; build matrix succeeded; container, unit, and functional jobs skipped.
- `.github/scripts/test_cache_keys.sh`
- `.github/scripts/test_docker_dependency_layers.sh`
- `.github/scripts/test_queue_bypass.sh`
- Negative mutation of one bypass condition: regression script failed on `cicd-compute-build-matrix` as expected.
- `shellcheck .github/scripts/test_queue_bypass.sh`
- `bash -n .github/scripts/test_queue_bypass.sh`
- `actionlint` with existing main-branch `mcore_branch`, Azure-input, and ShellCheck findings ignored; no new findings.
- `uv run --no-sync pre-commit run --all-files`
- `git diff --check`
