### PR TITLE
docs(skills): make activation recompute guidance evidence-based

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -134,6 +134,22 @@
         "line_number": 5
       }
     ],
+    "skills/nemo-mbridge-perf-activation-recompute/card.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "skills/nemo-mbridge-perf-activation-recompute/card.yaml",
+        "hashed_secret": "d876c978038bac9df264c6ba47160bc17ed72bfc",
+        "is_verified": false,
+        "line_number": 140
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "skills/nemo-mbridge-perf-activation-recompute/card.yaml",
+        "hashed_secret": "38b998c3a3888627c3fee0a8f76de6dc1b8d2c32",
+        "is_verified": false,
+        "line_number": 141
+      }
+    ],
     "tests/functional_tests/inference/test_vlm_inference.py": [
       {
         "type": "Base64 High Entropy String",
@@ -185,5 +201,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-08T18:04:52Z"
+  "generated_at": "2026-08-14T05:04:36Z"
 }

--- a/docs/training/activation-recomputation.md
+++ b/docs/training/activation-recomputation.md
@@ -17,9 +17,12 @@ As a rule of thumb:
 
 - start with **selective recomputation** before using full recomputation
 - use **full recomputation** only when selective recomputation still does not fit
-- for MoE and long-context training, prefer recomputing smaller modules such as
-  normalization, activation, MoE-side, or model-specific up-projection work
-  rather than recomputing the whole layer
+- choose selective modules from the model and measured peak: `core_attn` is a
+  common standard-attention candidate, MLA often benefits from `mla_up_proj`,
+  and grouped MoE often starts with `moe_act` or `layernorm` plus `moe_act`
+- with TE fused or Flash Attention, compare `core_attn` against an empty
+  selective module list because the backend already rematerializes attention
+  internals
 - revisit recomputation after enabling CUDA graphs, because TE-scoped graphs and
   full recomputation are not always compatible
 
@@ -86,7 +89,10 @@ When training with pipeline parallelism:
 
 ## Self-attention Recomputation
 
-Megatron Bridge supports selective self-attention recomputation that checkpoints the inputs of each self-attention block and recomputes the intermediate input activations. This cost-efficient method achieves high memory savings with minimal recomputation cost.
+Megatron Bridge supports selective self-attention recomputation that checkpoints
+the core-attention boundary and recomputes it during backward. This can be a
+cost-efficient choice for standard attention, but it is not the universal first
+boundary for MLA, MoE, or fused-attention workloads.
 
 The intermediate layers of the self-attention block account for a large share
 of activation memory because softmax, dropout, and QKV dot-product attention
@@ -105,36 +111,38 @@ from megatron.bridge.models import GPTModelProvider
 
 model_config = GPTModelProvider(
     recompute_granularity="selective",  # Enable selective recomputation
-    recompute_modules=["core_attn"],    # Recompute attention modules (default)
+    recompute_modules=["core_attn"],    # Common standard-attention candidate and MCore default
     # ... other model parameters
 )
 ```
 
 ### Recomputation Modules
 
-Megatron Bridge supports selective recomputation for various modules:
+The pinned Megatron Core accepts these selective labels. Do not combine them
+blindly: some are architecture-specific and some checkpoint overlapping
+regions.
 
-```python
-model_config = GPTModelProvider(
-    recompute_granularity="selective",
-    recompute_modules=[
-        "core_attn",      # Core attention computation (default)
-        "mlp",            # MLP layers
-        "layernorm",      # Layer normalization
-        "moe",            # Mixture of Experts layers
-        "moe_act",        # MoE activation functions
-        "shared_experts", # Shared expert layers
-        "mla_up_proj",    # Multi-Latent Attention up projection
-    ],
-)
-```
+| Label | Boundary and typical use |
+|---|---|
+| `core_attn` | Core attention; a common standard-attention candidate that can replay context-parallel communication |
+| `mla_up_proj` | Expanded MLA Q/KV projections and RoPE; often the first MLA candidate |
+| `moe_act` | Grouped-expert activation output without replaying dispatch or expert GEMMs |
+| `layernorm` | Input and pre-MLP normalization outputs, often paired with a MoE or MLA boundary |
+| `mlp` | Whole dense MLP; broader replay and no effect on pure-MoE layers |
+| `moe` | Whole MoE forward, including routing, expert compute, and communication |
+| `shared_experts` | Non-overlapped shared-expert MLP |
+| `gdn_norm_out` | GatedDeltaNet output norm and HP-to-CP communication |
+
+An empty list is valid under selective granularity and is useful as a matched
+no-recompute control.
 
 ### Flash Attention Integration
 
-Self-attention recomputation is automatically enabled when using Flash Attention
-through Transformer Engine. Flash Attention already recovers some memory by
-recomputing attention scores rather than storing them, so extra explicit
-attention recomputation is often less important than recomputing other modules.
+Flash Attention through Transformer Engine already recovers memory by
+rematerializing attention internals. That does not automatically make
+`recompute_modules=["core_attn"]` the right explicit setting. Compare it with an
+empty selective module list; MLA up projections, MoE activations, normalization,
+or another boundary may set the actual peak.
 
 ## Advanced Recomputation Configuration
 
@@ -169,29 +177,38 @@ model_config = GPTModelProvider(
     # MoE configuration
     num_moe_experts=8,
     expert_model_parallel_size=2,
+    moe_grouped_gemm=True,
     
     # MoE recomputation
     recompute_granularity="selective",
-    recompute_modules=["moe", "moe_act"],  # Recompute MoE-specific modules
+    recompute_modules=["moe_act", "layernorm"],  # Narrow MoE-side candidates
 )
 ```
 
-For MoE training, it is often better to start with selective recomputation of
-MoE-side modules, normalization, activation functions, or model-specific
-up-projection modules than to enable blanket full recomputation immediately.
+`moe_act` requires grouped-GEMM experts. Whole-`moe` recompute is a broader
+alternative that replays routing, dispatch/combine communication, expert
+compute, and shared-expert work; it is incompatible with expert-parallel
+overlap. `shared_experts` recompute is likewise incompatible with shared-expert
+overlap. Prefer the narrow boundary that satisfies the memory target.
 
 ## Feature Interactions
 
-- TE-scoped CUDA graphs are usually paired with selective recomputation rather
-  than full recomputation.
+- Full recomputation with CUDA graphs requires
+  `cuda_graph_impl="full_iteration"` in the pinned Megatron Core. Otherwise use
+  selective recomputation or disable CUDA graphs.
+- A selective checkpoint boundary must lie wholly inside or wholly outside its
+  CUDA-graph scope.
 - MoE communication overlap paths often require recomputation settings that are
   more selective than "full."
 - At long context, recomputing SDPA-heavy attention internals can cost more than
   recomputing smaller supporting modules.
+- Advancing from a forward OOM to a gradient-synchronization or optimizer OOM
+  is useful diagnosis, but not a pass. Validate through optimizer-state
+  initialization and multiple steady-state iterations.
 
 ## Related Docs
 
 - [docs/training/cuda-graphs.md](cuda-graphs.md)
 - [docs/training/moe-optimization.md](moe-optimization.md)
-- [skills/nemo-mbridge-perf-activation-recompute/SKILL.md](../skills/nemo-mbridge-perf-activation-recompute/SKILL.md) — per-module cost/savings data, measured results
-- [skills/nemo-mbridge-perf-memory-tuning/SKILL.md](../skills/nemo-mbridge-perf-memory-tuning/SKILL.md) — expandable segments, parallelism resizing, and other memory reduction strategies
+- [skills/nemo-mbridge-perf-activation-recompute/SKILL.md](../../skills/nemo-mbridge-perf-activation-recompute/SKILL.md) — architecture-specific module selection, compatibility, and measurement guidance
+- [skills/nemo-mbridge-perf-memory-tuning/SKILL.md](../../skills/nemo-mbridge-perf-memory-tuning/SKILL.md) — expandable segments, parallelism resizing, and other memory reduction strategies

--- a/skills/nemo-mbridge-perf-activation-recompute/BENCHMARK.md
+++ b/skills/nemo-mbridge-perf-activation-recompute/BENCHMARK.md
@@ -2,6 +2,8 @@
 
 Evaluation of the `nemo-mbridge-perf-activation-recompute` skill before publication through NVSkills-Eval.
 
+> **Refresh required:** the skill guidance and evaluation task changed on 2026-08-12. The results below are retained as historical evidence for the previous version and do not validate the current version.
+
 This benchmark summarizes 3-Tier Evaluation from NVSkills-Eval results for the skill. The goal is to document whether the skill is safe, discoverable, effective, and useful for agents before it is published for broader workflow use.
 
 ## Evaluation Summary
@@ -13,7 +15,8 @@ This benchmark summarizes 3-Tier Evaluation from NVSkills-Eval results for the s
 - Dataset: 1 evaluation tasks
 - Attempts per task: 1
 - Pass threshold: 50%
-- Overall verdict: PASS
+- Historical verdict: PASS
+- Current-version verdict: pending a fresh NVSkills-Eval run
 
 ## Agents Used
 
@@ -77,6 +80,6 @@ Top findings:
 
 This tier was not run or did not produce findings in this report.
 
-## Publication Recommendation
+## Historical Publication Recommendation
 
-The skill is suitable to proceed toward NVSkills-Eval publication based on this benchmark. Skill owners should keep this file with the skill and refresh it when the evaluation dataset, skill behavior, or target agents materially change.
+The previous skill version was suitable to proceed toward publication based on this benchmark. Because the evaluation dataset and skill behavior have now changed materially, rerun NVSkills-Eval before treating the current version as benchmark-validated.

--- a/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
+++ b/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: nemo-mbridge-perf-activation-recompute
-description: Validate and use selective and full activation recompute in Megatron Bridge to reduce GPU memory usage at the cost of extra compute.
+description: >-
+  Validate and use selective and full activation recompute in Megatron Bridge
+  to reduce GPU memory usage at the cost of extra compute. Use for activation
+  memory OOMs or regressions involving recompute_granularity,
+  recompute_num_layers, recompute_modules, recompute_method, selective
+  recompute, full recompute, or activation checkpointing.
 license: Apache-2.0
-when_to_use: Reducing GPU memory via activation recompute, or investigating a commit that changed recompute settings and caused OOM or a regression; 'recompute_granularity', 'recompute_num_layers', 'recompute_modules', 'recompute_method', 'selective recompute', 'full recompute', 'activation memory OOM'.
 ---
 
 # Activation Recompute
@@ -10,41 +14,24 @@ when_to_use: Reducing GPU memory via activation recompute, or investigating a co
 Stable docs: @docs/training/activation-recomputation.md
 Card: @skills/nemo-mbridge-perf-activation-recompute/card.yaml
 
-<!-- NVSkills CI refresh: 2026-06-15. No instruction changes. -->
+<!-- Guidance refreshed: 2026-08-12. -->
 
-## What It Is
+Activation recompute (activation checkpointing) trades additional forward work during backward for lower retained-activation memory. The useful checkpoint boundary depends on the model architecture, attention backend, parallelism, and the tensor that actually drives the per-rank peak.
 
-Activation recompute trades GPU compute for memory by discarding intermediate
-activations during the forward pass and recomputing them during backward.
-Megatron Bridge supports two granularities:
+## Quick Decision Guide
 
-| Granularity | What you specify | What gets recomputed | Memory savings | Compute cost |
-|---|---|---|---|---|
-| `selective` | `recompute_modules` list (e.g. `core_attn`, `mlp`) | specific submodules within each layer | moderate (module-dependent) | low to high |
-| `full` | `recompute_num_layers` + `recompute_method` | entire transformer layers (N layers) | strongest | highest |
+1. Confirm the pressure is real allocation, not allocator fragmentation. Compare `max_memory_allocated()` with `max_memory_reserved()` on every rank.
+2. Keep an explicit no-recompute control when the workload fits. Under selective granularity, `recompute_modules=[]` is valid and useful for this comparison.
+3. Select the first boundary from the architecture and observed peak:
+   - **Standard attention:** `core_attn` is the common first candidate. It is strongest when unfused attention materializes score/probability tensors. With Transformer Engine fused or Flash Attention, compare it against `[]` because those backends already rematerialize attention internals.
+   - **Multi-Latent Attention (MLA):** start with `mla_up_proj` when expanded Q/K/V projections dominate. Add `core_attn` only when the attention-core state still matters.
+   - **Grouped MoE:** start with `moe_act` when the expert intermediate activation dominates; add `layernorm` when norm outputs are material. Use whole `moe` recompute only after accounting for the extra expert compute and communication it replays.
+   - **Dense FFN:** `mlp` can save the whole dense-MLP activation region, but it usually costs more compute than a narrow output-discard boundary.
+4. Change one label at a time. Record per-rank allocated/reserved peaks plus steady-state step time or throughput; do not infer a global module ranking from one recipe.
+5. Use full-layer recompute only when targeted selective boundaries do not make the workload fit. Full recompute has the broadest memory effect and the largest replay cost.
+6. Treat CUDA graphs, FP8, context-parallel communication, and overlap features as compatibility constraints, not afterthoughts.
 
-Note: MCore names these "selective" (submodule-level) vs "full" (layer-level).
-"Full" means recomputing full layers, not the full model — you still choose
-how many layers via `recompute_num_layers`.
-
-## Quick Decision
-
-1. Rule out allocator fragmentation first with
-   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`; see
-   @skills/nemo-mbridge-perf-memory-tuning/SKILL.md.
-2. For activation pressure, start with selective recompute:
-   `recompute_granularity="selective"` and `recompute_modules=["core_attn"]`.
-3. Add modules by cost: `"layernorm"` is cheap but saves little, while `"mlp"`
-   saves much more memory at a clear throughput cost.
-4. Use full-layer recompute only when selective recompute does not fit, and set
-   all required fields: `recompute_granularity="full"`, `recompute_method`, and
-   `recompute_num_layers`.
-5. With FP8 or TE-scoped CUDA graphs, avoid full-layer recompute unless graph
-   scope is `full_iteration`; otherwise use selective recompute or disable TE
-   graph capture.
-
-CPU offloading (`cpu_offloading=True`) is an alternative that avoids recompute
-cost entirely, but it is **incompatible with PP > 1**.
+Megatron Core's `cpu_offloading=True` is an alternative when PCIe/NVLink transfer overhead is preferable to replayed compute. It cannot be combined with activation recompute and is not compatible with pipeline parallelism greater than one.
 
 ## Enablement
 
@@ -52,157 +39,229 @@ cost entirely, but it is **incompatible with PP > 1**.
 
 ```python
 cfg.model.recompute_granularity = "selective"
-cfg.model.recompute_modules = ["core_attn"]  # add "layernorm", "mlp", or other valid modules as needed
+cfg.model.recompute_modules = ["core_attn"]  # Common standard-attention candidate, not a universal default.
 ```
+
+Use the decision table below to replace or extend that list for MLA, MoE, dense-MLP, or GDN workloads.
 
 ### Full-layer recompute
 
 ```python
 cfg.model.recompute_granularity = "full"
 cfg.model.recompute_method = "uniform"
-cfg.model.recompute_num_layers = 4
+cfg.model.recompute_num_layers = 1
 ```
 
-### Available recompute_modules
+- `uniform`: checkpoint fixed groups of `recompute_num_layers` transformer layers.
+- `block`: checkpoint the first `recompute_num_layers` layers on each pipeline stage, with virtual-pipeline-aware distribution.
 
-| Module | What it recomputes | Compute cost | Memory savings |
+## Selective Module Decision Table
+
+The currently pinned Megatron Core accepts these labels. A development branch can add model-specific labels, so validate against the exact target revision rather than copying a list across branches.
+
+| Module | Checkpoint boundary | When to test it | Main cost or caveat |
 |---|---|---|---|
-| `core_attn` | attention softmax/dropout/QKV dot product | low (Flash Attention already recomputes internally) | moderate |
-| `layernorm` | layer normalization | negligible (~0%) | negligible |
-| `mlp` | full FFN block | high (~16% on Llama3 70B, hidden=28672) | ~3 GB |
-| `moe` | MoE expert dispatch | varies | varies |
-| `moe_act` | MoE activation functions | low | small |
-| `shared_experts` | shared expert layers | moderate | moderate |
-| `mla_up_proj` | Multi-Latent Attention up projection | moderate | moderate |
+| `core_attn` | Core attention | Standard attention, especially an unfused backend retaining attention intermediates | Replays attention. Incremental savings can be small with TE fused/Flash Attention; context parallelism can replay attention communication. |
+| `mla_up_proj` | MLA Q/KV up-projection plus RoPE region | MLA models retaining expanded Q/K/V tensors | Replays the MLA expansion path. It is a distinct, potentially additive boundary from `core_attn`. |
+| `layernorm` | Input and pre-MLP normalization outputs | Norm outputs contribute materially to the peak, often alongside MoE or MLA boundaries | Usually narrow, but savings depend on hidden size, sequence length, and which graph paths are active. |
+| `moe_act` | Activation output between grouped expert FC1 and FC2 | Grouped MoE expert-intermediate activations dominate | Narrow output-discard checkpoint. It does not replay dispatch, FC1, or FC2, but has FP8 delayed-scaling restrictions. |
+| `mlp` | Whole dense MLP | Dense layers dominate after narrower boundaries are exhausted | Replays the complete dense MLP. It has no effect on layers whose MLP is MoE. |
+| `moe` | Whole MoE forward | A broad MoE region must be discarded to make the workload fit | Replays routing, dispatch/combine communication, experts, and shared-expert work. It is incompatible with expert-parallel overlap. |
+| `shared_experts` | Non-overlapped shared-expert MLP | Shared experts are a distinct material peak | Replays the shared-expert MLP and is invalid with shared-expert overlap. Outer `moe` already removes its original-forward saves, but nesting can still change the transient backward-replay peak. |
+| `gdn_norm_out` | GDN gated-normalization output | GDN/hybrid models retain this output | Replays the normalization and its HP-to-CP all-to-all path. |
 
-### Performance harness CLI
+For example, DeepSeek V4 configurations can use the model-specific `mhc`
+label only with their required Megatron Core development branch. It is not a
+portable label for the pinned revision and therefore is not included in the
+table above.
 
-```bash
-uv run python scripts/performance/run_script.py \
-  -m llama \
-  -mr llama3_8b \
-  --task pretrain \
-  -g h100 \
-  -c bf16 \
-  -ng 8 \
-  --recompute_modules core_attn,layernorm \
-  ...
-```
+Common performance configurations consequently fall into several patterns rather than one universal list:
 
-## Compatibility and Constraints
+- standard transformer recipes often use `core_attn`;
+- MLA recipes often use `mla_up_proj`, sometimes with `mlp`;
+- grouped-MoE recipes often use `moe_act` or `layernorm` plus `moe_act`;
+- higher-pressure MoE recipes sometimes use broader combinations such as `moe` plus `layernorm`.
 
-- `recompute_granularity=selective` requires a non-empty `recompute_modules` list
-- `recompute_granularity=full` requires `recompute_method` and `recompute_num_layers`
-- **Layer-level recompute (`recompute_granularity="full"` +
-  `recompute_num_layers`) is incompatible with TE-scoped CUDA graphs.**
-  MCore calls this "full" granularity — the name refers to recomputing
-  full transformer layers, not the full model. Even though you're selecting
-  how many layers to recompute, MCore treats it differently from submodule
-  recompute. Any TE-scoped scope (`attn`, `mlp`, `moe_router`, etc.) will
-  assert. This commonly hits FP8 configs that enable TE-scoped graphs by
-  default (e.g. `LLAMA3_70B_SFT_CONFIG_H100_FP8_CS_V1` sets
-  `cuda_graph_impl="transformer_engine"`, `cuda_graph_scope="mlp"`). Options:
-  - use submodule recompute (`recompute_granularity="selective"` +
-    `recompute_modules`) — compatible with TE-scoped graphs
-  - disable CUDA graphs (`cuda_graph_impl="none"`) and use layer-level recompute
-  - switch to `cuda_graph_impl="local"`, `cuda_graph_scope="full_iteration"`
-- `distribute_saved_activations=True` cannot be combined with `sequence_parallel=True`
-- Combining `mlp` + `core_attn` recompute is slightly worse than `mlp` alone
-  due to double recompute overhead
+These are candidate patterns, not an ordering guarantee. Peak attribution and matched measurements decide the final list.
 
-## Measured Results
+## Measurement Contract
 
-Llama3 70B SFT on 32x H100 80GB, FP8 (Current Scaling):
-- Baseline: TP=4, PP=4, VPP=5, DP=2, MBS=1, GBS=32, seq_len=4096
-- Golden GPU utilization: 709.93 TFLOP/s/GPU
-- Regression threshold: 5%
+For every candidate, capture:
 
-| Experiment | recompute_modules | TFLOP/s/GPU | vs Golden | Peak Mem (GB) | Result |
-|---|---|---|---|---|---|
-| Baseline | [core_attn] | ~704 | -0.8% | 58.8 (OOM rank0) | OOM |
-| Exp 1 | [mlp] | 593.6 | -16.4% | 55.6 | Perf regression |
-| Exp 2 | [mlp, core_attn] | 586.8 | -17.3% | 55.6 | Perf regression |
-| Exp 3 | [core_attn, layernorm] | ~702 | -1.1% | 59.6 (OOM rank0) | OOM |
+- exact Bridge and Megatron Core revisions;
+- model, sequence length, micro/global batch sizes, precision, attention backend, and parallelism;
+- the exact `recompute_granularity`, module list, method, and layer count;
+- per-rank `max_memory_allocated()` and `max_memory_reserved()`;
+- steady-state step time or throughput after warmup;
+- a short convergence or numerical-sanity check appropriate to the task.
 
-Key takeaways:
+Use a matched no-recompute control and change one recompute choice at a time. Peak memory from different jobs, backends, or parallel layouts is not a module-ranking benchmark.
 
-- `layernorm` recompute is nearly free compute-wise but saves negligible memory
-- `mlp` recompute saves ~3 GB peak but costs ~16% because the Llama3 70B FFN
-  (hidden=28672) is expensive to recompute
-- Combining `mlp` + `core_attn` is slightly worse than `mlp` alone
-- For this workload, the actual OOM fix was `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`
-  (memory fragmentation, not capacity). See @skills/nemo-mbridge-perf-memory-tuning/SKILL.md.
+Do not call a candidate successful merely because it advances farther than the
+control. Run through optimizer-state initialization and multiple steady-state
+steps: selective recompute can move the memory wall from forward into gradient
+synchronization or the optimizer without making the workload viable.
+
+## Matched H100 Evidence: Moonlight 16B
+
+A 2026-08-12 short-run study used the exact Bridge revision
+`600d069b824dd5ce50367a311a5a3244478faf22` and Megatron Core revision
+`24bad8e677d22625d86ef2a54c9506b6e4992c93`. The Moonlight 16B BF16
+pretraining recipe ran on 8 H100 80GB GPUs with sequence length 4096, MBS=1,
+GBS=4, TP=2, PP=1, CP=1, EP=8, mock data, and 20 steps. This model mixes one
+dense layer with 26 MLA+MoE layers. Each row changed only
+`recompute_modules`; all 20 losses were finite with zero skipped or NaN
+iterations.
+
+Peak allocated memory is the maximum post-optimizer value reported after
+iteration 2. Time and throughput are means over iterations 11--20.
+
+| Selective modules | Peak allocated (GB) | Step time (ms) | TFLOP/s/GPU | Allocated vs `[]` | Time vs `[]` |
+|---|---:|---:|---:|---:|---:|
+| `[]` | 36.618 | 457.18 | 77.50 | control | control |
+| `core_attn` | 36.614 | 474.80 | 74.44 | -0.01% | +3.85% |
+| `mla_up_proj` | 35.902 | 480.89 | 73.72 | -1.96% | +5.19% |
+| `mla_up_proj`, `mlp` | 35.917 | 496.73 | 71.50 | -1.91% | +8.65% |
+| `moe_act` | 35.941 | 466.26 | 75.50 | -1.85% | +1.99% |
+| `layernorm`, `moe_act` | 35.949 | 506.53 | 70.27 | -1.83% | +10.79% |
+
+For this exact workload, `moe_act` is the best first boundary: it recovered
+nearly as much allocated memory as `mla_up_proj` for less replay cost.
+`mla_up_proj` is the next candidate if its roughly 39 MB additional reduction
+matters. Adding `mlp` to `mla_up_proj` or `layernorm` to `moe_act` did not
+improve the observed peak and made steps slower. Explicit `core_attn` added
+cost without material memory benefit under fused attention.
+
+Maximum reserved memory stayed near 40 GB and did not fall monotonically.
+That is allocator caching, not contrary evidence: boundary selection in this
+study is based on allocated memory and successful end-to-end steps.
+
+## Matched H100 Evidence: Nemotron 3 Nano
+
+The same 2026-08-12 study used the native 16-H100 BF16 performance recipe for
+the 52-layer hybrid Mamba/fused-attention MoE model. The matched short-run
+configuration used sequence length 8192, MBS=1, GBS=16, TP=1, PP=1, CP=1,
+EP=8, DP=16, expert-DP=2, HybridEP, grouped GEMM, TE CUDA graphs for attention and Mamba,
+mock data, and 12 steps. Each row changed only `recompute_modules`.
+
+| Selective modules | Outcome | Rank-0 measured peak | Failure or steady-state evidence |
+|---|---|---:|---|
+| `[]` | OOM after iteration 1 | 66.297 GB after iteration 1 | Iteration-2 MoE router allocation failed; hot ranks had about 72.9 GiB allocated. |
+| `core_attn` | OOM in iteration 1 | not comparable | Grouped-expert linear allocation failed; explicit attention recompute did not make the fused-attention workload fit. |
+| `moe_act` | OOM after iteration 1 | 62.103 GB after iteration 1 | 4.194 GB (6.33%) below the control at the matched checkpoint, but the iteration-2 output projection still needed 2 GiB. |
+| `layernorm`, `moe_act` | OOM in iteration 1 | not comparable | Output projection still needed 2 GiB; CUDA-graph private pools were material. |
+| `moe` | completed 12 steps | 64.653 GB after iteration 2 | 657.42 ms and 277.72 TFLOP/s/GPU over iterations 7--12. |
+| `moe`, `layernorm` | completed 12 steps | 63.639 GB after iteration 2 | 677.62 ms and 270.62 TFLOP/s/GPU over iterations 7--12. |
+
+Both successful rows had finite losses and zero skipped or NaN iterations.
+For this exact capacity-limited recipe, whole-`moe` recompute is the smallest
+tested passing boundary. Adding `layernorm` recovered another 1.014 GB (1.57%)
+of rank-0 peak at 3.07% higher step time, so the recipe's broader combination
+is justified when that headroom is required. Narrow `moe_act` produced real
+activation relief but did not make the whole training step viable.
+
+An exploratory native 8-H100 layout failed during FP32 optimizer-state
+initialization even at sequence length 4096. That is optimizer capacity, not a
+selective-boundary throughput baseline; no timing comparison from those runs
+is used here.
+
+### Cross-model conclusion
+
+These measurements do not define one ranking. Moonlight fit with an empty
+control and favored narrow `moe_act`; Nemotron required broad whole-`moe`
+recompute; historical dense Llama evidence found whole-`mlp` replay costly and
+lacked an empty control. The correct first candidate is therefore the narrowest
+boundary implicated by the architecture and peak, followed by broader replay
+only when the narrow choice does not pass the complete step.
+
+## Compatibility and Validation
+
+### Configuration semantics
+
+- `recompute_granularity="selective"` uses `recompute_modules`; an empty list is accepted as an explicit control.
+- `recompute_granularity="full"` uses `recompute_method` and `recompute_num_layers`; selective labels do not apply.
+- Full granularity supersedes selective module choices rather than composing with them.
+- Unknown labels fail Megatron Core validation. Labels may differ on development branches, so use the exact revision's `TransformerConfig` validator as the source of truth.
+
+### Attention backend and context parallelism
+
+- TE fused and Flash Attention already use internal rematerialization. Explicit `core_attn` may still change retained inputs/outputs, but it must earn its place in a matched `[]` comparison.
+- Under context parallelism, an attention checkpoint can replay communication as well as compute. Include CP size and topology in the measurement record.
+
+### MoE restrictions
+
+- Whole-`moe` recompute is incompatible with expert-parallel overlap because backward replay would repeat the overlapped routing/communication region.
+- `shared_experts` recompute is incompatible with shared-expert overlap.
+- `moe_act` applies to grouped-GEMM experts and is the narrower choice when only the expert activation needs to be discarded.
+- `mlp` targets dense MLPs and is a no-op on MoE layers; mixed dense/MoE models can still benefit on their dense layers.
+
+### FP8 restrictions
+
+- `moe_act` and `layernorm` recompute are not supported with FP8 delayed scaling and require a compatible Transformer Engine version.
+- Absorbed MLA paths have additional FP8/FP4 restrictions. Validate the exact model/provider path before selecting `mla_up_proj`.
+
+### CUDA graphs
+
+- Selective recompute is valid only when a checkpointed module lies wholly inside or wholly outside the selected graph scope. A checkpoint boundary that straddles a graph boundary is invalid.
+- Capture/warmup can bypass checkpoint wrappers, so verify the final graph scope and replay path rather than assuming eager behavior carries over.
+- Full recompute with CUDA graphs requires `cuda_graph_impl="full_iteration"` in the pinned Megatron Core. Otherwise disable CUDA graphs; scoped/local graph capture is not a substitute for full-iteration capture here.
+
+## Historical Measurement: Context, Not a Module Ranking
+
+Historical H100 measurements from Bridge PR #3107 used Llama 3 70B SFT on 32 H100 80GB GPUs with FP8 current scaling, sequence length 4096, micro-batch size 1, global batch size 32, TP=4, PP=4, VPP=5, and DP=2:
+
+| Configuration | TFLOP/s/GPU | Peak memory |
+|---|---:|---:|
+| `core_attn` baseline in that run | ~704 | 58.8 GB (OOM on rank 0) |
+| `mlp` | 593.6 | 55.6 GB |
+| `mlp` + `core_attn` | 586.8 | 55.6 GB |
+| `core_attn` + `layernorm` | ~702 | 59.6 GB (OOM on rank 0) |
+| Golden throughput recorded in the PR context | 709.93 | Not a paired memory measurement |
+
+Limitations of this evidence:
+
+- it did not include a matched no-recompute row;
+- the golden row was not a paired module-only comparison;
+- the measurements cover one dense Llama workload, not MLA or MoE;
+- the table supports the local memory/throughput tradeoff only and must not be used to rank all recompute labels.
 
 ## Code Anchors
 
-### Recompute modules enum and selective checkpoint logic
-
-```python
-# 3rdparty/Megatron-LM/megatron/core/transformer/transformer_block.py
-# _checkpointed_forward() applies selective recompute based on recompute_modules
-```
-
-### Recompute config validation
-
-```python
-# 3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
-# Validates recompute_granularity, recompute_method, recompute_num_layers
-```
-
-### Llama3 recipe defaults
-
-```99:103:src/megatron/bridge/recipes/llama/llama3.py
-    # Memory saving (recompute & offloading)
-    cfg.model.recompute_granularity = None
-    cfg.model.recompute_modules = None
-    cfg.model.fine_grained_activation_offloading = False
-    cfg.model.offload_modules = None
-```
-
-### Full recompute + CUDA graph assertion (MCore)
-
-```2001:2005:3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
-            if self.recompute_granularity:
-                if self.recompute_granularity != "selective":
-                    assert self.cuda_graph_scope == [
-                        CudaGraphScope.full_iteration
-                    ], "full recompute is only supported with full iteration CUDA graph."
-```
-
-### CPU offloading PP incompatibility (MCore)
-
-```1303:1306:3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
-        if self.cpu_offloading and self.pipeline_model_parallel_size > 1:
-            raise ValueError(
-                "Currently there is no support for Pipeline parallelism with CPU offloading"
-            )
-```
+- Selective-label validation and cross-feature checks: `3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py`
+- Checkpoint implementations: `3rdparty/Megatron-LM/megatron/core/tensor_parallel/random.py`
+- Standard-attention checkpoint boundary: `3rdparty/Megatron-LM/megatron/core/transformer/attention.py`
+- MLA up-projection boundary: `3rdparty/Megatron-LM/megatron/core/transformer/multi_latent_attention.py`
+- Layernorm, dense-MLP, and outer-MoE placement: `3rdparty/Megatron-LM/megatron/core/transformer/transformer_layer.py`
+- Grouped expert activation boundary: `3rdparty/Megatron-LM/megatron/core/transformer/moe/experts.py`
+- Shared-expert and whole-MoE paths: `3rdparty/Megatron-LM/megatron/core/transformer/moe/moe_layer.py`
+- GDN normalization boundary: `3rdparty/Megatron-LM/megatron/core/ssm/gated_delta_net/gdn.py`
 
 ## Failure Diagnosis
 
-| Symptom | Cause | Confirm | Fix |
-|---|---|---|---|
-| >15% GPU utilization drop | `mlp` recompute on a large FFN | check whether `recompute_modules` includes `mlp` | remove `mlp`, lower micro batch size, or use CPU offload if PP=1 |
-| Still OOM after adding layernorm | layernorm activations are too small to move the peak materially | compare peak memory before/after | switch to a higher-impact module or full-layer recompute |
-| `AssertionError: full recompute is only supported with full iteration CUDA graph` | layer-level recompute with TE-scoped graph capture | check `cuda_graph_impl` and `cuda_graph_scope` | use `selective`, set `cuda_graph_impl=none`, or use `local` + `full_iteration` |
-| ValueError: PP + CPU offloading | `cpu_offloading=True` with `pipeline_model_parallel_size > 1` | check PP config | disable CPU offloading or set PP=1 |
-| mlp+core_attn worse than mlp alone | double recompute overhead | compare Exp 1 vs Exp 2 | use mlp alone |
+| Symptom | Likely cause | Next action |
+|---|---|---|
+| `core_attn` gives little or no peak reduction | Fused/Flash attention already rematerializes the expensive internals, or the peak is elsewhere | Compare with `[]`, attribute the peak, then test the architecture-specific boundary such as `mla_up_proj` or `moe_act`. |
+| MLA still OOMs after `core_attn` | Expanded Q/K/V projection tensors, not attention-core tensors, dominate | Test `mla_up_proj`; add `core_attn` only if matched evidence supports it. |
+| MoE peak remains high | Expert intermediate or norm outputs dominate | Test `moe_act`, then `layernorm`; reserve whole `moe` for broader pressure. |
+| Expert-overlap validation fails | Whole-`moe` or `shared_experts` recompute conflicts with overlap | Keep overlap and use a compatible inner boundary, or disable overlap and remeasure the entire configuration. |
+| A selected label has no measurable effect | That module is absent or inactive on the measured layers, or graph capture bypassed the wrapper | Inspect the provider/layer mix and final graph scope; for example, `mlp` is ineffective on pure-MoE layers. |
+| Full recompute plus CUDA graphs asserts | Graph implementation is not full-iteration | Set `cuda_graph_impl="full_iteration"` or disable CUDA graphs. |
+| Reserved memory is high but allocated memory is stable | Allocator fragmentation or caching | Try `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` before adding recompute. |
+| OOM moves to a different rank after enabling recompute | Pipeline/virtual-pipeline layer distribution changed the bottleneck | Compare per-rank peaks and tune full block/uniform placement or selective boundaries for the actual hot stage. |
+| A candidate gets farther but still OOMs | Recompute moved the peak into gradient synchronization or optimizer-state initialization | Record the changed failure stage as diagnostic evidence, but require optimizer initialization and multiple steady steps before calling it a pass. |
 
 ## Known Limitations
 
-- Per-module memory savings vary significantly by model architecture and hidden
-  dimension
-- No automatic module selection — users must choose which modules to recompute
-- `layernorm` recompute is almost never worth it as a standalone fix
-- CPU offloading (the zero-compute-cost alternative) is blocked when PP > 1
+- A module list is not portable across model families, attention backends, parallel layouts, or Megatron Core revisions.
+- Memory savings are nonlinear when boundaries overlap or nest; additive arithmetic is unreliable.
+- Full recompute changes RNG execution paths; dropout workloads need a numerical/convergence check.
+- Activation recompute does not address parameter, optimizer-state, or allocator-fragmentation pressure.
+- The correct result is the smallest measured replay cost that satisfies the per-rank memory target, not the longest module list.
 
-## Verification
+## Further Reading
 
-```bash
-uv run python -m pytest \
-  tests/unit_tests/training/test_config.py -k "recompute" -q
-```
-
-Success criteria:
-- Unit tests pass for recompute config validation
-- No assertion errors from config validation
+- `docs/performance-guide.md`
+- `skills/nemo-mbridge-perf-memory-tuning/SKILL.md`
+- `skills/nemo-mbridge-perf-cuda-graphs/SKILL.md`
+- `skills/nemo-mbridge-perf-cpu-offloading/SKILL.md`
+- Megatron Core activation recomputation guide: <https://docs.nvidia.com/megatron-core/developer-guide/latest/api-guide/transformer.html#activation-recomputation>

--- a/skills/nemo-mbridge-perf-activation-recompute/card.yaml
+++ b/skills/nemo-mbridge-perf-activation-recompute/card.yaml
@@ -1,87 +1,112 @@
 title: activation_recompute
-validated_on: "2026-04-02"
+validated_on: "2026-08-12"
 summary: >
-  Selective activation recompute trades GPU compute for memory by recomputing
-  specific module outputs during backward instead of storing them. Megatron
-  Bridge exposes recompute_modules (core_attn, mlp, layernorm, moe, moe_act,
-  shared_experts, mla_up_proj) for fine-grained control. Measured on Llama3
-  70B SFT (32x H100, FP8 CS): mlp recompute saves ~3 GB peak memory but
-  costs ~16% GPU utilization; layernorm recompute is nearly free (~0% cost)
-  but saves negligible memory; core_attn recompute is the default and is
-  cheap when Flash Attention is active. Full-layer recompute
-  (recompute_granularity=full) gives the strongest memory reduction but the
-  highest compute overhead.
+  Selective activation recompute trades replayed forward work for lower retained
+  activation memory. The correct checkpoint boundary is architecture- and
+  backend-specific: core_attn is common for standard attention, mla_up_proj is
+  often more relevant for MLA, and moe_act or layernorm plus moe_act are common
+  narrow choices for grouped MoE. The pinned Megatron Core also accepts mlp,
+  moe, shared_experts, and gdn_norm_out. Full-layer recompute has the broadest
+  memory effect and replay cost. Development branches may expose additional
+  model-specific labels, so the exact target revision is authoritative.
 validation_status:
   selective_recompute_config:
-    - code_verified  # transformer_config.py, transformer_block.py
+    - code_verified  # transformer_config.py and module-local checkpoint sites
   full_layer_recompute_config:
-    - code_verified  # transformer_config.py
+    - code_verified  # transformer_config.py and transformer_block.py
   recompute_modules_enum:
-    - code_verified  # transformer_block.py
+    - code_verified  # transformer_config.py
   llama3_70b_sft_fp8_cs_experiment:
-    - measured  # PR #3107, 32x H100, TP4 PP4 VPP5 DP2
+    - measured  # historical PR #3107; contextual, not a cross-module ranking
+  moonlight_16b_bf16_experiment:
+    - measured  # matched 8-H100 module sweep with an empty-list control
+  nemotron_3_nano_bf16_experiment:
+    - measured  # matched 16-H100 capacity sweep through complete training steps
 training_dimensions:
   speed:
-    effect: "~0% (core_attn/layernorm) to ~16% slower (mlp)"
-    confidence: high
-    rationale: >
-      Measured on Llama3 70B SFT 32x H100: core_attn recompute costs ~0.8%
-      (704 vs 710 TFLOP/s/GPU); layernorm recompute adds ~0.3% on top;
-      mlp recompute costs ~16% (594 TFLOP/s/GPU) because the FFN
-      (hidden=28672) is expensive to recompute.
-  memory:
-    effect: "~0 GB (layernorm) to ~3 GB (mlp) peak memory reduction"
-    confidence: high
-    rationale: >
-      Measured on Llama3 70B SFT 32x H100: mlp recompute reduced peak from
-      58.8 to 55.6 GB. Layernorm recompute did not measurably reduce peak.
-      core_attn+layernorm together still OOMed at 59.6 GB.
-  scale:
-    effect: "neutral"
+    effect: workload-dependent replay overhead
     confidence: medium
     rationale: >
-      Recompute is per-GPU and does not change communication patterns.
+      Narrow output-discard boundaries such as moe_act can replay much less work
+      than whole mlp or moe boundaries. Attention cost also depends on the
+      backend and context-parallel communication. The historical Llama 3 70B
+      run measured mlp only relative to a core_attn baseline, not to a matched
+      no-recompute control. The matched Moonlight run found 1.99% overhead for
+      moe_act, 5.19% for mla_up_proj, and no useful core_attn memory reduction
+      in that exact fused-attention recipe. In the matched Nemotron run,
+      whole-moe recompute was the smallest tested passing boundary; adding
+      layernorm cost 3.07% more step time for 1.014 GB more rank-0 headroom.
+  memory:
+    effect: workload-dependent reduction in retained activations
+    confidence: medium
+    rationale: >
+      Savings depend on which tensors drive the per-rank peak. Standard
+      attention, MLA expansions, dense FFNs, grouped expert activations, and
+      norm outputs require different boundaries; nested boundaries are not
+      additive. The matched Moonlight sweep directly confirmed comparable
+      savings from moe_act and mla_up_proj, no material core_attn reduction,
+      and no incremental peak benefit from the tested nested additions. The
+      Nemotron sweep showed that a narrow boundary can materially reduce an
+      intermediate peak yet remain insufficient for the complete step.
+  scale:
+    effect: can replay communication at some boundaries
+    confidence: high
+    rationale: >
+      core_attn under context parallelism, whole moe, and gdn_norm_out can
+      replay communication during backward. Scale and topology therefore form
+      part of the measurement contract.
   convergence:
-    effect: "no change expected (numerically identical forward)"
-    confidence: high
+    effect: no semantic change expected when RNG replay is correct; verify
+    confidence: medium
     rationale: >
-      Recompute replays the same forward computation — no numerical change.
+      Recomputation should reproduce the forward region during backward, but
+      dropout, graph capture, precision, and branch-specific behavior warrant a
+      numerical or short convergence check.
   stability:
-    effect: "neutral"
+    effect: conditional on feature compatibility
     confidence: high
     rationale: >
-      No additional failure modes beyond the existing config constraints.
+      Megatron Core validates restrictions involving CUDA graphs, FP8 modes,
+      overlap features, and the selected module labels.
 enable_when:
-  - training OOMs or is close to the GPU memory limit
-  - memory savings from lighter modules (core_attn, layernorm) are enough
-  - throughput loss from mlp recompute is acceptable for the use case
-  - full-layer recompute is needed as a last resort for very tight memory
+  - allocated activation memory, rather than allocator fragmentation, drives OOM or inadequate headroom
+  - a matched architecture-specific checkpoint boundary reduces the hot rank's peak at acceptable throughput
+  - full-layer recompute is needed after narrower selective boundaries are exhausted
 avoid_when:
-  - the model already fits with acceptable headroom
-  - mlp recompute cost (~16%) is too high and VPP or parallelism tuning can fix OOM instead
-  - TE-scoped CUDA graphs are enabled with recompute_granularity=full (incompatible)
-  - CPU offloading is available and cheaper (PP=1 only)
+  - the model fits with acceptable headroom and recompute does not improve another measured objective
+  - max reserved memory is high but max allocated memory does not support an activation-capacity diagnosis
+  - the selected module is absent or inactive for the model's measured layers
+  - a required CUDA-graph, FP8, or overlap feature is incompatible with the boundary
 interactions:
   required: []
   conditional:
-    - recompute_granularity=full is incompatible with TE-scoped CUDA graphs
-    - recompute_granularity=full with uniform method requires recompute_num_layers
-    - recompute_granularity=selective requires recompute_modules list
-    - mlp recompute combined with core_attn is slightly worse than mlp alone due to double recompute overhead
+    - selective granularity accepts an empty recompute_modules list as a matched no-recompute control
+    - full granularity requires recompute_method and recompute_num_layers
+    - full recompute with CUDA graphs requires cuda_graph_impl=full_iteration
+    - selective graph capture requires each checkpoint boundary to lie wholly inside or wholly outside the graph scope
+    - core_attn can replay context-parallel communication and may add little with fused or Flash Attention
+    - moe_act and layernorm have FP8 delayed-scaling restrictions
+    - whole moe recompute is incompatible with expert-parallel overlap
+    - shared_experts recompute is incompatible with shared-expert overlap
   incompatible:
-    - recompute_granularity=full with cuda_graph_impl=transformer_engine
+    - full recompute with scoped or local non-full-iteration CUDA graphs
+    - whole moe recompute with expert-parallel overlap
+    - shared_experts recompute with shared-expert overlap
 feature_meaning:
   recompute_granularity: >
-    Controls scope: null (no recompute), selective (per-module), full
-    (entire transformer layer).
+    Controls scope: null (no recompute), selective (per-module), or full
+    (complete transformer-layer regions).
   recompute_modules: >
-    List of modules to selectively recompute: core_attn, mlp, layernorm,
-    moe, moe_act, shared_experts, mla_up_proj.
+    Pinned-revision labels are core_attn, mla_up_proj, layernorm, moe_act, mlp,
+    moe, shared_experts, and gdn_norm_out. Development revisions can add labels;
+    for example, DeepSeek V4's mhc label requires its development MCore branch.
   recompute_method: >
-    For full granularity: uniform (divide layers evenly into blocks) or
-    block (recompute a fixed number of layers per PP stage).
+    For full granularity: uniform groups fixed-size layer blocks; block selects
+    a fixed number of layers per pipeline stage with virtual-pipeline-aware
+    distribution.
   recompute_num_layers: >
-    For full granularity: number of layers per recomputation block.
+    For full granularity: the layer group size or number of selected layers,
+    depending on recompute_method.
 config_keys:
   - model.recompute_granularity
   - model.recompute_modules
@@ -89,22 +114,140 @@ config_keys:
   - model.recompute_num_layers
   - model.distribute_saved_activations
 recommended_path:
-  first_try: "recompute_granularity=selective, recompute_modules=[core_attn]"
-  if_still_oom: "add layernorm (cheap) or mlp (expensive but saves ~3 GB)"
-  last_resort: "recompute_granularity=full, recompute_method=uniform"
-  alternative: "see skills/nemo-mbridge-perf-memory-tuning/ for VPP tuning and other memory strategies"
+  first_step: compare per-rank allocated and reserved peaks and keep a matched no-recompute control
+  standard_attention: test core_attn, but compare it with an empty list under fused or Flash Attention
+  mla: test mla_up_proj first when expanded Q/K/V tensors dominate; add core_attn only with evidence
+  grouped_moe: test moe_act and then layernorm when their outputs drive the peak
+  dense_ffn: test mlp only when its broader replay cost is acceptable
+  broader_moe: reserve whole moe for cases where narrower MoE boundaries do not fit
+  last_resort: use full recompute with recompute_method and recompute_num_layers
+  alternative: see skills/nemo-mbridge-perf-memory-tuning for allocator, parallelism, and offloading options
 expected_metric_change:
   - metric: peak_memory
     direction: down
-    magnitude: "~0 GB (layernorm) to ~3 GB (mlp) on Llama3 70B SFT"
-    conditions: Llama3 70B, TP4 PP4 VPP5 DP2, 32x H100 80GB, FP8 CS
-    evidence: measured_pr_3107
-  - metric: gpu_utilization
-    direction: down
-    magnitude: "~0% (core_attn/layernorm) to ~16% (mlp)"
-    conditions: same as peak_memory
-    evidence: measured_pr_3107
+    magnitude: must be measured for the exact boundary and hot rank
+    conditions: matched model, backend, parallelism, precision, batch, and sequence configuration
+    evidence: module checkpoint implementations, matched Moonlight and Nemotron studies, and historical measured_pr_3107
+  - metric: steady_state_step_time
+    direction: up
+    magnitude: depends on replayed compute and communication
+    conditions: same matched configuration and warmup
+    evidence: module checkpoint implementations, matched Moonlight and Nemotron studies, and historical measured_pr_3107
 measured_results:
+  - model: Moonlight 16B
+    task: pretrain_short_run
+    revisions:
+      bridge: 600d069b824dd5ce50367a311a5a3244478faf22
+      megatron_core: 24bad8e677d22625d86ef2a54c9506b6e4992c93
+    parallelism: TP2_PP1_CP1_EP8_DP4
+    gpus: 8
+    gpu: H100_80GB
+    precision: BF16
+    seq_length: 4096
+    mbs: 1
+    gbs: 4
+    steps: 20
+    measurement: peak allocated after iteration 2; mean time and throughput over iterations 11-20
+    numerical_sanity: all losses finite; zero skipped and NaN iterations
+    experiments:
+      - name: empty_control
+        recompute_modules: []
+        peak_mem_gb: 36.618
+        step_time_ms: 457.18
+        tflops_per_gpu: 77.50
+      - name: core_attn
+        recompute_modules: ["core_attn"]
+        peak_mem_gb: 36.614
+        peak_mem_vs_control_pct: -0.01
+        step_time_ms: 474.80
+        step_time_vs_control_pct: 3.85
+      - name: mla_up_proj
+        recompute_modules: ["mla_up_proj"]
+        peak_mem_gb: 35.902
+        peak_mem_vs_control_pct: -1.96
+        step_time_ms: 480.89
+        step_time_vs_control_pct: 5.19
+      - name: mla_up_proj_plus_mlp
+        recompute_modules: ["mla_up_proj", "mlp"]
+        peak_mem_gb: 35.917
+        peak_mem_vs_control_pct: -1.91
+        step_time_ms: 496.73
+        step_time_vs_control_pct: 8.65
+      - name: moe_act
+        recompute_modules: ["moe_act"]
+        peak_mem_gb: 35.941
+        peak_mem_vs_control_pct: -1.85
+        step_time_ms: 466.26
+        step_time_vs_control_pct: 1.99
+      - name: layernorm_plus_moe_act
+        recompute_modules: ["layernorm", "moe_act"]
+        peak_mem_gb: 35.949
+        peak_mem_vs_control_pct: -1.83
+        step_time_ms: 506.53
+        step_time_vs_control_pct: 10.79
+    conclusion: >
+      For this exact mixed dense/MLA/MoE recipe, moe_act is the efficient first
+      boundary and mla_up_proj is the next candidate when its roughly 39 MB
+      additional saving matters. Adding mlp or layernorm did not reduce the
+      observed peak, and core_attn added cost without material memory benefit.
+  - model: Nemotron 3 Nano
+    task: pretrain_capacity_short_run
+    revisions:
+      bridge: 600d069b824dd5ce50367a311a5a3244478faf22
+      megatron_core: 24bad8e677d22625d86ef2a54c9506b6e4992c93
+    architecture: 52-layer hybrid Mamba/fused-attention MoE
+    parallelism: TP1_PP1_CP1_EP8_DP16
+    expert_data_parallel_size: 2
+    gpus: 16
+    gpu: H100_80GB
+    precision: BF16
+    seq_length: 8192
+    mbs: 1
+    gbs: 16
+    steps: 12
+    execution: HybridEP, grouped GEMM, TE CUDA graphs for attention and Mamba
+    measurement: rank-0 reported peak; mean time and throughput over iterations 7-12 for passing rows
+    experiments:
+      - name: empty_control
+        recompute_modules: []
+        peak_mem_gb_after_iteration_1: 66.297
+        status: OOM_iteration_2_moe_router
+      - name: core_attn
+        recompute_modules: ["core_attn"]
+        status: OOM_iteration_1_grouped_expert_linear
+      - name: moe_act
+        recompute_modules: ["moe_act"]
+        peak_mem_gb_after_iteration_1: 62.103
+        peak_mem_vs_control_pct_at_iteration_1: -6.33
+        status: OOM_iteration_2_output_projection
+      - name: layernorm_plus_moe_act
+        recompute_modules: ["layernorm", "moe_act"]
+        status: OOM_iteration_1_output_projection
+      - name: moe
+        recompute_modules: ["moe"]
+        peak_mem_gb: 64.653
+        step_time_ms: 657.42
+        tflops_per_gpu: 277.72
+        status: completed_12_steps
+      - name: moe_plus_layernorm
+        recompute_modules: ["moe", "layernorm"]
+        peak_mem_gb: 63.639
+        peak_mem_vs_moe_pct: -1.57
+        step_time_ms: 677.62
+        step_time_vs_moe_pct: 3.07
+        tflops_per_gpu: 270.62
+        status: completed_12_steps
+    numerical_sanity: both passing rows had finite losses and zero skipped or NaN iterations
+    comparison_limitations: >
+      Failed rows do not provide steady-state timing, and peaks from different
+      failure phases are not directly rankable. A native 8-H100 exploration
+      hit FP32 optimizer-state capacity and is excluded from throughput claims.
+    conclusion: >
+      Whole-moe recompute was the smallest tested boundary that completed the
+      exact capacity-limited workload. Adding layernorm bought 1.014 GB more
+      rank-0 headroom at 3.07% higher step time. Moe-act provided real relief
+      but did not make the complete step viable; core-attn did not make the
+      workload fit and yielded no positive memory evidence.
   - model: Llama3 70B
     task: sft
     parallelism: TP4_PP4_VPP5_DP2
@@ -115,8 +258,11 @@ measured_results:
     mbs: 1
     gbs: 32
     golden_tflops: 709.93
+    comparison_limitations: >
+      No matched no-recompute row was recorded; golden throughput was not a
+      paired module-only comparison; results do not cover MLA or MoE.
     experiments:
-      - name: baseline
+      - name: core_attn_baseline
         recompute_modules: ["core_attn"]
         tflops: 704
         vs_golden_pct: -0.8
@@ -141,34 +287,51 @@ measured_results:
         peak_mem_gb: 59.6
         status: OOM_on_rank0
 failure_modes:
-  - name: mlp_recompute_too_expensive
-    symptom: ">15% GPU utilization drop"
-    likely_cause: FFN hidden dimension is large (e.g. 28672 for Llama3 70B)
-    fix: use VPP tuning or parallelism changes instead
-  - name: layernorm_insufficient_savings
-    symptom: still OOM after adding layernorm recompute
-    likely_cause: layernorm activations are small relative to total peak
-    fix: add mlp recompute or switch to VPP tuning
-  - name: full_recompute_with_te_cuda_graphs
+  - name: core_attn_has_little_incremental_effect
+    symptom: no material peak reduction against the empty-list control
+    likely_cause: fused attention already rematerializes the expensive internals or another architecture region sets the peak
+    fix: attribute the peak and test mla_up_proj, moe_act, layernorm, or another applicable boundary
+  - name: module_is_inactive
+    symptom: selected recompute label causes no measurable change
+    likely_cause: the module is absent on the measured layers, such as mlp on pure-MoE layers, or graph capture bypasses the wrapper
+    fix: inspect the provider and final graph scope before choosing another boundary
+  - name: overlap_validation_failure
+    symptom: Megatron Core rejects whole-moe or shared-expert recompute
+    likely_cause: expert-parallel or shared-expert overlap conflicts with backward replay
+    fix: retain overlap and use a compatible inner boundary, or disable overlap and remeasure the complete configuration
+  - name: later_failure_is_misclassified_as_success
+    symptom: recompute advances beyond the control's failure point but still OOMs
+    likely_cause: the boundary moved the peak into a later forward region, gradient synchronization, or optimizer initialization
+    fix: record the changed failure stage, but require optimizer initialization and multiple steady-state steps before calling it a pass
+  - name: full_recompute_with_scoped_cuda_graphs
     symptom: "AssertionError: full recompute is only supported with full iteration CUDA graph"
-    likely_cause: recompute_granularity=full with any TE-scoped CUDA graph (attn, mlp, moe_router, etc.). Common on FP8 CS configs that default to cuda_graph_impl=transformer_engine + scope=mlp (e.g. LLAMA3_70B_SFT_CONFIG_H100_FP8_CS_V1). Enforced in MCore transformer_config.py:2001-2005.
-    fix: use recompute_granularity=selective with recompute_modules, or set cuda_graph_impl=none, or switch to cuda_graph_impl=local + cuda_graph_scope=full_iteration
+    likely_cause: full granularity is combined with a non-full-iteration graph implementation
+    fix: use selective recompute, set cuda_graph_impl=none, or use cuda_graph_impl=full_iteration
 known_constraints:
-  - recompute_granularity=selective requires a non-empty recompute_modules list
+  - recompute_granularity=selective accepts an empty recompute_modules list
   - recompute_granularity=full requires recompute_method and recompute_num_layers
   - distribute_saved_activations cannot be used with sequence_parallel=True
-  - combining mlp+core_attn is slightly worse than mlp alone due to double overhead
+  - valid module labels are revision-specific; use the exact target Megatron Core validator
+  - module boundaries can overlap or nest, so memory and replay costs are not additive
 known_limitations:
-  - per-module memory savings vary significantly by model architecture
-  - no automatic selection of optimal recompute_modules
-  - memory savings from layernorm are negligible on most architectures
+  - no automatic selection of the optimal recompute_modules list
+  - no single module ordering applies across standard attention, MLA, MoE, and GDN models
+  - matched Moonlight evidence covers one short BF16 MLA+MoE configuration and is not a universal ranking
+  - matched Nemotron evidence covers one short BF16 hybrid MoE capacity configuration and is not a universal ranking
+  - historical Llama evidence lacks a matched empty-list control
 evidence:
   - docs/training/activation-recomputation.md
-  - "PR #3107 (Llama3 70B SFT OOM fix experiment)"
-  - src/megatron/bridge/recipes/llama/llama3.py
+  - "2026-08-12 matched H100 Moonlight 16B activation-recompute study"
+  - "2026-08-12 matched H100 Nemotron 3 Nano activation-recompute study"
+  - "PR #3107 (historical Llama3 70B SFT experiment)"
   - 3rdparty/Megatron-LM/megatron/core/transformer/transformer_config.py
-  - 3rdparty/Megatron-LM/megatron/core/transformer/transformer_block.py
+  - 3rdparty/Megatron-LM/megatron/core/transformer/attention.py
+  - 3rdparty/Megatron-LM/megatron/core/transformer/multi_latent_attention.py
+  - 3rdparty/Megatron-LM/megatron/core/transformer/transformer_layer.py
+  - 3rdparty/Megatron-LM/megatron/core/transformer/moe/experts.py
+  - 3rdparty/Megatron-LM/megatron/core/transformer/moe/moe_layer.py
+  - 3rdparty/Megatron-LM/megatron/core/ssm/gated_delta_net/gdn.py
 follow_up_validation:
-  - Measure selective recompute impact on MoE models (moe, moe_act modules).
-  - Measure mla_up_proj recompute impact on DeepSeek-style MLA models.
-  - Test selective recompute + TE-scoped CUDA graphs combined perf impact.
+  - Add matched GDN measurements.
+  - Measure context-parallel communication replay for attention and GDN boundaries.
+  - Validate representative selective boundaries under the supported CUDA-graph scopes and FP8 recipes.

--- a/skills/nemo-mbridge-perf-activation-recompute/evals/evals.json
+++ b/skills/nemo-mbridge-perf-activation-recompute/evals/evals.json
@@ -1,16 +1,47 @@
 [
   {
-    "id": "activation-recompute-positive-memory-smoke",
-    "question": "Use the nemo-mbridge-perf-activation-recompute skill. My Megatron Bridge model is close to OOM and an FP8 config already uses TE-scoped CUDA graphs. Give a concise checklist with the first environment fix, the exact selective-to-full recompute order, the required full-recompute config fields, and the CUDA-graph assertion workaround.",
+    "id": "activation-recompute-architecture-aware-memory-smoke",
+    "question": "Use the nemo-mbridge-perf-activation-recompute skill. I have three Megatron Bridge jobs near OOM: one uses standard attention with Transformer Engine fused attention, one uses MLA, and one uses grouped MoE. Give a concise first-candidate recompute choice for each, explain why core_attn is not universal, state the required full-recompute fields, and cover the CUDA-graph workaround.",
     "expected_skill": "nemo-mbridge-perf-activation-recompute",
     "expected_script": null,
-    "ground_truth": "The answer should use the activation recompute skill. It should say to try PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True first, then start with recompute_granularity=\"selective\" and recompute_modules=[\"core_attn\"], optionally add layernorm, and use full recompute only if selective still does not fit. It should state full recompute requires recompute_method and recompute_num_layers, and that full/layer-level recompute is incompatible with TE-scoped CUDA graph scopes such as attn, mlp, or moe_router. It should give valid workarounds: use selective recompute, disable CUDA graphs with cuda_graph_impl=\"none\", or switch to cuda_graph_impl=\"local\" with cuda_graph_scope=\"full_iteration\".",
+    "ground_truth": "The answer should first distinguish allocated activation pressure from reserved-memory fragmentation and keep a matched no-recompute control. For standard attention, core_attn is a common candidate, but with TE fused or Flash Attention it must be compared with an empty selective module list because the backend already rematerializes attention internals. For MLA, mla_up_proj is the first candidate when expanded Q/K/V tensors dominate; core_attn can be additive when the attention core remains material. For grouped MoE, moe_act is the narrow first candidate and layernorm can be added when norm outputs matter; whole moe is broader and replays routing, experts, and communication. Full recompute requires recompute_method and recompute_num_layers. Full recompute with CUDA graphs requires cuda_graph_impl=full_iteration; otherwise use selective recompute or cuda_graph_impl=none.",
     "expected_behavior": [
       "Read the nemo-mbridge-perf-activation-recompute skill before answering.",
-      "Recommend PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True before recompute changes.",
-      "Prefer selective recompute with core_attn and optionally layernorm before full recompute.",
+      "Use a matched no-recompute control and distinguish allocated memory from allocator fragmentation.",
+      "Describe core_attn as common for standard attention but not a universal first choice.",
+      "Recommend mla_up_proj for MLA and moe_act, optionally layernorm, for grouped MoE based on peak attribution.",
       "State that full recompute requires recompute_method and recompute_num_layers.",
-      "Explain the TE-scoped CUDA graph incompatibility and list a valid workaround."
+      "Explain that full recompute with CUDA graphs requires full_iteration, with selective recompute or disabled graphs as alternatives."
+    ]
+  },
+  {
+    "id": "activation-recompute-moonlight-evidence",
+    "question": "Use the nemo-mbridge-perf-activation-recompute skill. For the exact Moonlight 16B H100 configuration measured by the skill, which selective boundary should I try first? Explain the tradeoff versus mla_up_proj, core_attn, and adding layernorm or mlp, and state whether the conclusion is portable to other recipes.",
+    "expected_skill": "nemo-mbridge-perf-activation-recompute",
+    "expected_script": null,
+    "ground_truth": "For the exact measured Moonlight workload, recommend moe_act first: it lowered peak allocated memory 1.85% with 1.99% step-time overhead. mla_up_proj saved 1.96%, only about 39 MB more, with 5.19% overhead, so it is the next choice only if the small additional saving matters. core_attn provided no material allocated-memory reduction and cost 3.85% under fused attention. Adding mlp to mla_up_proj or layernorm to moe_act did not improve the observed peak and increased step time. The answer must limit this conclusion to the exact measured architecture, backend, topology, precision, and shape rather than claim a universal label ranking.",
+    "expected_behavior": [
+      "Read the nemo-mbridge-perf-activation-recompute skill before answering.",
+      "Recommend moe_act first for the exact measured Moonlight workload.",
+      "Compare allocated-memory and step-time deltas against the matched empty-list control.",
+      "Explain that mla_up_proj provides only a small additional saving at higher cost in this run.",
+      "Reject core_attn and the broader tested additions as first choices for this exact run.",
+      "Do not extrapolate the measured ordering into a universal recommendation."
+    ]
+  },
+  {
+    "id": "activation-recompute-nemotron-capacity-evidence",
+    "question": "Use the nemo-mbridge-perf-activation-recompute skill. In the measured Nemotron 3 Nano 16-H100 workload, moe_act lowered an iteration-1 peak but the job still OOMed. What is the smallest tested passing choice, what does layernorm add, and how should I classify the moe_act result?",
+    "expected_skill": "nemo-mbridge-perf-activation-recompute",
+    "expected_script": null,
+    "ground_truth": "Whole moe recompute was the smallest tested choice that completed all 12 steps. Adding layernorm lowered the rank-0 post-iteration-2 peak from 64.653 GB to 63.639 GB, another 1.014 GB or 1.57%, but raised steady-state step time from 657.42 ms to 677.62 ms, or 3.07%. Moe_act lowered the matched iteration-1 rank-0 peak by 4.194 GB or 6.33% relative to the empty control, but then OOMed in the iteration-2 output projection. It is diagnostic evidence of real activation relief, not a pass. A pass requires optimizer initialization and multiple steady-state steps.",
+    "expected_behavior": [
+      "Read the nemo-mbridge-perf-activation-recompute skill before answering.",
+      "Identify whole moe as the smallest tested passing boundary for the exact Nemotron workload.",
+      "Quantify the extra memory headroom and step-time cost from adding layernorm.",
+      "Classify moe_act as useful failure-stage evidence rather than a successful configuration.",
+      "Require optimizer initialization and multiple steady-state steps for a pass.",
+      "Limit the conclusion to the measured Nemotron configuration."
     ]
   }
 ]

--- a/skills/nemo-mbridge-perf-activation-recompute/skill-card.md
+++ b/skills/nemo-mbridge-perf-activation-recompute/skill-card.md
@@ -1,7 +1,9 @@
 ## Description: <br>
-Validate and use selective and full activation recompute in Megatron Bridge to reduce GPU memory usage at the cost of extra compute. <br>
+Validate and use architecture-aware selective and full activation recompute in Megatron Bridge to reduce GPU memory usage at the cost of extra compute. <br>
 
 This skill is ready for commercial/non-commercial use. <br>
+
+The skill guidance and evaluation dataset changed materially on 2026-08-12. The evaluation results below are historical results for the previous version and do not validate the current version; a fresh NVSkills-Eval run is pending. <br>
 
 ## Owner
 NVIDIA <br>
@@ -19,7 +21,7 @@ Risk: Review before execution as proposals could introduce incorrect or misleadi
 Mitigation: Review and scan skill before deployment. <br>
 
 ## Reference(s): <br>
-- [Megatron Bridge Performance Tuning Guide](docs/performance-guide.md) <br>
+- [Megatron Bridge Performance Tuning Guide](../../docs/performance-guide.md) <br>
 - [Megatron Bridge Documentation](https://docs.nvidia.com/nemo/megatron-bridge/latest/) <br>
 
 
@@ -36,7 +38,7 @@ Mitigation: Review and scan skill before deployment. <br>
 
 
 ## Evaluation Tasks: <br>
-Evaluated against 1 internal skill-activation task in the NVSkills-Eval external profile. <br>
+The current package defines 3 internal skill-activation tasks. The historical results below used 1 previous-version task in the NVSkills-Eval external profile. <br>
 
 ## Evaluation Metrics Used: <br>
 Reported benchmark dimensions: <br>
@@ -57,7 +59,7 @@ Underlying evaluation signals used in this run: <br>
 
 
 
-## Evaluation Results: <br>
+## Historical Evaluation Results: <br>
 | Dimension | Num | `claude-code` | `codex` |
 |---|---:|---:|---:|
 | Security | 1 | 100% (+0%) | 100% (+0%) |
@@ -67,7 +69,7 @@ Underlying evaluation signals used in this run: <br>
 | Efficiency | 1 | 94% (+67%) | 96% (-0%) |
 
 ## Skill Version(s): <br>
-v0.2.0rc6-1622-g853062e4 (source: git describe) <br>
+Historical evaluated version: v0.2.0rc6-1622-g853062e4 (source: git describe). Current version: evaluation pending. <br>
 
 ## Ethical Considerations: <br>
 NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>


### PR DESCRIPTION
## Summary

- replace universal `core_attn` guidance with an architecture-, backend-, and peak-aware decision table covering every supported recompute label
- add matched H100 evidence for Moonlight 16B and Nemotron 3 Nano, with bounded historical Llama 3 70B context
- update the stable guide, skill metadata, and activation eval cases while clearly marking prior NVSkills results as historical

## Why

The previous guidance generalized a qualitative module ranking from an unmatched Llama experiment. It did not account for architecture-specific boundaries, fused-attention behavior, nested boundaries, runtime compatibility, or the distinction between moving an OOM later and making a workload viable.

## Evidence

| Model | Evidence-based conclusion |
|---|---|
| Moonlight 16B | `moe_act` reduced peak allocation by 1.85% for a 1.99% step-time cost; `mla_up_proj` reduced it by 1.96% for a 5.19% cost; explicit `core_attn` produced no material memory reduction under fused attention. |
| Nemotron 3 Nano | Whole-`moe` was the smallest tested boundary that completed; adding `layernorm` recovered another 1.014 GB at a 3.07% step-time cost. Narrow `moe_act` saved 4.194 GB at the intermediate peak but still OOMed after advancing farther. |
| Llama 3 70B (historical) | Whole-`mlp` recovered about 3.2 GB but cost about 16% throughput in the prior unmatched experiment; this is retained only as contextual evidence. |

The cross-model conclusion is to start with the narrowest architecture-specific boundary responsible for the measured per-rank peak, then broaden only when matched measurements show that it is necessary. There is no universal recompute-module ordering.

## Validation

- `uv run --no-sync pre-commit run --all-files`
- skill package validation with `quick_validate.py`
- JSON and YAML parsing, Markdown link checks, privacy scan, and `git diff --check`
- independent pre-publication technical review
- all successful experimental rows reported finite losses with zero skipped or NaN iterations

## Publication note

The existing `skill.oms.sig` belongs to the previous skill contents. This PR remains draft while a fresh NVSkills evaluation/signature refresh is requested; the historical signature must not be treated as validation of the amended package.
