### PR TITLE
feat(model): let callers supply a media-token validity mask

### DIFF
--- a/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
+++ b/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
@@ -642,6 +642,7 @@ class NemotronOmniModel(MegatronModule):
         sound_clips: Optional[torch.Tensor] = None,
         sound_length: Optional[torch.Tensor] = None,
         *,
+        media_token_validity_mask: torch.Tensor | None = None,
         inference_params=None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
@@ -689,16 +690,24 @@ class NemotronOmniModel(MegatronModule):
             if image_embeddings is None:
                 image_embeddings = combined_embeddings.new_empty((0, combined_embeddings.shape[-1]))
 
-            # MBridge collators use a 2-D attention mask as a token-validity
-            # mask, while NeMo RL's dense Megatron path supplies MCore's 4-D
-            # causal mask (where True means blocked).  Only the former can
-            # filter media placeholders.  Padding masks are unambiguous and
-            # take precedence for collator-owned packed inputs.
-            media_token_validity_mask = None
-            if padding_mask is not None:
-                media_token_validity_mask = ~padding_mask
-            elif attention_mask is not None and attention_mask.dim() == input_ids.dim():
-                media_token_validity_mask = attention_mask
+            # An explicit mask from the caller wins: padding and attention masks
+            # answer "is this a real token", which is a different question from
+            # "is this a media anchor".  They coincide only while every media
+            # token in a valid position anchors an image.  A caller whose text
+            # legitimately contains the placeholder -- it is an ordinary token in
+            # that vocabulary -- marks those positions here so they keep their
+            # embedding instead of demanding a projected feature.
+            #
+            # Otherwise: MBridge collators use a 2-D attention mask as a
+            # token-validity mask, while NeMo RL's dense Megatron path supplies
+            # MCore's 4-D causal mask (where True means blocked).  Only the
+            # former can filter media placeholders.  Padding masks are
+            # unambiguous and take precedence for collator-owned packed inputs.
+            if media_token_validity_mask is None:
+                if padding_mask is not None:
+                    media_token_validity_mask = ~padding_mask
+                elif attention_mask is not None and attention_mask.dim() == input_ids.dim():
+                    media_token_validity_mask = attention_mask
 
             combined_embeddings = self._merge_projected_media(
                 combined_embeddings,

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
@@ -561,6 +561,48 @@ def test_padded_placeholder_is_not_treated_as_media():
     assert torch.equal(output[3, 0], torch.zeros(3))
 
 
+def test_text_containing_the_placeholder_trains_with_a_caller_mask():
+    """A row with no media may still spell the placeholder in ordinary prose.
+
+    The media token is a normal vocabulary entry, so text can contain it -- a
+    problem statement quoting ``<image>``, for instance. Derived masks answer
+    "is this a real token", which cannot distinguish that from an anchor, so
+    without a caller-supplied mask the merge demands a feature that was never
+    meant to exist.
+    """
+    model = _BoundaryModel(torch.empty(0, 3))
+    input_ids = torch.tensor([[7, 18, 9]])
+
+    with pytest.raises(ValueError, match="1 valid placeholders for 0 projected features"):
+        model(input_ids=input_ids)
+
+    output = model(
+        input_ids=input_ids,
+        media_token_validity_mask=torch.tensor([[True, False, True]]),
+    )
+
+    # The spared placeholder keeps the language embedding the forward gave it.
+    # That embedding is of token id 0, because the forward masks media tokens
+    # out of the text before embedding regardless of the validity mask.
+    assert torch.equal(output, torch.tensor([[[7.0] * 3], [[0.0] * 3], [[9.0] * 3]]))
+
+
+def test_caller_mask_takes_precedence_over_the_derived_one():
+    """An explicit mask must win, or the caller cannot express this at all."""
+    model = _BoundaryModel(torch.empty(0, 3))
+    input_ids = torch.tensor([[7, 18, 9]])
+
+    # A padding mask marks every position valid, so on its own it would treat
+    # the placeholder as an anchor and raise.
+    output = model(
+        input_ids=input_ids,
+        padding_mask=torch.zeros(1, 3, dtype=torch.bool),
+        media_token_validity_mask=torch.tensor([[True, False, True]]),
+    )
+
+    assert output.shape == (3, 1, 3)
+
+
 def test_media_merge_supports_backward_for_batch_size_one():
     language_embeddings = torch.randn(4, 1, 3, requires_grad=True)
     media_embeddings = torch.randn(2, 3, requires_grad=True)


### PR DESCRIPTION
## What

`NemotronOmniModel.forward` gains a keyword-only `media_token_validity_mask`
that takes precedence over the masks it currently derives. Behavior is
unchanged when the argument is omitted.

## Why

`_merge_projected_media` enforces a strict 1:1 contract — one projected feature
per valid placeholder. That contract is right; the question is where the
placeholder mask comes from. Today it is derived from the padding mask, or a
2-D attention mask:

```python
media_token_validity_mask = None
if padding_mask is not None:
    media_token_validity_mask = ~padding_mask
elif attention_mask is not None and attention_mask.dim() == input_ids.dim():
    media_token_validity_mask = attention_mask
```

Both answer **"is this a real token?"**. The merge needs **"is this a media
anchor?"**. Those coincide only while every media token in a non-padding
position anchors an image.

A media placeholder is an ordinary vocabulary entry, so text can legitimately
contain it. Such a row attaches no image, but the derived mask still marks the
position valid, so the merge demands a feature that was never meant to exist
and raises.

This is not hypothetical. The text post-training data can include `<image>` with zero attached images —
competitive-programming statements where `<image>` replaced inline math, e.g.
`"for any character <image> there is exactly one character"`. They carry between
1 and 12 placeholders each.

Callers know how many media items each row carries, so they can answer the
question the model cannot. This lets them do so.

Rows that do carry media keep every position valid, so a genuine
placeholder/feature disagreement is still reported rather than masked away — the
argument cannot be used to silence real misalignment.

## Tests

Two tests via the existing `_BoundaryModel` harness, which exercises the real
forward on CPU:

- `test_text_containing_the_placeholder_trains_with_a_caller_mask` — a row that
  spells the placeholder raises without a mask, and trains with one.
- `test_caller_mask_takes_precedence_over_the_derived_one` — an explicit mask
  wins over a padding mask that would otherwise treat the placeholder as an
  anchor.

Verified against this branch: 9 passed, 0 failed for
`tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py`
(`-k "caller_mask or validity_mask or placeholder or text_only or media_alignment or collapsed"`).

`ruff check` and `ruff format --check` clean under the repo config.
