### PR TITLE
[ckpt] fix: Honor retention for MSC checkpoints

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1668,7 +1668,12 @@ def cleanup_old_non_persistent_checkpoint(
     """
     if torch.distributed.is_initialized() and torch.distributed.get_rank() != 0:
         return
-    save_dir = Path(save_dir)
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        save_dir = msc.Path(save_dir)
+    else:
+        msc = None
+        save_dir = Path(save_dir)
 
     iter_prefix = "iter_"
     iter_ckpts = save_dir.glob(f"{iter_prefix}*")
@@ -1694,7 +1699,10 @@ def cleanup_old_non_persistent_checkpoint(
         with _CHECKPOINT_CLEANUP_LOCK:
             for ckpt in _iter_ckpts:
                 if ckpt.exists():
-                    shutil.rmtree(ckpt)
+                    if msc is not None:
+                        msc.delete(str(ckpt), recursive=True)
+                    else:
+                        shutil.rmtree(ckpt)
 
     if do_async:
         threading.Thread(target=remove_iter_ckpts, args=(rm_iter_ckpts,)).start()

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -1901,6 +1901,20 @@ class TestCleanupNonPersistentCheckpoints:
             # Should remove the two older checkpoints
             assert mock_rmtree.call_count == 2
 
+    @patch("torch.distributed.is_initialized", return_value=False)
+    def test_cleanup_old_non_persistent_checkpoint_with_msc_url(self, mock_dist_init, tmp_path):
+        """Retention removes old checkpoints from an MSC-backed root."""
+        MultiStorageClientFeature.enable()
+        msc = MultiStorageClientFeature.import_package()
+        save_dir = f"msc://default{tmp_path}/checkpoints"
+        for name in ("iter_0001000", "iter_0002000", "iter_0003000"):
+            msc.os.makedirs(os.path.join(save_dir, name), exist_ok=True)
+
+        cleanup_old_non_persistent_checkpoint(save_dir, leave_ckpt_num=1, do_async=False)
+
+        retained_checkpoints = sorted(checkpoint.name for checkpoint in msc.Path(save_dir).glob("iter_*"))
+        assert retained_checkpoints == ["iter_0003000"]
+
     @patch("torch.distributed.is_initialized")
     @patch("torch.distributed.get_rank")
     def test_cleanup_old_non_persistent_checkpoint_non_rank0(self, mock_get_rank, mock_dist_init):


### PR DESCRIPTION
## What does this PR do?

Make `checkpoint.most_recent_k` retention remove old checkpoint generations from MultiStorageClient-backed checkpoint roots.

## User impact and root cause

A supported training run with MultiStorageClient enabled, an `msc://...` checkpoint root, and bounded retention saved checkpoints successfully but silently kept every generation. Large model and optimizer checkpoints could therefore accumulate without bound despite `most_recent_k`, consuming object-storage capacity and quota.

Checkpoint construction, payload I/O, and tracker/train-state finalization already use MSC-aware APIs. The retention helper was the exception: it converted the original MSC URI with stdlib `pathlib.Path`, which parses `msc://profile/prefix` as the unrelated local path `msc:/profile/prefix`, and deleted through local-only `shutil.rmtree`. Its scan found no remote generations and returned without warning.

The fix uses `msc.Path` for retention enumeration and `msc.delete(..., recursive=True)` for deletion whenever MSC is enabled. The existing stdlib `Path` and `shutil.rmtree` path remains unchanged when MSC is disabled.

## Regression evidence

The focused regression creates three checkpoint generations through the real MSC default-profile filesystem API and requests retention of one.

Before the production fix:

```text
uv run --project /opt/Megatron-Bridge --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints::test_cleanup_old_non_persistent_checkpoint_with_msc_url -q --tb=short
1 failed: all three generations remained
```

The unchanged regression after the fix:

```text
uv run --project /opt/Megatron-Bridge --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints::test_cleanup_old_non_persistent_checkpoint_with_msc_url -q --tb=short
1 passed
```

Adjacent local, synchronous, asynchronous, persistent, and global-nonpersistent retention coverage:

```text
uv run --project /opt/Megatron-Bridge --no-sync python -m pytest -p no:cacheprovider \
  tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_retention_keeps_tracker_checkpoint_until_finalize \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_global_non_persistent_overlap_preserves_tracker_checkpoint \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_sync_global_non_persistent_honors_configured_retention \
  -q --tb=short
11 passed
```

Quality gates:

```text
git diff --check
uv run --project /opt/Megatron-Bridge --no-sync pre-commit run --all-files
```

Both passed. A strict mypy check was also attempted but mypy 2.2.0 exited with its own internal error before analyzing the file.

## Scope

This changes only the storage primitives used by checkpoint retention and adds a CPU unit regression. It does not change public APIs, checkpoint formats, retention counts/timing, dependencies, CI workflows, or Megatron-Core. The default-profile contract was exercised without remote credentials; no named remote-backend end-to-end, GPU/distributed, full-suite, model-quality, convergence, cost, or performance validation is claimed.
