### PR TITLE
fix(build): restore root user for framework image build

### DIFF
--- a/.github/scripts/test_docker_dependency_layers.sh
+++ b/.github/scripts/test_docker_dependency_layers.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 dockerfile="${1:-docker/Dockerfile.ci}"
 workflow="${2:-.github/workflows/cicd-main.yml}"
+fw_final_dockerfile="${3:-docker/Dockerfile.fw_final}"
 
 baseline_arg_line=$(grep -n '^ARG BASELINE_MCORE_REF$' "$dockerfile" | cut -d: -f1)
 baseline_clone_line=$(grep -n 'git clone --filter=blob:none --no-checkout' "$dockerfile" | cut -d: -f1)
@@ -23,6 +24,15 @@ trap 'rm -rf "$temporary_dir"' EXIT
 ((baseline_clone_line < baseline_line))
 ((baseline_line < dispatched_copy_line))
 ((dispatched_copy_line < delta_line))
+
+fw_final_from_line=$(grep -n '^FROM ${NEMO_FW_FINAL_BASE_IMAGE} AS nemo_fw_final$' "$fw_final_dockerfile" | cut -d: -f1)
+fw_final_root_line=$(grep -n '^USER root$' "$fw_final_dockerfile" | cut -d: -f1)
+fw_final_clone_line=$(grep -n '^RUN git clone --depth 1 https://github.com/NVIDIA-NeMo/NeMo.git' "$fw_final_dockerfile" | cut -d: -f1)
+[[ -n "$fw_final_from_line" ]]
+[[ -n "$fw_final_root_line" ]]
+[[ -n "$fw_final_clone_line" ]]
+((fw_final_from_line < fw_final_root_line))
+((fw_final_root_line < fw_final_clone_line))
 
 grep -q -- '--mount=type=cache,target=/root/.cache/uv' "$dockerfile"
 if grep -q -- '--mount=type=secret,id=GH_TOKEN' "$dockerfile"; then

--- a/docker/Dockerfile.fw_final
+++ b/docker/Dockerfile.fw_final
@@ -15,6 +15,9 @@
 ARG NEMO_FW_FINAL_BASE_IMAGE
 FROM ${NEMO_FW_FINAL_BASE_IMAGE} AS nemo_fw_final
 
+# The CI base image runs as UID 1000, while framework assembly writes to root-owned system paths.
+USER root
+
 WORKDIR /opt
 
 ##############################################################################


### PR DESCRIPTION
## Background / motivation

PR #5536 intentionally made the Megatron-Bridge CI image run as UID 1000. Docker user state is inherited by downstream stages, so `docker/Dockerfile.fw_final` also began running as UID 1000 when it consumed that CI image through `NEMO_FW_FINAL_BASE_IMAGE`.

The framework build writes under root-owned `/opt` immediately. This caused GitLab job 396041842 to fail at the first clone with:

```console
fatal: could not create work tree dir 'NeMo': Permission denied
```

## What changed

- Switch the derived framework-image build back to `USER root` immediately after `FROM`.
- Extend the Docker dependency-layer check to require that transition before the first clone into `/opt`.

## Details

This keeps the CI image's non-root runtime from #5536 intact while restoring the framework assembly stage's previous effective user. Later framework-image layers also require root for system package installation and writes outside user-owned paths.

## Tested

- `.github/scripts/test_docker_dependency_layers.sh` — passed, including the new `FROM` → `USER root` → clone ordering assertions.
- `bash -n .github/scripts/test_docker_dependency_layers.sh` — passed.
- `uv run --no-sync pre-commit run --all-files` — all configured hooks passed.
- `git diff --check` — passed.

The normal `uv run pre-commit run --all-files` environment bootstrap was also attempted; dependency synchronization stopped while building `fast-hadamard-transform` because its isolated build environment did not provide its undeclared `torch` build dependency. Running the already-installed pre-commit tool with `--no-sync` completed successfully.
