### PR TITLE
Add canonical ModelOpt quantized export bridge

### DIFF
--- a/docs/fern/versions/nightly/pages/modelopt/quantization.mdx
+++ b/docs/fern/versions/nightly/pages/modelopt/quantization.mdx
@@ -140,46 +140,24 @@ Use `AutoBridge.export_hf_weights_modelopt()` when you need to stream ModelOpt d
 already-loaded Megatron model instead of writing a full checkpoint through the export script. This is useful for
 integrations that consume Hugging Face weight names directly, such as inference-engine refit paths.
 
-The API currently only supports `quant_mode="nvfp4"`. Quantized parameters are yielded as the original Hugging Face
-`*.weight` name plus the ModelOpt NVFP4 scale tensors:
+The initialized ModelOpt quantizer graph determines the deployment format. Use
+`get_hf_modelopt_quantization_config()` for the matching Hugging Face configuration and
+`export_hf_weights_modelopt()` for its canonical named tensors. Unquantized parameters keep their regular Hugging
+Face names, and quantizer-internal tensors are skipped.
 
-- `*.weight`
-- `*.weight_scale`
-- `*.weight_scale_2`
-
-Unquantized parameters are yielded under their regular Hugging Face names. Quantizer-internal tensors are skipped.
-
-```python
-from safetensors.torch import save_file
-
-state_dict = {}
-for name, weight in bridge.export_hf_weights_modelopt(
-    model,
-    quant_mode="nvfp4",
-    cpu=True,
-    show_progress=False,
-):
-    state_dict[name] = weight.contiguous()
-
-save_file(state_dict, "modelopt-nvfp4.safetensors")
-```
-
-For large models, consume the iterator directly in the downstream writer or refit path instead of materializing the
-full `state_dict`.
+The programmatic API is an in-memory integration surface, not a standalone checkpoint writer. Use the export script
+above when you need a complete checkpoint on disk. For a refit integration, initialize the consumer from the returned
+configuration before streaming the matching tensors:
 
 ```python
+quantization_config = bridge.get_hf_modelopt_quantization_config(model)
+refit_engine.configure_quantization(quantization_config)
 for name, weight in bridge.export_hf_weights_modelopt(
     model,
-    quant_mode="nvfp4",
-    ignore_patterns=["lm_head", "*self_attn.o_proj*"],
     show_progress=False,
 ):
     refit_engine.replace_weight(name, weight)
 ```
-
-`ignore_patterns` are matched against Hugging Face parameter names. The matcher handles the optional `model.` prefix
-and ModelOpt scale suffixes, so a pattern can target the logical parameter name without separately listing
-`*.weight_scale` and `*.weight_scale_2`.
 
 ### Supported Models For PTQ
 

--- a/docs/modelopt/quantization.md
+++ b/docs/modelopt/quantization.md
@@ -140,46 +140,24 @@ Use `AutoBridge.export_hf_weights_modelopt()` when you need to stream ModelOpt d
 already-loaded Megatron model instead of writing a full checkpoint through the export script. This is useful for
 integrations that consume Hugging Face weight names directly, such as inference-engine refit paths.
 
-The API currently only supports `quant_mode="nvfp4"`. Quantized parameters are yielded as the original Hugging Face
-`*.weight` name plus the ModelOpt NVFP4 scale tensors:
+The initialized ModelOpt quantizer graph determines the deployment format. Use
+`get_hf_modelopt_quantization_config()` for the matching Hugging Face configuration and
+`export_hf_weights_modelopt()` for its canonical named tensors. Unquantized parameters keep their regular Hugging
+Face names, and quantizer-internal tensors are skipped.
 
-- `*.weight`
-- `*.weight_scale`
-- `*.weight_scale_2`
-
-Unquantized parameters are yielded under their regular Hugging Face names. Quantizer-internal tensors are skipped.
-
-```python
-from safetensors.torch import save_file
-
-state_dict = {}
-for name, weight in bridge.export_hf_weights_modelopt(
-    model,
-    quant_mode="nvfp4",
-    cpu=True,
-    show_progress=False,
-):
-    state_dict[name] = weight.contiguous()
-
-save_file(state_dict, "modelopt-nvfp4.safetensors")
-```
-
-For large models, consume the iterator directly in the downstream writer or refit path instead of materializing the
-full `state_dict`.
+The programmatic API is an in-memory integration surface, not a standalone checkpoint writer. Use the export script
+above when you need a complete checkpoint on disk. For a refit integration, initialize the consumer from the returned
+configuration before streaming the matching tensors:
 
 ```python
+quantization_config = bridge.get_hf_modelopt_quantization_config(model)
+refit_engine.configure_quantization(quantization_config)
 for name, weight in bridge.export_hf_weights_modelopt(
     model,
-    quant_mode="nvfp4",
-    ignore_patterns=["lm_head", "*self_attn.o_proj*"],
     show_progress=False,
 ):
     refit_engine.replace_weight(name, weight)
 ```
-
-`ignore_patterns` are matched against Hugging Face parameter names. The matcher handles the optional `model.` prefix
-and ModelOpt scale suffixes, so a pattern can target the logical parameter name without separately listing
-`*.weight_scale` and `*.weight_scale_2`.
 
 ### Supported Models For PTQ
 

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -31,6 +31,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 
 
 if TYPE_CHECKING:
+    from megatron.bridge.models.conversion.modelopt_utils import ModelOptExportPlan
     from megatron.bridge.peft.base import PEFT
 
 from megatron.core.transformer.module import MegatronModule
@@ -771,58 +772,64 @@ class AutoBridge(Generic[MegatronModelT]):
     def export_hf_weights_modelopt(
         self,
         model: MegatronModelT | list[MegatronModelT],
-        quant_mode: str = "nvfp4",
         cpu: bool = False,
         show_progress: bool = True,
         conversion_tasks: Optional[List[WeightConversionTask]] = None,
-        ignore_patterns: Optional[List[str]] = None,
         merge_adapter_weights: bool = True,
     ) -> Iterable["HFWeightTuple"]:
         """Export Megatron weights to HuggingFace ModelOpt deployment format.
 
+        This method prepares ModelOpt state eagerly before returning the lazy weight iterator. Because state
+        preparation uses model-parallel collectives, every rank must call this method in the same order and fully
+        consume the returned iterator before starting another distributed conversion operation.
+
         Args:
             model: Megatron model instance or list of instances.
-            quant_mode: ModelOpt quantization mode to export. Currently supports
-                ``"nvfp4"`` and ``"w4a16_nvfp4"``.
             cpu: Whether to move exported tensors to CPU before yielding.
             show_progress: Display progress bar during base Hugging Face weight export.
             conversion_tasks: Pre-built conversion tasks. If not provided, tasks will be built
                 automatically from the models.
-            ignore_patterns: Hugging Face parameter name patterns that should remain unquantized.
-                Scale tensor suffixes and the optional ``model.`` prefix are ignored when matching.
             merge_adapter_weights: Whether to gather and merge LoRA adapter weights into the base
                 tensors during export.
 
-        Yields:
-            HFWeightTuple: Named tuples containing Hugging Face parameter names and tensors. Quantized
-            weights yield the packed weight under the original ``*.weight`` name followed by the
-            corresponding ``*.weight_scale`` and ``*.weight_scale_2`` tensors.
-
-        Raises:
-            RuntimeError: If a matched quantized Megatron parameter uses a qformat unsupported by
-                ``quant_mode``.
+        Returns:
+            A lazy iterator of named Hugging Face tensors. Quantized weights produce the packed weight and
+            scale tensors named by ModelOpt's deployment format.
         """
+        model, plan = self._build_modelopt_export_plan(model, conversion_tasks)
+        hf_weights = self.export_hf_weights(
+            model,
+            cpu=cpu,
+            show_progress=show_progress,
+            conversion_tasks=plan.conversion_tasks,
+            merge_adapter_weights=merge_adapter_weights,
+        )
+        return hf_weights
+
+    def get_hf_modelopt_quantization_config(
+        self,
+        model: MegatronModelT | list[MegatronModelT],
+        conversion_tasks: Optional[List[WeightConversionTask]] = None,
+    ) -> dict[str, Any]:
+        """Return ModelOpt's deployment config for the initialized Megatron model.
+
+        This method uses model-parallel collectives and must be called by every rank in the same order.
+        """
+        _, plan = self._build_modelopt_export_plan(model, conversion_tasks)
+        return plan.quantization_config
+
+    def _build_modelopt_export_plan(
+        self,
+        model: MegatronModelT | list[MegatronModelT],
+        conversion_tasks: Optional[List[WeightConversionTask]],
+    ) -> tuple[list[MegatronModelT], "ModelOptExportPlan"]:
         from megatron.bridge.models.conversion.modelopt_utils import build_modelopt_export_plan
 
         if not isinstance(model, list):
             model = [model]
         if conversion_tasks is None:
             conversion_tasks = self._model_bridge.build_conversion_tasks(self.hf_pretrained, model)
-        export_tasks = build_modelopt_export_plan(
-            conversion_tasks,
-            model=model,
-            bridge=self._model_bridge,
-            quant_mode=quant_mode,
-            ignore_patterns=ignore_patterns or [],
-        )
-        hf_weights = self.export_hf_weights(
-            model,
-            cpu=cpu,
-            show_progress=show_progress,
-            conversion_tasks=export_tasks,
-            merge_adapter_weights=merge_adapter_weights,
-        )
-        yield from hf_weights
+        return model, build_modelopt_export_plan(conversion_tasks, model=model)
 
     def export_hf_weights_quant(
         self,

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -167,6 +167,8 @@ class WeightConversionTask(Generic[MappingT]):
             dtype; bridges that requantize on export skip it (no scale companions).
         export_hook: Export-only transformation applied after mapping conversion and
             before final device placement.
+        grouped_export_hook: Export-only transformation applied to each canonical
+            expert before a grouped HF tensor is stacked.
 
     """
 
@@ -179,6 +181,9 @@ class WeightConversionTask(Generic[MappingT]):
     param_weight: Optional[torch.Tensor] = None
     weight_dtype: Optional[torch.dtype] = None
     export_hook: Optional[Callable[[str, torch.Tensor], Iterable[HFWeightTuple]]] = field(
+        default=None, compare=False, repr=False
+    )
+    grouped_export_hook: Optional[Callable[[str, torch.Tensor, int], Iterable[HFWeightTuple]]] = field(
         default=None, compare=False, repr=False
     )
 
@@ -1164,21 +1169,34 @@ class MegatronModelBridge(
         except ValueError:
             return None
 
-        merged_result: Dict[str, torch.Tensor] = {}
-        for group_key, value in converted_weights_dict.items():
-            if group_key not in grouped_buffers:
-                grouped_buffers[group_key] = {}
+        updated_group_keys: Dict[str, None] = {}
+        grouped_export_hook = getattr(task, "grouped_export_hook", None)
 
-            if ep_size == 1:
-                grouped_buffers[group_key][local_expert_number] = value
+        def store_expert(group_key: str, expert_number: int, value: torch.Tensor) -> None:
+            if grouped_export_hook is None:
+                exported = (HFWeightTuple(group_key, value),)
             else:
-                if value.ndim > 0 and value.shape[0] == ep_size:
-                    for i in range(ep_size):
-                        global_expert_number = local_expert_number + (i * experts_per_rank)
-                        grouped_buffers[group_key][global_expert_number] = value[i]
-                else:
-                    grouped_buffers[group_key][local_expert_number] = value
+                value = self._align_grouped_expert_for_export(
+                    task,
+                    group_key,
+                    value,
+                    hf_state_dict,
+                )
+                exported = grouped_export_hook(group_key, value, expert_number)
+            for exported_name, exported_tensor in exported:
+                grouped_buffers.setdefault(exported_name, {})[expert_number] = exported_tensor
+                updated_group_keys[exported_name] = None
 
+        for group_key, value in converted_weights_dict.items():
+            if ep_size > 1 and value.ndim > 0 and value.shape[0] == ep_size:
+                for i in range(ep_size):
+                    global_expert_number = local_expert_number + (i * experts_per_rank)
+                    store_expert(group_key, global_expert_number, value[i])
+            else:
+                store_expert(group_key, local_expert_number, value)
+
+        merged_result: Dict[str, torch.Tensor] = {}
+        for group_key in updated_group_keys:
             if len(grouped_buffers[group_key]) != num_experts:
                 continue
 
@@ -1200,7 +1218,11 @@ class MegatronModelBridge(
                     torch.cuda.empty_cache()
                 merged = torch.stack(cpu_tensors, dim=0)
 
-            if getattr(task.mapping, "transpose_on_export", False):
+            if grouped_export_hook is None and getattr(
+                task.mapping,
+                "transpose_on_export",
+                False,
+            ):
                 if group_key in hf_state_dict:
                     # Adaptive: only transpose when the stacked shape doesn't match the original HF
                     # shape but the transposed shape does.  This handles configurations where the
@@ -1217,6 +1239,25 @@ class MegatronModelBridge(
             merged_result[group_key] = merged
 
         return merged_result or None
+
+    @staticmethod
+    def _align_grouped_expert_for_export(
+        task: "WeightConversionTask",
+        hf_name: str,
+        tensor: torch.Tensor,
+        hf_state_dict: Mapping[str, torch.Tensor],
+    ) -> torch.Tensor:
+        """Apply a grouped mapping's final transpose before per-expert export."""
+        if not getattr(task.mapping, "transpose_on_export", False):
+            return tensor
+        if hf_name not in hf_state_dict:
+            return tensor.transpose(-1, -2).contiguous()
+
+        expected = tuple(hf_state_dict[hf_name].shape[1:])
+        if tuple(tensor.shape) == expected:
+            return tensor
+        transposed = tensor.transpose(-1, -2).contiguous()
+        return transposed if tuple(transposed.shape) == expected else tensor
 
     def load_weights_hf_to_megatron(
         self,

--- a/src/megatron/bridge/models/conversion/modelopt_utils.py
+++ b/src/megatron/bridge/models/conversion/modelopt_utils.py
@@ -647,7 +647,11 @@ def build_modelopt_export_plan(
     num_experts = None
     eligible_groups: set[str] = set()
     global_expert_orders: dict[str, tuple[int, ...]] = {}
-    local_expert_orders: dict[str, tuple[int, ...]] = {}
+    local_pre_ep_groups: dict[str, tuple[tuple[int, ...], QuantizedWeightState]] = {}
+    from modelopt.torch.export.quantized_weight import (
+        quantized_weight_export_states_compatible,
+    )
+
     if candidate_groups:
         model_config = model_bridge_utils.unwrap_model(model)[0].config
         num_experts = getattr(model_config, "num_moe_experts", None)
@@ -655,30 +659,45 @@ def build_modelopt_export_plan(
         experts_per_rank = num_experts // ep_world_size if valid_layout else 0
         for group_key, task_indices in candidate_groups.items():
             experts = tuple(sorted(candidate_experts[task_index] for task_index in task_indices))
-            if valid_layout and len(experts) == experts_per_rank and len(set(experts)) == experts_per_rank:
-                local_expert_orders[group_key] = experts
+            group_states = tuple(states[concrete_tasks[task_index].global_param_name] for task_index in task_indices)
+            compatible_states = group_states and all(
+                quantized_weight_export_states_compatible(group_states[0], state) for state in group_states[1:]
+            )
+            if (
+                valid_layout
+                and len(experts) == experts_per_rank
+                and len(set(experts)) == experts_per_rank
+                and compatible_states
+            ):
+                local_pre_ep_groups[group_key] = experts, group_states[0]
+
+    local_expert_orders = {group_key: value[0] for group_key, value in local_pre_ep_groups.items()}
 
     if ep_world_size > 1:
-        gathered_experts: list[dict[str, tuple[int, ...]] | None] = [None] * ep_world_size
+        gathered_groups: list[dict[str, tuple[tuple[int, ...], QuantizedWeightState]] | None] = [None] * ep_world_size
         torch.distributed.all_gather_object(
-            gathered_experts,
-            local_expert_orders,
+            gathered_groups,
+            local_pre_ep_groups,
             group=ep_group,
         )
-        group_keys = set().union(*(rank_groups or {} for rank_groups in gathered_experts))
+        group_keys = set().union(*(rank_groups or {} for rank_groups in gathered_groups))
         for group_key in group_keys:
-            rank_orders = [(rank_groups or {}).get(group_key, ()) for rank_groups in gathered_experts]
+            rank_entries = [(rank_groups or {}).get(group_key) for rank_groups in gathered_groups]
+            rank_orders = [entry[0] if entry is not None else () for entry in rank_entries]
+            rank_states = [entry[1] for entry in rank_entries if entry is not None]
             global_order = tuple(expert for rank_order in rank_orders for expert in rank_order)
             if (
                 isinstance(num_experts, int)
                 and all(len(rank_order) == experts_per_rank for rank_order in rank_orders)
                 and len(set(global_order)) == len(global_order)
                 and set(global_order) == set(range(num_experts))
+                and len(rank_states) == ep_world_size
+                and all(quantized_weight_export_states_compatible(rank_states[0], state) for state in rank_states[1:])
             ):
                 eligible_groups.add(group_key)
                 global_expert_orders[group_key] = global_order
     else:
-        for group_key, local_order in local_expert_orders.items():
+        for group_key, (local_order, _) in local_pre_ep_groups.items():
             if isinstance(num_experts, int) and set(local_order) == set(range(num_experts)):
                 eligible_groups.add(group_key)
                 global_expert_orders[group_key] = local_order

--- a/src/megatron/bridge/models/conversion/modelopt_utils.py
+++ b/src/megatron/bridge/models/conversion/modelopt_utils.py
@@ -159,9 +159,9 @@ def _get_modelopt_tp_process_group(module: object) -> object | None:
     if isinstance(process_group, int) and process_group == -1:
         return None
 
-    world_size = getattr(tp_group, "world_size", None)
-    world_size = world_size() if callable(world_size) else torch.distributed.get_world_size(group=process_group)
-    return process_group if world_size > 1 else None
+    # Preserve an explicit TP-size-1 group: ModelOpt treats ``group=None`` as
+    # the world group, which would mix calibration state across PP/EP ranks.
+    return process_group
 
 
 def collect_modelopt_config_weights(

--- a/src/megatron/bridge/models/conversion/modelopt_utils.py
+++ b/src/megatron/bridge/models/conversion/modelopt_utils.py
@@ -647,7 +647,10 @@ def build_modelopt_export_plan(
     num_experts = None
     eligible_groups: set[str] = set()
     global_expert_orders: dict[str, tuple[int, ...]] = {}
-    local_pre_ep_groups: dict[str, tuple[tuple[int, ...], QuantizedWeightState]] = {}
+    local_pre_ep_groups: dict[
+        str,
+        tuple[tuple[int, ...], tuple[QuantizedWeightState, ...]],
+    ] = {}
     from modelopt.torch.export.quantized_weight import (
         quantized_weight_export_states_compatible,
     )
@@ -660,21 +663,19 @@ def build_modelopt_export_plan(
         for group_key, task_indices in candidate_groups.items():
             experts = tuple(sorted(candidate_experts[task_index] for task_index in task_indices))
             group_states = tuple(states[concrete_tasks[task_index].global_param_name] for task_index in task_indices)
-            compatible_states = group_states and all(
-                quantized_weight_export_states_compatible(group_states[0], state) for state in group_states[1:]
-            )
-            if (
-                valid_layout
-                and len(experts) == experts_per_rank
-                and len(set(experts)) == experts_per_rank
-                and compatible_states
-            ):
-                local_pre_ep_groups[group_key] = experts, group_states[0]
+            if valid_layout and len(experts) == experts_per_rank and len(set(experts)) == experts_per_rank:
+                local_pre_ep_groups[group_key] = experts, group_states
 
     local_expert_orders = {group_key: value[0] for group_key, value in local_pre_ep_groups.items()}
 
     if ep_world_size > 1:
-        gathered_groups: list[dict[str, tuple[tuple[int, ...], QuantizedWeightState]] | None] = [None] * ep_world_size
+        gathered_groups: list[
+            dict[
+                str,
+                tuple[tuple[int, ...], tuple[QuantizedWeightState, ...]],
+            ]
+            | None
+        ] = [None] * ep_world_size
         torch.distributed.all_gather_object(
             gathered_groups,
             local_pre_ep_groups,
@@ -684,21 +685,30 @@ def build_modelopt_export_plan(
         for group_key in group_keys:
             rank_entries = [(rank_groups or {}).get(group_key) for rank_groups in gathered_groups]
             rank_orders = [entry[0] if entry is not None else () for entry in rank_entries]
-            rank_states = [entry[1] for entry in rank_entries if entry is not None]
+            global_states = tuple(state for entry in rank_entries if entry is not None for state in entry[1])
             global_order = tuple(expert for rank_order in rank_orders for expert in rank_order)
-            if (
+            valid_global_layout = (
                 isinstance(num_experts, int)
                 and all(len(rank_order) == experts_per_rank for rank_order in rank_orders)
                 and len(set(global_order)) == len(global_order)
                 and set(global_order) == set(range(num_experts))
-                and len(rank_states) == ep_world_size
-                and all(quantized_weight_export_states_compatible(rank_states[0], state) for state in rank_states[1:])
-            ):
+                and len(global_states) == num_experts
+            )
+            if valid_global_layout:
+                if any(
+                    not quantized_weight_export_states_compatible(global_states[0], state)
+                    for state in global_states[1:]
+                ):
+                    raise RuntimeError(f"Inconsistent ModelOpt state for pre-EP expert group {group_key}")
                 eligible_groups.add(group_key)
                 global_expert_orders[group_key] = global_order
     else:
-        for group_key, (local_order, _) in local_pre_ep_groups.items():
+        for group_key, (local_order, local_states) in local_pre_ep_groups.items():
             if isinstance(num_experts, int) and set(local_order) == set(range(num_experts)):
+                if any(
+                    not quantized_weight_export_states_compatible(local_states[0], state) for state in local_states[1:]
+                ):
+                    raise RuntimeError(f"Inconsistent ModelOpt state for pre-EP expert group {group_key}")
                 eligible_groups.add(group_key)
                 global_expert_orders[group_key] = local_order
 

--- a/src/megatron/bridge/models/conversion/modelopt_utils.py
+++ b/src/megatron/bridge/models/conversion/modelopt_utils.py
@@ -15,12 +15,12 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, replace
-from fnmatch import fnmatchcase
-from typing import TYPE_CHECKING, Any, Iterator, cast
+from typing import Any
 
 import torch
+from megatron.core.transformer.moe.router import Router
 from megatron.core.utils import get_pg_size
 
 from megatron.bridge.models.conversion import model_bridge as model_bridge_utils
@@ -28,8 +28,6 @@ from megatron.bridge.models.conversion.model_bridge import HFWeightTuple, Weight
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     ColumnParallelMapping,
-    FusedExpertMapping,
-    FusedGatedExpertMapping,
     GatedMLPMapping,
     ReplicatedMapping,
     RowParallelMapping,
@@ -37,93 +35,25 @@ from megatron.bridge.models.conversion.param_mapping import (
 from megatron.bridge.utils.common_utils import extract_expert_number_from_param
 
 
-if TYPE_CHECKING:
-    from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge
-
 HFExportHook = Callable[[str, torch.Tensor], Iterable[HFWeightTuple]]
+GroupedHFExportHook = Callable[[str, torch.Tensor, int], Iterable[HFWeightTuple]]
+QuantizedWeightState = object
+GroupedQuantizedWeightState = tuple[QuantizedWeightState, ...]
+MappedQuantizedWeightState = QuantizedWeightState | GroupedQuantizedWeightState
 
-_NVFP4_AMAX_DENOMINATOR = 6.0 * 448.0
-_NVFP4_MAXBOUND = 6.0
-_FP8_E4M3_MIN = 2**-9
-_FP8_E4M3_MAX = 448.0
-_QUANT_IGNORE_NAME_SUFFIXES = (
-    ".weight",
-    ".weight_scale",
-    ".weight_scale_2",
-)
 _EXPERT_NUMBER_PATTERNS = (
     re.compile(r"(local_experts\.)(\d+)(\.)"),
     re.compile(r"((?:weight|bias))(\d+)(?=$|\.)"),
     re.compile(r"(experts\.)(\d+)(\.)"),
 )
-_FUSED_MOE_NVFP4_NAME_MAP = {
-    ".experts.gate_up_proj": ".experts.w13_weight",
-    # vLLM uses the w13 family for both gated and non-gated first projections;
-    # ``is_act_and_mul=False`` selects a single projection shard.
-    ".experts.up_proj": ".experts.w13_weight",
-    ".experts.down_proj": ".experts.w2_weight",
-}
 
 
 @dataclass(frozen=True)
-class QuantMeta:
-    """ModelOpt quantization metadata for one Megatron parameter."""
+class ModelOptExportPlan:
+    """Prepared ModelOpt conversion tasks and their canonical HF config."""
 
-    qformat: str
-    block_size: int
-    weight_amax: torch.Tensor | None
-    weight_scale_2: torch.Tensor | None = None
-    input_amax: torch.Tensor | None = None
-
-
-@dataclass(frozen=True)
-class _Nvfp4InputQuantizerView:
-    """Minimal quantizer interface for ModelOpt activation-scale export."""
-
-    input_amax: torch.Tensor
-    is_enabled: bool = True
-    maxbound: float = _NVFP4_MAXBOUND
-
-    def export_amax(self) -> torch.Tensor:
-        return self.input_amax
-
-
-@dataclass(frozen=True)
-class _Nvfp4WeightQuantizerView:
-    """CPU-only quantizer state needed by ModelOpt's canonical scale export."""
-
-    _amax: torch.Tensor
-    block_sizes: object | None = None
-
-
-def _iter_quant_ignore_name_candidates(name: str) -> Iterator[str]:
-    yield name
-    for suffix in _QUANT_IGNORE_NAME_SUFFIXES:
-        if name.endswith(suffix):
-            yield name[: -len(suffix)]
-            break
-
-    alternate = name.removeprefix("model.") if name.startswith("model.") else f"model.{name}"
-
-    yield alternate
-    for suffix in _QUANT_IGNORE_NAME_SUFFIXES:
-        if alternate.endswith(suffix):
-            yield alternate[: -len(suffix)]
-            break
-
-
-def matches_quant_ignore_pattern(name: str, patterns: list[str]) -> bool:
-    """Return whether a parameter name matches any ModelOpt ignore pattern."""
-    return any(
-        fnmatchcase(candidate, pattern)
-        for candidate in _iter_quant_ignore_name_candidates(name)
-        for pattern in patterns
-    )
-
-
-def is_modelopt_quantizable_weight_name(name: str) -> bool:
-    """Return whether an exported HF tensor name should be ModelOpt-quantized."""
-    return name.endswith(".weight") or any(name.endswith(suffix) for suffix in _FUSED_MOE_NVFP4_NAME_MAP)
+    conversion_tasks: list[WeightConversionTask]
+    quantization_config: dict[str, Any]
 
 
 def _is_same_tensor(param_weight: object, weight: object) -> bool:
@@ -148,117 +78,71 @@ def _is_same_tensor(param_weight: object, weight: object) -> bool:
     )
 
 
+def _is_enabled_quantizer(quantizer: object) -> bool:
+    return bool(getattr(quantizer, "is_enabled", False))
+
+
+def _weight_name(module: torch.nn.Module, weight: torch.Tensor) -> str:
+    for name, candidate in module.named_parameters(recurse=False):
+        if _is_same_tensor(candidate, weight):
+            return name
+    raise RuntimeError(f"Cannot identify the parameter name for a quantized weight owned by {type(module).__name__}")
+
+
+def _input_quantizer(module: torch.nn.Module, weight_name: str) -> object | None:
+    from modelopt.torch.quantization.utils import quantizer_attr_names
+
+    quantizer = getattr(module, quantizer_attr_names(weight_name).input_quantizer, None)
+    if quantizer is None and weight_name != "weight":
+        quantizer = getattr(module, "input_quantizer", None)
+    return quantizer
+
+
 def _iter_modelopt_weight_quantizers(
     module: torch.nn.Module,
-) -> Iterator[tuple[object, object, bool]]:
+    *,
+    enabled_only: bool = True,
+) -> Iterator[tuple[torch.Tensor, str, object, object | None]]:
     iter_weights = getattr(module, "iter_weights_for_calibration", None)
-    if iter_weights is not None:
+    if callable(iter_weights):
         for weight, weight_quantizer in iter_weights():
-            if not _is_enabled_quantizer(weight_quantizer):
+            if enabled_only and not _is_enabled_quantizer(weight_quantizer):
                 continue
+            weight_name = _weight_name(module, weight)
             yield (
                 weight,
+                weight_name,
                 weight_quantizer,
-                _is_same_tensor(
-                    getattr(module, "weight", None),
-                    weight,
-                ),
+                _input_quantizer(module, weight_name),
             )
         return
 
     weight_quantizer = getattr(module, "weight_quantizer", None)
-    if _is_enabled_quantizer(weight_quantizer):
-        for weight_name, weight in module.named_parameters(recurse=False):
-            if weight_name == "weight" or (weight_name.startswith("weight") and weight_name[6:].isdigit()):
-                yield weight, weight_quantizer, weight_name == "weight"
+    if weight_quantizer is None or (enabled_only and not _is_enabled_quantizer(weight_quantizer)):
+        return
+    for weight_name, weight in module.named_parameters(recurse=False):
+        if weight_name == "weight" or (weight_name.startswith("weight") and weight_name[6:].isdigit()):
+            yield weight, weight_name, weight_quantizer, _input_quantizer(module, weight_name)
 
 
-def _is_enabled_quantizer(quantizer: object) -> bool:
-    is_enabled = getattr(quantizer, "is_enabled", None)
-    return bool(is_enabled)
-
-
-def find_modelopt_weight_quantizer_and_module(
+def find_modelopt_quantizers(
     module: torch.nn.Module,
     param_weight: object,
-) -> tuple[object | None, torch.nn.Module | None]:
-    """Find the enabled weight quantizer and owning module for ``param_weight``."""
-    for _, candidate_module in module.named_modules():
-        for weight, weight_quantizer, can_use_module in _iter_modelopt_weight_quantizers(candidate_module):
-            if _is_same_tensor(param_weight, weight):
-                if can_use_module:
-                    return weight_quantizer, candidate_module
-                quant_module = torch.nn.Module()
-                quant_module.weight = weight
-                quant_module.weight_quantizer = weight_quantizer
-                input_quantizer = getattr(candidate_module, "input_quantizer", None)
-                if input_quantizer is not None:
-                    quant_module.input_quantizer = input_quantizer
-                parallel_state = getattr(candidate_module, "parallel_state", None)
-                if parallel_state is not None:
-                    quant_module.parallel_state = parallel_state
-                return weight_quantizer, quant_module
-
-    return None, None
-
-
-def _with_quant_meta_tensors(
-    meta: QuantMeta,
     *,
-    weight_amax: torch.Tensor | None,
-    weight_scale_2: torch.Tensor | None,
-) -> QuantMeta:
-    return QuantMeta(
-        qformat=meta.qformat,
-        block_size=meta.block_size,
-        weight_amax=weight_amax,
-        weight_scale_2=weight_scale_2,
-        input_amax=meta.input_amax,
-    )
-
-
-def _clone_cpu(value: torch.Tensor | None) -> torch.Tensor | None:
-    if value is None:
-        return None
-    return value.detach().cpu().float().clone()
-
-
-def _clone_positive_cpu(value: torch.Tensor | None) -> torch.Tensor | None:
-    cloned = _clone_cpu(value)
-    return None if cloned is None else cloned.abs()
-
-
-def _get_modelopt_weight_amax(weight_quantizer: object) -> tuple[torch.Tensor | None, bool]:
-    """Read the raw global amax without deriving a scale on its CUDA device."""
-    value = getattr(weight_quantizer, "global_amax", None)
-    if isinstance(value, torch.Tensor):
-        return value, True
-    value = getattr(weight_quantizer, "_global_amax", None)
-    if isinstance(value, torch.Tensor):
-        return value, True
-    value = getattr(weight_quantizer, "_amax", None)
-    return (value, False) if isinstance(value, torch.Tensor) else (None, False)
-
-
-def _compute_modelopt_weight_scale_2_cpu(
-    weight_amax: torch.Tensor | None,
-    weight_quantizer: object,
-) -> torch.Tensor | None:
-    """Run ModelOpt's quantizer-specific global-scale derivation on CPU."""
-    if weight_amax is None:
-        return None
-
-    from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
-
-    view = _Nvfp4WeightQuantizerView(
-        _amax=weight_amax,
-        block_sizes=getattr(weight_quantizer, "block_sizes", None),
-    )
-    return NVFP4QTensor.get_weights_scaling_factor_2_from_quantizer(view).detach().float().abs()
+    enabled_only: bool = True,
+) -> tuple[torch.nn.Module, str, object, object | None] | None:
+    """Find the exact ModelOpt quantizers that own ``param_weight``."""
+    for _, candidate_module in module.named_modules():
+        for weight, weight_name, weight_quantizer, input_quantizer in _iter_modelopt_weight_quantizers(
+            candidate_module,
+            enabled_only=enabled_only,
+        ):
+            if _is_same_tensor(param_weight, weight):
+                return candidate_module, weight_name, weight_quantizer, input_quantizer
+    return None
 
 
 def _get_modelopt_tp_process_group(module: object) -> object | None:
-    """Return the raw TP process group attached to a ModelOpt quantized module."""
     if not torch.distributed.is_available() or not torch.distributed.is_initialized():
         return None
 
@@ -275,613 +159,312 @@ def _get_modelopt_tp_process_group(module: object) -> object | None:
     if isinstance(process_group, int) and process_group == -1:
         return None
 
-    get_world_size = getattr(tp_group, "world_size", None)
-    world_size = (
-        get_world_size() if callable(get_world_size) else torch.distributed.get_world_size(group=process_group)
-    )
+    world_size = getattr(tp_group, "world_size", None)
+    world_size = world_size() if callable(world_size) else torch.distributed.get_world_size(group=process_group)
     return process_group if world_size > 1 else None
 
 
-def _max_reduce_modelopt_tp_scalar(
-    value: torch.Tensor | None,
-    module: object,
-    field_name: str,
-) -> torch.Tensor | None:
-    """MAX-reduce one per-tensor quantization value over its owning TP group."""
-    if value is None:
-        return None
-
-    process_group = _get_modelopt_tp_process_group(module)
-    if process_group is None:
-        return value
-    if value.numel() != 1:
-        raise RuntimeError(f"Cannot TP-synchronize non-scalar ModelOpt {field_name} with shape {tuple(value.shape)}")
-
-    reduced = value.detach().clone()
-    torch.distributed.all_reduce(
-        reduced,
-        op=torch.distributed.ReduceOp.MAX,
-        group=process_group,
-    )
-    return reduced
+def collect_modelopt_config_weights(
+    conversion_tasks: list[WeightConversionTask | None],
+) -> set[str]:
+    """Return weight tasks represented in ModelOpt's deployment config."""
+    config_weights = set()
+    for task in conversion_tasks:
+        if task is None or task.megatron_module is None or task.param_weight is None:
+            continue
+        has_quantizer = (
+            find_modelopt_quantizers(
+                task.megatron_module,
+                task.param_weight,
+                enabled_only=False,
+            )
+            is not None
+        )
+        if has_quantizer or isinstance(task.megatron_module, Router):
+            config_weights.add(task.global_param_name)
+    return config_weights
 
 
-def _slice_optional_quant_tensor(
-    value: torch.Tensor | None,
-    split: slice,
-    leading_dim: int,
-) -> torch.Tensor | None:
-    if value is None or value.dim() == 0:
-        return value
-    if value.shape[0] != leading_dim:
-        return value
-    return value[split].contiguous()
-
-
-def _slice_gated_quant_meta(meta: QuantMeta, hf_key: str) -> QuantMeta:
-    """Slice fused ``[gate; up]`` metadata to match a split HF tensor."""
-    if hf_key not in {"gate", "up"} or meta.weight_amax is None or meta.weight_amax.dim() == 0:
-        return meta
-
-    leading_dim = meta.weight_amax.shape[0]
-    if leading_dim % 2 != 0:
-        return meta
-
-    midpoint = leading_dim // 2
-    split = slice(0, midpoint) if hf_key == "gate" else slice(midpoint, leading_dim)
-    return _with_quant_meta_tensors(
-        meta,
-        weight_amax=_slice_optional_quant_tensor(meta.weight_amax, split, leading_dim),
-        weight_scale_2=meta.weight_scale_2,
+def collect_modelopt_quant_states(
+    conversion_tasks: list[WeightConversionTask | None],
+) -> dict[str, QuantizedWeightState]:
+    """Capture scalar ModelOpt export state for every quantized Megatron weight."""
+    from modelopt.torch.export.quantized_weight import (
+        capture_quantized_weight_export_state,
+        synchronize_quantized_weight_export_state,
     )
 
+    states: dict[str, QuantizedWeightState] = {}
+    cached_states: dict[tuple[int, int, str], QuantizedWeightState] = {}
+    for task in conversion_tasks:
+        if task is None or task.megatron_module is None or task.param_weight is None:
+            continue
 
-def _stack_optional_quant_tensors(
-    values: list[torch.Tensor | None],
-    *,
-    hf_name: str,
-    field_name: str,
-) -> torch.Tensor | None:
-    if all(value is None for value in values):
-        return None
-    if any(value is None for value in values):
-        raise RuntimeError(f"Incomplete ModelOpt {field_name} metadata for grouped parameter {hf_name}")
-    return torch.stack(cast(list[torch.Tensor], values), dim=0).contiguous()
+        found = find_modelopt_quantizers(task.megatron_module, task.param_weight)
+        if found is None:
+            continue
+        module, weight_name, weight_quantizer, input_quantizer = found
+        cache_key = (id(weight_quantizer), id(input_quantizer), weight_name)
+        if cache_key in cached_states:
+            states[task.global_param_name] = cached_states[cache_key]
+            continue
+
+        state = capture_quantized_weight_export_state(
+            module,
+            weight_name,
+            weight_quantizer=weight_quantizer,
+            input_quantizer=input_quantizer,
+        )
+        state = synchronize_quantized_weight_export_state(
+            state,
+            group=_get_modelopt_tp_process_group(module),
+            device="cpu",
+        )
+        cached_states[cache_key] = state
+        states[task.global_param_name] = state
+    return states
 
 
-def _stack_grouped_quant_meta(hf_name: str, expert_meta: dict[int, QuantMeta]) -> QuantMeta:
-    if not expert_meta:
-        raise RuntimeError(f"Missing ModelOpt metadata for grouped parameter {hf_name}")
+def sync_modelopt_quant_states(
+    states: dict[str, QuantizedWeightState],
+    group: object | None = None,
+) -> None:
+    """Synchronize quantized-weight states across a distributed group."""
+    world_size = torch.distributed.get_world_size(group=group)
+    from modelopt.torch.export.quantized_weight import quantized_weight_export_states_equal
 
-    expected_experts = set(range(max(expert_meta) + 1))
-    missing_experts = sorted(expected_experts.difference(expert_meta))
-    if missing_experts:
-        raise RuntimeError(f"Missing ModelOpt metadata for experts {missing_experts} of grouped parameter {hf_name}")
-
-    metas = [expert_meta[idx] for idx in sorted(expert_meta)]
-    qformat = metas[0].qformat
-    block_size = metas[0].block_size
-    for meta in metas[1:]:
-        if meta.qformat != qformat or meta.block_size != block_size:
-            raise RuntimeError(f"Inconsistent ModelOpt metadata for grouped parameter {hf_name}")
-
-    return QuantMeta(
-        qformat=qformat,
-        block_size=block_size,
-        weight_amax=_stack_optional_quant_tensors(
-            [meta.weight_amax for meta in metas],
-            hf_name=hf_name,
-            field_name="weight_amax",
-        ),
-        weight_scale_2=_stack_optional_quant_tensors(
-            [meta.weight_scale_2 for meta in metas],
-            hf_name=hf_name,
-            field_name="weight_scale_2",
-        ),
-        input_amax=_stack_optional_quant_tensors(
-            [meta.input_amax for meta in metas],
-            hf_name=hf_name,
-            field_name="input_amax",
-        ),
-    )
+    gathered: list[dict[str, QuantizedWeightState] | None] = [None] * world_size
+    torch.distributed.all_gather_object(gathered, states, group=group)
+    for rank_states in gathered:
+        if not rank_states:
+            continue
+        for name, state in rank_states.items():
+            existing = states.get(name)
+            if existing is not None and not quantized_weight_export_states_equal(existing, state):
+                raise RuntimeError(f"Conflicting ModelOpt state for {name}")
+            states[name] = state
 
 
 def _expert_param_template(param_name: str) -> str | None:
     for pattern in _EXPERT_NUMBER_PATTERNS:
         match = pattern.search(param_name)
-        if match is None:
-            continue
-        return f"{param_name[: match.start(2)]}{{expert}}{param_name[match.end(2) :]}"
+        if match is not None:
+            return f"{param_name[: match.start(2)]}{{expert}}{param_name[match.end(2) :]}"
     return None
 
 
-def _iter_grouped_quant_meta(
-    task: WeightConversionTask,
-    metadata: dict[str, QuantMeta],
-) -> Iterator[tuple[int, QuantMeta]]:
-    """Yield all synced per-expert metadata entries for a grouped export task."""
-    from megatron.bridge.utils.common_utils import extract_expert_number_from_param
-
-    task_template = _expert_param_template(task.global_param_name)
-    if task_template is None:
-        raise ValueError(f"Expected expert parameter name for grouped export: {task.global_param_name}")
-
-    for global_name, meta in metadata.items():
-        if _expert_param_template(global_name) == task_template:
-            yield extract_expert_number_from_param(global_name), meta
+def _group_quant_states_by_expert(
+    states: dict[str, QuantizedWeightState],
+) -> dict[str, dict[int, QuantizedWeightState]]:
+    grouped: dict[str, dict[int, QuantizedWeightState]] = {}
+    for global_name, state in states.items():
+        template = _expert_param_template(global_name)
+        if template is not None:
+            grouped.setdefault(template, {})[extract_expert_number_from_param(global_name)] = state
+    return grouped
 
 
-def build_hf_modelopt_quant_metadata(
+def _ordered_grouped_states(
+    hf_name: str,
+    expert_states: dict[int, QuantizedWeightState],
+    num_experts: int,
+) -> GroupedQuantizedWeightState:
+    from modelopt.torch.export.quantized_weight import (
+        quantized_weight_export_states_compatible,
+    )
+
+    if not expert_states:
+        raise RuntimeError(f"Missing ModelOpt state for grouped parameter {hf_name}")
+    expected_experts = set(range(num_experts))
+    missing_experts = sorted(expected_experts.difference(expert_states))
+    if missing_experts:
+        raise RuntimeError(f"Missing ModelOpt state for experts {missing_experts} of grouped parameter {hf_name}")
+    unexpected_experts = sorted(set(expert_states).difference(expected_experts))
+    if unexpected_experts:
+        raise RuntimeError(
+            f"Unexpected ModelOpt state for experts {unexpected_experts} of grouped parameter {hf_name}"
+        )
+    ordered = tuple(expert_states[index] for index in range(num_experts))
+    first = ordered[0]
+    if any(not quantized_weight_export_states_compatible(first, state) for state in ordered[1:]):
+        raise RuntimeError(f"Inconsistent ModelOpt state for grouped parameter {hf_name}")
+    return ordered
+
+
+def _hf_weight_names(task: WeightConversionTask) -> tuple[str, ...]:
+    hf_param = task.mapping.hf_param
+    if isinstance(hf_param, str):
+        return (hf_param,)
+    return tuple(hf_param.values())
+
+
+def build_hf_modelopt_quant_states(
     conversion_tasks: list[WeightConversionTask],
-    metadata: dict[str, QuantMeta],
-) -> dict[str, QuantMeta]:
-    """Map Megatron ModelOpt metadata onto exported Hugging Face names."""
-    hf_metadata: dict[str, QuantMeta] = {}
-    grouped_metadata: dict[str, dict[int, QuantMeta]] = {}
+    states: dict[str, QuantizedWeightState],
+    *,
+    num_experts: int | None = None,
+) -> dict[str, MappedQuantizedWeightState]:
+    """Map Megatron quantized-weight states onto canonical HF weight names."""
+    from modelopt.torch.export.quantized_weight import (
+        replicate_quantized_weight_export_state,
+    )
 
+    hf_states: dict[str, MappedQuantizedWeightState] = {}
+    grouped_by_template = _group_quant_states_by_expert(states)
     for task in conversion_tasks:
-        if task.global_param_name not in metadata:
+        state = states.get(task.global_param_name)
+        if state is None:
             continue
-
-        meta = metadata[task.global_param_name]
-        hf_param = task.mapping.hf_param
-        if isinstance(hf_param, str):
-            hf_items = (("", hf_param),)
-        else:
-            hf_items = tuple(hf_param.items())
-
         if getattr(task.mapping, "is_grouped_export", False):
-            for expert_number, expert_meta in _iter_grouped_quant_meta(task, metadata):
-                for hf_key, hf_name in hf_items:
-                    grouped_metadata.setdefault(hf_name, {})[expert_number] = _slice_gated_quant_meta(
-                        expert_meta,
-                        hf_key,
-                    )
+            if num_experts is None:
+                raise RuntimeError("Grouped ModelOpt export requires model.config.num_moe_experts")
+            template = _expert_param_template(task.global_param_name)
+            if template is None:
+                raise ValueError(f"Expected expert parameter name for grouped export: {task.global_param_name}")
+            hf_names = _hf_weight_names(task)
+            grouped_states = _ordered_grouped_states(hf_names[0], grouped_by_template.get(template, {}), num_experts)
+            replicated_by_expert = [
+                replicate_quantized_weight_export_state(expert_state, len(hf_names)) for expert_state in grouped_states
+            ]
+            for hf_index, hf_name in enumerate(hf_names):
+                _set_hf_quant_state(
+                    hf_states,
+                    hf_name,
+                    tuple(states[hf_index] for states in replicated_by_expert),
+                )
             continue
-
-        for hf_key, hf_name in hf_items:
-            hf_metadata[hf_name] = _slice_gated_quant_meta(meta, hf_key)
-
-    for hf_name, expert_meta in grouped_metadata.items():
-        hf_metadata[hf_name] = _stack_grouped_quant_meta(hf_name, expert_meta)
-
-    return hf_metadata
-
-
-def _build_hf_modelopt_pre_ep_quant_metadata(
-    conversion_tasks: list[WeightConversionTask],
-    metadata: dict[str, QuantMeta],
-) -> dict[str, QuantMeta]:
-    """Build metadata for selected local expert batches before EP gathering."""
-    from megatron.bridge.utils.common_utils import extract_expert_number_from_param
-
-    grouped_metadata: dict[str, dict[int, QuantMeta]] = {}
-    for task in conversion_tasks:
-        if not getattr(task.mapping, "is_modelopt_pre_ep_export", False):
-            raise ValueError(f"Expected a pre-EP ModelOpt task, got {task.global_param_name}")
-        if task.global_param_name not in metadata:
-            raise RuntimeError(f"Missing ModelOpt metadata for pre-EP task {task.global_param_name}")
-        if not isinstance(task.mapping.hf_param, str):
-            raise ValueError(f"Expected one fused HF name for pre-EP task {task.global_param_name}")
-
-        expert_number = extract_expert_number_from_param(task.global_param_name)
-        grouped_metadata.setdefault(task.mapping.hf_param, {})[expert_number] = metadata[task.global_param_name]
-
-    hf_metadata: dict[str, QuantMeta] = {}
-    for hf_name, expert_meta in grouped_metadata.items():
-        # Global expert ids on EP rank N start at N * experts_per_rank. Rebase
-        # the sorted local batch before applying the usual dense validation.
-        local_expert_meta = {local_idx: meta for local_idx, (_, meta) in enumerate(sorted(expert_meta.items()))}
-        hf_metadata[hf_name] = _stack_grouped_quant_meta(hf_name, local_expert_meta)
-    return hf_metadata
+        hf_names = _hf_weight_names(task)
+        for hf_name, projected_state in zip(
+            hf_names,
+            replicate_quantized_weight_export_state(state, len(hf_names)),
+            strict=True,
+        ):
+            _set_hf_quant_state(hf_states, hf_name, projected_state)
+    return hf_states
 
 
-def collect_modelopt_quant_metadata(
-    conversion_tasks: list[WeightConversionTask | None],
-) -> dict[str, QuantMeta]:
-    """Collect ModelOpt quantization metadata from conversion task modules."""
-    from modelopt.torch.export import quant_utils
-    from modelopt.torch.export.quant_utils import (
-        QUANTIZATION_NONE,
-        QUANTIZATION_NVFP4,
-        get_quantization_format,
-        get_weight_block_size,
-    )
+def _set_hf_quant_state(
+    hf_states: dict[str, MappedQuantizedWeightState],
+    hf_name: str,
+    state: MappedQuantizedWeightState,
+) -> None:
+    from modelopt.torch.export.quantized_weight import quantized_weight_export_states_equal
 
-    w4a16_nvfp4 = getattr(quant_utils, "QUANTIZATION_W4A16_NVFP4", None)
-    metadata: dict[str, QuantMeta] = {}
-    quantizer_metadata: dict[tuple[int, int, str, int], QuantMeta | None] = {}
-    for task in conversion_tasks:
-        if task is None or task.megatron_module is None or task.param_weight is None:
-            continue
-
-        weight_quantizer, quant_module = find_modelopt_weight_quantizer_and_module(
-            task.megatron_module,
-            task.param_weight,
-        )
-        if weight_quantizer is None:
-            continue
-
-        qformat = get_quantization_format(quant_module)
-        block_size = get_weight_block_size(quant_module)
-        input_quantizer = getattr(quant_module, "input_quantizer", None)
-        quantizer_key = (id(weight_quantizer), id(input_quantizer), qformat, block_size)
-        if quantizer_key in quantizer_metadata:
-            cached_meta = quantizer_metadata[quantizer_key]
-            if cached_meta is not None:
-                metadata[task.global_param_name] = cached_meta
-            continue
-
-        if qformat == QUANTIZATION_NONE:
-            quantizer_metadata[quantizer_key] = None
-            continue
-
-        if block_size == 0:
-            quantizer_metadata[quantizer_key] = None
-            continue
-        weight_amax, is_static_weight_quantizer = _get_modelopt_weight_amax(weight_quantizer)
-        is_nvfp4 = qformat == QUANTIZATION_NVFP4 or (w4a16_nvfp4 is not None and qformat == w4a16_nvfp4)
-        if is_nvfp4 and is_static_weight_quantizer:
-            raise RuntimeError(
-                "Static NVFP4 weight quantizers are not supported by CPU ModelOpt export: "
-                "their calibrated per-block amax values cannot be reconstructed after TP/EP gathering. "
-                "Use dynamic NVFP4 block scaling."
-            )
-        input_amax = None
-        if qformat == QUANTIZATION_NVFP4:
-            if _is_enabled_quantizer(input_quantizer):
-                input_amax = getattr(input_quantizer, "_amax", None)
-                if input_amax is None:
-                    export_amax = getattr(input_quantizer, "export_amax", None)
-                    if callable(export_amax):
-                        input_amax = export_amax()
-
-        weight_amax = _max_reduce_modelopt_tp_scalar(weight_amax, quant_module, "weight amax")
-        input_amax = _max_reduce_modelopt_tp_scalar(input_amax, quant_module, "input amax")
-        weight_amax = _clone_positive_cpu(weight_amax)
-        weight_scale_2 = None
-        if weight_amax is not None and is_nvfp4:
-            weight_scale_2 = _compute_modelopt_weight_scale_2_cpu(
-                weight_amax,
-                weight_quantizer,
-            )
-
-        quant_meta = QuantMeta(
-            qformat=qformat,
-            block_size=block_size,
-            weight_amax=weight_amax,
-            weight_scale_2=weight_scale_2,
-            input_amax=_clone_cpu(input_amax),
-        )
-        quantizer_metadata[quantizer_key] = quant_meta
-        metadata[task.global_param_name] = quant_meta
-    return metadata
-
-
-def sync_modelopt_quant_metadata(metadata: dict[str, QuantMeta], group=None) -> None:
-    """Synchronize ModelOpt quantization metadata across a distributed group."""
-    world_size = torch.distributed.get_world_size(group=group)
-    gathered: list[dict[str, QuantMeta] | None] = [None] * world_size
-    torch.distributed.all_gather_object(gathered, metadata, group=group)
-
-    for rank_metadata in gathered:
-        if rank_metadata:
-            metadata.update(rank_metadata)
-
-
-def _reshape_nvfp4_weight_scale_2_for_compute(
-    weight: torch.Tensor,
-    weight_scale_2: torch.Tensor,
-) -> torch.Tensor:
-    if weight.dim() != 3 or weight_scale_2.dim() == 0:
-        return weight_scale_2
-    if weight_scale_2.dim() == 1:
-        return weight_scale_2.view(-1, 1, 1)
-    if weight_scale_2.dim() == 2:
-        if weight_scale_2.shape[1] == 1:
-            return weight_scale_2.view(weight_scale_2.shape[0], 1, 1)
-        if weight.shape[1] % weight_scale_2.shape[1] == 0:
-            repeat = weight.shape[1] // weight_scale_2.shape[1]
-            return weight_scale_2.repeat_interleave(repeat, dim=1).unsqueeze(-1)
-    return weight_scale_2
-
-
-def compute_nvfp4_weight_scale(
-    weight: torch.Tensor,
-    block_size: int,
-    weight_amax: torch.Tensor | None = None,
-    weight_scale_2: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Compute the NVFP4 per-block weight scale tensor for ModelOpt export."""
-    from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
-
-    if weight_scale_2 is not None:
-        scale_2_for_export = weight_scale_2.to(weight.device).float().abs()
-    elif weight_amax is not None:
-        scale_2_for_export = weight_amax.to(weight.device).float().abs() / _NVFP4_AMAX_DENOMINATOR
-    else:
-        raise RuntimeError("Missing ModelOpt weight amax for NVFP4 export")
-
-    scale_2_for_compute = _reshape_nvfp4_weight_scale_2_for_compute(
-        weight,
-        scale_2_for_export,
-    )
-
-    weight_scale = NVFP4QTensor.get_weights_scaling_factor(
-        weight,
-        block_size,
-        weights_scaling_factor_2=scale_2_for_compute,
-        keep_high_precision=False,
-    )[0]
-    weight_scale_for_validation = weight_scale.float()
-    if not torch.isfinite(weight_scale_for_validation).all():
-        raise RuntimeError(f"Invalid ModelOpt NVFP4 per-block weight scale: {weight_scale_for_validation}")
-    # ModelOpt versions before its E4M3 clamp can underflow a tiny positive
-    # per-block scale to zero. Normalize to the same representable range as the
-    # current canonical exporter before the packed weight consumes this scale.
-    weight_scale = (
-        weight_scale_for_validation.abs().clamp(min=_FP8_E4M3_MIN, max=_FP8_E4M3_MAX).to(torch.float8_e4m3fn)
-    )
-    return weight_scale, scale_2_for_export
-
-
-def compute_nvfp4_input_scale(input_amax: torch.Tensor | None) -> torch.Tensor:
-    """Compute a static NVFP4 activation scale from synchronized input amax."""
-    if input_amax is None:
-        raise RuntimeError("Missing ModelOpt input amax for NVFP4 W4A4 export")
-
-    input_amax = input_amax.detach().float()
-    if input_amax.numel() == 0 or not torch.isfinite(input_amax).all() or not torch.all(input_amax > 0):
-        raise RuntimeError(f"Invalid ModelOpt input amax for NVFP4 W4A4 export: {input_amax}")
-
-    from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
-
-    canonical_export = getattr(NVFP4QTensor, "get_activation_scaling_factor", None)
-    if callable(canonical_export):
-        input_scale = canonical_export(_Nvfp4InputQuantizerView(input_amax))
-    else:
-        input_scale = input_amax / _NVFP4_AMAX_DENOMINATOR
-
-    if (
-        input_scale is None
-        or input_scale.numel() == 0
-        or not torch.isfinite(input_scale).all()
-        or not torch.all(input_scale > 0)
+    existing = hf_states.get(hf_name)
+    if existing is None:
+        hf_states[hf_name] = state
+        return
+    if isinstance(existing, tuple) != isinstance(state, tuple):
+        raise RuntimeError(f"Conflicting ModelOpt state layouts for {hf_name}")
+    existing_states = existing if isinstance(existing, tuple) else (existing,)
+    new_states = state if isinstance(state, tuple) else (state,)
+    if len(existing_states) != len(new_states) or any(
+        not quantized_weight_export_states_equal(lhs, rhs)
+        for lhs, rhs in zip(existing_states, new_states, strict=True)
     ):
-        raise RuntimeError(f"Invalid ModelOpt input scale for NVFP4 W4A4 export: {input_scale}")
-    return input_scale.detach().float()
+        raise RuntimeError(f"Conflicting ModelOpt states for {hf_name}")
 
 
-def _nvfp4_export_names(name: str) -> tuple[str, str, str, str]:
-    if name.endswith(".weight"):
-        base = name[: -len(".weight")]
-        return (
-            name,
-            f"{base}.weight_scale",
-            f"{base}.weight_scale_2",
-            f"{base}.input_scale",
-        )
-    for hf_suffix, vllm_suffix in _FUSED_MOE_NVFP4_NAME_MAP.items():
-        if name.endswith(hf_suffix):
-            base = name[: -len(hf_suffix)] + vllm_suffix
-            input_scale_base = base.removesuffix("_weight")
-            return (
-                base,
-                f"{base}_scale",
-                f"{base}_scale_2",
-                f"{input_scale_base}_input_scale",
-            )
-    raise ValueError(f"Expected quantizable NVFP4 export parameter name: {name}")
+def _is_weight_task(task: WeightConversionTask) -> bool:
+    return re.search(r"(?:^|\.)weight\d*$", task.global_param_name) is not None
 
 
-def _format_nvfp4_weight_scale_2_for_export(
-    source_name: str,
-    weight_name: str,
+def _is_quantizer_state_task(task: WeightConversionTask) -> bool:
+    """Return whether a task carries ModelOpt's internal quantizer state."""
+    return any(segment.endswith(("quantizer", "quantizers")) for segment in task.global_param_name.split("."))
+
+
+def _quantization_layer_name(hf_weight_name: str) -> str:
+    return hf_weight_name.removesuffix(".weight")
+
+
+def build_modelopt_quantization_config(
+    conversion_tasks: list[WeightConversionTask],
+    hf_states: dict[str, MappedQuantizedWeightState],
+    *,
+    config_weights: set[str],
+    sync_groups: Iterable[object | None] = (),
+) -> dict[str, Any]:
+    """Build the canonical ModelOpt HF config for mapped conversion tasks."""
+    from modelopt.torch.export.quantized_weight import (
+        build_hf_quantization_config,
+        quantized_weight_export_states_compatible,
+    )
+
+    layer_states: dict[str, QuantizedWeightState | None] = {}
+    for task in conversion_tasks:
+        if not _is_weight_task(task) or task.global_param_name not in config_weights:
+            continue
+        for hf_name in _hf_weight_names(task):
+            mapped_state = hf_states.get(hf_name)
+            if isinstance(mapped_state, tuple):
+                mapped_state = mapped_state[0]
+            layer_name = _quantization_layer_name(hf_name)
+            if layer_name not in layer_states or layer_states[layer_name] is None:
+                layer_states[layer_name] = mapped_state
+            elif mapped_state is not None and not quantized_weight_export_states_compatible(
+                layer_states[layer_name],
+                mapped_state,
+            ):
+                raise RuntimeError(f"Conflicting ModelOpt configs for {layer_name}")
+    for group in sync_groups:
+        _sync_modelopt_layer_states(layer_states, group)
+    if not any(state is not None for state in layer_states.values()):
+        raise RuntimeError("No ModelOpt-quantized weights were found in the conversion tasks")
+    return build_hf_quantization_config(layer_states)
+
+
+def _sync_modelopt_layer_states(
+    layer_states: dict[str, QuantizedWeightState | None],
+    group: object | None,
+) -> None:
+    from modelopt.torch.export.quantized_weight import (
+        quantized_weight_export_states_compatible,
+    )
+
+    world_size = torch.distributed.get_world_size(group=group)
+    gathered: list[dict[str, QuantizedWeightState | None] | None] = [None] * world_size
+    torch.distributed.all_gather_object(gathered, layer_states, group=group)
+    for rank_states in gathered:
+        if not rank_states:
+            continue
+        for name, state in rank_states.items():
+            if name not in layer_states or layer_states[name] is None:
+                layer_states[name] = state
+            elif state is not None and not quantized_weight_export_states_compatible(layer_states[name], state):
+                raise RuntimeError(f"Conflicting ModelOpt configs for {name}")
+
+
+def _named_export_tensors(
+    hf_name: str,
+    state: QuantizedWeightState,
     weight: torch.Tensor,
-    weight_scale_2: torch.Tensor,
-) -> torch.Tensor:
-    if source_name.endswith(".experts.up_proj"):
-        if weight_scale_2.dim() == 0:
-            return weight_scale_2.expand(weight.shape[0], 1).contiguous()
-        if weight_scale_2.dim() == 1:
-            return weight_scale_2[:, None].contiguous()
-        if weight_scale_2.dim() == 2 and weight_scale_2.shape[1] == 1:
-            return weight_scale_2.contiguous()
-        raise RuntimeError(
-            "Expected one non-gated W13 weight_scale_2 per expert for "
-            f"{weight_name}, got shape {tuple(weight_scale_2.shape)}"
-        )
-    if weight_name.endswith("w13_weight"):
-        if weight_scale_2.dim() == 0:
-            weight_scale_2 = weight_scale_2.expand(weight.shape[0])
-        if weight_scale_2.dim() == 1:
-            return weight_scale_2[:, None].expand(-1, 2).contiguous()
-        if weight_scale_2.dim() == 2 and weight_scale_2.shape[1] == 1:
-            return weight_scale_2.expand(-1, 2).contiguous()
-    if weight_name.endswith("w2_weight"):
-        if weight_scale_2.dim() == 0:
-            return weight_scale_2.expand(weight.shape[0]).contiguous()
-        if weight_scale_2.dim() == 2 and weight_scale_2.shape[1] == 1:
-            return weight_scale_2[:, 0].contiguous()
-    return weight_scale_2
-
-
-def _format_nvfp4_input_scale_for_export(
-    source_name: str,
-    weight_name: str,
-    weight: torch.Tensor,
-    input_scale: torch.Tensor,
-) -> torch.Tensor:
-    """Shape static activation scales for dense and fused-MoE vLLM loaders."""
-    if source_name.endswith(".experts.up_proj"):
-        num_experts = weight.shape[0]
-        if input_scale.numel() == 1:
-            return input_scale.reshape(1, 1).expand(num_experts, 1).contiguous()
-        if input_scale.shape == (num_experts,):
-            return input_scale[:, None].contiguous()
-        if input_scale.shape == (num_experts, 1):
-            return input_scale.contiguous()
-        raise RuntimeError(
-            f"Expected one non-gated up-projection input scale per expert for "
-            f"{weight_name}, got shape {tuple(input_scale.shape)}"
-        )
-
-    if weight_name.endswith("w13_weight"):
-        num_experts = weight.shape[0]
-        if input_scale.numel() == 1:
-            expert_scales = input_scale.reshape(1).expand(num_experts)
-        elif input_scale.shape == (num_experts,):
-            expert_scales = input_scale
-        elif input_scale.shape == (num_experts, 1):
-            expert_scales = input_scale[:, 0]
-        elif input_scale.shape == (num_experts, 2):
-            return input_scale.contiguous()
-        else:
-            raise RuntimeError(
-                f"Expected one or two W13 input scales per expert for {weight_name}, "
-                f"got shape {tuple(input_scale.shape)}"
-            )
-        return expert_scales[:, None].expand(-1, 2).contiguous()
-
-    if weight_name.endswith("w2_weight"):
-        num_experts = weight.shape[0]
-        if input_scale.numel() == 1:
-            return input_scale.reshape(1).expand(num_experts).contiguous()
-        if input_scale.shape == (num_experts,):
-            return input_scale.contiguous()
-        if input_scale.shape == (num_experts, 1):
-            return input_scale[:, 0].contiguous()
-        raise RuntimeError(
-            f"Expected one input scale per expert for {weight_name}, got shape {tuple(input_scale.shape)}"
-        )
-
-    if input_scale.numel() != 1:
-        raise RuntimeError(
-            f"Expected one input scale for dense parameter {weight_name}, got shape {tuple(input_scale.shape)}"
-        )
-    return input_scale.reshape(())
-
-
-def quantize_nvfp4_weight(
-    name: str,
-    weight: torch.Tensor,
-    meta: QuantMeta,
 ) -> Iterator[tuple[str, torch.Tensor]]:
-    """Yield NVFP4 quantized weight tensors and associated scale tensors."""
-    from modelopt.torch.export.quant_utils import QUANTIZATION_NVFP4, to_quantized_weight
+    from modelopt.torch.export.quantized_weight import export_quantized_weight
 
-    weight_name, weight_scale_name, weight_scale_2_name, input_scale_name = _nvfp4_export_names(name)
-    weight_scale, weight_scale_2 = compute_nvfp4_weight_scale(
-        weight,
-        meta.block_size,
-        weight_amax=meta.weight_amax,
-        weight_scale_2=meta.weight_scale_2,
-    )
-    if not torch.isfinite(weight_scale_2).all() or not torch.all(weight_scale_2 > 0):
-        raise RuntimeError(f"Invalid ModelOpt weight_scale_2 for quantized parameter {name}: {weight_scale_2}")
-    weight_scale_2_for_quant = weight_scale_2
-    if weight.dim() == 3:
-        weight_scale_2_for_quant = _reshape_nvfp4_weight_scale_2_for_compute(
-            weight,
-            weight_scale_2,
-        )
-    if weight.dim() == 2 and weight_scale_2.numel() == 1:
-        weight_scale_2_for_quant = weight_scale_2.reshape(())
-
-    quantized = to_quantized_weight(
-        weight,
-        weight_scale,
-        meta.qformat,
-        weight_scale_2_for_quant,
-        meta.block_size,
-    )
-
-    yield weight_name, quantized.detach()
-    yield weight_scale_name, weight_scale.detach()
-    yield (
-        weight_scale_2_name,
-        _format_nvfp4_weight_scale_2_for_export(
-            name,
-            weight_name,
-            weight,
-            weight_scale_2,
-        ).detach(),
-    )
-    if meta.qformat == QUANTIZATION_NVFP4:
-        input_scale = compute_nvfp4_input_scale(meta.input_amax).to(weight.device)
-        yield (
-            input_scale_name,
-            _format_nvfp4_input_scale_for_export(
-                name,
-                weight_name,
-                weight,
-                input_scale,
-            ).detach(),
-        )
+    prefix, separator, weight_name = hf_name.rpartition(".")
+    exported = export_quantized_weight(weight, state, dtype=weight.dtype)
+    for relative_name, tensor in exported.named_tensors(weight_name).items():
+        yield f"{prefix}{separator}{relative_name}", tensor.detach()
 
 
-def get_modelopt_quant_exporter(quant_mode: str):
-    """Return the ModelOpt quantization format and exporter for a quantization mode."""
-    from modelopt.torch.export import quant_utils
-
-    normalized_mode = quant_mode.lower()
-    if normalized_mode == "nvfp4":
-        qformat = quant_utils.QUANTIZATION_NVFP4
-    elif normalized_mode == "w4a16_nvfp4":
-        qformat = getattr(quant_utils, "QUANTIZATION_W4A16_NVFP4", None)
-        if qformat is None:
-            raise RuntimeError(
-                "The installed nvidia-modelopt version does not support W4A16 NVFP4 export; "
-                "install a version that exposes QUANTIZATION_W4A16_NVFP4."
-            )
-    else:
-        raise ValueError(f"Unsupported ModelOpt quant_mode: {quant_mode}")
-    return qformat, quantize_nvfp4_weight
-
-
-def _grouped_expert_projection_name(hf_name: str) -> tuple[str, int] | None:
-    """Remove a resolved expert index and terminal weight suffix from an HF name."""
+def _expert_hf_name_template(hf_name: str) -> tuple[str, int] | None:
+    """Replace one resolved expert index with a formatting placeholder."""
     parts = hf_name.split(".")
-    if parts and parts[-1] == "weight":
-        parts.pop()
+    expert_segments = [index for index, part in enumerate(parts[:-1]) if part == "experts"]
+    if len(expert_segments) != 1:
+        return None
+    expert_segment = expert_segments[0] + 1
     if (
-        len(parts) < 4
-        or parts[-3] != "experts"
-        or not parts[-2].isascii()
-        or not parts[-2].isdecimal()
-        or not parts[-1]
-        or parts.count("experts") != 1
+        expert_segment >= len(parts)
+        or not parts[expert_segment].isascii()
+        or not parts[expert_segment].isdecimal()
         or any(not part or "*" in part for part in parts)
     ):
         return None
-    return ".".join((*parts[:-2], parts[-1])), int(parts[-2])
-
-
-def _fuse_grouped_projection_names(gate_name: str, up_name: str) -> str | None:
-    """Merge two projection leaves while preserving their common underscore suffix."""
-    gate_parent, separator, gate_projection = gate_name.rpartition(".")
-    up_parent, up_separator, up_projection = up_name.rpartition(".")
-    if not separator or not up_separator or gate_parent != up_parent:
-        return None
-
-    gate_parts = gate_projection.split("_")
-    up_parts = up_projection.split("_")
-    if any(not part for part in (*gate_parts, *up_parts)):
-        return None
-    common_suffix = 0
-    while (
-        common_suffix < len(gate_parts)
-        and common_suffix < len(up_parts)
-        and gate_parts[-(common_suffix + 1)] == up_parts[-(common_suffix + 1)]
-    ):
-        common_suffix += 1
-    if common_suffix == 0 or common_suffix == len(gate_parts) or common_suffix == len(up_parts):
-        return None
-
-    fused_projection = "_".join(
-        (*gate_parts[:-common_suffix], *up_parts[:-common_suffix], *gate_parts[-common_suffix:])
-    )
-    return f"{gate_parent}.{fused_projection}"
+    expert = int(parts[expert_segment])
+    parts[expert_segment] = "{expert}"
+    return ".".join(parts), expert
 
 
 class _LocalExpertMappingMixin:
@@ -912,10 +495,9 @@ class _LocalExpertGatedMLPMapping(_LocalExpertMappingMixin, GatedMLPMapping):
     pass
 
 
-class _ModelOptFusedExpertMapping(FusedExpertMapping):
-    """Build one E/EP-local expert batch without a BF16 EP gather."""
+class _ModelOptLocalExpertMapping(AutoMapping):
+    """Export one canonical HF expert without a BF16 EP gather."""
 
-    is_grouped_export = False
     is_modelopt_pre_ep_export = True
 
     def _get_or_create_mapping(self, parallelism_type: str):
@@ -933,70 +515,58 @@ class _ModelOptFusedExpertMapping(FusedExpertMapping):
         return mapping
 
 
-class _ModelOptFusedGatedExpertMapping(FusedGatedExpertMapping):
-    """Fuse gate/up locally without a BF16 EP gather."""
+class _ModelOptLocalGatedExpertMapping(_LocalExpertGatedMLPMapping):
+    """Split one canonical HF gate/up expert without a BF16 EP gather."""
 
-    is_grouped_export = False
     is_modelopt_pre_ep_export = True
 
-    def __init__(
-        self,
-        megatron_param: str,
-        hf_param: str,
-        permute_dims: tuple[int, ...] | None = None,
-        transpose_on_export: bool = False,
-    ) -> None:
-        super().__init__(megatron_param, hf_param, permute_dims, transpose_on_export)
-        self._gated_mapping = _LocalExpertGatedMLPMapping(
-            megatron_param=self.megatron_param,
-            gate=f"{self.hf_param}.gate",
-            up=f"{self.hf_param}.up",
-        )
 
-
-def _modelopt_pre_ep_mapping(
-    mapping: Any,
-    pg_collection: Any = None,
-) -> tuple[Any, tuple[str, ...]] | None:
-    """Build a fused local-expert mapping for ModelOpt expert projections."""
+def _modelopt_pre_ep_mapping(mapping: Any, pg_collection: Any = None) -> Any | None:
+    """Build a local-expert mapping while preserving canonical HF names."""
     if type(mapping) is GatedMLPMapping and isinstance(mapping.hf_param, dict):
         gate_name = mapping.hf_param.get("gate")
         up_name = mapping.hf_param.get("up")
         if isinstance(gate_name, str) and isinstance(up_name, str):
-            grouped_gate = _grouped_expert_projection_name(gate_name)
-            grouped_up = _grouped_expert_projection_name(up_name)
-            if grouped_gate is not None and grouped_up is not None and grouped_gate[1] == grouped_up[1]:
-                grouped_name = _fuse_grouped_projection_names(grouped_gate[0], grouped_up[0])
-            else:
-                grouped_name = None
-            if grouped_name is not None and is_modelopt_quantizable_weight_name(grouped_name):
-                replacement = _ModelOptFusedGatedExpertMapping(
+            gate_expert = _expert_hf_name_template(gate_name)
+            up_expert = _expert_hf_name_template(up_name)
+            if gate_expert is not None and up_expert is not None and gate_expert[1] == up_expert[1]:
+                replacement = _ModelOptLocalGatedExpertMapping(
                     mapping.megatron_param,
-                    grouped_name,
+                    gate=gate_name,
+                    up=up_name,
                 )
                 replacement.set_process_groups_from_pg_collection(pg_collection)
-                return replacement, (gate_name, up_name)
+                return replacement
 
     if type(mapping) is not AutoMapping or not isinstance(mapping.hf_param, str):
         return None
-
-    grouped_projection = _grouped_expert_projection_name(mapping.hf_param)
-    if grouped_projection is None or not is_modelopt_quantizable_weight_name(grouped_projection[0]):
+    if _expert_hf_name_template(mapping.hf_param) is None:
         return None
-
-    replacement = _ModelOptFusedExpertMapping(
+    replacement = _ModelOptLocalExpertMapping(
         mapping.megatron_param,
-        grouped_projection[0],
+        mapping.hf_param,
         mapping.permute_dims,
     )
     replacement.set_process_groups_from_pg_collection(pg_collection)
-    return replacement, (mapping.hf_param,)
+    return replacement
+
+
+def _pre_ep_group(mapping: Any) -> tuple[str, int] | None:
+    """Return a stable projection-family key and its resolved expert index."""
+    names = (mapping.hf_param,) if isinstance(mapping.hf_param, str) else tuple(mapping.hf_param.values())
+    templated = [_expert_hf_name_template(name) for name in names]
+    if not templated or any(item is None for item in templated):
+        return None
+    templates = tuple(item[0] for item in templated if item is not None)
+    experts = {item[1] for item in templated if item is not None}
+    if len(experts) != 1:
+        return None
+    return "|".join(templates), experts.pop()
 
 
 def _stage_tensor_for_collective(tensor: torch.Tensor, group: Any) -> torch.Tensor:
-    """Move a CPU tensor to CUDA only when its collective backend requires it."""
-    backend = str(torch.distributed.get_backend(group)).lower()
-    if backend != "nccl" or tensor.device.type != "cpu":
+    """Move a CPU tensor to CUDA only when an NCCL collective requires it."""
+    if str(torch.distributed.get_backend(group)).lower() != "nccl" or tensor.device.type != "cpu":
         return tensor
     if not torch.cuda.is_available():
         raise RuntimeError("NCCL ModelOpt expert gather requires CUDA")
@@ -1017,199 +587,279 @@ def _compose_export_hooks(exporter: HFExportHook, finalizer: HFExportHook | None
     return export_and_finalize
 
 
+def _compose_grouped_export_hooks(
+    exporter: GroupedHFExportHook,
+    finalizer: GroupedHFExportHook | None,
+) -> GroupedHFExportHook:
+    if finalizer is None:
+        return exporter
+
+    def export_and_finalize(
+        hf_name: str,
+        tensor: torch.Tensor,
+        expert_number: int,
+    ) -> Iterable[HFWeightTuple]:
+        for exported_name, exported_tensor in exporter(hf_name, tensor, expert_number):
+            yield from finalizer(exported_name, exported_tensor, expert_number)
+
+    return export_and_finalize
+
+
 def build_modelopt_export_plan(
     conversion_tasks: list[WeightConversionTask | None],
     *,
     model: list[torch.nn.Module],
-    bridge: "MegatronModelBridge",
-    quant_mode: str,
-    ignore_patterns: list[str],
-) -> list[WeightConversionTask]:
-    """Prepare mapped conversion tasks and hooks for a ModelOpt export."""
-    expected_qformat, export_weight = get_modelopt_quant_exporter(quant_mode)
+) -> ModelOptExportPlan:
+    """Prepare topology-aware conversion tasks for ModelOpt HF export."""
+    concrete_tasks = [task for task in conversion_tasks if task is not None and not _is_quantizer_state_task(task)]
+    config_weights = collect_modelopt_config_weights(concrete_tasks)
+    states = collect_modelopt_quant_states(concrete_tasks)
+
     pg_collection = model_bridge_utils._get_pg_collection_from_model(model)
-    local_metadata = collect_modelopt_quant_metadata(conversion_tasks)
-    # ``None`` slots represent global names without conversion tasks. They are
-    # not termination sentinels, so retain every concrete task after a hole.
-    concrete_tasks: list[WeightConversionTask] = [task for task in conversion_tasks if task is not None]
     if torch.distributed.is_initialized():
         pp_group = model_bridge_utils._get_pp_group(model)
         ep_group = model_bridge_utils._get_ep_group(model)
     else:
         pp_group = None
         ep_group = None
-
-    # PP stages need metadata for their EP-local experts, but pre-EP packing
-    # must retain the E/EP-local view rather than a full global-E copy.
     pp_world_size = get_pg_size(pp_group)
     ep_world_size = pp_world_size if ep_group is pp_group else get_pg_size(ep_group)
     if pp_world_size > 1:
-        sync_modelopt_quant_metadata(local_metadata, pp_group)
+        sync_modelopt_quant_states(states, pp_group)
 
-    # A shared non-singleton PP/EP group has already globalized metadata, so it
-    # cannot provide the local view required by pre-EP packing.
     can_export_before_ep = not (pp_world_size > 1 and pp_group is not None and ep_group is pp_group)
-    candidate_mappings: dict[int, Any] = {}
+    candidates: dict[int, Any] = {}
     candidate_groups: dict[str, list[int]] = {}
-    eligible_groups: dict[str, bool] = {}
-    for task_idx, task in enumerate(concrete_tasks):
-        candidate = _modelopt_pre_ep_mapping(task.mapping, pg_collection) if can_export_before_ep else None
-        if candidate is None:
+    candidate_experts: dict[int, int] = {}
+    for task_index, task in enumerate(concrete_tasks):
+        if task.global_param_name not in states or not can_export_before_ep:
             continue
-        replacement, original_hf_names = candidate
-        group_key = str(replacement.hf_param)
-        candidate_mappings[task_idx] = replacement
-        candidate_groups.setdefault(group_key, []).append(task_idx)
-
-        meta = local_metadata.get(task.global_param_name)
-        task_is_eligible = (
-            meta is not None
-            and meta.qformat == expected_qformat
-            and not any(matches_quant_ignore_pattern(name, ignore_patterns) for name in original_hf_names)
-        )
-        eligible_groups[group_key] = eligible_groups.get(group_key, True) and task_is_eligible
+        candidate = _modelopt_pre_ep_mapping(task.mapping, pg_collection)
+        group = _pre_ep_group(task.mapping)
+        if candidate is None or group is None:
+            continue
+        group_key, expert = group
+        candidates[task_index] = candidate
+        candidate_experts[task_index] = expert
+        candidate_groups.setdefault(group_key, []).append(task_index)
 
     experts_per_rank = 0
+    num_experts = None
+    eligible_groups: set[str] = set()
+    global_expert_orders: dict[str, tuple[int, ...]] = {}
+    local_expert_orders: dict[str, tuple[int, ...]] = {}
     if candidate_groups:
-        unwrapped_model = model_bridge_utils.unwrap_model(model)[0]
-        num_experts = getattr(unwrapped_model.config, "num_moe_experts", None)
-        valid_expert_layout = isinstance(num_experts, int) and num_experts > 0 and num_experts % ep_world_size == 0
-        experts_per_rank = num_experts // ep_world_size if valid_expert_layout else 0
-        expected_local_ids = set(range(experts_per_rank))
+        model_config = model_bridge_utils.unwrap_model(model)[0].config
+        num_experts = getattr(model_config, "num_moe_experts", None)
+        valid_layout = isinstance(num_experts, int) and num_experts > 0 and num_experts % ep_world_size == 0
+        experts_per_rank = num_experts // ep_world_size if valid_layout else 0
         for group_key, task_indices in candidate_groups.items():
-            local_ids: list[int] = []
-            if valid_expert_layout:
-                try:
-                    for task_idx in task_indices:
-                        candidate_task = concrete_tasks[task_idx]
-                        local_ids.append(
-                            extract_expert_number_from_param(candidate_task.param_name) % experts_per_rank
-                        )
-                except ValueError:
-                    local_ids = []
-            eligible_groups[group_key] = eligible_groups[group_key] and (
-                valid_expert_layout and len(local_ids) == experts_per_rank and set(local_ids) == expected_local_ids
-            )
+            experts = tuple(sorted(candidate_experts[task_index] for task_index in task_indices))
+            if valid_layout and len(experts) == experts_per_rank and len(set(experts)) == experts_per_rank:
+                local_expert_orders[group_key] = experts
 
     if ep_world_size > 1:
-        gathered_eligibility: list[dict[str, bool] | None] = [None] * ep_world_size
-        torch.distributed.all_gather_object(gathered_eligibility, eligible_groups, group=ep_group)
-        all_group_keys = set().union(*(rank_groups or {} for rank_groups in gathered_eligibility))
-        eligible_groups = {
-            group_key: all(bool((rank_groups or {}).get(group_key, False)) for rank_groups in gathered_eligibility)
-            for group_key in all_group_keys
-        }
+        gathered_experts: list[dict[str, tuple[int, ...]] | None] = [None] * ep_world_size
+        torch.distributed.all_gather_object(
+            gathered_experts,
+            local_expert_orders,
+            group=ep_group,
+        )
+        group_keys = set().union(*(rank_groups or {} for rank_groups in gathered_experts))
+        for group_key in group_keys:
+            rank_orders = [(rank_groups or {}).get(group_key, ()) for rank_groups in gathered_experts]
+            global_order = tuple(expert for rank_order in rank_orders for expert in rank_order)
+            if (
+                isinstance(num_experts, int)
+                and all(len(rank_order) == experts_per_rank for rank_order in rank_orders)
+                and len(set(global_order)) == len(global_order)
+                and set(global_order) == set(range(num_experts))
+            ):
+                eligible_groups.add(group_key)
+                global_expert_orders[group_key] = global_order
+    else:
+        for group_key, local_order in local_expert_orders.items():
+            if isinstance(num_experts, int) and set(local_order) == set(range(num_experts)):
+                eligible_groups.add(group_key)
+                global_expert_orders[group_key] = local_order
 
     mapped_tasks = list(concrete_tasks)
+    pre_ep_groups_by_name: dict[str, str] = {}
     for group_key, task_indices in candidate_groups.items():
-        if not eligible_groups[group_key]:
+        if group_key not in eligible_groups:
             continue
-        for task_idx in task_indices:
-            mapped_tasks[task_idx] = replace(
-                concrete_tasks[task_idx],
-                mapping=candidate_mappings[task_idx],
+        for task_index in task_indices:
+            mapped_tasks[task_index] = replace(
+                concrete_tasks[task_index],
+                mapping=candidates[task_index],
             )
+            pre_ep_groups_by_name[concrete_tasks[task_index].global_param_name] = group_key
 
-    regular_metadata_tasks: list[WeightConversionTask] = []
-    pre_ep_tasks: list[WeightConversionTask] = []
-    for original_task, mapped_task in zip(concrete_tasks, mapped_tasks, strict=True):
-        if getattr(mapped_task.mapping, "is_modelopt_pre_ep_export", False):
-            pre_ep_tasks.append(mapped_task)
-        else:
-            regular_metadata_tasks.append(original_task)
-
-    regular_metadata_names = {task.global_param_name for task in regular_metadata_tasks}
-    pre_ep_only_metadata_names = {task.global_param_name for task in pre_ep_tasks}.difference(regular_metadata_names)
-    regular_metadata = {name: meta for name, meta in local_metadata.items() if name not in pre_ep_only_metadata_names}
+    pre_ep_tasks = [task for task in mapped_tasks if getattr(task.mapping, "is_modelopt_pre_ep_export", False)]
+    regular_tasks = [task for task in mapped_tasks if not getattr(task.mapping, "is_modelopt_pre_ep_export", False)]
+    pre_ep_only_names = {task.global_param_name for task in pre_ep_tasks}.difference(
+        task.global_param_name for task in regular_tasks
+    )
+    regular_states = {name: state for name, state in states.items() if name not in pre_ep_only_names}
     if ep_world_size > 1 and ep_group is not pp_group:
-        sync_modelopt_quant_metadata(regular_metadata, ep_group)
+        sync_modelopt_quant_states(regular_states, ep_group)
 
-    hf_metadata = build_hf_modelopt_quant_metadata(regular_metadata_tasks, regular_metadata)
-    pre_ep_hf_metadata = _build_hf_modelopt_pre_ep_quant_metadata(pre_ep_tasks, local_metadata)
-    hf_metadata.update(pre_ep_hf_metadata)
-    pre_ep_hf_names = set(pre_ep_hf_metadata)
-    mapping_registry = None
+    model_config = model_bridge_utils.unwrap_model(model)[0].config
+    regular_hf_states = build_hf_modelopt_quant_states(
+        regular_tasks,
+        regular_states,
+        num_experts=getattr(model_config, "num_moe_experts", None),
+    )
+    pre_ep_hf_states = build_hf_modelopt_quant_states(pre_ep_tasks, states)
+    hf_states: dict[str, MappedQuantizedWeightState] = dict(regular_hf_states)
+    for hf_name, state in pre_ep_hf_states.items():
+        _set_hf_quant_state(hf_states, hf_name, state)
 
-    def modelopt_export_weight(hf_name: str, tensor: torch.Tensor) -> Iterable[HFWeightTuple]:
-        nonlocal mapping_registry
-        if "_quantizer." in hf_name:
-            return
+    def export_weight(hf_name: str, tensor: torch.Tensor) -> Iterable[HFWeightTuple]:
+        state = regular_hf_states.get(hf_name)
+        if state is None:
+            yield HFWeightTuple(hf_name, tensor)
+        elif isinstance(state, tuple):
+            raise RuntimeError(f"Grouped ModelOpt weight {hf_name} was not exported per expert")
+        else:
+            for name, exported_tensor in _named_export_tensors(hf_name, state, tensor):
+                yield HFWeightTuple(name, exported_tensor)
 
-        meta = None
-        if is_modelopt_quantizable_weight_name(hf_name) and (
-            hf_name in pre_ep_hf_names or not matches_quant_ignore_pattern(hf_name, ignore_patterns)
+    def export_grouped_weight(
+        hf_name: str,
+        tensor: torch.Tensor,
+        expert_number: int,
+    ) -> Iterable[HFWeightTuple]:
+        grouped_states = regular_hf_states.get(hf_name)
+        if not isinstance(grouped_states, tuple):
+            raise RuntimeError(f"Missing grouped ModelOpt state for {hf_name}")
+        if expert_number >= len(grouped_states):
+            raise RuntimeError(f"Missing ModelOpt state for expert {expert_number} of grouped parameter {hf_name}")
+        for name, exported_tensor in _named_export_tensors(
+            hf_name,
+            grouped_states[expert_number],
+            tensor,
         ):
-            meta = hf_metadata.get(hf_name)
-            if meta is None and regular_metadata:
-                if mapping_registry is None:
-                    mapping_registry = bridge.mapping_registry()
-                    mapping_registry.set_process_groups_from_pg_collection(pg_collection)
-                mapping = mapping_registry.hf_to_megatron_lookup(hf_name)
-                if mapping is not None:
-                    meta = regular_metadata.get(mapping.megatron_param)
+            yield HFWeightTuple(name, exported_tensor)
 
-        if meta is None:
-            yield HFWeightTuple(hf_name, tensor)
+    def gather_ep_experts(
+        hf_name_template: str,
+        tensor: torch.Tensor,
+        group_key: str,
+    ) -> Iterable[HFWeightTuple]:
+        global_order = global_expert_orders[group_key]
+        if ep_world_size == 1:
+            for expert, expert_tensor in zip(global_order, tensor, strict=True):
+                yield HFWeightTuple(hf_name_template.format(expert=expert), expert_tensor)
             return
-        if meta.qformat != expected_qformat:
-            raise RuntimeError(f"Unsupported qformat for ModelOpt {quant_mode} export: {meta.qformat}")
-        for quant_name, quant_tensor in export_weight(hf_name, tensor, meta):
-            yield HFWeightTuple(quant_name, quant_tensor)
-
-    def finalize_ep_weight(hf_name: str, tensor: torch.Tensor) -> Iterable[HFWeightTuple]:
-        if get_pg_size(ep_group) == 1:
-            yield HFWeightTuple(hf_name, tensor)
-            return
-
         local_tensor = tensor.contiguous()
-        if local_tensor.ndim == 0:
-            raise ValueError("Pre-EP ModelOpt tensor must have an expert dimension")
         collective_tensor = _stage_tensor_for_collective(local_tensor, ep_group)
         local_bytes = collective_tensor.reshape(-1).view(torch.uint8)
-        world_size = get_pg_size(ep_group)
         gathered_bytes = torch.empty(
-            world_size * local_bytes.numel(),
+            ep_world_size * local_bytes.numel(),
             dtype=torch.uint8,
             device=collective_tensor.device,
         )
-        torch.distributed.all_gather_into_tensor(gathered_bytes, local_bytes, group=ep_group)
-        global_shape = (world_size * local_tensor.shape[0], *local_tensor.shape[1:])
-        yield HFWeightTuple(
-            hf_name,
-            gathered_bytes.view(local_tensor.dtype).reshape(global_shape),
+        torch.distributed.all_gather_into_tensor(
+            gathered_bytes,
+            local_bytes,
+            group=ep_group,
         )
+        gathered = gathered_bytes.view(local_tensor.dtype).reshape(
+            ep_world_size * local_tensor.shape[0],
+            *local_tensor.shape[1:],
+        )
+        for expert, expert_tensor in zip(global_order, gathered, strict=True):
+            yield HFWeightTuple(hf_name_template.format(expert=expert), expert_tensor)
 
-    pre_ep_buffers: dict[str, dict[int, torch.Tensor]] = {}
+    pre_ep_buffers: dict[tuple[str, str], dict[int, torch.Tensor]] = {}
 
     def build_pre_ep_hook(task: WeightConversionTask) -> HFExportHook:
-        local_expert_id = extract_expert_number_from_param(task.param_name) % experts_per_rank
+        group_key = pre_ep_groups_by_name[task.global_param_name]
+        local_expert_order = local_expert_orders[group_key]
 
-        def export_local_expert(hf_name: str, tensor: torch.Tensor) -> Iterable[HFWeightTuple]:
-            expert_tensors = pre_ep_buffers.setdefault(hf_name, {})
-            if local_expert_id in expert_tensors:
-                raise RuntimeError(f"Duplicate local expert {local_expert_id} for {hf_name}")
-            expert_tensors[local_expert_id] = tensor
-            if len(expert_tensors) != experts_per_rank:
-                return
-
-            missing = set(range(experts_per_rank)).difference(expert_tensors)
-            if missing:
-                raise RuntimeError(f"Missing local experts {sorted(missing)} for {hf_name}")
-            local_batch = torch.stack(
-                [expert_tensors[expert_id] for expert_id in range(experts_per_rank)],
-                dim=0,
-            )
-            del pre_ep_buffers[hf_name]
-            for exported_name, exported_tensor in modelopt_export_weight(hf_name, local_batch):
-                yield from finalize_ep_weight(exported_name, exported_tensor)
+        def export_local_expert(
+            hf_name: str,
+            tensor: torch.Tensor,
+        ) -> Iterable[HFWeightTuple]:
+            state = pre_ep_hf_states.get(hf_name)
+            templated_name = _expert_hf_name_template(hf_name)
+            if state is None or isinstance(state, tuple) or templated_name is None:
+                raise RuntimeError(f"Missing ModelOpt state for pre-EP parameter {hf_name}")
+            _, expert = templated_name
+            for exported_name, exported_tensor in _named_export_tensors(
+                hf_name,
+                state,
+                tensor,
+            ):
+                exported_template = _expert_hf_name_template(exported_name)
+                if exported_template is None or exported_template[1] != expert:
+                    raise RuntimeError(f"Invalid expert checkpoint name {exported_name}")
+                name_template, _ = exported_template
+                expert_tensors = pre_ep_buffers.setdefault((group_key, name_template), {})
+                if expert in expert_tensors:
+                    raise RuntimeError(f"Duplicate local expert {expert} for {exported_name}")
+                expert_tensors[expert] = exported_tensor
+                if len(expert_tensors) != experts_per_rank:
+                    continue
+                missing = set(local_expert_order).difference(expert_tensors)
+                if missing:
+                    raise RuntimeError(f"Missing local experts {sorted(missing)} for {exported_name}")
+                local_batch = torch.stack(
+                    [expert_tensors[index] for index in local_expert_order],
+                    dim=0,
+                )
+                del pre_ep_buffers[(group_key, name_template)]
+                for final_name, final_tensor in gather_ep_experts(
+                    name_template,
+                    local_batch,
+                    group_key,
+                ):
+                    if task.export_hook is None:
+                        yield HFWeightTuple(final_name, final_tensor)
+                    else:
+                        yield from task.export_hook(final_name, final_tensor)
 
         return export_local_expert
 
-    regular_hook = _compose_export_hooks(modelopt_export_weight, None)
     export_tasks = []
     for task in mapped_tasks:
-        export_hook = (
-            build_pre_ep_hook(task) if getattr(task.mapping, "is_modelopt_pre_ep_export", False) else regular_hook
+        if getattr(task.mapping, "is_modelopt_pre_ep_export", False):
+            export_tasks.append(replace(task, export_hook=build_pre_ep_hook(task)))
+            continue
+        is_grouped = getattr(task.mapping, "is_grouped_export", False)
+        has_grouped_state = is_grouped and any(
+            isinstance(regular_hf_states.get(hf_name), tuple) for hf_name in _hf_weight_names(task)
         )
-        export_tasks.append(replace(task, export_hook=export_hook))
-    return export_tasks
+        if has_grouped_state:
+            export_tasks.append(
+                replace(
+                    task,
+                    grouped_export_hook=_compose_grouped_export_hooks(
+                        export_grouped_weight,
+                        task.grouped_export_hook,
+                    ),
+                )
+            )
+        else:
+            export_tasks.append(
+                replace(
+                    task,
+                    export_hook=_compose_export_hooks(export_weight, task.export_hook),
+                )
+            )
+    config_sync_groups = []
+    if pp_world_size > 1:
+        config_sync_groups.append(pp_group)
+    if ep_world_size > 1 and ep_group is not pp_group:
+        config_sync_groups.append(ep_group)
+
+    return ModelOptExportPlan(
+        conversion_tasks=export_tasks,
+        quantization_config=build_modelopt_quantization_config(
+            mapped_tasks,
+            hf_states,
+            config_weights=config_weights,
+            sync_groups=config_sync_groups,
+        ),
+    )

--- a/src/megatron/bridge/models/conversion/modelopt_utils.py
+++ b/src/megatron/bridge/models/conversion/modelopt_utils.py
@@ -854,6 +854,10 @@ def build_modelopt_export_plan(
     if ep_world_size > 1 and ep_group is not pp_group:
         config_sync_groups.append(ep_group)
 
+    # Native layerwise loaders retain incomplete parent modules. Canonical HF
+    # order keeps each module's weight and scale tensors adjacent during refit.
+    export_tasks.sort(key=_hf_weight_names)
+
     return ModelOptExportPlan(
         conversion_tasks=export_tasks,
         quantization_config=build_modelopt_quantization_config(

--- a/tests/unit_tests/models/test_model_bridge.py
+++ b/tests/unit_tests/models/test_model_bridge.py
@@ -73,19 +73,20 @@ def test_modelopt_plan_skips_unmapped_task_slot_and_keeps_later_task(monkeypatch
     assert tasks[1] is None
     assert tasks[2].global_param_name == last_name
 
-    monkeypatch.setattr(modelopt_utils, "get_modelopt_quant_exporter", lambda _mode: ("unused", lambda *_args: ()))
+    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_states", lambda _tasks: {})
+    monkeypatch.setattr(
+        modelopt_utils,
+        "build_modelopt_quantization_config",
+        lambda *_args, **_kwargs: {},
+    )
     monkeypatch.setattr(modelopt_utils, "get_pg_size", lambda _group: 1)
-    monkeypatch.setattr(modelopt_utils.model_bridge_utils, "_get_pg_collection_from_model", lambda _model: None)
 
-    export_tasks = modelopt_utils.build_modelopt_export_plan(
+    plan = modelopt_utils.build_modelopt_export_plan(
         tasks,
         model=[model],
-        bridge=bridge,
-        quant_mode="nvfp4",
-        ignore_patterns=[],
     )
 
-    assert [task.global_param_name for task in export_tasks] == [first_name, last_name]
+    assert [task.global_param_name for task in plan.conversion_tasks] == [first_name, last_name]
 
 
 def test_hf_weight_tuple_iter_finalized_preserves_two_field_abi():

--- a/tests/unit_tests/models/test_modelopt_utils.py
+++ b/tests/unit_tests/models/test_modelopt_utils.py
@@ -451,6 +451,33 @@ def test_build_modelopt_export_plan_omits_internal_quantizer_state(monkeypatch):
     assert [task.global_param_name for task in plan.conversion_tasks] == [weight_task.global_param_name]
 
 
+def test_build_modelopt_export_plan_orders_tasks_by_hf_name(monkeypatch):
+    tasks = [
+        _task(
+            "decoder.layers.1.mlp.linear_fc1.weight",
+            "model.layers.1.mlp.up_proj.weight",
+        ),
+        _task(
+            "decoder.layers.0.mlp.linear_fc1.weight",
+            "model.layers.0.mlp.up_proj.weight",
+        ),
+    ]
+    states = {task.global_param_name: _state(w4a16=True) for task in tasks}
+    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_states", lambda _tasks: states)
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_config_weights",
+        lambda _tasks: set(states),
+    )
+
+    plan = build_modelopt_export_plan(tasks, model=_model())
+
+    assert [_hf_task.mapping.hf_param for _hf_task in plan.conversion_tasks] == [
+        "model.layers.0.mlp.up_proj.weight",
+        "model.layers.1.mlp.up_proj.weight",
+    ]
+
+
 def test_build_modelopt_export_plan_packs_grouped_experts_independently(monkeypatch):
     hf_name = "model.layers.0.mlp.experts.gate_up_proj.weight"
     tasks = [

--- a/tests/unit_tests/models/test_modelopt_utils.py
+++ b/tests/unit_tests/models/test_modelopt_utils.py
@@ -12,36 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
 from types import SimpleNamespace
 
+import modelopt.torch.quantization as mtq
 import pytest
 import torch
-
-
-quant_utils = pytest.importorskip("modelopt.torch.export.quant_utils")
-QUANTIZATION_NONE = quant_utils.QUANTIZATION_NONE
-QUANTIZATION_NVFP4 = quant_utils.QUANTIZATION_NVFP4
+from megatron.core.transformer.moe.router import TopKRouter
+from modelopt.torch.export.quantized_weight import (
+    capture_quantized_weight_export_state,
+    export_quantized_weight,
+    quantized_weight_export_states_equal,
+)
+from modelopt.torch.quantization.nn import GroupedQuantizer
 
 from megatron.bridge.models.conversion import modelopt_utils
 from megatron.bridge.models.conversion.auto_bridge import AutoBridge
-from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
-from megatron.bridge.models.conversion.modelopt_utils import (
-    QuantMeta,
-    _fuse_grouped_projection_names,
-    _grouped_expert_projection_name,
-    _modelopt_pre_ep_mapping,
-    _stage_tensor_for_collective,
-    build_hf_modelopt_quant_metadata,
-    collect_modelopt_quant_metadata,
-    compute_nvfp4_input_scale,
-    find_modelopt_weight_quantizer_and_module,
-    get_modelopt_quant_exporter,
-    is_modelopt_quantizable_weight_name,
-    matches_quant_ignore_pattern,
-    quantize_nvfp4_weight,
-    sync_modelopt_quant_metadata,
+from megatron.bridge.models.conversion.model_bridge import (
+    HFWeightTuple,
+    MegatronModelBridge,
+    WeightConversionTask,
 )
-from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping
+from megatron.bridge.models.conversion.modelopt_utils import (
+    ModelOptExportPlan,
+    build_hf_modelopt_quant_states,
+    build_modelopt_export_plan,
+    build_modelopt_quantization_config,
+    collect_modelopt_config_weights,
+    collect_modelopt_quant_states,
+    find_modelopt_quantizers,
+    sync_modelopt_quant_states,
+)
+from megatron.bridge.models.conversion.param_mapping import AutoMapping
+
+
+def _state(
+    *,
+    w4a16=False,
+    weight_amax=2.0,
+    input_amax=3.0,
+):
+    module = torch.nn.Linear(16, 4, bias=False)
+    mtq.quantize(
+        module,
+        deepcopy(mtq.W4A16_NVFP4_CFG if w4a16 else mtq.NVFP4_DEFAULT_CFG),
+        lambda model: model(torch.ones(1, 16)),
+    )
+    module.weight_quantizer.amax = torch.tensor(weight_amax)
+    if module.input_quantizer.is_enabled:
+        module.input_quantizer.amax = torch.tensor(input_amax)
+    return capture_quantized_weight_export_state(module)
+
+
+def _assert_state_equal(actual, expected):
+    assert quantized_weight_export_states_equal(actual, expected)
 
 
 def _task(
@@ -50,2136 +74,605 @@ def _task(
     *,
     megatron_module=None,
     param_weight=None,
+    is_grouped_export=False,
+    ep_size=1,
+    transpose_on_export=False,
+    export_hook=None,
 ):
     return WeightConversionTask(
         param_name=global_param_name,
         global_param_name=global_param_name,
-        mapping=SimpleNamespace(hf_param=hf_param),
+        mapping=SimpleNamespace(
+            hf_param=hf_param,
+            is_grouped_export=is_grouped_export,
+            ep_size=ep_size,
+            transpose_on_export=transpose_on_export,
+        ),
         megatron_module=megatron_module,
         param_weight=param_weight,
+        export_hook=export_hook,
     )
 
 
-def _quant_meta(qformat=QUANTIZATION_NVFP4):
-    return QuantMeta(
-        qformat=qformat,
-        block_size=16,
-        weight_amax=torch.tensor([1.0]),
-        weight_scale_2=torch.tensor([1.0 / (6.0 * 448.0)]),
-        input_amax=torch.tensor([1.0]),
-    )
+def _model(*, num_moe_experts=None):
+    model = torch.nn.Module()
+    model.config = SimpleNamespace(num_moe_experts=num_moe_experts)
+    return [model]
 
 
-def _bridge_for_export(conversion_tasks, exported_weights):
-    class FakeBridge:
-        hf_pretrained = object()
-        _model_bridge = SimpleNamespace(
-            build_conversion_tasks=lambda *_args, **_kwargs: conversion_tasks,
+class _GroupedLinear(torch.nn.Module):
+    def __init__(self, linears):
+        super().__init__()
+        self.weight0 = linears[0].weight
+        self.weight1 = linears[1].weight
+        self.weight_quantizer = GroupedQuantizer(
+            linears[0].weight_quantizer,
+            linears[1].weight_quantizer,
         )
+        self.weight0_input_quantizer = linears[0].input_quantizer
+        self.weight1_input_quantizer = linears[1].input_quantizer
 
-        def __init__(self):
-            self.export_calls = []
-
-        def export_hf_weights(self, model, **kwargs):
-            self.export_calls.append((model, kwargs))
-            export_hf_weight = next(
-                (task.export_hook for task in kwargs.get("conversion_tasks", ()) if task.export_hook is not None),
-                None,
-            )
-            for hf_name, tensor in exported_weights:
-                finalized_weights = (
-                    export_hf_weight(hf_name, tensor.detach())
-                    if export_hf_weight is not None
-                    else ((hf_name, tensor.detach()),)
-                )
-                for finalized_name, finalized_tensor in finalized_weights:
-                    finalized_tensor = finalized_tensor.detach()
-                    if kwargs.get("cpu", False):
-                        finalized_tensor = finalized_tensor.cpu()
-                    yield finalized_name, finalized_tensor
-
-    return FakeBridge()
+    def iter_weights_for_calibration(self):
+        yield self.weight0, self.weight_quantizer[0]
+        yield self.weight1, self.weight_quantizer[1]
 
 
-def test_matches_quant_ignore_pattern_handles_model_prefix_and_scale_suffixes():
-    ignore_patterns = [
-        "lm_head",
-        "*self_attn*",
-        "*mlp.gate",
-        "*router*",
-    ]
-
-    assert matches_quant_ignore_pattern(
-        "model.layers.0.self_attn.o_proj.weight",
-        ignore_patterns,
-    )
-    assert matches_quant_ignore_pattern(
-        "layers.0.self_attn.o_proj.weight",
-        ignore_patterns,
-    )
-    assert matches_quant_ignore_pattern("model.layers.0.mlp.gate.weight", ignore_patterns)
-    assert matches_quant_ignore_pattern("model.layers.0.router.weight", ignore_patterns)
-    assert matches_quant_ignore_pattern("lm_head.weight", ignore_patterns)
-    assert matches_quant_ignore_pattern("model.layers.0.mlp.gate.weight_scale", ignore_patterns)
-    assert not matches_quant_ignore_pattern(
-        "model.layers.0.mlp.experts.0.w1.weight",
-        ignore_patterns,
-    )
-
-
-def test_find_modelopt_weight_quantizer_uses_proxy_for_custom_weight():
-    class FakeQuantModule(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.weight = torch.nn.Parameter(torch.zeros(1))
-            self.custom_weight = torch.nn.Parameter(torch.ones(1))
-            self.weight_quantizer = SimpleNamespace(is_enabled=True)
-            self.custom_quantizer = SimpleNamespace(is_enabled=True)
-            self.input_quantizer = SimpleNamespace(is_enabled=True)
-
-        def iter_weights_for_calibration(self):
-            yield self.custom_weight, self.custom_quantizer
-
-    module = FakeQuantModule()
-
-    weight_quantizer, quant_module = find_modelopt_weight_quantizer_and_module(
-        module,
-        module.custom_weight,
-    )
-
-    assert weight_quantizer is module.custom_quantizer
-    assert quant_module is not module
-    assert quant_module.weight is module.custom_weight
-    assert quant_module.weight_quantizer is module.custom_quantizer
-    assert quant_module.input_quantizer is module.input_quantizer
-
-
-def test_find_modelopt_weight_quantizer_returns_owner_for_weight_param():
-    class FakeQuantModule(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.weight = torch.nn.Parameter(torch.ones(1))
-            self.weight_quantizer = SimpleNamespace(is_enabled=True)
-
-        def iter_weights_for_calibration(self):
-            yield self.weight, self.weight_quantizer
-
-    module = FakeQuantModule()
-
-    weight_quantizer, quant_module = find_modelopt_weight_quantizer_and_module(
-        module,
-        module.weight,
-    )
-
-    assert weight_quantizer is module.weight_quantizer
-    assert quant_module is module
-
-
-def test_iter_modelopt_weight_quantizers_does_not_repeat_calibration_weight():
-    class FakeQuantModule(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.weight = torch.nn.Parameter(torch.ones(1))
-            self.weight_quantizer = SimpleNamespace(is_enabled=True)
-
-        def iter_weights_for_calibration(self):
-            yield self.weight, self.weight_quantizer
-
-    module = FakeQuantModule()
-
-    matches = list(modelopt_utils._iter_modelopt_weight_quantizers(module))
-
-    assert len(matches) == 1
-    weight, quantizer, can_use_module = matches[0]
-    assert weight is module.weight
-    assert quantizer is module.weight_quantizer
-    assert can_use_module is True
-
-
-def test_collect_modelopt_quant_metadata_skips_unquantized_tasks(monkeypatch):
-    monkeypatch.delattr(quant_utils, "QUANTIZATION_W4A16_NVFP4", raising=False)
-    quantizer_amax = torch.tensor([-2688.0])
-    input_amax = torch.tensor([1344.0])
-    quant_module = SimpleNamespace(
-        weight_quantizer=SimpleNamespace(_amax=quantizer_amax),
-        input_quantizer=SimpleNamespace(_amax=input_amax, is_enabled=True),
-    )
-    unquantized_module = SimpleNamespace(weight_quantizer=SimpleNamespace(_amax=torch.tensor([1.0])))
-    blockless_module = SimpleNamespace(weight_quantizer=SimpleNamespace(_amax=torch.tensor([2.0])))
-
-    qformat_by_module = {
-        id(quant_module): QUANTIZATION_NVFP4,
-        id(unquantized_module): QUANTIZATION_NONE,
-        id(blockless_module): QUANTIZATION_NVFP4,
-    }
-    block_size_by_module = {
-        id(quant_module): 16,
-        id(unquantized_module): 16,
-        id(blockless_module): 0,
-    }
-
-    monkeypatch.setattr(
-        quant_utils,
-        "get_quantization_format",
-        lambda module: qformat_by_module[id(module)],
-    )
-    monkeypatch.setattr(
-        quant_utils,
-        "get_weight_block_size",
-        lambda module: block_size_by_module[id(module)],
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "find_modelopt_weight_quantizer_and_module",
-        lambda module, _weight: (module.weight_quantizer, module),
-    )
-
-    metadata = collect_modelopt_quant_metadata(
-        [
-            _task(
-                "missing.module.weight",
-                "hf.missing.weight",
-                megatron_module=None,
-                param_weight=torch.empty(1),
-            ),
-            _task(
-                "missing.param.weight",
-                "hf.missing_param.weight",
-                megatron_module=quant_module,
-            ),
-            _task(
-                "unquantized.weight",
-                "hf.unquantized.weight",
-                megatron_module=unquantized_module,
-                param_weight=torch.empty(1),
-            ),
-            _task(
-                "blockless.weight",
-                "hf.blockless.weight",
-                megatron_module=blockless_module,
-                param_weight=torch.empty(1),
-            ),
-            _task(
-                "quantized.weight",
-                "hf.quantized.weight",
-                megatron_module=quant_module,
-                param_weight=torch.empty(1),
-            ),
-        ]
-    )
-
-    assert list(metadata) == ["quantized.weight"]
-    assert metadata["quantized.weight"].qformat == QUANTIZATION_NVFP4
-    assert metadata["quantized.weight"].block_size == 16
-    torch.testing.assert_close(
-        metadata["quantized.weight"].weight_amax,
-        quantizer_amax.abs(),
-    )
-    torch.testing.assert_close(
-        metadata["quantized.weight"].weight_scale_2,
-        torch.tensor([1.0]),
-    )
-    torch.testing.assert_close(metadata["quantized.weight"].input_amax, input_amax)
-    assert metadata["quantized.weight"].weight_amax.data_ptr() != quantizer_amax.data_ptr()
-    assert metadata["quantized.weight"].input_amax.data_ptr() != input_amax.data_ptr()
-
-
-def test_collect_modelopt_quant_metadata_collects_w4a16_scale_2_and_omits_input_amax(monkeypatch):
-    w4a16_qformat = "modelopt_w4a16_nvfp4"
-    quantizer_amax = torch.tensor([-2688.0])
-    quantizer = SimpleNamespace(_amax=quantizer_amax)
-    quant_module = SimpleNamespace(
-        weight_quantizer=quantizer,
-        input_quantizer=SimpleNamespace(_amax=torch.tensor([123.0]), is_enabled=True),
-    )
-
-    monkeypatch.setattr(
-        quant_utils,
-        "QUANTIZATION_W4A16_NVFP4",
-        w4a16_qformat,
-        raising=False,
-    )
-    monkeypatch.setattr(quant_utils, "get_quantization_format", lambda _module: w4a16_qformat)
-    monkeypatch.setattr(quant_utils, "get_weight_block_size", lambda _module: 16)
-    monkeypatch.setattr(
-        modelopt_utils,
-        "find_modelopt_weight_quantizer_and_module",
-        lambda _module, _weight: (quantizer, quant_module),
-    )
-    metadata = collect_modelopt_quant_metadata(
-        [
-            _task(
-                "quantized.weight",
-                "hf.quantized.weight",
-                megatron_module=quant_module,
-                param_weight=torch.empty(1),
-            )
-        ]
-    )
-
-    meta = metadata["quantized.weight"]
-    assert meta.qformat == w4a16_qformat
-    assert meta.block_size == 16
-    torch.testing.assert_close(meta.weight_amax, torch.tensor([2688.0]))
-    torch.testing.assert_close(meta.weight_scale_2, torch.tensor([1.0]))
-    assert meta.input_amax is None
-
-
-def test_collect_modelopt_quant_metadata_rejects_static_nvfp4(monkeypatch):
-    quantizer = SimpleNamespace(
-        global_amax=torch.tensor([-2688.0]),
-        _amax=torch.tensor([1.0, 2.0, 3.0, 4.0]),
-        block_sizes={"four_over_six": True},
-    )
-    quant_module = SimpleNamespace(weight_quantizer=quantizer)
-    monkeypatch.setattr(quant_utils, "get_quantization_format", lambda _module: QUANTIZATION_NVFP4)
-    monkeypatch.setattr(quant_utils, "get_weight_block_size", lambda _module: 16)
-    monkeypatch.setattr(
-        modelopt_utils,
-        "find_modelopt_weight_quantizer_and_module",
-        lambda _module, _weight: (quantizer, quant_module),
-    )
-
-    with pytest.raises(RuntimeError, match="Static NVFP4 weight quantizers.*dynamic NVFP4"):
-        collect_modelopt_quant_metadata(
-            [
-                _task(
-                    "quantized.weight",
-                    "hf.quantized.weight",
-                    megatron_module=quant_module,
-                    param_weight=torch.empty(1),
-                )
-            ]
+def _quantized_linears():
+    linears = [torch.nn.Linear(16, 4, bias=False) for _ in range(2)]
+    for linear, weight_amax, input_amax in zip(
+        linears,
+        (2.0, 5.0),
+        (3.0, 7.0),
+        strict=True,
+    ):
+        mtq.quantize(
+            linear,
+            deepcopy(mtq.NVFP4_DEFAULT_CFG),
+            lambda module: module(torch.ones(1, 16)),
         )
+        linear.weight_quantizer.amax = torch.tensor(weight_amax)
+        linear.input_quantizer.amax = torch.tensor(input_amax)
+    return linears
 
 
-def test_modelopt_weight_amax_prefers_live_then_restored_static_amax():
-    public_amax = torch.tensor([2688.0])
-    private_amax = torch.tensor([5376.0])
-    block_amax = torch.tensor([1.0, 2.0])
+def test_find_modelopt_quantizers_returns_exact_grouped_quantizer():
+    module = _GroupedLinear(_quantized_linears())
 
-    value, is_static = modelopt_utils._get_modelopt_weight_amax(
-        SimpleNamespace(
-            global_amax=public_amax,
-            _global_amax=private_amax,
-            _amax=block_amax,
-        )
+    found = find_modelopt_quantizers(module, module.weight1)
+
+    assert found is not None
+    owner, weight_name, weight_quantizer, input_quantizer = found
+    assert owner is module
+    assert weight_name == "weight1"
+    assert weight_quantizer is module.weight_quantizer[1]
+    assert input_quantizer is module.weight1_input_quantizer
+
+
+def test_collect_modelopt_config_weights_includes_disabled_quantizers():
+    quantized, plain = _quantized_linears()[0], torch.nn.Linear(16, 4, bias=False)
+    quantized.weight_quantizer.disable()
+    quantized_task = _task(
+        "decoder.layers.0.mlp.linear_fc1.weight",
+        "model.layers.0.mlp.up_proj.weight",
+        megatron_module=quantized,
+        param_weight=quantized.weight,
     )
-    assert value is public_amax
-    assert is_static
-
-    value, is_static = modelopt_utils._get_modelopt_weight_amax(
-        SimpleNamespace(
-            _global_amax=private_amax,
-            _amax=block_amax,
-        )
-    )
-    assert value is private_amax
-    assert is_static
-
-
-def test_collect_modelopt_quant_metadata_max_reduces_scalars_per_tp_projection(monkeypatch):
-    process_groups = [object(), object()]
-
-    def tp_group(process_group):
-        return SimpleNamespace(
-            group=process_group,
-            is_initialized=lambda: True,
-            world_size=lambda: 2,
-        )
-
-    modules = [
-        SimpleNamespace(
-            weight_quantizer=SimpleNamespace(_amax=torch.tensor([2688.0])),
-            input_quantizer=SimpleNamespace(_amax=torch.tensor([672.0]), is_enabled=True),
-            parallel_state=SimpleNamespace(tensor_parallel_group=tp_group(process_groups[0])),
-        ),
-        SimpleNamespace(
-            weight_quantizer=SimpleNamespace(_amax=torch.tensor([1344.0])),
-            input_quantizer=SimpleNamespace(_amax=torch.tensor([336.0]), is_enabled=True),
-            parallel_state=SimpleNamespace(tensor_parallel_group=tp_group(process_groups[1])),
-        ),
-    ]
-    reduced_groups = []
-
-    monkeypatch.setattr(quant_utils, "get_quantization_format", lambda _module: QUANTIZATION_NVFP4)
-    monkeypatch.setattr(quant_utils, "get_weight_block_size", lambda _module: 16)
-    monkeypatch.setattr(
-        modelopt_utils,
-        "find_modelopt_weight_quantizer_and_module",
-        lambda module, _weight: (module.weight_quantizer, module),
-    )
-    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
-
-    def fake_all_reduce(value, op, group):
-        assert op == torch.distributed.ReduceOp.MAX
-        reduced_groups.append(group)
-        value.mul_(2)
-
-    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
-
-    metadata = collect_modelopt_quant_metadata(
-        [
-            _task(
-                f"projection_{index}.weight",
-                f"hf.projection_{index}.weight",
-                megatron_module=module,
-                param_weight=torch.empty(1),
-            )
-            for index, module in enumerate(modules)
-        ]
+    plain_task = _task(
+        "decoder.layers.0.mlp.linear_fc2.weight",
+        "model.layers.0.mlp.down_proj.weight",
+        megatron_module=plain,
+        param_weight=plain.weight,
     )
 
-    torch.testing.assert_close(metadata["projection_0.weight"].weight_amax, torch.tensor([5376.0]))
-    torch.testing.assert_close(metadata["projection_0.weight"].weight_scale_2, torch.tensor([2.0]))
-    torch.testing.assert_close(metadata["projection_0.weight"].input_amax, torch.tensor([1344.0]))
-    torch.testing.assert_close(metadata["projection_1.weight"].weight_amax, torch.tensor([2688.0]))
-    torch.testing.assert_close(metadata["projection_1.weight"].weight_scale_2, torch.tensor([1.0]))
-    torch.testing.assert_close(metadata["projection_1.weight"].input_amax, torch.tensor([672.0]))
-    assert reduced_groups == [
-        process_groups[0],
-        process_groups[0],
-        process_groups[1],
-        process_groups[1],
-    ]
+    assert collect_modelopt_config_weights([quantized_task, plain_task]) == {quantized_task.global_param_name}
 
 
-def test_collect_modelopt_quant_metadata_reuses_only_compatible_shared_quantizer_metadata(monkeypatch):
-    quantizer = SimpleNamespace(_amax=torch.tensor([2688.0]))
-    quant_module = SimpleNamespace(weight_quantizer=quantizer, block_size=16)
-    different_block_module = SimpleNamespace(weight_quantizer=quantizer, block_size=32)
+def test_collect_modelopt_config_weights_includes_unquantized_moe_router():
+    router = object.__new__(TopKRouter)
+    torch.nn.Module.__init__(router)
+    router.weight = torch.nn.Parameter(torch.ones(2, 16))
+    router_task = _task(
+        "decoder.layers.0.mlp.router.weight",
+        "model.layers.0.mlp.gate.weight",
+        megatron_module=router,
+        param_weight=router.weight,
+    )
+
+    assert collect_modelopt_config_weights([router_task]) == {router_task.global_param_name}
+
+
+def test_collect_modelopt_quant_states_preserves_independent_experts():
+    module = _GroupedLinear(_quantized_linears())
     tasks = [
         _task(
             f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-            f"model.layers.0.mlp.experts.{expert}.up_proj.weight",
+            f"model.layers.0.mlp.experts.{expert}.gate_up_proj.weight",
             megatron_module=module,
-            param_weight=torch.ones(1),
+            param_weight=getattr(module, f"weight{expert}"),
         )
-        for expert, module in enumerate((quant_module, quant_module, different_block_module))
+        for expert in range(2)
     ]
-    clone_calls = []
 
-    monkeypatch.setattr(
-        modelopt_utils,
-        "find_modelopt_weight_quantizer_and_module",
-        lambda module, _weight: (quantizer, module),
+    states = collect_modelopt_quant_states(tasks)
+
+    _assert_state_equal(
+        states[tasks[0].global_param_name],
+        _state(weight_amax=2.0, input_amax=3.0),
     )
-    monkeypatch.setattr(
-        quant_utils,
-        "get_quantization_format",
-        lambda _module: QUANTIZATION_NVFP4,
-    )
-    monkeypatch.setattr(quant_utils, "get_weight_block_size", lambda module: module.block_size)
-    monkeypatch.setattr(
-        modelopt_utils,
-        "_clone_positive_cpu",
-        lambda value: clone_calls.append(value) or value.clone(),
+    _assert_state_equal(
+        states[tasks[1].global_param_name],
+        _state(weight_amax=5.0, input_amax=7.0),
     )
 
-    metadata = collect_modelopt_quant_metadata(tasks)
 
-    assert list(metadata) == [task.global_param_name for task in tasks]
-    assert metadata[tasks[0].global_param_name] is metadata[tasks[1].global_param_name]
-    assert metadata[tasks[2].global_param_name] is not metadata[tasks[0].global_param_name]
-    assert metadata[tasks[2].global_param_name].block_size == 32
-    assert len(clone_calls) == 2
-
-
-def test_collect_modelopt_quant_metadata_does_not_reuse_different_input_amax(monkeypatch):
-    weight_quantizer = SimpleNamespace(_amax=torch.tensor([2688.0]))
-    modules = [
-        SimpleNamespace(
-            weight_quantizer=weight_quantizer,
-            input_quantizer=SimpleNamespace(_amax=torch.tensor([value]), is_enabled=True),
-        )
-        for value in (672.0, 336.0)
-    ]
-    monkeypatch.setattr(quant_utils, "get_quantization_format", lambda _module: QUANTIZATION_NVFP4)
-    monkeypatch.setattr(quant_utils, "get_weight_block_size", lambda _module: 16)
-    monkeypatch.setattr(
-        modelopt_utils,
-        "find_modelopt_weight_quantizer_and_module",
-        lambda module, _weight: (weight_quantizer, module),
+def test_collect_modelopt_quant_states_max_reduces_tp_scalars(monkeypatch):
+    module = _GroupedLinear(_quantized_linears())
+    expected = _state(weight_amax=11.0, input_amax=13.0)
+    task = _task(
+        "decoder.layers.0.mlp.experts.linear_fc1.weight0",
+        "model.layers.0.mlp.experts.0.gate_up_proj.weight",
+        megatron_module=module,
+        param_weight=module.weight0,
     )
-    metadata = collect_modelopt_quant_metadata(
-        [
-            _task(
-                f"projection_{index}.weight",
-                f"hf.projection_{index}.weight",
-                megatron_module=module,
-                param_weight=torch.empty(1),
-            )
-            for index, module in enumerate(modules)
-        ]
-    )
+    reductions = iter((11.0, 13.0))
 
-    assert metadata["projection_0.weight"] is not metadata["projection_1.weight"]
-    torch.testing.assert_close(metadata["projection_0.weight"].input_amax, torch.tensor([672.0]))
-    torch.testing.assert_close(metadata["projection_1.weight"].input_amax, torch.tensor([336.0]))
-
-
-def test_sync_modelopt_quant_metadata_merges_gathered_rank_metadata(monkeypatch):
-    rank1_meta = QuantMeta(
-        qformat=QUANTIZATION_NVFP4,
-        block_size=16,
-        weight_amax=torch.tensor([2.0]),
-    )
-    metadata = {
-        "rank0.weight": QuantMeta(
-            qformat=QUANTIZATION_NVFP4,
-            block_size=16,
-            weight_amax=torch.tensor([1.0]),
-        )
-    }
-
+    monkeypatch.setattr(modelopt_utils, "_get_modelopt_tp_process_group", lambda _module: object())
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
     monkeypatch.setattr(torch.distributed, "get_world_size", lambda group=None: 2)
 
-    def fake_all_gather_object(gathered, local_metadata, group=None):
-        gathered[0] = dict(local_metadata)
-        gathered[1] = {"rank1.weight": rank1_meta}
+    def fake_all_reduce(value, **_kwargs):
+        value.fill_(next(reductions))
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    state = collect_modelopt_quant_states([task])[task.global_param_name]
+
+    _assert_state_equal(
+        state,
+        expected,
+    )
+
+
+def test_sync_modelopt_quant_states_merges_disjoint_ranks(monkeypatch):
+    local = {"layer.0.weight": _state(weight_amax=1.0)}
+    remote = {"layer.1.weight": _state(weight_amax=2.0)}
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group=None: 2)
+
+    def fake_all_gather_object(gathered, _states, group=None):
+        gathered[:] = [local.copy(), remote]
 
     monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather_object)
 
-    sync_modelopt_quant_metadata(metadata, group=object())
+    sync_modelopt_quant_states(local)
 
-    assert set(metadata) == {"rank0.weight", "rank1.weight"}
-    assert metadata["rank1.weight"] is rank1_meta
+    assert set(local) == {"layer.0.weight", "layer.1.weight"}
 
 
-def test_build_hf_modelopt_quant_metadata_stacks_synced_grouped_experts():
+def test_sync_modelopt_quant_states_rejects_conflicting_copies(monkeypatch):
+    local = {"layer.weight": _state(weight_amax=1.0)}
+    remote = {"layer.weight": _state(weight_amax=2.0)}
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group=None: 2)
+
+    def fake_all_gather_object(gathered, _states, group=None):
+        gathered[:] = [local.copy(), remote]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather_object)
+
+    with pytest.raises(RuntimeError, match="Conflicting ModelOpt state"):
+        sync_modelopt_quant_states(local)
+
+
+def test_build_hf_states_copies_fused_projection_state():
+    task = _task(
+        "decoder.layers.0.self_attention.linear_qkv.weight",
+        {
+            "q": "model.layers.0.self_attn.q_proj.weight",
+            "k": "model.layers.0.self_attn.k_proj.weight",
+            "v": "model.layers.0.self_attn.v_proj.weight",
+        },
+    )
+    state = _state()
+
+    hf_states = build_hf_modelopt_quant_states(
+        [task],
+        {task.global_param_name: state},
+    )
+
+    assert set(hf_states) == set(task.mapping.hf_param.values())
+    assert all(quantized_weight_export_states_equal(mapped_state, state) for mapped_state in hf_states.values())
+    assert all(mapped_state is not state for mapped_state in hf_states.values())
+
+
+def test_build_hf_states_orders_grouped_experts():
     hf_name = "model.layers.0.mlp.experts.gate_up_proj.weight"
-    task = SimpleNamespace(
-        global_param_name="decoder.layers.0.mlp.experts.linear_fc1.weight0",
-        mapping=SimpleNamespace(hf_param=hf_name, is_grouped_export=True),
-    )
-    metadata = {
-        f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert_idx}": QuantMeta(
-            qformat=QUANTIZATION_NVFP4,
-            block_size=16,
-            weight_amax=torch.tensor([float(expert_idx)]),
-            weight_scale_2=torch.tensor([float(expert_idx + 10)]),
-            input_amax=torch.tensor([float(expert_idx + 20)]),
-        )
-        for expert_idx in range(4)
-    }
-
-    hf_metadata = build_hf_modelopt_quant_metadata([task], metadata)
-
-    meta = hf_metadata[hf_name]
-    assert meta.qformat == QUANTIZATION_NVFP4
-    assert meta.block_size == 16
-    torch.testing.assert_close(
-        meta.weight_amax,
-        torch.tensor([[0.0], [1.0], [2.0], [3.0]]),
-    )
-    torch.testing.assert_close(
-        meta.weight_scale_2,
-        torch.tensor([[10.0], [11.0], [12.0], [13.0]]),
-    )
-    torch.testing.assert_close(
-        meta.input_amax,
-        torch.tensor([[20.0], [21.0], [22.0], [23.0]]),
-    )
-
-
-def test_build_hf_modelopt_quant_metadata_slices_non_grouped_gated_amax():
-    gate_name = "model.layers.0.mlp.gate_proj.weight"
-    up_name = "model.layers.0.mlp.up_proj.weight"
-    task = SimpleNamespace(
-        global_param_name="decoder.layers.0.mlp.linear_fc1.weight",
-        mapping=SimpleNamespace(
-            hf_param={"gate": gate_name, "up": up_name},
-            is_grouped_export=False,
-        ),
-    )
-    shared_scale_2 = torch.tensor(0.5)
-    shared_input_amax = torch.tensor([1344.0])
-    metadata = {
-        task.global_param_name: QuantMeta(
-            qformat=QUANTIZATION_NVFP4,
-            block_size=16,
-            weight_amax=torch.tensor(
-                [
-                    [1.0, 2.0],
-                    [3.0, 4.0],
-                    [5.0, 6.0],
-                    [7.0, 8.0],
-                ]
-            ),
-            weight_scale_2=shared_scale_2,
-            input_amax=shared_input_amax,
-        )
-    }
-
-    hf_metadata = build_hf_modelopt_quant_metadata([task], metadata)
-
-    torch.testing.assert_close(
-        hf_metadata[gate_name].weight_amax,
-        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
-    )
-    torch.testing.assert_close(
-        hf_metadata[up_name].weight_amax,
-        torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
-    )
-    torch.testing.assert_close(hf_metadata[gate_name].weight_scale_2, shared_scale_2)
-    torch.testing.assert_close(hf_metadata[up_name].weight_scale_2, shared_scale_2)
-    torch.testing.assert_close(hf_metadata[gate_name].input_amax, shared_input_amax)
-    torch.testing.assert_close(hf_metadata[up_name].input_amax, shared_input_amax)
-
-
-def test_build_hf_modelopt_quant_metadata_shares_grouped_gated_scale_2():
-    gate_name = "model.layers.0.mlp.experts.gate_proj.weight"
-    up_name = "model.layers.0.mlp.experts.up_proj.weight"
-    task = SimpleNamespace(
-        global_param_name="decoder.layers.0.mlp.experts.linear_fc1.weight0",
-        mapping=SimpleNamespace(
-            hf_param={"gate": gate_name, "up": up_name},
-            is_grouped_export=True,
-        ),
-    )
-    metadata = {
-        f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert_idx}": QuantMeta(
-            qformat=QUANTIZATION_NVFP4,
-            block_size=16,
-            weight_amax=torch.tensor(
-                [
-                    float(expert_idx * 4 + 1),
-                    float(expert_idx * 4 + 2),
-                    float(expert_idx * 4 + 3),
-                    float(expert_idx * 4 + 4),
-                ]
-            ),
-            weight_scale_2=torch.tensor(float(expert_idx + 10)),
-            input_amax=torch.tensor([float(expert_idx + 20)]),
-        )
-        for expert_idx in range(2)
-    }
-
-    hf_metadata = build_hf_modelopt_quant_metadata([task], metadata)
-
-    torch.testing.assert_close(
-        hf_metadata[gate_name].weight_amax,
-        torch.tensor([[1.0, 2.0], [5.0, 6.0]]),
-    )
-    torch.testing.assert_close(
-        hf_metadata[up_name].weight_amax,
-        torch.tensor([[3.0, 4.0], [7.0, 8.0]]),
-    )
-    expected_scale_2 = torch.tensor([10.0, 11.0])
-    torch.testing.assert_close(hf_metadata[gate_name].weight_scale_2, expected_scale_2)
-    torch.testing.assert_close(hf_metadata[up_name].weight_scale_2, expected_scale_2)
-    expected_input_amax = torch.tensor([[20.0], [21.0]])
-    torch.testing.assert_close(hf_metadata[gate_name].input_amax, expected_input_amax)
-    torch.testing.assert_close(hf_metadata[up_name].input_amax, expected_input_amax)
-
-
-def test_build_hf_modelopt_pre_ep_quant_metadata_rebases_local_expert_ids():
-    hf_name = "backbone.layers.0.mixer.experts.up_proj"
-    pre_ep_mapping = SimpleNamespace(hf_param=hf_name, is_modelopt_pre_ep_export=True)
     tasks = [
-        SimpleNamespace(
-            global_param_name=f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert_idx}",
-            mapping=pre_ep_mapping,
+        _task(
+            f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
+            hf_name,
+            is_grouped_export=True,
         )
-        for expert_idx in (5, 4)
+        for expert in range(2)
     ]
-    metadata = {
-        f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert_idx}": QuantMeta(
-            qformat=QUANTIZATION_NVFP4,
-            block_size=16,
-            weight_amax=torch.tensor(float(expert_idx)),
-            weight_scale_2=torch.tensor(float(expert_idx + 10)),
-            input_amax=torch.tensor(float(expert_idx + 20)),
-        )
-        for expert_idx in (4, 5)
+    states = {
+        tasks[0].global_param_name: _state(weight_amax=2.0),
+        tasks[1].global_param_name: _state(weight_amax=5.0),
     }
 
-    hf_metadata = modelopt_utils._build_hf_modelopt_pre_ep_quant_metadata(tasks, metadata)
+    hf_states = build_hf_modelopt_quant_states(tasks, states, num_experts=2)
 
-    torch.testing.assert_close(
-        hf_metadata[hf_name].weight_amax,
-        torch.tensor([4.0, 5.0]),
-    )
-    torch.testing.assert_close(
-        hf_metadata[hf_name].weight_scale_2,
-        torch.tensor([14.0, 15.0]),
-    )
-    torch.testing.assert_close(
-        hf_metadata[hf_name].input_amax,
-        torch.tensor([24.0, 25.0]),
-    )
+    grouped = hf_states[hf_name]
+    assert isinstance(grouped, tuple)
+    _assert_state_equal(grouped[0], states[tasks[0].global_param_name])
+    _assert_state_equal(grouped[1], states[tasks[1].global_param_name])
 
 
-@pytest.mark.parametrize(
-    ("weight_shape", "weight_scale_2", "expected"),
-    [
-        (
-            (2, 4, 4),
-            torch.tensor([1.0, 0.5]),
-            torch.tensor([[[1.0]], [[0.5]]]),
-        ),
-        (
-            (2, 4, 4),
-            torch.tensor([[1.0], [0.5]]),
-            torch.tensor([[[1.0]], [[0.5]]]),
-        ),
-        (
-            (2, 4, 4),
-            torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
-            torch.tensor(
-                [
-                    [[1.0], [1.0], [2.0], [2.0]],
-                    [[3.0], [3.0], [4.0], [4.0]],
-                ]
-            ),
-        ),
-    ],
-    ids=["per-expert-vector", "singleton-column", "grouped-scales"],
-)
-def test_reshape_nvfp4_weight_scale_2_for_compute(weight_shape, weight_scale_2, expected):
-    actual = modelopt_utils._reshape_nvfp4_weight_scale_2_for_compute(
-        torch.ones(weight_shape),
-        weight_scale_2,
+def test_build_hf_states_rejects_missing_trailing_grouped_expert():
+    task = _task(
+        "decoder.layers.0.mlp.experts.linear_fc1.weight0",
+        "model.layers.0.mlp.experts.gate_up_proj.weight",
+        is_grouped_export=True,
     )
 
-    torch.testing.assert_close(actual, expected)
-
-
-@pytest.mark.parametrize(
-    ("weight_shape", "weight_scale_2"),
-    [
-        ((2, 4), torch.tensor([1.0, 0.5])),
-        ((2, 4, 4), torch.tensor(1.0)),
-        ((2, 5, 4), torch.tensor([[1.0, 2.0], [3.0, 4.0]])),
-        ((2, 4, 4), torch.ones(2, 1, 1)),
-    ],
-    ids=["non-3d-weight", "scalar", "non-divisible-groups", "already-reshaped"],
-)
-def test_reshape_nvfp4_weight_scale_2_for_compute_keeps_unsupported_shapes(
-    weight_shape,
-    weight_scale_2,
-):
-    actual = modelopt_utils._reshape_nvfp4_weight_scale_2_for_compute(
-        torch.ones(weight_shape),
-        weight_scale_2,
-    )
-
-    assert actual is weight_scale_2
-
-
-def test_quantize_nvfp4_weight_uses_modelopt_scale_export_and_emits_scale_names(monkeypatch):
-    captured = {}
-
-    def fake_to_quantized_weight(
-        weight,
-        weight_scale,
-        qformat,
-        weight_scale_2,
-        block_size,
-    ):
-        captured.update(
-            weight=weight,
-            weight_scale=weight_scale,
-            qformat=qformat,
-            weight_scale_2=weight_scale_2,
-            block_size=block_size,
+    with pytest.raises(RuntimeError, match=r"Missing ModelOpt state for experts \[1\]"):
+        build_hf_modelopt_quant_states(
+            [task],
+            {task.global_param_name: _state()},
+            num_experts=2,
         )
-        return torch.zeros(weight.shape, dtype=torch.uint8, device=weight.device)
 
-    monkeypatch.setattr(quant_utils, "to_quantized_weight", fake_to_quantized_weight)
 
-    tensors = dict(
-        quantize_nvfp4_weight(
+def test_build_modelopt_quantization_config_uses_canonical_hf_layers():
+    linears = _quantized_linears()
+    linears[1].input_quantizer.disable()
+    router = object.__new__(TopKRouter)
+    torch.nn.Module.__init__(router)
+    router.weight = torch.nn.Parameter(torch.ones(2, 16))
+    embedding = torch.nn.Embedding(8, 16)
+    tasks = [
+        _task(
+            "decoder.layers.0.mlp.linear_fc1.weight",
             "model.layers.0.mlp.up_proj.weight",
-            torch.tensor([[-1.0, 0.25, 0.5, 2.0]], dtype=torch.float32),
-            QuantMeta(
-                qformat=QUANTIZATION_NVFP4,
-                block_size=4,
-                weight_amax=torch.tensor([2688.0]),
-                weight_scale_2=torch.tensor([1.0]),
-                input_amax=torch.tensor([1344.0]),
-            ),
-        )
+            megatron_module=linears[0],
+            param_weight=linears[0].weight,
+        ),
+        _task(
+            "decoder.layers.1.mlp.linear_fc1.weight",
+            "model.layers.1.mlp.up_proj.weight",
+            megatron_module=linears[1],
+            param_weight=linears[1].weight,
+        ),
+        _task(
+            "decoder.layers.0.mlp.router.weight",
+            "model.layers.0.mlp.gate.weight",
+            megatron_module=router,
+            param_weight=router.weight,
+        ),
+        _task(
+            "embedding.word_embeddings.weight",
+            "model.embed_tokens.weight",
+            megatron_module=embedding,
+            param_weight=embedding.weight,
+        ),
+    ]
+    hf_states = {
+        tasks[0].mapping.hf_param: _state(),
+        tasks[1].mapping.hf_param: _state(w4a16=True),
+    }
+
+    config = build_modelopt_quantization_config(
+        tasks,
+        hf_states,
+        config_weights=collect_modelopt_config_weights(tasks),
     )
 
-    assert set(tensors) == {
+    quantization = config
+    assert quantization["quant_algo"] == "MIXED_PRECISION"
+    assert quantization["quantized_layers"]["model.layers.0.mlp.up_proj"] == {
+        "quant_algo": "NVFP4",
+        "group_size": 16,
+    }
+    assert quantization["quantized_layers"]["model.layers.1.mlp.up_proj"] == {
+        "quant_algo": "W4A16_NVFP4",
+        "group_size": 16,
+    }
+    assert "model.layers.0.mlp.gate" in quantization["ignore"]
+    assert "model.embed_tokens" not in quantization["ignore"]
+
+
+def test_build_modelopt_export_plan_packs_lazily_and_preserves_source(monkeypatch):
+    task = _task(
+        "decoder.layers.0.mlp.linear_fc1.weight",
+        "model.layers.0.mlp.up_proj.weight",
+    )
+    state = _state()
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_quant_states",
+        lambda _tasks: {task.global_param_name: state},
+    )
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_config_weights",
+        lambda _tasks: {task.global_param_name},
+    )
+    export_calls = []
+    real_export = export_quantized_weight
+
+    def tracked_export(weight, export_state, *, dtype):
+        export_calls.append(weight)
+        return real_export(weight, export_state, dtype=dtype)
+
+    import modelopt.torch.export.quantized_weight as quantized_weight
+
+    monkeypatch.setattr(quantized_weight, "export_quantized_weight", tracked_export)
+    source = torch.randn(4, 16)
+    source_copy = source.clone()
+
+    plan = build_modelopt_export_plan([None, task], model=_model())
+    exported = plan.conversion_tasks[0].export_hook(task.mapping.hf_param, source)
+
+    assert export_calls == []
+    tensors = dict(exported)
+    assert len(export_calls) == 1
+    assert torch.equal(source, source_copy)
+    assert list(tensors) == [
         "model.layers.0.mlp.up_proj.weight",
         "model.layers.0.mlp.up_proj.weight_scale",
         "model.layers.0.mlp.up_proj.weight_scale_2",
         "model.layers.0.mlp.up_proj.input_scale",
-    }
-    assert tensors["model.layers.0.mlp.up_proj.weight"].dtype == torch.uint8
-    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].dtype == torch.float8_e4m3fn
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.up_proj.weight_scale_2"],
-        torch.tensor([1.0]),
-    )
-    assert tensors["model.layers.0.mlp.up_proj.input_scale"].shape == torch.Size([])
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.up_proj.input_scale"],
-        torch.tensor(0.5),
-    )
-    assert captured["qformat"] == QUANTIZATION_NVFP4
-    assert captured["block_size"] == 4
-    assert captured["weight_scale"].dtype == torch.float8_e4m3fn
-    assert (captured["weight_scale"].to(torch.float32) >= 0).all()
-    assert captured["weight_scale_2"].dim() == 0
-    torch.testing.assert_close(captured["weight_scale_2"], torch.tensor(1.0))
+    ]
 
 
-def test_compute_nvfp4_weight_scale_uses_modelopt_fp8_clamp():
-    weight_scale, weight_scale_2 = modelopt_utils.compute_nvfp4_weight_scale(
-        torch.full((1, 16), 1.0e-20),
-        block_size=16,
-        weight_scale_2=torch.tensor(1.0),
-    )
-
-    assert weight_scale.dtype == torch.float8_e4m3fn
-    assert torch.all(weight_scale.float() >= 2**-9)
-    torch.testing.assert_close(weight_scale_2, torch.tensor(1.0))
-
-
-def test_quantize_nvfp4_weight_exports_fused_moe_internal_names(monkeypatch):
-    captured = {}
-
-    def fake_to_quantized_weight(
-        weight,
-        weight_scale,
-        qformat,
-        weight_scale_2,
-        block_size,
-    ):
-        captured.update(
-            weight=weight,
-            weight_scale=weight_scale,
-            qformat=qformat,
-            weight_scale_2=weight_scale_2,
-            block_size=block_size,
-        )
-        return torch.zeros(weight.shape, dtype=torch.uint8, device=weight.device)
-
-    monkeypatch.setattr(quant_utils, "to_quantized_weight", fake_to_quantized_weight)
-
-    tensors = dict(
-        quantize_nvfp4_weight(
-            "model.layers.0.mlp.experts.gate_up_proj",
-            torch.ones(2, 4, 4, dtype=torch.float32),
-            QuantMeta(
-                qformat=QUANTIZATION_NVFP4,
-                block_size=4,
-                weight_amax=torch.tensor([[2688.0], [1344.0]]),
-                weight_scale_2=torch.tensor([[1.0], [0.5]]),
-                input_amax=torch.tensor([[2688.0], [1344.0]]),
-            ),
-        )
-    )
-
-    assert set(tensors) == {
-        "model.layers.0.mlp.experts.w13_weight",
-        "model.layers.0.mlp.experts.w13_weight_scale",
-        "model.layers.0.mlp.experts.w13_weight_scale_2",
-        "model.layers.0.mlp.experts.w13_input_scale",
-    }
-    assert tensors["model.layers.0.mlp.experts.w13_weight"].dtype == torch.uint8
-    assert tensors["model.layers.0.mlp.experts.w13_weight_scale"].dtype == torch.float8_e4m3fn
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.experts.w13_weight_scale_2"],
-        torch.tensor([[1.0, 1.0], [0.5, 0.5]]),
-    )
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.experts.w13_input_scale"],
-        torch.tensor([[1.0, 1.0], [0.5, 0.5]]),
-    )
-    assert captured["weight_scale_2"].shape == (2, 1, 1)
-
-
-def test_quantize_w4a16_weight_exports_non_gated_fused_w13_family(
-    monkeypatch,
-):
-    w4a16_qformat = "modelopt_w4a16_nvfp4"
-    captured = {}
-
-    def fake_to_quantized_weight(
-        weight,
-        weight_scale,
-        qformat,
-        weight_scale_2,
-        block_size,
-    ):
-        captured["weight_scale_2"] = weight_scale_2
-        return torch.zeros(weight.shape, dtype=torch.uint8, device=weight.device)
-
-    monkeypatch.setattr(quant_utils, "to_quantized_weight", fake_to_quantized_weight)
-
-    tensors = dict(
-        quantize_nvfp4_weight(
-            "model.layers.0.mlp.experts.up_proj",
-            torch.ones(2, 4, 4, dtype=torch.float32),
-            QuantMeta(
-                qformat=w4a16_qformat,
-                block_size=4,
-                weight_amax=torch.tensor([[2688.0], [1344.0]]),
-                weight_scale_2=torch.tensor([[1.0], [0.5]]),
-            ),
-        )
-    )
-
-    assert set(tensors) == {
-        "model.layers.0.mlp.experts.w13_weight",
-        "model.layers.0.mlp.experts.w13_weight_scale",
-        "model.layers.0.mlp.experts.w13_weight_scale_2",
-    }
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.experts.w13_weight_scale_2"],
-        torch.tensor([[1.0], [0.5]]),
-    )
-    assert captured["weight_scale_2"].shape == (2, 1, 1)
-
-
-@pytest.mark.parametrize(
-    "input_amax",
-    [
-        torch.tensor([2688.0, 1344.0]),
-        torch.tensor([[2688.0], [1344.0]]),
-    ],
-    ids=("one_dimensional", "column"),
-)
-def test_quantize_nvfp4_weight_exports_non_gated_fused_w4a4_transport(monkeypatch, input_amax):
-    captured = {}
-
-    def fake_to_quantized_weight(
-        weight,
-        weight_scale,
-        qformat,
-        weight_scale_2,
-        block_size,
-    ):
-        captured["weight_scale_2"] = weight_scale_2
-        return torch.zeros(weight.shape, dtype=torch.uint8, device=weight.device)
-
-    monkeypatch.setattr(quant_utils, "to_quantized_weight", fake_to_quantized_weight)
-
-    tensors = dict(
-        quantize_nvfp4_weight(
-            "model.layers.0.mlp.experts.up_proj",
-            torch.ones(2, 4, 4, dtype=torch.float32),
-            QuantMeta(
-                qformat=QUANTIZATION_NVFP4,
-                block_size=4,
-                weight_amax=torch.tensor([[2688.0], [1344.0]]),
-                weight_scale_2=torch.tensor([[1.0], [0.5]]),
-                input_amax=input_amax,
-            ),
-        )
-    )
-
-    assert set(tensors) == {
-        "model.layers.0.mlp.experts.w13_weight",
-        "model.layers.0.mlp.experts.w13_weight_scale",
-        "model.layers.0.mlp.experts.w13_weight_scale_2",
-        "model.layers.0.mlp.experts.w13_input_scale",
-    }
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.experts.w13_weight_scale_2"],
-        torch.tensor([[1.0], [0.5]]),
-    )
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.experts.w13_input_scale"],
-        torch.tensor([[1.0], [0.5]]),
-    )
-    assert captured["weight_scale_2"].shape == (2, 1, 1)
-
-
-def test_quantize_nvfp4_weight_exports_fused_moe_w2_names_and_squeezes_scale_2(monkeypatch):
-    captured = {}
-
-    def fake_to_quantized_weight(
-        weight,
-        weight_scale,
-        qformat,
-        weight_scale_2,
-        block_size,
-    ):
-        captured["weight_scale_2"] = weight_scale_2
-        return torch.zeros(weight.shape, dtype=torch.uint8, device=weight.device)
-
-    monkeypatch.setattr(quant_utils, "to_quantized_weight", fake_to_quantized_weight)
-
-    tensors = dict(
-        quantize_nvfp4_weight(
-            "model.layers.0.mlp.experts.down_proj",
-            torch.ones(2, 4, 4, dtype=torch.float32),
-            QuantMeta(
-                qformat=QUANTIZATION_NVFP4,
-                block_size=4,
-                weight_amax=torch.tensor([[2688.0], [1344.0]]),
-                weight_scale_2=torch.tensor([[1.0], [0.5]]),
-                input_amax=torch.tensor([[2688.0], [672.0]]),
-            ),
-        )
-    )
-
-    assert set(tensors) == {
-        "model.layers.0.mlp.experts.w2_weight",
-        "model.layers.0.mlp.experts.w2_weight_scale",
-        "model.layers.0.mlp.experts.w2_weight_scale_2",
-        "model.layers.0.mlp.experts.w2_input_scale",
-    }
-    assert tensors["model.layers.0.mlp.experts.w2_weight"].dtype == torch.uint8
-    assert tensors["model.layers.0.mlp.experts.w2_weight_scale"].dtype == torch.float8_e4m3fn
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.experts.w2_weight_scale_2"],
-        torch.tensor([1.0, 0.5]),
-    )
-    torch.testing.assert_close(
-        tensors["model.layers.0.mlp.experts.w2_input_scale"],
-        torch.tensor([1.0, 0.25]),
-    )
-    assert captured["weight_scale_2"].shape == (2, 1, 1)
-
-
-def test_quantize_nvfp4_weight_prefers_synchronized_scale_2(monkeypatch):
-    captured = {}
-
-    def fake_to_quantized_weight(
-        weight,
-        weight_scale,
-        qformat,
-        weight_scale_2,
-        block_size,
-    ):
-        captured["weight_scale_2"] = weight_scale_2.detach().cpu()
-        return torch.zeros(weight.shape, dtype=torch.uint8, device=weight.device)
-
-    monkeypatch.setattr(quant_utils, "to_quantized_weight", fake_to_quantized_weight)
-
-    list(
-        quantize_nvfp4_weight(
-            "model.layers.0.mlp.down_proj.weight",
-            torch.tensor([[0.5, 1.0, 2.0, 4.0]], dtype=torch.float32),
-            QuantMeta(
-                qformat=QUANTIZATION_NVFP4,
-                block_size=4,
-                weight_amax=torch.tensor([2688.0]),
-                weight_scale_2=torch.tensor([0.5]),
-                input_amax=torch.tensor([2688.0]),
-            ),
-        )
-    )
-
-    assert captured["weight_scale_2"].dim() == 0
-    torch.testing.assert_close(captured["weight_scale_2"], torch.tensor(0.5))
-
-
-def test_compute_nvfp4_input_scale_uses_modelopt_canonical_export(monkeypatch):
-    from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
-
-    captured = {}
-
-    def fake_activation_scale(_cls, quantizer):
-        captured["is_enabled"] = quantizer.is_enabled
-        captured["maxbound"] = quantizer.maxbound
-        captured["amax"] = quantizer.export_amax().clone()
-        return quantizer.export_amax() / 100.0
-
-    monkeypatch.setattr(
-        NVFP4QTensor,
-        "get_activation_scaling_factor",
-        classmethod(fake_activation_scale),
-    )
-
-    input_scale = compute_nvfp4_input_scale(torch.tensor([25.0]))
-
-    torch.testing.assert_close(input_scale, torch.tensor([0.25]))
-    assert captured["is_enabled"] is True
-    assert captured["maxbound"] == 6.0
-    torch.testing.assert_close(captured["amax"], torch.tensor([25.0]))
-
-
-@pytest.mark.parametrize(
-    "input_amax",
-    [
-        None,
-        torch.tensor([]),
-        torch.tensor([0.0]),
-        torch.tensor([-1.0]),
-        torch.tensor([float("nan")]),
-        torch.tensor([float("inf")]),
-    ],
-)
-def test_compute_nvfp4_input_scale_rejects_missing_or_invalid_amax(input_amax):
-    with pytest.raises(RuntimeError, match="ModelOpt input amax"):
-        compute_nvfp4_input_scale(input_amax)
-
-
-def test_quantize_nvfp4_weight_does_not_emit_input_scale_for_w4a16(monkeypatch):
-    w4a16_qformat = "modelopt_w4a16_nvfp4"
-    monkeypatch.setattr(
-        quant_utils,
-        "to_quantized_weight",
-        lambda weight, *_args, **_kwargs: torch.zeros_like(weight, dtype=torch.uint8),
-    )
-
-    tensors = dict(
-        quantize_nvfp4_weight(
-            "model.layers.0.mlp.up_proj.weight",
-            torch.ones(1, 4, dtype=torch.float32),
-            QuantMeta(
-                qformat=w4a16_qformat,
-                block_size=4,
-                weight_amax=torch.tensor([2688.0]),
-                weight_scale_2=torch.tensor([1.0]),
-                input_amax=torch.tensor([float("nan")]),
-            ),
-        )
-    )
-
-    assert set(tensors) == {
+def test_build_modelopt_export_plan_omits_internal_quantizer_state(monkeypatch):
+    weight_task = _task(
+        "decoder.layers.0.mlp.linear_fc1.weight",
         "model.layers.0.mlp.up_proj.weight",
-        "model.layers.0.mlp.up_proj.weight_scale",
-        "model.layers.0.mlp.up_proj.weight_scale_2",
+    )
+    quantizer_task = _task(
+        "decoder.layers.0.mlp.linear_fc1.weight_quantizer._amax",
+        "model.layers.0.mlp.up_proj.weight_quantizer._amax",
+    )
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_quant_states",
+        lambda tasks: {tasks[0].global_param_name: _state(w4a16=True)},
+    )
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_config_weights",
+        lambda tasks: {tasks[0].global_param_name},
+    )
+
+    plan = build_modelopt_export_plan(
+        [weight_task, quantizer_task],
+        model=_model(),
+    )
+
+    assert [task.global_param_name for task in plan.conversion_tasks] == [weight_task.global_param_name]
+
+
+def test_build_modelopt_export_plan_packs_grouped_experts_independently(monkeypatch):
+    hf_name = "model.layers.0.mlp.experts.gate_up_proj.weight"
+    tasks = [
+        _task(
+            f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
+            hf_name,
+            is_grouped_export=True,
+        )
+        for expert in range(2)
+    ]
+    states = {
+        tasks[0].global_param_name: _state(weight_amax=2.0),
+        tasks[1].global_param_name: _state(weight_amax=5.0),
     }
-
-
-def test_quantize_nvfp4_weight_requires_quantizable_name():
-    with pytest.raises(ValueError, match="Expected quantizable NVFP4 export parameter name"):
-        list(
-            quantize_nvfp4_weight(
-                "model.layers.0.mlp.up_proj",
-                torch.ones(1, 4),
-                QuantMeta(
-                    qformat=QUANTIZATION_NVFP4,
-                    block_size=4,
-                    weight_amax=torch.tensor([1.0]),
-                    weight_scale_2=torch.tensor([1.0]),
-                ),
-            )
-        )
-
-
-def test_is_modelopt_quantizable_weight_name_includes_fused_moe_base_names():
-    assert is_modelopt_quantizable_weight_name("model.layers.0.mlp.down_proj.weight")
-    assert is_modelopt_quantizable_weight_name("model.layers.0.mlp.experts.gate_up_proj")
-    assert is_modelopt_quantizable_weight_name("model.layers.0.mlp.experts.down_proj")
-    assert not is_modelopt_quantizable_weight_name("model.layers.0.mlp.experts.gate_up_proj.bias")
-
-
-def test_get_modelopt_quant_exporter_is_case_insensitive_and_rejects_unknown_modes():
-    qformat, export_weight = get_modelopt_quant_exporter("NVFP4")
-
-    assert qformat == QUANTIZATION_NVFP4
-    assert export_weight is quantize_nvfp4_weight
-
-    with pytest.raises(ValueError, match="Unsupported ModelOpt quant_mode"):
-        get_modelopt_quant_exporter("w4a8")
-
-
-def test_get_modelopt_quant_exporter_returns_supported_w4a16_format(monkeypatch):
-    w4a16_qformat = "modelopt_w4a16_nvfp4"
-    monkeypatch.setattr(
-        quant_utils,
-        "QUANTIZATION_W4A16_NVFP4",
-        w4a16_qformat,
-        raising=False,
-    )
-
-    qformat, export_weight = get_modelopt_quant_exporter("W4A16_NVFP4")
-
-    assert qformat == w4a16_qformat
-    assert export_weight is quantize_nvfp4_weight
-
-
-def test_get_modelopt_quant_exporter_rejects_unsupported_w4a16(monkeypatch):
-    monkeypatch.delattr(quant_utils, "QUANTIZATION_W4A16_NVFP4", raising=False)
-
-    with pytest.raises(RuntimeError, match="does not support W4A16 NVFP4 export"):
-        get_modelopt_quant_exporter("w4a16_nvfp4")
-
-
-def test_auto_bridge_modelopt_export_quantizes_matching_weights(monkeypatch):
-    conversion_tasks = [
-        _task(
-            "decoder.layers.0.mlp.up_proj.weight",
-            "model.layers.0.mlp.up_proj.weight",
-        )
-    ]
-    bridge = _bridge_for_export(
-        conversion_tasks,
-        [
-            ("model.layers.0.mlp.up_proj.weight", torch.tensor([1.0])),
-            ("model.layers.0.mlp.up_proj.bias", torch.tensor([2.0])),
-            ("model.layers.0.mlp.up_proj._quantizer._amax", torch.tensor([3.0])),
-        ],
-    )
-
-    def fake_export_weight(name, tensor, meta):
-        assert name == "model.layers.0.mlp.up_proj.weight"
-        assert meta.qformat == QUANTIZATION_NVFP4
-        yield name, tensor.to(torch.uint8)
-        yield "model.layers.0.mlp.up_proj.weight_scale", torch.ones(1)
-
+    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_states", lambda _tasks: states)
     monkeypatch.setattr(
         modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: {"decoder.layers.0.mlp.up_proj.weight": _quant_meta()},
+        "collect_modelopt_config_weights",
+        lambda _tasks: set(states),
     )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "get_modelopt_quant_exporter",
-        lambda quant_mode: (QUANTIZATION_NVFP4, fake_export_weight),
-    )
+    source = torch.randn(2, 4, 16)
 
-    output = list(
-        AutoBridge.export_hf_weights_modelopt(
-            bridge,
-            [object()],
-            cpu=True,
-            conversion_tasks=conversion_tasks,
-        )
-    )
-
-    assert [(name, tensor.tolist()) for name, tensor in output] == [
-        ("model.layers.0.mlp.up_proj.weight", [1]),
-        ("model.layers.0.mlp.up_proj.weight_scale", [1.0]),
-        ("model.layers.0.mlp.up_proj.bias", [2.0]),
-    ]
-    assert bridge.export_calls[0][1]["cpu"] is True
-    export_tasks = bridge.export_calls[0][1]["conversion_tasks"]
-    assert export_tasks is not conversion_tasks
-    assert isinstance(export_tasks[0], WeightConversionTask)
-    assert export_tasks[0].global_param_name == conversion_tasks[0].global_param_name
-    assert callable(export_tasks[0].export_hook)
-
-
-@pytest.mark.parametrize("shared_group", [False, True], ids=["distinct-pp-ep", "shared-pp-ep"])
-def test_auto_bridge_modelopt_export_syncs_ep_and_deduplicates_groups(monkeypatch, shared_group):
-    conversion_tasks = [
-        _task(
-            "decoder.layers.0.mlp.up_proj.weight",
-            "model.layers.0.mlp.up_proj.weight",
-        )
-    ]
-    bridge = _bridge_for_export(
-        conversion_tasks,
-        [],
-    )
-    metadata = {conversion_tasks[0].global_param_name: _quant_meta()}
-    pp_group = object()
-    ep_group = pp_group if shared_group else object()
-    group_getter_calls = []
-    world_size_calls = []
-    sync_calls = []
-
-    def get_pg_size(group=None):
-        world_size_calls.append(group)
-        return 2 if group is ep_group else 1
-
-    def get_pp_group(_model):
-        group_getter_calls.append("pp")
-        return pp_group
-
-    def get_ep_group(_model):
-        group_getter_calls.append("ep")
-        return ep_group
-
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.is_initialized",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.get_pg_size",
-        get_pg_size,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.all_gather_object",
-        lambda gathered, value, *, group: gathered.__setitem__(
-            slice(None),
-            [value, value],
-        ),
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_pp_group",
-        get_pp_group,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_ep_group",
-        get_ep_group,
-    )
-    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_metadata", lambda _tasks: metadata)
-    monkeypatch.setattr(
-        modelopt_utils,
-        "build_hf_modelopt_quant_metadata",
-        lambda _tasks, _metadata: {},
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "sync_modelopt_quant_metadata",
-        lambda metadata, group: sync_calls.append((metadata, group)),
-    )
-
-    output = list(
-        AutoBridge.export_hf_weights_modelopt(
-            bridge,
-            [object()],
-            conversion_tasks=conversion_tasks,
-        )
-    )
-
-    assert output == []
-    assert group_getter_calls == ["pp", "ep"]
-    expected_groups = [pp_group] if shared_group else [pp_group, ep_group]
-    assert world_size_calls == expected_groups
-    assert [group for _, group in sync_calls] == [ep_group]
-    assert sync_calls[0][0] == metadata
-
-
-def test_auto_bridge_modelopt_export_keeps_regular_path_for_shared_pp_ep_group(
-    monkeypatch,
-):
-    shared_group = object()
-    conversion_tasks = [
-        WeightConversionTask(
-            param_name=f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-            global_param_name=f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-            mapping=AutoMapping(
-                f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-                f"model.layers.0.mlp.experts.{expert}.up_proj.weight",
-            ),
-            param_weight=torch.ones(1, 2),
-        )
-        for expert in range(2)
-    ]
-    metadata = {task.global_param_name: _quant_meta() for task in conversion_tasks}
-    captured_export_tasks = []
-    sync_calls = []
-
-    class FakeBridge:
-        hf_pretrained = object()
-        _model_bridge = SimpleNamespace()
-
-        def export_hf_weights(self, _model, **kwargs):
-            captured_export_tasks.extend(kwargs["conversion_tasks"])
-            return iter(())
-
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_pp_group",
-        lambda _model: shared_group,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_ep_group",
-        lambda _model: shared_group,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.is_initialized",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.get_pg_size",
-        lambda group=None: 2,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.all_gather_object",
-        lambda gathered, value, *, group: gathered.__setitem__(
-            slice(None),
-            [value, value],
-        ),
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: metadata.copy(),
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "sync_modelopt_quant_metadata",
-        lambda task_metadata, group: sync_calls.append((dict(task_metadata), group)),
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "build_hf_modelopt_quant_metadata",
-        lambda *_args: {},
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "get_modelopt_quant_exporter",
-        lambda _mode: (QUANTIZATION_NVFP4, lambda *_args: iter(())),
-    )
-
+    plan = build_modelopt_export_plan(tasks, model=_model(num_moe_experts=2))
+    bridge = object.__new__(MegatronModelBridge)
+    grouped_buffers = {}
     assert (
-        list(
-            AutoBridge.export_hf_weights_modelopt(
-                FakeBridge(),
-                [object()],
-                conversion_tasks=conversion_tasks,
-            )
+        bridge._accumulate_grouped_export(
+            plan.conversion_tasks[0],
+            {hf_name: source[0]},
+            SimpleNamespace(num_moe_experts=2),
+            grouped_buffers,
+            {},
         )
-        == []
+        is None
     )
-    assert len(captured_export_tasks) == 2
-    assert not any(getattr(task.mapping, "is_modelopt_pre_ep_export", False) for task in captured_export_tasks)
-    assert sync_calls == [(metadata, shared_group)]
+    tensors = bridge._accumulate_grouped_export(
+        plan.conversion_tasks[1],
+        {hf_name: source[1]},
+        SimpleNamespace(num_moe_experts=2),
+        grouped_buffers,
+        {},
+    )
 
-
-def test_auto_bridge_modelopt_export_ep_gathers_qwen_input_scale_in_rank_order(
-    monkeypatch,
-):
-    ep_group = object()
-    fused_name = "model.layers.0.mlp.experts.gate_up_proj"
-    packed_name = "model.layers.0.mlp.experts.w13_weight"
-    input_scale_name = "model.layers.0.mlp.experts.w13_input_scale"
-    expert_tasks = [
-        WeightConversionTask(
-            param_name=f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-            global_param_name=f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-            mapping=GatedMLPMapping(
-                f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-                gate=f"model.layers.0.mlp.experts.{expert}.gate_proj.weight",
-                up=f"model.layers.0.mlp.experts.{expert}.up_proj.weight",
-            ),
-            param_weight=torch.ones(1, 2),
-        )
-        for expert in range(2)
+    expected = [
+        export_quantized_weight(
+            source[index],
+            states[task.global_param_name],
+            dtype=source.dtype,
+        ).named_tensors()
+        for index, task in enumerate(tasks)
     ]
-    regular_task = _task(
-        "decoder.layers.0.mlp.router.weight",
-        "model.layers.0.mlp.router.weight",
-    )
-    conversion_tasks = [*expert_tasks, regular_task]
-    metadata = {task.global_param_name: _quant_meta() for task in conversion_tasks}
-    gather_inputs = []
-    metadata_build_calls = []
-    metadata_sync_calls = []
-
-    class FakeBridge:
-        hf_pretrained = object()
-        _model_bridge = SimpleNamespace()
-
-        def export_hf_weights(self, _model, **kwargs):
-            export_tasks = kwargs["conversion_tasks"]
-            assert [getattr(task.mapping, "is_modelopt_pre_ep_export", False) for task in export_tasks] == [
-                True,
-                True,
-                False,
-            ]
-            for task, value in zip(export_tasks[:2], (1.0, 2.0), strict=True):
-                yield from task.export_hook(fused_name, torch.full((1, 2), value))
-
-    def fake_export_weight(name, tensor, meta):
-        assert name == fused_name
-        assert meta.qformat == QUANTIZATION_NVFP4
-        assert meta.block_size == metadata[conversion_tasks[0].global_param_name].block_size
-        yield packed_name, tensor.to(torch.uint8)
-        yield f"{packed_name}_scale", (tensor[..., :1] + 10.0).to(torch.float8_e4m3fn)
-        yield f"{packed_name}_scale_2", tensor[:, 0, 0] + 20.0
-        yield (
-            input_scale_name,
-            torch.stack(
-                (tensor[:, 0, 0] + 30.0, tensor[:, 0, 0] + 31.0),
-                dim=1,
-            ),
-        )
-
-    def fake_all_gather_into_tensor(gathered, tensor, *, group):
-        assert group is ep_group
-        gather_inputs.append(tensor.clone())
-        assert tensor.dtype == torch.uint8
-        local_numel = tensor.numel()
-        gathered[:local_numel].copy_(tensor)
-        if len(gather_inputs) == 1:
-            remote = tensor + 100
-        elif len(gather_inputs) == 2:
-            remote = (tensor.view(torch.float8_e4m3fn).float() + 100).to(torch.float8_e4m3fn).view(torch.uint8)
-        else:
-            remote = (tensor.view(torch.float32) + 100).view(torch.uint8)
-        gathered[local_numel:].copy_(remote)
-
-    def fake_all_gather_object(gathered, value, *, group):
-        assert group is ep_group
-        gathered[:] = [value, value]
-
-    def fake_build_metadata(tasks, _task_metadata):
-        metadata_build_calls.append(("regular", list(tasks)))
-        return {}
-
-    original_build_pre_ep_metadata = modelopt_utils._build_hf_modelopt_pre_ep_quant_metadata
-
-    def tracked_build_pre_ep_metadata(tasks, task_metadata):
-        metadata_build_calls.append(("pre_ep", list(tasks)))
-        return original_build_pre_ep_metadata(tasks, task_metadata)
-
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_pp_group",
-        lambda _model: None,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_ep_group",
-        lambda _model: ep_group,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.is_initialized",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.get_pg_size",
-        lambda group=None: 2 if group is ep_group else 1,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.get_backend",
-        lambda group: "gloo",
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.all_gather_into_tensor",
-        fake_all_gather_into_tensor,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.all_gather_object",
-        fake_all_gather_object,
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: metadata.copy(),
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "sync_modelopt_quant_metadata",
-        lambda task_metadata, group: metadata_sync_calls.append((dict(task_metadata), group)),
-    )
-    monkeypatch.setattr(modelopt_utils, "build_hf_modelopt_quant_metadata", fake_build_metadata)
-    monkeypatch.setattr(
-        modelopt_utils,
-        "_build_hf_modelopt_pre_ep_quant_metadata",
-        tracked_build_pre_ep_metadata,
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "get_modelopt_quant_exporter",
-        lambda _mode: (QUANTIZATION_NVFP4, fake_export_weight),
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils.unwrap_model",
-        lambda _model: [SimpleNamespace(config=SimpleNamespace(num_moe_experts=4))],
-    )
-
-    output = dict(
-        AutoBridge.export_hf_weights_modelopt(
-            FakeBridge(),
-            [object()],
-            cpu=True,
-            conversion_tasks=conversion_tasks,
-        )
-    )
-
-    assert len(metadata_build_calls) == 2
-    assert [kind for kind, _ in metadata_build_calls] == ["regular", "pre_ep"]
-    regular_metadata_tasks = metadata_build_calls[0][1]
-    pre_ep_metadata_tasks = metadata_build_calls[1][1]
-    assert regular_metadata_tasks == [regular_task]
-    assert len(pre_ep_metadata_tasks) == 2
-    assert all(getattr(task.mapping, "is_modelopt_pre_ep_export", False) for task in pre_ep_metadata_tasks)
-    regular_task_ids = {id(task) for task in regular_metadata_tasks}
-    pre_ep_task_ids = {id(task) for task in pre_ep_metadata_tasks}
-    assert regular_task_ids.isdisjoint(pre_ep_task_ids)
-    assert metadata_sync_calls == [
-        ({regular_task.global_param_name: metadata[regular_task.global_param_name]}, ep_group)
-    ]
-    assert len(gather_inputs) == 4
-    assert [tensor.dtype for tensor in gather_inputs] == [torch.uint8] * 4
-    assert [tensor.shape for tensor in gather_inputs] == [
-        torch.Size([4]),
-        torch.Size([2]),
-        torch.Size([8]),
-        torch.Size([16]),
-    ]
-    torch.testing.assert_close(
-        output[packed_name][:, 0, 0],
-        torch.tensor([1, 2, 101, 102], dtype=torch.uint8),
-    )
+    assert tensors is not None
+    assert torch.equal(tensors[hf_name], torch.stack([item["weight"] for item in expected]))
     assert torch.equal(
-        output[f"{packed_name}_scale"][:, 0, 0].view(torch.uint8),
-        torch.tensor([11.0, 12.0, 111.0, 112.0]).to(torch.float8_e4m3fn).view(torch.uint8),
-    )
-    torch.testing.assert_close(
-        output[f"{packed_name}_scale_2"],
-        torch.tensor([21.0, 22.0, 121.0, 122.0]),
-    )
-    torch.testing.assert_close(
-        output[input_scale_name],
-        torch.tensor(
-            [
-                [31.0, 32.0],
-                [32.0, 33.0],
-                [131.0, 132.0],
-                [132.0, 133.0],
-            ]
-        ),
+        tensors[hf_name.removesuffix("weight") + "weight_scale_2"],
+        torch.stack([item["weight_scale_2"] for item in expected]),
     )
 
 
-@pytest.mark.parametrize("num_moe_experts", [4, None, 3])
-def test_auto_bridge_modelopt_export_rejects_incomplete_pre_ep_expert_family(
-    monkeypatch,
-    num_moe_experts,
-):
-    ep_group = object()
-    conversion_tasks = [
+def test_pre_ep_export_packs_before_gather_and_preserves_hf_names(monkeypatch):
+    hf_names = [f"model.layers.0.mlp.experts.{expert}.down_proj.weight" for expert in range(2)]
+    tasks = [
         WeightConversionTask(
-            param_name="decoder.layers.0.mlp.experts.linear_fc1.weight0",
-            global_param_name="decoder.layers.0.mlp.experts.linear_fc1.weight0",
+            param_name=f"decoder.layers.0.mlp.experts.linear_fc2.weight{expert}",
+            global_param_name=f"decoder.layers.0.mlp.experts.linear_fc2.weight{expert}",
             mapping=AutoMapping(
-                "decoder.layers.0.mlp.experts.linear_fc1.weight0",
-                "model.layers.0.mlp.experts.0.up_proj.weight",
+                f"decoder.layers.0.mlp.experts.linear_fc2.weight{expert}",
+                hf_name,
             ),
-            param_weight=torch.ones(1, 2),
         )
+        for expert, hf_name in enumerate(hf_names)
     ]
-    metadata = {conversion_tasks[0].global_param_name: _quant_meta()}
-    captured_export_tasks = []
-    metadata_sync_calls = []
-
-    class FakeBridge:
-        hf_pretrained = object()
-        _model_bridge = SimpleNamespace()
-
-        def export_hf_weights(self, _model, **kwargs):
-            captured_export_tasks.extend(kwargs["conversion_tasks"])
-            return iter(())
-
-    def fake_all_gather_object(gathered, value, *, group):
-        assert group is ep_group
-        gathered[:] = [value, value]
-
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_pp_group",
-        lambda _model: None,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils._get_ep_group",
-        lambda _model: ep_group,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils.unwrap_model",
-        lambda _model: [SimpleNamespace(config=SimpleNamespace(num_moe_experts=num_moe_experts))],
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.is_initialized",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.get_pg_size",
-        lambda group=None: 2 if group is ep_group else 1,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.all_gather_object",
-        fake_all_gather_object,
-    )
+    states = {task.global_param_name: _state(weight_amax=2.0 + expert) for expert, task in enumerate(tasks)}
+    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_states", lambda _tasks: states)
     monkeypatch.setattr(
         modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: metadata.copy(),
+        "collect_modelopt_config_weights",
+        lambda _tasks: set(states),
     )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "sync_modelopt_quant_metadata",
-        lambda task_metadata, group: metadata_sync_calls.append((dict(task_metadata), group)),
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "build_hf_modelopt_quant_metadata",
-        lambda *_args: {},
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "get_modelopt_quant_exporter",
-        lambda _mode: (QUANTIZATION_NVFP4, lambda *_args: iter(())),
-    )
+    sources = [torch.randn(4, 16) for _ in tasks]
+    packed_shapes = []
+    real_export = export_quantized_weight
 
-    assert (
-        list(
-            AutoBridge.export_hf_weights_modelopt(
-                FakeBridge(),
-                [object()],
-                cpu=True,
-                conversion_tasks=conversion_tasks,
-            )
-        )
-        == []
-    )
-    assert len(captured_export_tasks) == 1
-    assert not getattr(
-        captured_export_tasks[0].mapping,
-        "is_modelopt_pre_ep_export",
-        False,
-    )
-    assert metadata_sync_calls == [(metadata, ep_group)]
+    def tracked_export(weight, state, *, dtype):
+        packed_shapes.append(tuple(weight.shape))
+        return real_export(weight, state, dtype=dtype)
+
+    import modelopt.torch.export.quantized_weight as quantized_weight
+
+    monkeypatch.setattr(quantized_weight, "export_quantized_weight", tracked_export)
+
+    plan = build_modelopt_export_plan(tasks, model=_model(num_moe_experts=2))
+    output = {}
+    for task, source in zip(plan.conversion_tasks, sources, strict=True):
+        assert getattr(task.mapping, "is_modelopt_pre_ep_export", False)
+        output.update(dict(task.export_hook(task.mapping.hf_param, source)))
+
+    assert packed_shapes == [(4, 16), (4, 16)]
+    assert set(hf_names).issubset(output)
+    expected = [
+        export_quantized_weight(source, states[task.global_param_name], dtype=source.dtype).named_tensors()
+        for task, source in zip(tasks, sources, strict=True)
+    ]
+    for expert, hf_name in enumerate(hf_names):
+        assert torch.equal(output[hf_name], expected[expert]["weight"])
 
 
-@pytest.mark.parametrize(
-    ("megatron_projection", "hf_projection"),
-    [("linear_fc1", "up_proj"), ("linear_fc2", "down_proj")],
-)
-def test_modelopt_pre_ep_mapping_supports_nemotron_h_expert_projections(
-    megatron_projection,
-    hf_projection,
-):
-    megatron_name = f"decoder.layers.0.mlp.experts.{megatron_projection}.weight7"
-    hf_name = f"backbone.layers.0.mixer.experts.7.{hf_projection}.weight"
-    mapping = AutoMapping(megatron_name, hf_name)
-    process_groups = {
-        "pp_group": object(),
-        "ep_group": object(),
-        "_tp_group": object(),
-        "_etp_group": object(),
+def test_grouped_export_packs_ep_gather_before_global_stack(monkeypatch):
+    hf_name = "model.layers.0.mlp.experts.down_proj.weight"
+    local_task = _task(
+        "decoder.layers.0.mlp.experts.linear_fc2.weight0",
+        hf_name,
+        is_grouped_export=True,
+        ep_size=2,
+        transpose_on_export=True,
+    )
+    remote_name = "decoder.layers.0.mlp.experts.linear_fc2.weight1"
+    states = {
+        local_task.global_param_name: _state(weight_amax=2.0),
+        remote_name: _state(weight_amax=5.0),
     }
-    pg_collection = SimpleNamespace(
-        pp=process_groups["pp_group"],
-        ep=process_groups["ep_group"],
-        tp=process_groups["_tp_group"],
-        expt_tp=process_groups["_etp_group"],
+    monkeypatch.setattr(modelopt_utils, "collect_modelopt_quant_states", lambda _tasks: states)
+    monkeypatch.setattr(
+        modelopt_utils,
+        "collect_modelopt_config_weights",
+        lambda _tasks: set(states),
+    )
+    gathered_experts = torch.randn(2, 16, 4)
+
+    plan = build_modelopt_export_plan([local_task], model=_model(num_moe_experts=2))
+    bridge = object.__new__(MegatronModelBridge)
+    tensors = bridge._accumulate_grouped_export(
+        plan.conversion_tasks[0],
+        {hf_name: gathered_experts},
+        SimpleNamespace(num_moe_experts=2),
+        {},
+        {hf_name: torch.empty(2, 4, 16)},
     )
 
-    replacement, original_names = _modelopt_pre_ep_mapping(mapping, pg_collection)
-
-    assert replacement.megatron_param == megatron_name
-    assert replacement.hf_param == f"backbone.layers.0.mixer.experts.{hf_projection}"
-    assert replacement.is_modelopt_pre_ep_export
-    assert original_names == (hf_name,)
-    for attr, group in process_groups.items():
-        assert getattr(replacement, attr) is group
-    delegate = replacement._get_or_create_mapping("column")
-    assert not delegate.is_expert
-    assert delegate.tp_group is pg_collection.expt_tp
-
-
-@pytest.mark.parametrize(
-    ("quant_mode", "qformat"),
-    [
-        ("nvfp4", QUANTIZATION_NVFP4),
-        ("w4a16_nvfp4", "modelopt_w4a16_nvfp4"),
-    ],
-    ids=("w4a4", "w4a16"),
-)
-def test_auto_bridge_modelopt_export_selects_nemotron_h_pre_ep_family(
-    monkeypatch,
-    quant_mode,
-    qformat,
-):
-    conversion_tasks = [
-        WeightConversionTask(
-            param_name=f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-            global_param_name=f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-            mapping=AutoMapping(
-                f"decoder.layers.0.mlp.experts.linear_fc1.weight{expert}",
-                f"backbone.layers.0.mixer.experts.{expert}.up_proj.weight",
-            ),
-            param_weight=torch.ones(1, 2),
-        )
-        for expert in range(2)
+    expected = [
+        export_quantized_weight(
+            gathered_experts[index].t().contiguous(),
+            states[state_name],
+            dtype=gathered_experts.dtype,
+        ).named_tensors()
+        for index, state_name in enumerate((local_task.global_param_name, remote_name))
     ]
-    metadata = {task.global_param_name: _quant_meta(qformat) for task in conversion_tasks}
-    captured_export_tasks = []
+    assert tensors is not None
+    assert torch.equal(tensors[hf_name], torch.stack([item["weight"] for item in expected]))
 
-    class FakeBridge:
-        hf_pretrained = object()
-        _model_bridge = SimpleNamespace()
 
-        def export_hf_weights(self, _model, **kwargs):
-            captured_export_tasks.extend(kwargs["conversion_tasks"])
-            return iter(())
+def test_build_modelopt_export_plan_preserves_existing_export_hook(monkeypatch):
+    def finalizer(name, tensor):
+        yield HFWeightTuple(f"final.{name}", tensor)
 
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.is_initialized",
-        lambda: False,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.model_bridge_utils.unwrap_model",
-        lambda _model: [SimpleNamespace(config=SimpleNamespace(num_moe_experts=2))],
+    task = _task(
+        "decoder.layers.0.mlp.linear_fc1.weight",
+        "model.layers.0.mlp.up_proj.weight",
+        export_hook=finalizer,
     )
     monkeypatch.setattr(
         modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: metadata.copy(),
+        "collect_modelopt_quant_states",
+        lambda _tasks: {task.global_param_name: _state(w4a16=True)},
     )
-
-    def fake_get_modelopt_quant_exporter(requested_mode):
-        assert requested_mode == quant_mode
-        return qformat, lambda *_args: iter(())
-
     monkeypatch.setattr(
         modelopt_utils,
-        "get_modelopt_quant_exporter",
-        fake_get_modelopt_quant_exporter,
+        "collect_modelopt_config_weights",
+        lambda _tasks: {task.global_param_name},
     )
 
-    assert (
-        list(
-            AutoBridge.export_hf_weights_modelopt(
-                FakeBridge(),
-                [object()],
-                quant_mode=quant_mode,
-                cpu=True,
-                conversion_tasks=conversion_tasks,
-            )
+    plan = build_modelopt_export_plan([task], model=_model())
+    names = [
+        name
+        for name, _ in plan.conversion_tasks[0].export_hook(
+            task.mapping.hf_param,
+            torch.randn(4, 16),
         )
-        == []
-    )
-    assert len(captured_export_tasks) == 2
-    assert all(getattr(task.mapping, "is_modelopt_pre_ep_export", False) for task in captured_export_tasks)
-    assert {task.mapping.hf_param for task in captured_export_tasks} == {"backbone.layers.0.mixer.experts.up_proj"}
+    ]
 
-
-def test_modelopt_pre_ep_mapping_fuses_qwen3_gate_and_up_experts():
-    megatron_name = "decoder.layers.0.mlp.experts.linear_fc1.weight7"
-    gate_name = "model.layers.0.mlp.experts.7.gate_proj.weight"
-    up_name = "model.layers.0.mlp.experts.7.up_proj.weight"
-    mapping = GatedMLPMapping(megatron_name, gate=gate_name, up=up_name)
-    process_groups = {
-        "pp_group": object(),
-        "ep_group": object(),
-        "_tp_group": object(),
-        "_etp_group": object(),
-    }
-    pg_collection = SimpleNamespace(
-        pp=process_groups["pp_group"],
-        ep=process_groups["ep_group"],
-        tp=process_groups["_tp_group"],
-        expt_tp=process_groups["_etp_group"],
-    )
-
-    replacement, original_names = _modelopt_pre_ep_mapping(mapping, pg_collection)
-
-    assert replacement.megatron_param == megatron_name
-    assert replacement.hf_param == "model.layers.0.mlp.experts.gate_up_proj"
-    assert replacement.is_modelopt_pre_ep_export
-    assert original_names == (gate_name, up_name)
-    for attr, group in process_groups.items():
-        assert getattr(replacement, attr) is group
-        assert getattr(replacement._gated_mapping, attr) is group
-    assert not replacement._gated_mapping.is_expert
-    assert replacement._gated_mapping.tp_group is pg_collection.expt_tp
-
-
-def test_modelopt_pre_ep_mapping_rejects_mismatched_gate_up_experts():
-    mapping = GatedMLPMapping(
-        "decoder.layers.0.mlp.experts.linear_fc1.weight7",
-        gate="model.layers.0.mlp.experts.7.gate_proj.weight",
-        up="model.layers.0.mlp.experts.8.up_proj.weight",
-    )
-
-    assert _modelopt_pre_ep_mapping(mapping) is None
-
-
-def test_grouped_expert_projection_name_is_structural():
-    assert _grouped_expert_projection_name("model.layers.0.mlp.experts.7.value_proj.weight") == (
-        "model.layers.0.mlp.experts.value_proj",
-        7,
-    )
-
-
-def test_fuse_grouped_projection_names_is_structural():
-    assert (
-        _fuse_grouped_projection_names(
-            "model.layers.0.mlp.experts.left_proj",
-            "model.layers.0.mlp.experts.right_proj",
-        )
-        == "model.layers.0.mlp.experts.left_right_proj"
-    )
-
-
-def test_modelopt_pre_ep_mapping_requires_an_exact_experts_path_component():
-    mapping = AutoMapping(
-        "decoder.layers.0.mlp.experts.linear_fc2.weight7",
-        "model.layers.0.mlp.shared_experts.7.value_proj.weight",
-    )
-
-    assert _modelopt_pre_ep_mapping(mapping) is None
-
-
-def test_modelopt_pre_ep_mapping_rejects_unsupported_grouped_projection():
-    mapping = AutoMapping(
-        "decoder.layers.0.mlp.experts.linear_fc2.weight7",
-        "model.layers.0.mlp.experts.7.value_proj.weight",
-    )
-
-    assert _modelopt_pre_ep_mapping(mapping) is None
-
-
-def test_stage_tensor_for_collective_moves_pinned_cpu_tensor_for_nccl(monkeypatch):
-    group = object()
-    cuda_tensor = object()
-    tensor = SimpleNamespace(device=torch.device("cpu"))
-    tensor.is_pinned = lambda: True
-    calls = []
-
-    def move_to(*, device, non_blocking):
-        calls.append((device, non_blocking))
-        return cuda_tensor
-
-    tensor.to = move_to
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.get_backend",
-        lambda _group: "nccl",
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.cuda.is_available",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.cuda.current_device",
-        lambda: 3,
-    )
-
-    assert _stage_tensor_for_collective(tensor, group) is cuda_tensor
-    assert calls == [(torch.device("cuda", 3), True)]
-
-
-def test_stage_tensor_for_collective_keeps_cpu_tensor_for_gloo(monkeypatch):
-    group = object()
-    tensor = torch.ones(1)
-    monkeypatch.setattr(
-        "megatron.bridge.models.conversion.modelopt_utils.torch.distributed.get_backend",
-        lambda _group: "gloo",
-    )
-
-    assert _stage_tensor_for_collective(tensor, group) is tensor
-
-
-def test_auto_bridge_modelopt_export_falls_back_to_mapping_registry(monkeypatch):
-    megatron_name = "decoder.layers.0.mlp.up_proj.weight"
-    hf_name = "model.layers.0.mlp.up_proj.weight"
-    conversion_tasks = [_task(megatron_name, hf_name)]
-    bridge = _bridge_for_export(
-        conversion_tasks,
-        [(hf_name, torch.tensor([1.0]))],
-    )
-    quant_meta = _quant_meta()
-    registry_calls = []
-    lookup_calls = []
-
-    def hf_to_megatron_lookup(name):
-        lookup_calls.append(name)
-        return SimpleNamespace(megatron_param=megatron_name)
-
-    registry = SimpleNamespace(
-        hf_to_megatron_lookup=hf_to_megatron_lookup,
-        set_process_groups_from_pg_collection=lambda _pg_collection: None,
-    )
-
-    def get_registry():
-        registry_calls.append(True)
-        return registry
-
-    bridge._model_bridge.mapping_registry = get_registry
-
-    def fake_export_weight(name, tensor, meta):
-        assert name == hf_name
-        assert meta is quant_meta
-        yield name, tensor.to(torch.uint8)
-
-    monkeypatch.setattr(
-        modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: {megatron_name: quant_meta},
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "build_hf_modelopt_quant_metadata",
-        lambda _tasks, _metadata: {},
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "get_modelopt_quant_exporter",
-        lambda quant_mode: (QUANTIZATION_NVFP4, fake_export_weight),
-    )
-
-    output = list(
-        AutoBridge.export_hf_weights_modelopt(
-            bridge,
-            [object()],
-            conversion_tasks=conversion_tasks,
-        )
-    )
-
-    assert registry_calls == [True]
-    assert lookup_calls == [hf_name]
-    assert [(name, tensor.dtype, tensor.tolist()) for name, tensor in output] == [
-        (hf_name, torch.uint8, [1]),
+    assert names == [
+        "final.model.layers.0.mlp.up_proj.weight",
+        "final.model.layers.0.mlp.up_proj.weight_scale",
+        "final.model.layers.0.mlp.up_proj.weight_scale_2",
     ]
 
 
-def test_auto_bridge_modelopt_export_leaves_ignored_weights_unquantized(monkeypatch):
-    conversion_tasks = [
-        _task(
-            "decoder.layers.0.self_attention.linear_proj.weight",
-            "model.layers.0.self_attn.o_proj.weight",
+class _FakeAutoBridge:
+    hf_pretrained = object()
+    _build_modelopt_export_plan = AutoBridge._build_modelopt_export_plan
+
+    def __init__(self, tasks, plan):
+        self._model_bridge = SimpleNamespace(
+            build_conversion_tasks=lambda *_args: tasks,
         )
-    ]
-    bridge = _bridge_for_export(
-        conversion_tasks,
-        [("model.layers.0.self_attn.o_proj.weight", torch.tensor([1.0]))],
+        self.plan = plan
+        self.export_kwargs = None
+
+    def export_hf_weights(self, model, **kwargs):
+        self.export_kwargs = kwargs
+        return iter((HFWeightTuple("hf.weight", torch.ones(1)),))
+
+
+def test_auto_bridge_exposes_config_and_uses_prepared_tasks(monkeypatch):
+    task = _task("decoder.weight", "hf.weight")
+    export_task = _task("decoder.weight", "hf.weight")
+    plan = ModelOptExportPlan(
+        conversion_tasks=[export_task],
+        quantization_config={"quant_algo": "NVFP4"},
     )
+    fake = _FakeAutoBridge([task], plan)
+    monkeypatch.setattr(modelopt_utils, "build_modelopt_export_plan", lambda *_args, **_kwargs: plan)
+    model = torch.nn.Module()
 
-    def fail_export_weight(*_args, **_kwargs):
-        raise AssertionError("ignored weights should not be quantized")
+    config = AutoBridge.get_hf_modelopt_quantization_config(fake, model)
+    weights = AutoBridge.export_hf_weights_modelopt(fake, model, cpu=True)
 
-    monkeypatch.setattr(
-        modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: {"decoder.layers.0.self_attention.linear_proj.weight": _quant_meta()},
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "get_modelopt_quant_exporter",
-        lambda quant_mode: (QUANTIZATION_NVFP4, fail_export_weight),
-    )
+    assert fake.export_kwargs is not None
+    weights = list(weights)
 
-    output = list(
-        AutoBridge.export_hf_weights_modelopt(
-            bridge,
-            [object()],
-            conversion_tasks=conversion_tasks,
-            ignore_patterns=["*self_attn*"],
-        )
-    )
-
-    assert [(name, tensor.tolist()) for name, tensor in output] == [("model.layers.0.self_attn.o_proj.weight", [1.0])]
-
-
-def test_auto_bridge_modelopt_export_accepts_single_model_and_builds_tasks(monkeypatch):
-    model = object()
-    conversion_tasks = [
-        _task(
-            "decoder.embedding.word_embeddings.weight",
-            "model.embed_tokens.weight",
-        )
-    ]
-    build_calls = []
-
-    class FakeModelBridge:
-        def build_conversion_tasks(self, hf_pretrained, model_arg):
-            build_calls.append((hf_pretrained, model_arg))
-            return conversion_tasks
-
-    bridge = _bridge_for_export(
-        conversion_tasks,
-        [("model.embed_tokens.weight", torch.tensor([4.0]))],
-    )
-    bridge._model_bridge = FakeModelBridge()
-
-    monkeypatch.setattr(
-        modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: {},
-    )
-
-    output = list(
-        AutoBridge.export_hf_weights_modelopt(
-            bridge,
-            model,
-            show_progress=False,
-            merge_adapter_weights=False,
-        )
-    )
-
-    assert [(name, tensor.tolist()) for name, tensor in output] == [("model.embed_tokens.weight", [4.0])]
-    assert build_calls == [(bridge.hf_pretrained, [model])]
-    assert bridge.export_calls[0][0] == [model]
-    assert bridge.export_calls[0][1]["show_progress"] is False
-    assert bridge.export_calls[0][1]["merge_adapter_weights"] is False
-    export_tasks = bridge.export_calls[0][1]["conversion_tasks"]
-    assert export_tasks is not conversion_tasks
-    assert export_tasks[0].global_param_name == conversion_tasks[0].global_param_name
-
-
-def test_auto_bridge_modelopt_export_streams_base_weights_lazily(monkeypatch):
-    conversion_tasks = [
-        _task(
-            "decoder.layers.0.mlp.up_proj.weight",
-            "model.layers.0.mlp.up_proj.weight",
-        )
-    ]
-    events = []
-
-    class FakeBridge:
-        hf_pretrained = object()
-        _model_bridge = SimpleNamespace(
-            build_conversion_tasks=lambda *_args, **_kwargs: conversion_tasks,
-        )
-
-        def export_hf_weights(self, _model, **kwargs):
-            export_task = kwargs["conversion_tasks"][0]
-            events.append("start")
-            yield from export_task.export_hook(
-                "model.layers.0.mlp.up_proj.weight",
-                torch.tensor([1.0]),
-            )
-            events.append("after-first")
-            yield from export_task.export_hook(
-                "model.layers.0.mlp.down_proj.weight",
-                torch.tensor([2.0]),
-            )
-
-    monkeypatch.setattr(
-        modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: {},
-    )
-
-    weights = AutoBridge.export_hf_weights_modelopt(
-        FakeBridge(),
-        [object()],
-        conversion_tasks=conversion_tasks,
-    )
-
-    assert events == []
-    first = next(weights)
-    assert first.param_name == "model.layers.0.mlp.up_proj.weight"
-    torch.testing.assert_close(first.weight, torch.tensor([1.0]))
-    assert events == ["start"]
-    second = next(weights)
-    assert second.param_name == "model.layers.0.mlp.down_proj.weight"
-    torch.testing.assert_close(second.weight, torch.tensor([2.0]))
-    assert events == ["start", "after-first"]
-
-
-def test_auto_bridge_modelopt_export_rejects_mismatched_qformat(monkeypatch):
-    conversion_tasks = [
-        _task(
-            "decoder.layers.0.mlp.up_proj.weight",
-            "model.layers.0.mlp.up_proj.weight",
-        )
-    ]
-    bridge = _bridge_for_export(
-        conversion_tasks,
-        [("model.layers.0.mlp.up_proj.weight", torch.tensor([1.0]))],
-    )
-
-    def fail_export_weight(*_args, **_kwargs):
-        raise AssertionError("mismatched qformat should fail before quantization")
-
-    monkeypatch.setattr(
-        modelopt_utils,
-        "collect_modelopt_quant_metadata",
-        lambda _tasks: {
-            "decoder.layers.0.mlp.up_proj.weight": QuantMeta(
-                qformat="unexpected_qformat",
-                block_size=16,
-                weight_amax=torch.tensor([1.0]),
-                weight_scale_2=torch.tensor([1.0]),
-            )
-        },
-    )
-    monkeypatch.setattr(
-        modelopt_utils,
-        "get_modelopt_quant_exporter",
-        lambda quant_mode: (QUANTIZATION_NVFP4, fail_export_weight),
-    )
-
-    with pytest.raises(RuntimeError, match="Unsupported qformat"):
-        list(
-            AutoBridge.export_hf_weights_modelopt(
-                bridge,
-                [object()],
-                conversion_tasks=conversion_tasks,
-            )
-        )
+    assert config is plan.quantization_config
+    assert [weight.param_name for weight in weights] == ["hf.weight"]
+    assert torch.equal(weights[0].weight, torch.ones(1))
+    assert fake.export_kwargs["conversion_tasks"] == [export_task]
+    assert fake.export_kwargs["cpu"] is True

--- a/tests/unit_tests/models/test_modelopt_utils_distributed.py
+++ b/tests/unit_tests/models/test_modelopt_utils_distributed.py
@@ -48,9 +48,10 @@ def _quantized_linear(
     *,
     weight_amax: float,
     input_amax: float,
+    w4a16: bool = False,
 ) -> torch.nn.Module:
     module = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False, device=weight.device, dtype=weight.dtype)
-    quant_config = copy.deepcopy(mtq.NVFP4_DEFAULT_CFG)
+    quant_config = copy.deepcopy(mtq.W4A16_NVFP4_CFG if w4a16 else mtq.NVFP4_DEFAULT_CFG)
     quant_config["algorithm"] = {"method": "max", "distributed_sync": False}
     mtq.quantize(
         module,
@@ -60,7 +61,8 @@ def _quantized_linear(
     with torch.no_grad():
         module.weight.copy_(weight)
     module.weight_quantizer.amax = torch.tensor(weight_amax, device=weight.device)
-    module.input_quantizer.amax = torch.tensor(input_amax, device=weight.device)
+    if module.input_quantizer.is_enabled:
+        module.input_quantizer.amax = torch.tensor(input_amax, device=weight.device)
     return module
 
 
@@ -271,6 +273,35 @@ def test_modelopt_export_tp2_pp2_ep2_matches_canonical_export(monkeypatch) -> No
         ]
         expected_ep_tensors = {name: tensor for expert in terminal_experts for name, tensor in expert.items()}
         _assert_tensors_equal(ep_tensors, expected_ep_tensors)
+
+        # Mixed expert formats do not export before EP: their canonical tensor
+        # families differ, so ranks must take the regular gather-first path.
+        mixed_module = _quantized_linear(
+            expert_weight,
+            weight_amax=2.0 + rank,
+            input_amax=3.0 + rank,
+            w4a16=rank == 1,
+        )
+        mixed_module.parallel_state = ParallelState(
+            data_parallel_group=local_group,
+            tensor_parallel_group=local_group,
+        )
+        mixed_task = WeightConversionTask(
+            param_name="decoder.layers.0.mlp.experts.linear_fc2.weight0",
+            global_param_name=expert_global_name,
+            mapping=AutoMapping(expert_global_name, expert_hf_name),
+            megatron_module=mixed_module,
+            param_weight=mixed_module.weight,
+        )
+        mixed_plan = build_modelopt_export_plan(
+            [mixed_task],
+            model=_model(num_moe_experts=_WORLD_SIZE),
+        )
+        assert not getattr(
+            mixed_plan.conversion_tasks[0].mapping,
+            "is_modelopt_pre_ep_export",
+            False,
+        )
 
         # Grouped EP: exchange per-expert state, pack each expert independently,
         # then stack every canonical tensor family under the grouped HF name.

--- a/tests/unit_tests/models/test_modelopt_utils_distributed.py
+++ b/tests/unit_tests/models/test_modelopt_utils_distributed.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-rank ModelOpt export parity across TP, PP, and EP collectives.
+
+Run with:
+uv run python -m torch.distributed.run --nproc_per_node=2 -m pytest \
+    tests/unit_tests/models/test_modelopt_utils_distributed.py
+"""
+
+import copy
+import os
+from types import SimpleNamespace
+
+import modelopt.torch.quantization as mtq
+import pytest
+import torch
+import torch.distributed as dist
+from modelopt.torch.export.quantized_weight import (
+    build_hf_quantization_config,
+    capture_quantized_weight_export_state,
+    export_quantized_weight,
+)
+from modelopt.torch.utils.distributed import ParallelState
+
+from megatron.bridge.models.conversion import model_bridge as model_bridge_utils
+from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+from megatron.bridge.models.conversion.modelopt_utils import build_modelopt_export_plan
+from megatron.bridge.models.conversion.param_mapping import AutoMapping
+
+
+_WORLD_SIZE = 2
+
+
+def _quantized_linear(
+    weight: torch.Tensor,
+    *,
+    weight_amax: float,
+    input_amax: float,
+) -> torch.nn.Module:
+    module = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False, device=weight.device, dtype=weight.dtype)
+    mtq.quantize(
+        module,
+        copy.deepcopy(mtq.NVFP4_DEFAULT_CFG),
+        lambda model: model(torch.ones(1, weight.shape[1], device=weight.device, dtype=weight.dtype)),
+    )
+    with torch.no_grad():
+        module.weight.copy_(weight)
+    module.weight_quantizer.amax = torch.tensor(weight_amax, device=weight.device)
+    module.input_quantizer.amax = torch.tensor(input_amax, device=weight.device)
+    return module
+
+
+def _task(
+    module: torch.nn.Module,
+    global_name: str,
+    hf_name: str,
+    *,
+    local_name: str | None = None,
+    grouped: bool = False,
+) -> WeightConversionTask:
+    return WeightConversionTask(
+        param_name=local_name or global_name,
+        global_param_name=global_name,
+        mapping=SimpleNamespace(
+            hf_param=hf_name,
+            is_grouped_export=grouped,
+            ep_size=_WORLD_SIZE if grouped else 1,
+            transpose_on_export=False,
+        ),
+        megatron_module=module,
+        param_weight=module.weight,
+    )
+
+
+def _model(*, num_moe_experts: int | None = None) -> list[torch.nn.Module]:
+    model = torch.nn.Module()
+    model.config = SimpleNamespace(num_moe_experts=num_moe_experts)
+    return [model]
+
+
+def _capture_state(
+    weight: torch.Tensor,
+    *,
+    weight_amax: float,
+    input_amax: float,
+):
+    module = _quantized_linear(
+        weight,
+        weight_amax=weight_amax,
+        input_amax=input_amax,
+    )
+    return capture_quantized_weight_export_state(module)
+
+
+def _canonical_export(
+    hf_name: str,
+    weight: torch.Tensor,
+    *,
+    weight_amax: float,
+    input_amax: float,
+) -> dict[str, torch.Tensor]:
+    state = _capture_state(
+        weight,
+        weight_amax=weight_amax,
+        input_amax=input_amax,
+    )
+    prefix = hf_name.removesuffix("weight")
+    return {
+        f"{prefix}{name}": tensor
+        for name, tensor in export_quantized_weight(
+            weight,
+            state,
+            dtype=weight.dtype,
+        )
+        .named_tensors()
+        .items()
+    }
+
+
+def _assert_tensors_equal(actual: dict[str, torch.Tensor], expected: dict[str, torch.Tensor]) -> None:
+    assert actual.keys() == expected.keys()
+    for name in actual:
+        assert torch.equal(actual[name], expected[name]), name
+
+
+@pytest.mark.gpu
+def test_modelopt_export_tp2_pp2_ep2_matches_canonical_export(monkeypatch) -> None:
+    if int(os.environ.get("WORLD_SIZE", "1")) != _WORLD_SIZE:
+        pytest.skip("requires a two-rank torch.distributed launch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    owns_process_group = not dist.is_initialized()
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if owns_process_group:
+        dist.init_process_group(backend="nccl")
+
+    try:
+        rank = dist.get_rank()
+        singleton_groups = [dist.new_group(ranks=[group_rank]) for group_rank in range(_WORLD_SIZE)]
+        local_group = singleton_groups[rank]
+        world_group = dist.group.WORLD
+
+        # TP: each rank owns one input shard, while scalar calibration state is max-reduced.
+        local_tp_weight = torch.arange(64, device="cuda", dtype=torch.bfloat16).reshape(4, 16) / 8 + rank
+        tp_module = _quantized_linear(
+            local_tp_weight,
+            weight_amax=(2.0, 5.0)[rank],
+            input_amax=(3.0, 7.0)[rank],
+        )
+        tp_module.parallel_state = ParallelState(
+            data_parallel_group=local_group,
+            tensor_parallel_group=world_group,
+        )
+        tp_hf_name = "model.layers.0.mlp.up_proj.weight"
+        tp_task = _task(tp_module, "decoder.layers.0.mlp.linear_fc1.weight", tp_hf_name)
+        monkeypatch.setattr(model_bridge_utils, "_get_pp_group", lambda _model: local_group)
+        monkeypatch.setattr(model_bridge_utils, "_get_ep_group", lambda _model: local_group)
+        tp_plan = build_modelopt_export_plan([tp_task], model=_model())
+        gathered_tp_weights = [torch.empty_like(local_tp_weight) for _ in range(_WORLD_SIZE)]
+        dist.all_gather(gathered_tp_weights, local_tp_weight)
+        canonical_tp_weight = torch.cat(gathered_tp_weights, dim=1)
+
+        tp_stream = tp_plan.conversion_tasks[0].export_hook(tp_hf_name, canonical_tp_weight)
+        assert not isinstance(tp_stream, tuple)
+        _assert_tensors_equal(
+            dict(tp_stream),
+            _canonical_export(
+                tp_hf_name,
+                canonical_tp_weight,
+                weight_amax=5.0,
+                input_amax=7.0,
+            ),
+        )
+
+        # PP: disjoint canonical layers and their config records are exchanged across stages.
+        pp_weight = torch.arange(64, device="cuda", dtype=torch.bfloat16).reshape(4, 16) / 8 + rank
+        pp_module = _quantized_linear(
+            pp_weight,
+            weight_amax=2.0 + rank,
+            input_amax=3.0 + rank,
+        )
+        pp_global_name = f"decoder.layers.{rank}.mlp.linear_fc1.weight"
+        pp_hf_name = f"model.layers.{rank}.mlp.up_proj.weight"
+        pp_task = _task(pp_module, pp_global_name, pp_hf_name)
+        monkeypatch.setattr(model_bridge_utils, "_get_pp_group", lambda _model: world_group)
+        monkeypatch.setattr(model_bridge_utils, "_get_ep_group", lambda _model: local_group)
+        pp_plan = build_modelopt_export_plan([pp_task], model=_model())
+        expected_config = build_hf_quantization_config(
+            {
+                f"model.layers.{layer}.mlp.up_proj": _capture_state(
+                    torch.ones(4, 16, device="cuda", dtype=torch.bfloat16),
+                    weight_amax=2.0 + layer,
+                    input_amax=3.0 + layer,
+                )
+                for layer in range(_WORLD_SIZE)
+            }
+        )
+        assert pp_plan.quantization_config == expected_config
+        _assert_tensors_equal(
+            dict(pp_plan.conversion_tasks[0].export_hook(pp_hf_name, pp_weight)),
+            _canonical_export(
+                pp_hf_name,
+                pp_weight,
+                weight_amax=2.0 + rank,
+                input_amax=3.0 + rank,
+            ),
+        )
+
+        # EP: expert calibration remains distinct through exchange and packing happens per expert.
+        expert_weight = torch.arange(64, device="cuda", dtype=torch.bfloat16).reshape(4, 16) / 8 + rank
+        expert_module = _quantized_linear(
+            expert_weight,
+            weight_amax=2.0 + rank,
+            input_amax=3.0 + rank,
+        )
+        expert_global_name = f"decoder.layers.0.mlp.experts.linear_fc2.weight{rank}"
+        expert_hf_name = f"model.layers.0.mlp.experts.{rank}.down_proj.weight"
+        expert_task = WeightConversionTask(
+            param_name="decoder.layers.0.mlp.experts.linear_fc2.weight0",
+            global_param_name=expert_global_name,
+            mapping=AutoMapping(expert_global_name, expert_hf_name),
+            megatron_module=expert_module,
+            param_weight=expert_module.weight,
+        )
+        monkeypatch.setattr(model_bridge_utils, "_get_pp_group", lambda _model: local_group)
+        monkeypatch.setattr(model_bridge_utils, "_get_ep_group", lambda _model: world_group)
+        ep_plan = build_modelopt_export_plan(
+            [expert_task],
+            model=_model(num_moe_experts=_WORLD_SIZE),
+        )
+        gathered_expert_weights = [torch.empty_like(expert_weight) for _ in range(_WORLD_SIZE)]
+        dist.all_gather(gathered_expert_weights, expert_weight)
+        ep_tensors = dict(
+            ep_plan.conversion_tasks[0].export_hook(
+                expert_hf_name,
+                expert_weight,
+            )
+        )
+        terminal_experts = [
+            _canonical_export(
+                f"model.layers.0.mlp.experts.{expert}.down_proj.weight",
+                gathered_expert_weights[expert],
+                weight_amax=2.0 + expert,
+                input_amax=3.0 + expert,
+            )
+            for expert in range(_WORLD_SIZE)
+        ]
+        expected_ep_tensors = {name: tensor for expert in terminal_experts for name, tensor in expert.items()}
+        _assert_tensors_equal(ep_tensors, expected_ep_tensors)
+
+        # Grouped EP: exchange per-expert state, pack each expert independently,
+        # then stack every canonical tensor family under the grouped HF name.
+        grouped_hf_name = "model.layers.0.mlp.experts.down_proj.weight"
+        grouped_task = _task(
+            expert_module,
+            expert_global_name,
+            grouped_hf_name,
+            grouped=True,
+        )
+        grouped_plan = build_modelopt_export_plan(
+            [grouped_task],
+            model=_model(num_moe_experts=_WORLD_SIZE),
+        )
+        grouped_bridge = object.__new__(model_bridge_utils.MegatronModelBridge)
+        grouped_tensors = grouped_bridge._accumulate_grouped_export(
+            grouped_plan.conversion_tasks[0],
+            {grouped_hf_name: torch.stack(gathered_expert_weights)},
+            SimpleNamespace(num_moe_experts=_WORLD_SIZE),
+            {},
+            {},
+        )
+        grouped_experts = [
+            _canonical_export(
+                grouped_hf_name,
+                gathered_expert_weights[expert],
+                weight_amax=2.0 + expert,
+                input_amax=3.0 + expert,
+            )
+            for expert in range(_WORLD_SIZE)
+        ]
+        expected_grouped_tensors = {
+            name: torch.stack([expert[name] for expert in grouped_experts]) for name in grouped_experts[0]
+        }
+        assert grouped_tensors is not None
+        _assert_tensors_equal(grouped_tensors, expected_grouped_tensors)
+    finally:
+        if owns_process_group and dist.is_initialized():
+            dist.destroy_process_group()

--- a/tests/unit_tests/models/test_modelopt_utils_distributed.py
+++ b/tests/unit_tests/models/test_modelopt_utils_distributed.py
@@ -274,8 +274,8 @@ def test_modelopt_export_tp2_pp2_ep2_matches_canonical_export(monkeypatch) -> No
         expected_ep_tensors = {name: tensor for expert in terminal_experts for name, tensor in expert.items()}
         _assert_tensors_equal(ep_tensors, expected_ep_tensors)
 
-        # Mixed expert formats do not export before EP: their canonical tensor
-        # families differ, so ranks must take the regular gather-first path.
+        # Mixed expert formats emit different canonical tensor families. Every
+        # rank must reject the group before any lazy tensor collective begins.
         mixed_module = _quantized_linear(
             expert_weight,
             weight_amax=2.0 + rank,
@@ -293,15 +293,14 @@ def test_modelopt_export_tp2_pp2_ep2_matches_canonical_export(monkeypatch) -> No
             megatron_module=mixed_module,
             param_weight=mixed_module.weight,
         )
-        mixed_plan = build_modelopt_export_plan(
-            [mixed_task],
-            model=_model(num_moe_experts=_WORLD_SIZE),
-        )
-        assert not getattr(
-            mixed_plan.conversion_tasks[0].mapping,
-            "is_modelopt_pre_ep_export",
-            False,
-        )
+        with pytest.raises(
+            RuntimeError,
+            match="Inconsistent ModelOpt state for pre-EP expert group",
+        ):
+            build_modelopt_export_plan(
+                [mixed_task],
+                model=_model(num_moe_experts=_WORLD_SIZE),
+            )
 
         # Grouped EP: exchange per-expert state, pack each expert independently,
         # then stack every canonical tensor family under the grouped HF name.

--- a/tests/unit_tests/models/test_modelopt_utils_distributed.py
+++ b/tests/unit_tests/models/test_modelopt_utils_distributed.py
@@ -195,6 +195,10 @@ def test_modelopt_export_tp2_pp2_ep2_matches_canonical_export(monkeypatch) -> No
             weight_amax=2.0 + rank,
             input_amax=3.0 + rank,
         )
+        pp_module.parallel_state = ParallelState(
+            data_parallel_group=local_group,
+            tensor_parallel_group=local_group,
+        )
         pp_global_name = f"decoder.layers.{rank}.mlp.linear_fc1.weight"
         pp_hf_name = f"model.layers.{rank}.mlp.up_proj.weight"
         pp_task = _task(pp_module, pp_global_name, pp_hf_name)
@@ -228,6 +232,10 @@ def test_modelopt_export_tp2_pp2_ep2_matches_canonical_export(monkeypatch) -> No
             expert_weight,
             weight_amax=2.0 + rank,
             input_amax=3.0 + rank,
+        )
+        expert_module.parallel_state = ParallelState(
+            data_parallel_group=local_group,
+            tensor_parallel_group=local_group,
         )
         expert_global_name = f"decoder.layers.0.mlp.experts.linear_fc2.weight{rank}"
         expert_hf_name = f"model.layers.0.mlp.experts.{rank}.down_proj.weight"

--- a/tests/unit_tests/models/test_modelopt_utils_distributed.py
+++ b/tests/unit_tests/models/test_modelopt_utils_distributed.py
@@ -50,9 +50,11 @@ def _quantized_linear(
     input_amax: float,
 ) -> torch.nn.Module:
     module = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False, device=weight.device, dtype=weight.dtype)
+    quant_config = copy.deepcopy(mtq.NVFP4_DEFAULT_CFG)
+    quant_config["algorithm"] = {"method": "max", "distributed_sync": False}
     mtq.quantize(
         module,
-        copy.deepcopy(mtq.NVFP4_DEFAULT_CFG),
+        quant_config,
         lambda model: model(torch.ones(1, weight.shape[1], device=weight.device, dtype=weight.dtype)),
     )
     with torch.no_grad():


### PR DESCRIPTION
## Summary
- capture opaque ModelOpt export state from Megatron weights
- preserve TP, PP, and EP ownership while mapping state to canonical HF names
- pack each expert before grouped export and emit ModelOpt canonical quantization metadata

Depends on NVIDIA/Model-Optimizer#2193.

## Verification
- 39 focused CPU tests passed
- two-rank TP2, PP2, EP2, and grouped-EP export parity passed on GPU
- Ruff format/check, compileall, and git diff check passed

This PR is intentionally draft while the dependent NeMo-RL integration is validated.