### PR TITLE
[model] fix: map optional Step3.7 vision parameters

### DIFF
--- a/src/megatron/bridge/models/stepfun/step37_bridge.py
+++ b/src/megatron/bridge/models/stepfun/step37_bridge.py
@@ -497,6 +497,8 @@ class Step37Bridge(MegatronModelBridge):
         vision_norm_param_mappings = {
             "vision_model.ln_pre.weight": "vision_model.ln_pre.weight",
             "vision_model.ln_pre.bias": "vision_model.ln_pre.bias",
+            "vision_model.ln_post.weight": "vision_model.ln_post.weight",
+            "vision_model.ln_post.bias": "vision_model.ln_post.bias",
             "vision_model.transformer.resblocks.*.ln_1.weight": "vision_model.transformer.resblocks.*.ln_1.weight",
             "vision_model.transformer.resblocks.*.ln_1.bias": "vision_model.transformer.resblocks.*.ln_1.bias",
             "vision_model.transformer.resblocks.*.ln_2.weight": "vision_model.transformer.resblocks.*.ln_2.weight",
@@ -516,6 +518,7 @@ class Step37Bridge(MegatronModelBridge):
             "vision_model.vit_downsampler2.bias": "vision_model.vit_downsampler2.bias",
             # Top-level nn.Parameter on Step37VisionModel — AutoMapping
             # would see the top-level vision class as the owning module.
+            "vision_model.class_embedding": "vision_model.class_embedding",
             "vision_model.positional_embedding": "vision_model.positional_embedding",
             # Attention — in_proj_* are bare nn.Parameter on
             # EncoderVisionAttention; out_proj.* are plain nn.Linear.

--- a/tests/unit_tests/models/stepfun/test_step37_bridge.py
+++ b/tests/unit_tests/models/stepfun/test_step37_bridge.py
@@ -19,9 +19,10 @@ from unittest.mock import patch
 
 from megatron.bridge.models.conversion.utils import conform_config_to_reference
 from megatron.bridge.models.stepfun import step37_bridge as _step37_bridge_mod
-from megatron.bridge.models.stepfun.configuration_step37 import Step37Config
+from megatron.bridge.models.stepfun.configuration_step37 import Step37Config, Step37VisionConfig
 from megatron.bridge.models.stepfun.modelling_step37 import transformer_block as _step37_block_mod
 from megatron.bridge.models.stepfun.modelling_step37.transformer_block import get_step37_text_layer_spec
+from megatron.bridge.models.stepfun.modelling_step37.vision_model import Step37VisionModel
 from megatron.bridge.models.stepfun.step35_bridge import build_step35_layer_spec
 from megatron.bridge.models.stepfun.step37_bridge import Step37Bridge
 
@@ -95,6 +96,53 @@ class TestStep37BridgeReverseConfig:
         synthesized_config = Step37Config(**exported_config)
 
         assert synthesized_config.text_config.num_nextn_predict_layers == 0
+
+
+class TestStep37VisionMappings:
+    def test_optional_vision_parameters_have_checkpoint_mappings(self):
+        vision_config = Step37VisionConfig(
+            width=8,
+            layers=0,
+            heads=1,
+            image_size=14,
+            patch_size=14,
+            mlp_ratio=1,
+            use_cls_token=True,
+            use_ln_pre=False,
+            use_ln_post=True,
+        )
+        vision_model = Step37VisionModel(vision_config)
+        parameter_names = set(dict(vision_model.named_parameters()))
+        assert {"class_embedding", "ln_post.weight", "ln_post.bias"} <= parameter_names
+
+        disabled_model = Step37VisionModel(
+            Step37VisionConfig(
+                width=8,
+                layers=0,
+                heads=1,
+                image_size=14,
+                patch_size=14,
+                mlp_ratio=1,
+                use_cls_token=False,
+                use_ln_pre=False,
+                use_ln_post=False,
+            )
+        )
+        disabled_parameter_names = set(dict(disabled_model.named_parameters()))
+        assert "class_embedding" not in disabled_parameter_names
+        assert "ln_post.weight" not in disabled_parameter_names
+        assert "ln_post.bias" not in disabled_parameter_names
+
+        bridge = Step37Bridge()
+        bridge.hf_config = SimpleNamespace(
+            text_config=SimpleNamespace(num_hidden_layers=0, num_nextn_predict_layers=0)
+        )
+        registry = bridge.mapping_registry()
+        for parameter_name in ("class_embedding", "ln_post.weight", "ln_post.bias"):
+            megatron_name = f"vision_model.{parameter_name}"
+            mapping = registry.megatron_to_hf_lookup(megatron_name)
+            assert mapping is not None
+            assert mapping.hf_param == megatron_name
 
 
 class TestGetStep37TextLayerSpec:


### PR DESCRIPTION
## Problem

Step3.7 explicitly accepts `vision_config.use_cls_token=true` and `vision_config.use_ln_post=true`. Those settings instantiate and execute `vision_model.class_embedding` and `vision_model.ln_post.{weight,bias}`, but the Step3.7 conversion registry did not map any of the three parameters.

During HF import, conversion-task construction therefore left `None` slots that the normal load loop later dereferenced. Export likewise could not emit the parameters. Alternate/custom Step3.7 checkpoints using either upstream-supported option could not be converted or round-tripped.

The currently published `stepfun-ai/Step-3.7-Flash` checkpoint disables both options and is unaffected.

## Root cause and fix

The vision registry enumerated the always-present vision parameters and `ln_pre`, but omitted the conditional class token and final LayerNorm parameters.

This change adds only the corresponding direct mappings:

- `class_embedding` uses `ReplicatedMapping`, matching the other top-level replicated vision parameters.
- `ln_post.weight` and `ln_post.bias` use the existing LayerNorm-aware `AutoMapping` path.

## Regression evidence

The new unit test builds a tiny vision tower with both options enabled, proves all three parameters are instantiated, and requires exact bidirectional checkpoint names. It also builds a disabled negative control and verifies the conditional parameters are absent.

Fail before (unchanged regression on `5237d6b5`):

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/models/stepfun/test_step37_bridge.py::TestStep37VisionMappings::test_optional_vision_parameters_have_checkpoint_mappings -q

1 failed: registry.megatron_to_hf_lookup("vision_model.class_embedding") returned None
```

Pass after:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/models/stepfun/test_step37_bridge.py::TestStep37VisionMappings::test_optional_vision_parameters_have_checkpoint_mappings -q

1 passed
```

Focused adjacent validation on final base `7e1ba2828`:

```text
uv run --active --no-sync python -m pytest \
  tests/unit_tests/models/stepfun/test_step37_bridge.py \
  tests/unit_tests/models/stepfun/test_configuration_step37.py -q

8 passed
```

Additional checks:

```text
git diff --check
VIRTUAL_ENV=<preinstalled-env> uv run --active --no-sync pre-commit run --all-files
```

Both passed; all pre-commit hooks passed.

## Scope

This changes only Step3.7 checkpoint parameter registration and its unit coverage. It does not change the vision forward path, configuration defaults, public APIs, dependencies, or CI. GPU and full-model quality/performance validation were not run because the defect and fix are deterministic registry behavior exercised on CPU.
