### PR TITLE
[data] fix: reject empty FLUX mock epochs

### DIFF
--- a/src/megatron/bridge/diffusion/data/flux/flux_mock_datamodule.py
+++ b/src/megatron/bridge/diffusion/data/flux/flux_mock_datamodule.py
@@ -220,6 +220,11 @@ class FluxMockDataModuleConfig(DatasetProvider):
 
     def __post_init__(self):
         """Initialize the mock dataset and dataloader."""
+        if 0 < self.num_train_samples < self.micro_batch_size:
+            raise ValueError(
+                "num_train_samples must be at least micro_batch_size so drop_last=True yields a complete batch."
+            )
+
         self._mock_ds = _MockT2IDataset(
             image_H=self.image_H,
             image_W=self.image_W,

--- a/tests/unit_tests/diffusion/data/flux/test_flux_mock_datamodule.py
+++ b/tests/unit_tests/diffusion/data/flux/test_flux_mock_datamodule.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 
 from megatron.bridge.diffusion.data.flux.flux_mock_datamodule import FluxMockDataModuleConfig
@@ -101,6 +102,23 @@ def test_flux_mock_datamodule_repeats_with_independent_splits():
     next(test_dl)
     assert train_dl is not val_dl
     assert val_dl is not test_dl
+
+
+def test_flux_mock_datamodule_rejects_empty_repeated_epochs():
+    with pytest.raises(ValueError, match="num_train_samples.*micro_batch_size"):
+        FluxMockDataModuleConfig(
+            micro_batch_size=2,
+            global_batch_size=2,
+            num_workers=0,
+            image_H=8,
+            image_W=8,
+            vae_channels=1,
+            vae_scale_factor=8,
+            prompt_seq_len=2,
+            context_dim=2,
+            pooled_prompt_dim=2,
+            num_train_samples=1,
+        )
 
 
 def test_flux_mock_datamodule_without_precaching():


### PR DESCRIPTION
## What

Reject FLUX mock-data configurations that cannot produce a complete microbatch when drop_last=True.

## Supported trigger and impact

FluxMockDataModuleConfig accepts both num_train_samples and micro_batch_size. When 0 < num_train_samples < micro_batch_size, the underlying DataLoader has zero batches. The infinite repeated-epoch iterator introduced in #5534 then continually reopens empty epochs, so the first FLUX batch fetch spins forever instead of returning data or failing promptly.

This affects direct/custom use of the public mock provider. Checked-in FLUX recipes remain unchanged and use safe defaults.

## Root cause

Runtime path:

    FluxMockDataModuleConfig
      -> DataLoader(drop_last=True)
      -> chain.from_iterable(repeat(dataloader))
      -> external-loader passthrough
      -> flux_data_step next(dataloader_iter)

Repeating an empty iterable forever can neither yield a batch nor terminate.

## Fix

Validate the demonstrated configuration boundary in FluxMockDataModuleConfig.__post_init__ before constructing the repeated loaders. This is the narrow owning boundary; no iterator, real Energon dataset, distributed API, or training semantic changes.

## Regression evidence

Fail before:

- Exact production-module CPU reproducer printed READY_FOR_FIRST_BATCH, then timed out after 15 seconds with exit 124 at the first next(train_iterator).
- The unchanged regression selector failed with: Failed: DID NOT RAISE ValueError.

Pass after:

    uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/diffusion/data/flux tests/unit_tests/diffusion/data/flux/test_flux_mock_datamodule.py::test_flux_mock_datamodule_rejects_empty_repeated_epochs -q
    # 1 passed

    uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/diffusion/data/flux tests/unit_tests/diffusion/data/flux/test_flux_mock_datamodule.py -q
    # 5 passed

    git diff --check
    # passed

    uv run --no-sync pre-commit run --all-files
    # all hooks passed

The focused CPU run used an isolated package-initialization harness because this workstation's optional CUDA stack fails during top-level megatron.bridge import; it imported the exact production FLUX submodule and exact repository test while leaving PyTorch DataLoader and iterator behavior unmocked.

## Scope

- No dependency, lockfile, workflow, public signature, checkpoint, or real-dataset changes.
- No GPU, convergence, model-quality, or performance claims.
