### PR TITLE
[recipe] fix: Rebuild GLM-4.5V layouts after PP overrides

### DIFF
--- a/src/megatron/bridge/recipes/glm_vl/h100/glm_45v.py
+++ b/src/megatron/bridge/recipes/glm_vl/h100/glm_45v.py
@@ -17,6 +17,7 @@
 This module provides SFT and PEFT configurations for GLM-4.5V (106B MoE).
 """
 
+from functools import partial
 from typing import List, Optional, Union
 
 import torch
@@ -31,23 +32,10 @@ from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam
 from megatron.bridge.training.config import ConfigContainer
 
 
-def set_glm_45v_pipeline_model_parallel_layout(
-    model_cfg: GPTModelProvider, layout: Optional[Union[str, List[List[str]]]] = None, is_peft: bool = False
-) -> None:
-    """Set the GLM-4.5V pipeline model parallel layout.
-
-    GLM-4.5V (based on GLM-4.5 Air) has 46 decoder layers and no MTP layers.
-    This function sets up predefined layouts for common PP/VP combinations.
-
-    Args:
-        model_cfg: The model provider configuration to modify.
-        layout: Optional custom layout. If None, uses predefined layouts based on PP/VP sizes.
-        is_peft: Whether the model is trained with PEFT.
-    """
+def _get_glm_45v_pipeline_layout(pp_size: int, vp_size: int | None, *, is_peft: bool) -> list[list[str]]:
+    """Get a GLM-4.5V pipeline layout for the requested topology."""
     # GLM-4.5V has no MTP layers
     last_layer = ["loss"]
-    pp_size = model_cfg.pipeline_model_parallel_size or 1
-    vp_size = model_cfg.virtual_pipeline_model_parallel_size or 1
 
     # GLM-4.5 Air has 46 decoder layers
     # GLM-4.5 Vision Encoder is huge, we need to balance the first stage with the least number of layers
@@ -73,13 +61,46 @@ def set_glm_45v_pipeline_model_parallel_layout(
                 ["decoder"] * 11 + last_layer,
             ],
             (8, 1): [["embedding"] + ["decoder"]] + [["decoder"] * 7] * 6 + [["decoder"] * 3 + last_layer],
-            (16, 1): [["embedding"]] + [["decoder"] * 3] * 14 + [["decoder"] * 3 + last_layer],
+            (16, 1): [["embedding", "decoder"]] + [["decoder"] * 3] * 14 + [["decoder"] * 3 + last_layer],
         }
 
+    effective_vp_size = 1 if vp_size is None else vp_size
+    if (pp_size, effective_vp_size) not in layout_map:
+        raise ValueError(
+            f"Invalid PP and VP size: {pp_size} and {effective_vp_size} to infer PP layout "
+            f"for GLM-4.5V. Known PP and VP combinations: {layout_map.keys()}"
+        )
+    return layout_map[(pp_size, effective_vp_size)]
+
+
+def set_glm_45v_pipeline_model_parallel_layout(
+    model_cfg: GPTModelProvider, layout: Optional[Union[str, List[List[str]]]] = None, is_peft: bool = False
+) -> None:
+    """Set the GLM-4.5V pipeline model parallel layout.
+
+    GLM-4.5V (based on GLM-4.5 Air) has 46 decoder layers and no MTP layers.
+    This function sets up predefined layouts for common PP/VP combinations.
+
+    Args:
+        model_cfg: The model provider configuration to modify.
+        layout: Optional custom layout. If None, uses predefined layouts based on PP/VP sizes.
+        is_peft: Whether the model is trained with PEFT.
+    """
     if layout is not None:
         model_cfg.pipeline_model_parallel_layout = layout
-    elif (pp_size, vp_size) in layout_map:
-        model_cfg.pipeline_model_parallel_layout = layout_map[(pp_size, vp_size)]
+        if hasattr(model_cfg, "_pipeline_model_parallel_layout_builder"):
+            del model_cfg._pipeline_model_parallel_layout_builder
+        return
+
+    layout_builder = partial(_get_glm_45v_pipeline_layout, is_peft=is_peft)
+    model_cfg._pipeline_model_parallel_layout_builder = layout_builder
+    try:
+        model_cfg.pipeline_model_parallel_layout = layout_builder(
+            model_cfg.pipeline_model_parallel_size or 1,
+            model_cfg.virtual_pipeline_model_parallel_size,
+        )
+    except ValueError:
+        pass
 
 
 # =============================================================================

--- a/tests/unit_tests/recipes/test_glm_45v_recipes.py
+++ b/tests/unit_tests/recipes/test_glm_45v_recipes.py
@@ -27,6 +27,7 @@ from typing import Callable
 import pytest
 
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
+from tests.unit_tests.training.test_run_recipe_qwen3_omni import _load_recipe_runner_module
 
 
 _glm_45v_module = importlib.import_module("megatron.bridge.recipes.glm_vl.glm_45v")
@@ -362,3 +363,36 @@ def test_glm_45v_sft_uses_pipeline_layout(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.pipeline_model_parallel_size >= 1
     # Check if pipeline_model_parallel_layout is set
     assert hasattr(cfg.model, "pipeline_model_parallel_layout")
+
+
+@pytest.mark.parametrize(
+    ("recipe_func", "first_stage_decoders"),
+    [
+        (_glm_45v_module.glm_45v_sft_config, {4: 11, 8: 1, 16: 1}),
+        (_glm_45v_module.glm_45v_peft_config, {4: 11, 8: 5, 16: 2}),
+    ],
+)
+@pytest.mark.parametrize("pp_size", [4, 8, 16])
+def test_glm_45v_pipeline_layout_tracks_supported_cli_topology(
+    recipe_func: Callable,
+    first_stage_decoders: dict[int, int],
+    pp_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Recipe-owned layouts must follow supported pipeline overrides."""
+    patch_recipe_module_global(monkeypatch, _glm_45v_module, "AutoBridge", _FakeAutoBridge)
+    cfg = recipe_func()
+    recipe_runner, _ = _load_recipe_runner_module()
+
+    cfg.model.pipeline_model_parallel_size = pp_size
+    recipe_runner.sync_model_pipeline_layout(
+        cfg,
+        cli_overrides=[f"model.pipeline_model_parallel_size={pp_size}"],
+    )
+
+    layout = cfg.model.pipeline_model_parallel_layout
+    assert len(layout) == pp_size
+    assert sum(stage.count("decoder") for stage in layout) == 46
+    assert layout[0].count("decoder") == first_stage_decoders[pp_size]
+    assert layout[0][0] == "embedding"
+    assert layout[-1][-1] == "loss"


### PR DESCRIPTION
## Problem

The public GLM-4.5V SFT and PEFT recipes build a PP=8 pipeline layout before
runner CLI overrides are applied. Unlike sibling layout-owning recipes, they did
not register a layout builder, so `-pp 4` retained eight stages and MCore
silently interpreted them as VP=2 instead of selecting the recipe's PP=4/VP=1
layout. `-pp 16` failed MCore's stage-divisibility assertion.

The SFT PP=16 entry also contained only 45 of the provider's 46 decoder layers,
which would have kept that supported topology invalid once rebuilding was
enabled.

## Fix

- Expose the existing topology maps through the runner's private layout-builder
  contract, binding the SFT/PEFT mode for later PP/VP synchronization.
- Preserve explicit custom-layout ownership by removing the recipe builder when
  the exported setter receives a custom layout.
- Add the missing decoder to the SFT PP=16 layout.
- Cover both public recipe aliases across every declared PP=4/8/16 topology.

## Validation

Fail-before:

- `python3 reproduce_pipeline_override.py` — failed with
  `expected 4 pipeline stages after PP override, got 8` against
  `2b8cb21d90548a5796c748f1986c77fc1cfe2417`.

Pass-after:

- `python3 reproduce_pipeline_override.py` — passed all six SFT/PEFT PP=4/8/16
  layouts through the exact pinned MCore layout constructor and validator.
- `python3 adjacent_controls.py` — passed default-layout and
  default-then-custom ownership controls.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed all hooks.

The submitted focused pytest is
`uv run python -m pytest -q tests/unit_tests/recipes/test_glm_45v_recipes.py -k pipeline_layout_tracks_supported_cli_topology`.
Local collection was blocked before test execution by the available container's
CUDA/Transformer Engine initialization, so it is not reported as a local pass;
the fail-before/pass-after gate used the deterministic production-source
reproducer above.

## Scope

This changes only the recipe-owned PP=4/8/16, VP=1 layouts already declared by
GLM-4.5V. It does not add new topology combinations or change runner/public API
signatures.
