### PR TITLE
[recipe] fix: Repartition uneven stages after PP override

### DIFF
--- a/scripts/training/recipe_runner.py
+++ b/scripts/training/recipe_runner.py
@@ -389,6 +389,35 @@ def sync_model_pipeline_layout(
     model = getattr(config, "model", None)
     layout_builder = getattr(model, "_pipeline_model_parallel_layout_builder", None)
     if layout_builder is None:
+        stage_fields = (
+            "num_layers_in_first_pipeline_stage",
+            "num_layers_in_last_pipeline_stage",
+        )
+        first_stage_layers, last_stage_layers = (getattr(model, field_name, None) for field_name in stage_fields)
+        if first_stage_layers is None and last_stage_layers is None:
+            return config
+        if all(f"model.{field_name}" in override_fields for field_name in stage_fields):
+            return config
+        middle_stage_count = model.pipeline_model_parallel_size - sum(
+            stage_layers is not None for stage_layers in (first_stage_layers, last_stage_layers)
+        )
+        middle_layer_count = model.num_layers - sum(
+            stage_layers or 0 for stage_layers in (first_stage_layers, last_stage_layers)
+        )
+        stages_are_compatible = (
+            middle_stage_count >= 0
+            and middle_layer_count >= 0
+            and bool(middle_stage_count) == bool(middle_layer_count)
+            and (middle_stage_count == 0 or middle_layer_count % middle_stage_count == 0)
+        )
+        if (
+            "model.pipeline_model_parallel_size" in override_fields
+            and getattr(model, "pipeline_model_parallel_layout", None) is None
+            and not stages_are_compatible
+        ):
+            for field_name in stage_fields:
+                if hasattr(model, field_name) and f"model.{field_name}" not in override_fields:
+                    setattr(model, field_name, None)
         return config
 
     model.pipeline_model_parallel_layout = layout_builder(

--- a/tests/unit_tests/scripts/training/test_recipe_runner.py
+++ b/tests/unit_tests/scripts/training/test_recipe_runner.py
@@ -294,6 +294,83 @@ def test_sync_model_pipeline_layout_preserves_explicit_layout_override(recipe_ru
     layout_builder.assert_not_called()
 
 
+def test_sync_model_pipeline_layout_repartitions_layers_after_pp_override(recipe_runner: ModuleType) -> None:
+    """A standalone public PP override must not retain recipe-default uneven stages."""
+    config = SimpleNamespace(
+        model=SimpleNamespace(
+            num_layers=46,
+            pipeline_model_parallel_size=2,
+            virtual_pipeline_model_parallel_size=None,
+            pipeline_model_parallel_layout=None,
+            num_layers_in_first_pipeline_stage=11,
+            num_layers_in_last_pipeline_stage=11,
+            account_for_embedding_in_pipeline_split=False,
+            account_for_loss_in_pipeline_split=False,
+        )
+    )
+
+    recipe_runner.sync_model_pipeline_layout(
+        config,
+        cli_overrides=["model.pipeline_model_parallel_size=2"],
+    )
+
+    assert (
+        config.model.num_layers_in_first_pipeline_stage,
+        config.model.num_layers_in_last_pipeline_stage,
+    ) == (None, None)
+
+
+def test_sync_model_pipeline_layout_preserves_explicit_uneven_stages(recipe_runner: ModuleType) -> None:
+    """Explicit stage-count overrides take precedence over automatic repartitioning."""
+    config = SimpleNamespace(
+        model=SimpleNamespace(
+            pipeline_model_parallel_size=2,
+            virtual_pipeline_model_parallel_size=None,
+            pipeline_model_parallel_layout=None,
+            num_layers_in_first_pipeline_stage=11,
+            num_layers_in_last_pipeline_stage=35,
+        )
+    )
+
+    recipe_runner.sync_model_pipeline_layout(
+        config,
+        cli_overrides=[
+            "model.pipeline_model_parallel_size=2",
+            "model.num_layers_in_first_pipeline_stage=11",
+            "model.num_layers_in_last_pipeline_stage=35",
+        ],
+    )
+
+    assert (
+        config.model.num_layers_in_first_pipeline_stage,
+        config.model.num_layers_in_last_pipeline_stage,
+    ) == (11, 35)
+
+
+def test_sync_model_pipeline_layout_preserves_compatible_recipe_stages(recipe_runner: ModuleType) -> None:
+    """Restating a recipe's default PP size must preserve its compatible uneven stages."""
+    config = SimpleNamespace(
+        model=SimpleNamespace(
+            num_layers=46,
+            pipeline_model_parallel_size=4,
+            virtual_pipeline_model_parallel_size=None,
+            pipeline_model_parallel_layout=None,
+            num_layers_in_first_pipeline_stage=11,
+            num_layers_in_last_pipeline_stage=11,
+        )
+    )
+
+    recipe_runner.sync_model_pipeline_layout(
+        config,
+        cli_overrides=["model.pipeline_model_parallel_size=4"],
+    )
+
+    assert (
+        config.model.num_layers_in_first_pipeline_stage,
+        config.model.num_layers_in_last_pipeline_stage,
+    ) == (11, 11)
+
+
 @pytest.mark.parametrize(
     "dataset",
     [


### PR DESCRIPTION
## What changed

Changing the pipeline-parallel size through the common `-pp` recipe override now drops recipe-owned first/last stage counts only when those counts are incompatible with the resolved topology. Explicit edge-count overrides, compatible recipe defaults, custom layouts, and layout builders remain unchanged.

## User impact

Merged PR #5551 added uneven pipeline partitions for the GLM-4.5 text recipes. Those fixed counts remained after a standalone PP override. For example, `glm45_air_106b -pp 2` kept the PP4 recipe's 11/11 first/last counts, leaving 24 layers but zero middle stages. MCore then aborted configuration validation before training. The 355B recipes similarly retained 10/10 and left 72 layers unassigned at PP2.

The runner now checks the resolved uneven partition using the same middle-stage count and divisibility invariants enforced by MCore. When it is incompatible, only non-explicit recipe-owned edge counts are cleared so normal even partitioning can take over.

## Validation

Fail before the production fix:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/scripts/training tests/unit_tests/scripts/training/test_recipe_runner.py::test_sync_model_pipeline_layout_repartitions_layers_after_pp_override -q --tb=short

assert (11, 11) == (None, None)
1 failed
```

Pass after the fix:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/scripts/training tests/unit_tests/scripts/training/test_recipe_runner.py -q --tb=short
37 passed

uv run pre-commit run --all-files
Passed

git diff --check
Passed
```

The focused controls cover the PP2 repartition, explicit uneven counts, and an idempotent default PP4 override.

## Scope

This changes only recipe-runner synchronization for explicit PP overrides on layout-less models with incompatible uneven stage counts. No conversion API, dependency, CI workflow, MCore source, GPU execution, convergence, or performance behavior was changed or validated.
