### PR TITLE
[data] fix: Preserve external VPP iterator lists

### DIFF
--- a/src/megatron/bridge/data/iterator_utils.py
+++ b/src/megatron/bridge/data/iterator_utils.py
@@ -14,15 +14,16 @@
 
 """Iterator utilities for handling virtual pipeline parallelism."""
 
-from typing import Iterator, TypeVar, Union
+from typing import Iterator, TypeVar
 
 
 DataT = TypeVar("DataT")
+ModelT = TypeVar("ModelT")
 
 
 def make_data_iterator_list(
-    model: list, data_iterator: Iterator[DataT]
-) -> Union[Iterator[DataT], list[Iterator[DataT]]]:
+    model: list[ModelT], data_iterator: Iterator[DataT] | list[Iterator[DataT]]
+) -> Iterator[DataT] | list[Iterator[DataT]]:
     """Convert data iterator into form expected by Megatron with virtual pipeline parallelism.
 
     With interleaved/virtual pipeline parallelism, Megatron expects a list of one data
@@ -33,7 +34,8 @@ def make_data_iterator_list(
 
     Args:
         model: List of model chunks (when virtual PP is used) or single-element list
-        data_iterator: Iterator yielding microbatch data
+        data_iterator: Iterator yielding microbatch data, or an existing list of
+            per-model-chunk iterators
 
     Returns:
         If model has only 1 chunk: returns the iterator as-is
@@ -49,8 +51,8 @@ def make_data_iterator_list(
         >>> batch_from_chunk0 = next(iters[0])  # Fetches from data_iterator, caches
         >>> batch_from_chunk1 = next(iters[1])  # Reads from cache, same data
     """
-    # Single model chunk - no caching needed
-    if not isinstance(model, list) or len(model) <= 1:
+    # Single model chunk or an already-partitioned iterator list - no caching needed
+    if not isinstance(model, list) or len(model) <= 1 or isinstance(data_iterator, list):
         return data_iterator
 
     class SharedCache:
@@ -78,10 +80,10 @@ def make_data_iterator_list(
             self.cache = cache
             self.index = 0
 
-        def __iter__(self):
+        def __iter__(self) -> Iterator[DataT]:
             return self
 
-        def __next__(self):
+        def __next__(self) -> DataT:
             """Return the next value for this chunk from the shared cache."""
             val = self.cache.get(self.index)
             self.index += 1

--- a/tests/unit_tests/data/test_iterator_utils.py
+++ b/tests/unit_tests/data/test_iterator_utils.py
@@ -93,6 +93,18 @@ def test_make_data_iterator_list_supports_out_of_order_chunks():
     assert next(result[0]) == {"batch": 2}
 
 
+def test_make_data_iterator_list_preserves_existing_chunk_iterators():
+    """Test that already-partitioned model-chunk iterators are not wrapped again."""
+    data = [iter([{"chunk": 0}]), iter([{"chunk": 1}])]
+    model = ["chunk1", "chunk2"]
+
+    result = make_data_iterator_list(model, data)
+
+    assert next(result[0]) == {"chunk": 0}
+    assert next(result[1]) == {"chunk": 1}
+    assert result is data
+
+
 def test_make_data_iterator_list_empty_model_list():
     """Test with empty model list."""
     data = iter([1, 2, 3])


### PR DESCRIPTION
## Summary

Preserve already-partitioned external iterator lists when adapting data for virtual pipeline parallelism.

## User impact

A supported custom dataset provider can return `dataloader_type="external"` data as one iterator per model chunk. Bridge setup explicitly wraps that shape as `list[RerunDataIterator]`. With VPP enabled, training and evaluation passed the outer list through `make_data_iterator_list` again. The first model-chunk read then called `next()` on the Python list and crashed before the first forward pass with `TypeError: list object is not an iterator`.

## Root cause and fix

Pinned MCore already expects the per-chunk list and indexes it by model-chunk id. The iterator adapter handled only a single shared source and could not distinguish that final representation.

Return an existing iterator list unchanged. Scalar iterators retain the shared-cache behavior required for out-of-order VPP scheduling. The type annotation and docstring now describe both accepted forms.

## Validation

Fail-before, unchanged regression:

- Focused pytest harness for `test_make_data_iterator_list_preserves_existing_chunk_iterators`: failed at `SharedCache.get()` with `TypeError: list object is not an iterator`.

Pass-after:

- Same unchanged focused regression: `1 passed, 6 deselected`.
- Entire `tests/unit_tests/data/test_iterator_utils.py`: `7 passed`.
- `git diff --check`: passed.
- `uv run --no-sync pre-commit run --all-files`: all hooks passed.

The focused harness preloaded only `iterator_utils.py` before invoking pytest because the workstation environment initializes GPU-only optional packages during normal package import. The bug itself is deterministic Python iterator adaptation and occurs before a distributed model forward.

## Scope

This change does not alter scalar iterator caching, data sampling, distributed schedules, dependencies, public conversion APIs, CI workflows, or the pinned MCore submodule.