### PR TITLE
[inference] fix: Cap request capacity by token budget

### DIFF
--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import torch
 from megatron.core.inference.apis import SamplingParams
 from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.utils import get_attr_wrapped_model
 from transformers import AutoConfig, AutoTokenizer
@@ -342,6 +343,18 @@ def build_inference_config(
             f"so it is divisible by tensor parallel size {tp}."
         )
         max_requests = rounded
+
+    max_tokens_limit = max_tokens or DynamicInferenceContext.DEFAULT_MAX_TOKENS
+    if max_requests is not None and max_requests > max_tokens_limit:
+        if max_batch_size is not None:
+            raise ValueError(f"--max_batch_size ({max_batch_size}) cannot exceed --max_tokens ({max_tokens_limit}).")
+        max_requests = max_tokens_limit // tp * tp
+        if max_requests == 0:
+            raise ValueError(f"--max_tokens ({max_tokens_limit}) must be at least --tp ({tp}).")
+        print_rank_0(
+            f"Capping max batch size at {max_requests} because active requests cannot exceed "
+            f"max tokens ({max_tokens_limit})."
+        )
 
     return InferenceConfig(
         block_size_tokens=effective_block_size,

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -44,6 +44,10 @@ class _MambaInferenceStateConfig:
         return cls()
 
 
+class _DynamicInferenceContext:
+    DEFAULT_MAX_TOKENS = 16_384
+
+
 class _SamplingParams:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
@@ -72,6 +76,10 @@ def _install_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
             "megatron.core.inference.config",
             InferenceConfig=_PassthroughInit,
             MambaInferenceStateConfig=_MambaInferenceStateConfig,
+        ),
+        "megatron.core.inference.contexts.dynamic_context": _module(
+            "megatron.core.inference.contexts.dynamic_context",
+            DynamicInferenceContext=_DynamicInferenceContext,
         ),
         "megatron.core.transformer.enums": _module(
             "megatron.core.transformer.enums",
@@ -196,6 +204,49 @@ def test_build_inference_config_auto_sizes_max_requests_when_unset(text_generati
     )
 
     assert config.kwargs["max_requests"] is None
+
+
+@pytest.mark.parametrize(
+    ("num_prompts", "tp", "max_tokens", "expected_max_requests"),
+    ((16_385, 1, None, 16_384), (10, 2, 3, 2)),
+)
+def test_build_inference_config_caps_default_requests_at_token_budget(
+    text_generation, num_prompts, tp, max_tokens, expected_max_requests
+):
+    model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
+
+    config = text_generation.build_inference_config(
+        model=model,
+        max_sequence_length=4096,
+        max_batch_size=None,
+        num_prompts=num_prompts,
+        tp=tp,
+        block_size_tokens=256,
+        kv_cache_buffer_size_gb=20.0,
+        max_tokens=max_tokens,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+    )
+
+    assert config.kwargs["max_requests"] == expected_max_requests
+
+
+def test_build_inference_config_rejects_explicit_batch_above_token_budget(text_generation):
+    model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
+
+    with pytest.raises(ValueError, match=r"--max_batch_size \(4\) cannot exceed --max_tokens \(3\)"):
+        text_generation.build_inference_config(
+            model=model,
+            max_sequence_length=4096,
+            max_batch_size=4,
+            num_prompts=10,
+            tp=2,
+            block_size_tokens=256,
+            kv_cache_buffer_size_gb=20.0,
+            max_tokens=3,
+            return_log_probs=False,
+            enable_chunked_prefill=False,
+        )
 
 
 def test_build_inference_config_clamps_learned_absolute_sequence_length(text_generation):


### PR DESCRIPTION
## What changed

Cap prompt-derived dynamic-inference request capacity at the effective token budget, while preserving tensor-parallel divisibility. Explicit incompatible `--max_batch_size` values now fail early with a targeted `ValueError`.

## User impact and root cause

The supported offline generation CLIs default `max_requests` to the number of prompts. With 16,385 prompts and default engine arguments, Bridge passed `max_requests=16385` and `max_tokens=None`. MCore resolves the latter to 16,384 and aborts during context construction because active tokens must be at least active requests, before any prompt is processed.

Bridge now reads MCore's authoritative default token limit and caps only inferred request capacity to the largest TP-divisible value within that limit. Excess submitted prompts remain eligible for normal waiting-queue admission. Explicit request limits are never silently reduced.

## Regression evidence

Focused helper test (actual Bridge capacity logic; CPU-only dependency preload used on this workstation):

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts -p pytest_cpu_preload tests/unit_tests/scripts/test_text_generation.py::test_build_inference_config_caps_default_requests_at_token_budget -q
```

- Before: 2 failed. The default case produced 16,385 requests for 16,384 effective tokens; the TP=2 counterexample produced 10 requests for 3 tokens.
- After: both cases pass, producing compatible capacities of 16,384 and 2.

Adjacent validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts -p pytest_cpu_preload tests/unit_tests/scripts/test_text_generation.py -k build_inference_config -q
# 7 passed, 12 deselected

uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_async_text_generation_entrypoint.py -q
# 2 passed

uv run --no-sync pre-commit run --all-files
# passed

git diff --check
# passed
```

The preload only avoids collecting GPU-only sampling imports in the CPU environment; the regression loads the real Bridge helper and stubs its external dependencies in the existing fixture.

## Scope

- No public API signatures changed.
- Server auto-sizing remains unchanged when both request inputs are unset.
- No GPU execution, convergence, performance, or full-suite validation is claimed.
