### PR TITLE
feat(verification): add training TPS per GPU

### DIFF
--- a/examples/model_verification_cards/gemma-3-4b-it/card.yaml
+++ b/examples/model_verification_cards/gemma-3-4b-it/card.yaml
@@ -172,6 +172,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Megatron Bridge does not provide a public Gemma 3 VL 4B pretraining
         recipe. The available exact-model recipes cover SFT and PEFT, so a
@@ -197,10 +198,11 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Pending exact-revision CORD-v2 full-SFT verification with the public
         Gemma 3 VL 4B H100 recipe. The run must complete at least ten optimizer
-        steps with finite loss, no skipped or NaN iterations, all four metrics,
+        steps with finite loss, no skipped or NaN iterations, all five metrics,
         and a reloadable final full-model checkpoint.
 
   sft_export_inference:
@@ -228,6 +230,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Gemma 3 VL image-bidirectional attention uses dense local/global
         additive biases with FusedAttention. The provider rejects context
@@ -255,10 +258,11 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Pending exact-revision CORD-v2 LoRA verification with the public Gemma 3
         VL 4B H100 recipe. The run must complete at least ten optimizer steps
-        with finite loss, no skipped or NaN iterations, all four metrics, and a
+        with finite loss, no skipped or NaN iterations, all five metrics, and a
         reloadable adapter checkpoint.
 
   checkpoint_resume:
@@ -273,6 +277,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison: null
       expected_result: >
         Checkpoint-resume verification depends on a supported pretraining

--- a/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
+++ b/examples/model_verification_cards/gemma-4-26b-a4b-it/card.yaml
@@ -172,6 +172,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Megatron Bridge does not publish a pretraining recipe for this Gemma 4
         conditional-generation variant; the current model package provides SFT
@@ -199,6 +200,7 @@ items:
         final_loss: 0.09127883
         last_10_steps_step_time_ms_avg: 15936.25
         last_10_steps_model_tflops_per_gpu_avg: 32.20
+        last_10_steps_tokens_per_second_per_gpu_avg: 1028.096
         peak_allocated_memory_gib: 65.223
         peak_reserved_memory_gib: 72.356
       expected_result: >
@@ -244,11 +246,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         No Gemma 4 VL long-context recipe or run was verified. A future
         workload must establish sequence-packing and context-parallel settings,
         complete at least 10 optimizer steps with finite loss and no skipped or
-        NaN iterations, report all four required metrics, and save a reloadable
+        NaN iterations, report all five required metrics, and save a reloadable
         final checkpoint.
 
   peft:
@@ -273,6 +276,7 @@ items:
         final_loss: 0.1072377
         last_10_steps_step_time_ms_avg: 14163.25
         last_10_steps_model_tflops_per_gpu_avg: 65.01
+        last_10_steps_tokens_per_second_per_gpu_avg: 2313.593
         peak_allocated_memory_gib: 44.252
         peak_reserved_memory_gib: 45.637
       expected_result: >
@@ -303,6 +307,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison: null
       expected_result: >
         Megatron Bridge does not provide a Gemma 4 VLM pretraining recipe, so

--- a/examples/model_verification_cards/glm5-2/card.yaml
+++ b/examples/model_verification_cards/glm5-2/card.yaml
@@ -177,6 +177,7 @@ items:
         final_loss: 6.385243
         last_10_steps_step_time_ms_avg: 31204.920
         last_10_steps_model_tflops_per_gpu_avg: 54.595
+        last_10_steps_tokens_per_second_per_gpu_avg: 190.926
       expected_result: >
         The uninterrupted 352-H100 TP1/PP11/CP1/EP32/ETP1 run completed 100
         real-data steps at GBS/MBS 1024/1 with cuDNN DSA, sparse indexer loss
@@ -216,6 +217,7 @@ items:
         final_loss: 6.523522
         last_10_steps_step_time_ms_avg: 64786.540
         last_10_steps_model_tflops_per_gpu_avg: 102.520
+        last_10_steps_tokens_per_second_per_gpu_avg: 337.189
       expected_result: >
         The 192-GB200 TP1/PP6/CP1/EP32/ETP1 run completed exactly 100
         RP2 head_01 pretraining steps at GBS/MBS 1024/1 with cuDNN DSA, sparse
@@ -254,6 +256,7 @@ items:
         final_loss: 0.6634203
         last_10_steps_step_time_ms_avg: 4436.290
         last_10_steps_model_tflops_per_gpu_avg: 10.154
+        last_10_steps_tokens_per_second_per_gpu_avg: 35.511
       expected_result: >
         The immutable-revision 416-H100 run completes exactly 100 full-SFT
         steps at TP1/PP13/CP2/EP32/ETP1, GBS/MBS 32/1, with cuDNN DSA, sparse
@@ -286,6 +289,7 @@ items:
         final_loss: 0.3682597
         last_10_steps_step_time_ms_avg: 8593.990
         last_10_steps_model_tflops_per_gpu_avg: 12.446
+        last_10_steps_tokens_per_second_per_gpu_avg: 39.718
       expected_result: >
         The immutable-revision 192-GB200 run completed exactly 100 full-SFT
         steps at TP1/PP6/CP4/EP32/ETP1, DP8, and GBS/MBS 8/1 without gradient
@@ -363,6 +367,7 @@ items:
         final_loss: 2.557671
         last_10_steps_step_time_ms_avg: 36603.370
         last_10_steps_model_tflops_per_gpu_avg: 39.648
+        last_10_steps_tokens_per_second_per_gpu_avg: 116.828
       expected_result: >
         The 608-H100 TP1/PP19/CP32/EP32/ETP1 run completed exactly 20 optimizer
         steps over 200,000-token packed rows with cuDNN DSA, sparse indexer loss
@@ -394,6 +399,7 @@ items:
         final_loss: 0.000511673
         last_10_steps_step_time_ms_avg: 143248.820
         last_10_steps_model_tflops_per_gpu_avg: 88.848
+        last_10_steps_tokens_per_second_per_gpu_avg: 266.874
       expected_result: >
         The immutable-revision 192-GB200 run completed exactly 20 optimizer
         steps at TP1/PP6/CP32/EP32/ETP1, DP1, and GBS/MBS 56/1 with cuDNN DSA,
@@ -427,6 +433,7 @@ items:
         final_loss: 0.8835775
         last_10_steps_step_time_ms_avg: 4638.550
         last_10_steps_model_tflops_per_gpu_avg: 19.423
+        last_10_steps_tokens_per_second_per_gpu_avg: 67.926
       expected_result: >
         The immutable-revision 208-H100 run completes exactly 100 LoRA steps at
         TP1/PP13/CP1/EP16/ETP1, GBS/MBS 32/1, with cuDNN DSA, sparse indexer
@@ -455,6 +462,7 @@ items:
         final_loss: 0.8957523
         last_10_steps_step_time_ms_avg: 68588.270
         last_10_steps_model_tflops_per_gpu_avg: 1.423
+        last_10_steps_tokens_per_second_per_gpu_avg: 4.977
       expected_result: >
         The immutable-revision 192-GB200 run completed exactly 100 LoRA steps
         at TP1/PP6/CP1/EP32/ETP1, GBS/MBS 32/1, with offline-packed Tulu 3
@@ -491,6 +499,7 @@ items:
         final_loss: 6.372624
         last_10_steps_step_time_ms_avg: 32002.290
         last_10_steps_model_tflops_per_gpu_avg: 53.235
+        last_10_steps_tokens_per_second_per_gpu_avg: 186.168
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -536,6 +545,7 @@ items:
         final_loss: 6.503141
         last_10_steps_step_time_ms_avg: 60079.390
         last_10_steps_model_tflops_per_gpu_avg: 110.552
+        last_10_steps_tokens_per_second_per_gpu_avg: 363.608
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]

--- a/examples/model_verification_cards/glm5/card.yaml
+++ b/examples/model_verification_cards/glm5/card.yaml
@@ -139,9 +139,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A public GLM-5 H100 recipe must complete a bounded 100-step run with
-        finite loss, no skipped or NaN iterations, all four metrics, and a
+        finite loss, no skipped or NaN iterations, all five metrics, and a
         reloadable final checkpoint. Training is deferred by this card.
 
   sft:
@@ -156,9 +157,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A pinned-data 100-step full-SFT run must finish with finite loss, no
-        skipped or NaN iterations, all four metrics, and a reloadable final
+        skipped or NaN iterations, all five metrics, and a reloadable final
         checkpoint. Training is deferred by this card.
 
   sft_export_inference:
@@ -185,9 +187,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A dedicated packed long-context SFT run must complete a bounded run
-        with finite loss, no skipped or NaN iterations, all four metrics, and
+        with finite loss, no skipped or NaN iterations, all five metrics, and
         a reloadable checkpoint. Training is deferred by this card.
 
   peft:
@@ -202,9 +205,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A GLM-5 PEFT recipe with an audited adapter target set must complete a
-        bounded run with finite loss, all four metrics, and a reloadable
+        bounded run with finite loss, all five metrics, and a reloadable
         adapter checkpoint. Training is deferred by this card.
 
   checkpoint_resume:
@@ -219,6 +223,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]

--- a/examples/model_verification_cards/gpt-oss-20b/card.yaml
+++ b/examples/model_verification_cards/gpt-oss-20b/card.yaml
@@ -173,11 +173,12 @@ items:
         final_loss: 5.725391
         last_10_steps_step_time_ms_avg: 22400.880
         last_10_steps_model_tflops_per_gpu_avg: 117.010
+        last_10_steps_tokens_per_second_per_gpu_avg: 5851.199
       expected_result: >
         On 16x H100, the command completes exactly 100 bounded pretraining
         optimizer steps. All 100 optimizer-step rows are present exactly once
         with finite loss, zero skipped iterations, and zero NaN iterations.
-        Loss decreases from 10.90364 to 5.725391, all four metrics are
+        Loss decreases from 10.90364 to 5.725391, all five metrics are
         recorded, the post-setup run_config.yaml persists, and complete
         16-shard iter_0000050 and iter_0000100 checkpoints are saved with
         metadata, train state, tokenizer artifacts, and latest-checkpoint
@@ -215,13 +216,14 @@ items:
         final_loss: 0.758708
         last_10_steps_step_time_ms_avg: 6618.850
         last_10_steps_model_tflops_per_gpu_avg: 109.050
+        last_10_steps_tokens_per_second_per_gpu_avg: 4950.709
       expected_result: >
         On 8x H100, the command completes exactly 100 full-SFT optimizer steps
         from the imported GPT-OSS 20B checkpoint with immutable Tulu3 data
         selection, assistant-token loss masking, and offline packing. All 100
         optimizer-step rows are present exactly once with finite loss, zero
         skipped iterations, and zero NaN iterations. Loss decreases from
-        2.130852 to 0.758708, all four metrics are recorded, packing is 98.56%
+        2.130852 to 0.758708, all five metrics are recorded, packing is 98.56%
         efficient, and a complete 8-shard iter_0000100 full-model checkpoint is
         saved with metadata, train state, tokenizer artifacts, and
         latest-checkpoint markers.
@@ -298,6 +300,7 @@ items:
         final_loss: 1.175326
         last_10_steps_step_time_ms_avg: 306108.170
         last_10_steps_model_tflops_per_gpu_avg: 13.430
+        last_10_steps_tokens_per_second_per_gpu_avg: 428.189
       expected_result: >
         Completed 20 optimizer steps using the 32K SFT recipe, immutable Tulu3
         data selection, offline packing, TP4, CP2, sequence parallelism,
@@ -339,6 +342,7 @@ items:
         final_loss: 1.075515
         last_10_steps_step_time_ms_avg: 50689.940
         last_10_steps_model_tflops_per_gpu_avg: 113.240
+        last_10_steps_tokens_per_second_per_gpu_avg: 5171.519
       expected_result: >
         On 1x H100, the command completes exactly 100 LoRA PEFT optimizer steps
         from the imported GPT-OSS 20B checkpoint with the base model frozen,
@@ -347,7 +351,7 @@ items:
         assistant-token loss masking, and offline packing. All 100
         optimizer-step rows are present exactly once with finite loss, zero
         skipped iterations, and zero NaN iterations. Loss decreases from
-        2.129699 to 1.075515, all four metrics are recorded, packing is 98.56%
+        2.129699 to 1.075515, all five metrics are recorded, packing is 98.56%
         efficient, and a complete single-shard iter_0000100 adapter checkpoint
         is saved with metadata, train state, run_config.yaml, and
         latest-checkpoint markers.
@@ -381,6 +385,7 @@ items:
         final_loss: 5.725306
         last_10_steps_step_time_ms_avg: 22130.160
         last_10_steps_model_tflops_per_gpu_avg: 118.420
+        last_10_steps_tokens_per_second_per_gpu_avg: 5922.777
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]

--- a/examples/model_verification_cards/k-exaone-2/card.yaml
+++ b/examples/model_verification_cards/k-exaone-2/card.yaml
@@ -162,10 +162,11 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The exported 512-GPU H100 recipe must complete a bounded public-data
         pretraining run at TP4/PP16/EP32 with natural routing, finite loss, no
-        skipped or NaN iterations, all four required metrics, and reloadable
+        skipped or NaN iterations, all five required metrics, and reloadable
         middle and final checkpoints.
 
   sft:
@@ -180,6 +181,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The exported 512-GPU H100 full-SFT recipe must load the pinned
         checkpoint and complete a bounded immutable-dataset run at
@@ -211,11 +213,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         No long-context SFT result is claimed. Future verification must first
         resolve a supported long-context topology, then verify sequence
         packing and context parallelism together with finite loss, no skipped
-        or NaN iterations, and all four required metrics.
+        or NaN iterations, and all five required metrics.
 
   peft:
     H100:
@@ -229,11 +232,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The exported 128-GPU H100 PEFT recipe must load the pinned checkpoint,
         verify that LoRA targets the model-native attention projections, and
         complete a bounded immutable-dataset run at TP4/PP8/EP16 with finite
-        loss, no skipped or NaN iterations, all four required metrics, and a
+        loss, no skipped or NaN iterations, all five required metrics, and a
         reloadable adapter checkpoint.
 
   checkpoint_resume:
@@ -248,6 +252,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]

--- a/examples/model_verification_cards/kimi-k3/card.yaml
+++ b/examples/model_verification_cards/kimi-k3/card.yaml
@@ -145,11 +145,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Training was intentionally excluded from this model-only verification
         pass. A future public Kimi K3 language-backbone recipe must complete a
         bounded 100-step pretrain run with finite loss, no skipped or NaN
-        iterations, all four metrics, and a reloadable final checkpoint.
+        iterations, all five metrics, and a reloadable final checkpoint.
 
   sft:
     GB300:
@@ -163,11 +164,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Training was intentionally excluded from this model-only verification
         pass. A future public Kimi K3 language-backbone recipe must complete a
         pinned-data 100-step full-SFT run with finite loss, no skipped or NaN
-        iterations, all four metrics, and a reloadable final checkpoint.
+        iterations, all five metrics, and a reloadable final checkpoint.
 
   sft_export_inference:
     GB300:
@@ -194,11 +196,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Training was intentionally excluded from this model-only verification
         pass. A future public long-context SFT recipe must define supported
         sequence packing and context parallelism, complete 100 steps with finite
-        loss and no skipped or NaN iterations, and record all four metrics.
+        loss and no skipped or NaN iterations, and record all five metrics.
 
   peft:
     GB300:
@@ -212,11 +215,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Training was intentionally excluded from this model-only verification
         pass. A future Kimi K3 PEFT recipe with an audited adapter target set
         must complete 100 steps with finite loss, no skipped or NaN iterations,
-        all four metrics, and a reloadable adapter checkpoint.
+        all five metrics, and a reloadable adapter checkpoint.
 
   checkpoint_resume:
     GB300:
@@ -230,6 +234,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]

--- a/examples/model_verification_cards/minimax-m3/card.yaml
+++ b/examples/model_verification_cards/minimax-m3/card.yaml
@@ -182,6 +182,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Complete a 100-step HybridEP language-backbone run with finite loss,
         reported metrics, and a reloadable checkpoint.
@@ -200,6 +201,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Complete a 100-step packed HybridEP language-backbone SFT run with
         finite loss, reported metrics, and a reloadable checkpoint.
@@ -232,10 +234,11 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A dedicated packed long-context recipe must complete 100 steps with
         context parallelism, finite loss, no skipped or NaN iterations, and all
-        four metrics. Beyond 2,048 tokens, Bridge uses full causal attention
+        five metrics. Beyond 2,048 tokens, Bridge uses full causal attention
         instead of MiniMax-M3's lightning-indexer sparse attention.
 
   peft:
@@ -250,6 +253,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A MiniMax-M3 PEFT recipe with an audited adapter target set must complete
         100 steps with finite loss, no skipped or NaN iterations, all four
@@ -267,6 +271,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]

--- a/examples/model_verification_cards/moonlight-16b-a3b/card.yaml
+++ b/examples/model_verification_cards/moonlight-16b-a3b/card.yaml
@@ -171,13 +171,14 @@ items:
         final_loss: 5.158420
         last_10_steps_step_time_ms_avg: 11636.350
         last_10_steps_model_tflops_per_gpu_avg: 386.590
+        last_10_steps_tokens_per_second_per_gpu_avg: 22528.026
       expected_result: >
         The uninterrupted 16-GPU bounded RP2 run completes exactly 100 steps at
         TP1/PP1/CP1/EP8/ETP1, DP16, GBS/MBS 1024/2, and 32-way gradient
         accumulation with natural MoE routing and the HybridEP flex dispatcher.
         It reaches peak learning rate at step 40 and completes cosine decay at
         step 100. LM loss is finite from 12.43248 to 5.158420 with no skipped or
-        NaN iterations, all four metrics are recorded, the post-setup
+        NaN iterations, all five metrics are recorded, the post-setup
         configuration persists, and complete 16-shard iter_0000050 and
         iter_0000100 checkpoints are saved.
 
@@ -215,6 +216,7 @@ items:
         final_loss: 1.180197
         last_10_steps_step_time_ms_avg: 562.140
         last_10_steps_model_tflops_per_gpu_avg: 229.500
+        last_10_steps_tokens_per_second_per_gpu_avg: 14572.882
       expected_result: >
         The immutable-revision 8-GPU run completes exactly 100 full-SFT steps at
         TP1/PP1/CP1/EP8/ETP1, DP8, SP off, GBS/MBS 8/1, and no gradient
@@ -223,7 +225,7 @@ items:
         pad-1 offline packing is 99.73% efficient and averages 21.550 source
         sequences per pack while retaining 6,553,600 token slots across the
         100 updates. LM loss is finite from 1.770799 to 1.180197 with no skipped
-        or NaN iterations, all four metrics are recorded, and the complete
+        or NaN iterations, all five metrics are recorded, and the complete
         eight-shard iter_0000100 full-model checkpoint saves successfully.
 
   sft_export_inference:
@@ -293,6 +295,7 @@ items:
         final_loss: 1.228019
         last_10_steps_step_time_ms_avg: 60599.310
         last_10_steps_model_tflops_per_gpu_avg: 40.840
+        last_10_steps_tokens_per_second_per_gpu_avg: 2162.929
       expected_result: >
         The immutable-revision 8-GPU run completes exactly 20 Tulu3 SFT steps at
         the model's 8192-token context limit with recipe-owned
@@ -332,6 +335,7 @@ items:
         final_loss: 1.100755
         last_10_steps_step_time_ms_avg: 3822.840
         last_10_steps_model_tflops_per_gpu_avg: 67.380
+        last_10_steps_tokens_per_second_per_gpu_avg: 4285.819
       expected_result: >
         The immutable-revision 4-GPU run completes exactly 100 PEFT steps at
         TP1/PP1/CP1/EP4/ETP1, DP4, SP off, GBS/MBS 32/1, and eight-way gradient
@@ -340,7 +344,7 @@ items:
         masking. Only rank-8, alpha-16, zero-dropout LoRA on linear_q_proj,
         linear_kv_down_proj, linear_kv_up_proj, and linear_proj is trainable. LM
         loss is finite from 1.264324 to 1.100755 with no skipped or NaN
-        iterations, all four metrics are recorded, and the complete four-shard
+        iterations, all five metrics are recorded, and the complete four-shard
         iter_0000100 adapter checkpoint covers all 216 expected adapter entries.
 
   checkpoint_resume:
@@ -375,6 +379,7 @@ items:
         final_loss: 5.150805
         last_10_steps_step_time_ms_avg: 11717.960
         last_10_steps_model_tflops_per_gpu_avg: 383.920
+        last_10_steps_tokens_per_second_per_gpu_avg: 22371.129
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -387,7 +392,7 @@ items:
         finishes exactly at step 100 in a distinct output root at
         TP1/PP1/CP1/EP8/ETP1, DP16, GBS/MBS 1024/2, and 32-way gradient
         accumulation. All 50 losses are finite with no skipped or NaN
-        iterations, all four metrics are recorded, the post-setup configuration
+        iterations, all five metrics are recorded, the post-setup configuration
         persists, and a complete 16-shard iter_0000100 checkpoint is saved.
         Step-51 resumed/reference loss is 5.775853/5.775853. Step-100
         resumed/reference loss is 5.150805/5.158420, an absolute difference of

--- a/examples/model_verification_cards/nemotron-3-nano-4b/card.yaml
+++ b/examples/model_verification_cards/nemotron-3-nano-4b/card.yaml
@@ -161,9 +161,10 @@ items:
         final_loss: 5.511951
         last_10_steps_step_time_ms_avg: 26775.11
         last_10_steps_model_tflops_per_gpu_avg: 402.51
+        last_10_steps_tokens_per_second_per_gpu_avg: 19581.171
       expected_result: >
         The uninterrupted bounded random-initialization RP2 reference finishes
-        all 100 steps at recipe-owned GBS/MBS 1024/1 with the four recorded
+        all 100 steps at recipe-owned GBS/MBS 1024/1 with the five recorded
         metrics, finite loss, and no skipped or NaN iterations. It reaches peak
         learning rate 3e-4 at step 40 and completes cosine decay to 3e-5 at step
         100. Both iter_0000050 and iter_0000100 contain all eight distributed
@@ -201,6 +202,7 @@ items:
         final_loss: 1.234906
         last_10_steps_step_time_ms_avg: 627.0
         last_10_steps_model_tflops_per_gpu_avg: 262.89
+        last_10_steps_tokens_per_second_per_gpu_avg: 13065.391
       expected_result: >
         Pad-1 offline packing is 99.27% efficient. The TP1/DP8 run uses four
         microbatches per optimizer step and completes all 100 steps with the four
@@ -272,10 +274,11 @@ items:
         final_loss: 1.100197
         last_10_steps_step_time_ms_avg: 5575.59
         last_10_steps_model_tflops_per_gpu_avg: 142.06
+        last_10_steps_tokens_per_second_per_gpu_avg: 5877.046
       expected_result: >
         Pad-4 offline packing is 99.35% efficient. The TP2/CP2/SP-on/DP2 run uses
         four microbatches per optimizer step and completes all 100 32K steps with
-        the four recorded metrics, finite loss, and no skipped or NaN iterations.
+        the five recorded metrics, finite loss, and no skipped or NaN iterations.
         Across 26,214,400 token slots, assistant-only loss masks contain
         16,734,347 supervised tokens. The complete eight-shard iter_0000100
         checkpoint is saved and reloads at the same topology.
@@ -310,6 +313,7 @@ items:
         final_loss: 1.256916
         last_10_steps_step_time_ms_avg: 381.69
         last_10_steps_model_tflops_per_gpu_avg: 431.90
+        last_10_steps_tokens_per_second_per_gpu_avg: 21462.443
       expected_result: >
         Pad-4 offline packing is 99.36% efficient. The frozen-base LoRA run uses
         rank 8, alpha 16, zero dropout, and linear_qkv/linear_proj targets. Its
@@ -349,6 +353,7 @@ items:
         final_loss: 5.512038
         last_10_steps_step_time_ms_avg: 26943.07
         last_10_steps_model_tflops_per_gpu_avg: 400.11
+        last_10_steps_tokens_per_second_per_gpu_avg: 19459.104
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -358,7 +363,7 @@ items:
       expected_result: >
         The continuation restores optimizer, scheduler, data-order, and RNG state
         directly from iter_0000050 and executes exactly steps 51 through 100 into
-        a distinct output root with the four recorded metrics, finite loss, and
+        a distinct output root with the five recorded metrics, finite loss, and
         no skipped or NaN iterations. Step 51 matches the uninterrupted reference
         exactly at 6.173212. At step 100, resumed loss 5.512038 differs from
         reference loss 5.511951 by 0.000087 (0.00158%), inside the declared 1%

--- a/examples/model_verification_cards/nemotron-3-nano-omni-30b-a3b-reasoning/card.yaml
+++ b/examples/model_verification_cards/nemotron-3-nano-omni-30b-a3b-reasoning/card.yaml
@@ -170,6 +170,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         Megatron Bridge does not publish a pretraining recipe for this
         multimodal conditional-generation model; the supported package provides
@@ -202,6 +203,7 @@ items:
         final_loss: 0.4893276
         last_10_steps_step_time_ms_avg: 24454.11
         last_10_steps_model_tflops_per_gpu_avg: 60.73
+        last_10_steps_tokens_per_second_per_gpu_avg: 669.990
       expected_result: >
         The immutable-revision CORD v2 run completes exactly 10 full-SFT
         optimizer steps on 16 H100 GPUs at TP2/PP2/CP1/EP4/ETP1, GBS/MBS
@@ -270,6 +272,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The 8K TP4/PP1/CP2/EP1/ETP4, MBS2 in-batch-packing run uses
         precision-aware Adam with FP16 main parameters and stored FP32
@@ -303,6 +306,7 @@ items:
         final_loss: 0.3166811
         last_10_steps_step_time_ms_avg: 41897.41
         last_10_steps_model_tflops_per_gpu_avg: 22.22
+        last_10_steps_tokens_per_second_per_gpu_avg: 782.101
       expected_result: >
         The ten-step TP4/PP1/CP1/EP1 LoRA run exits successfully and saves a
         complete eight-shard iter_0000010 adapter checkpoint. LM loss is finite
@@ -322,6 +326,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison: null
       expected_result: >
         There is no supported pretraining reference workflow for this model, so

--- a/examples/model_verification_cards/nemotron-3-super-120b-a12b/card.yaml
+++ b/examples/model_verification_cards/nemotron-3-super-120b-a12b/card.yaml
@@ -178,6 +178,7 @@ items:
         final_loss: 5.706429
         last_10_steps_step_time_ms_avg: 29368.690
         last_10_steps_model_tflops_per_gpu_avg: 236.330
+        last_10_steps_tokens_per_second_per_gpu_avg: 2789.365
       expected_result: >
         On exactly 64 H100s, the BF16 support run completes 100 bounded RP2
         optimizer steps at TP1/PP2/CP1/EP32/ETP1, GBS/MBS 1280/1, natural
@@ -222,6 +223,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         On 16 GB200s, the BF16 support run must complete exactly 100 bounded RP2
         optimizer steps at TP8/PP1/CP1/EP16/ETP1 and the recipe's cohort
@@ -271,6 +273,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The immutable-revision Tulu3 run must complete exactly 100 full-SFT steps
         on 16 H100s at sequence length 8192, TP8/EP16, the recipe's cohort
@@ -318,6 +321,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The immutable-revision Tulu3 run must complete exactly 100 full-SFT steps
         on 16 GB200s at sequence length 8192, TP8/EP16, the recipe's cohort
@@ -425,6 +429,7 @@ items:
         final_loss: 1.008992
         last_10_steps_step_time_ms_avg: 132859.580
         last_10_steps_model_tflops_per_gpu_avg: 5.580
+        last_10_steps_tokens_per_second_per_gpu_avg: 30.830
       expected_result: >
         On 16 H100s, the dedicated TP1/PP8/CP2/EP2 recipe completes exactly
         ten packed 32K SFT steps with pad-4 alignment, full recompute, and full
@@ -457,9 +462,10 @@ items:
         final_loss: 6.406034
         last_10_steps_step_time_ms_avg: 21544.740
         last_10_steps_model_tflops_per_gpu_avg: 15.930
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A dedicated GB200 run must complete at least ten packed 32K SFT steps
-        with CP2, finite loss, no skipped or NaN iterations, all four metrics,
+        with CP2, finite loss, no skipped or NaN iterations, all five metrics,
         a persisted resolved configuration, and a reloadable final checkpoint.
 
   peft:
@@ -496,6 +502,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         H100 training has completed 100 finite LoRA steps and saved an adapter,
         but this leaf remains unverified until the exported adapter reloads
@@ -536,10 +543,11 @@ items:
         final_loss: 0.8878498
         last_10_steps_step_time_ms_avg: 12699.460
         last_10_steps_model_tflops_per_gpu_avg: 54.120
+        last_10_steps_tokens_per_second_per_gpu_avg: 645.067
       expected_result: >
         On 16 GB200s, the immutable-revision Tulu3 run completes exactly 100
         pad-8 packed LoRA steps with finite loss from 1.23861 to 0.8878498, no
-        skipped or NaN iterations, all four metrics, and a final adapter
+        skipped or NaN iterations, all five metrics, and a final adapter
         checkpoint. The adapter contains only 82,304 LoRA tensors targeting
         linear_qkv, linear_proj, linear_fc1, linear_fc2, in_proj, and out_proj.
         Native PEFT reload over the pinned base succeeds; all logits are finite
@@ -581,11 +589,12 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A direct H100 continuation must restore model, optimizer, scheduler,
         data-order, and RNG state from iter_0000050, execute exactly steps
         51-100 into a distinct output root, match both declared loss sentinels,
-        record all four metrics, and save a complete iter_0000100 checkpoint.
+        record all five metrics, and save a complete iter_0000100 checkpoint.
 
     GB200:
       status: unverified
@@ -626,6 +635,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The direct GB200 continuation must restore full model, optimizer,
         scheduler, data-order, and RNG state from iter_0000050 and execute
@@ -652,6 +662,7 @@ items:
         final_loss: 0.006422824
         last_10_steps_step_time_ms_avg: 27588.580
         last_10_steps_model_tflops_per_gpu_avg: 248.610
+        last_10_steps_tokens_per_second_per_gpu_avg: 2969.345
       expected_result: >
         On exactly 64 H100s, the canonical BF16 performance recipe must
         complete 50 mock-data steps at TP1/PP2/CP1/EP32/ETP1, GBS/MBS 1280/1,
@@ -680,6 +691,7 @@ items:
         final_loss: 0.01120061
         last_10_steps_step_time_ms_avg: 9926.350
         last_10_steps_model_tflops_per_gpu_avg: 559.390
+        last_10_steps_tokens_per_second_per_gpu_avg: 3301.113
       expected_result: >
         On exactly 64 GB200s, the canonical BF16 performance recipe completes
         50 mock-data steps at TP2/PP1/CP1/EP64, GBS/MBS 512/1, HybridEP flex

--- a/examples/model_verification_cards/nemotron-3.5-lightning/card.yaml
+++ b/examples/model_verification_cards/nemotron-3.5-lightning/card.yaml
@@ -180,6 +180,7 @@ items:
         last_10_steps_step_time_ms_avg: 36869.270
         # Real RP2 convergence-verification run, not a mock-data benchmark.
         last_10_steps_model_tflops_per_gpu_avg: 200.180
+        last_10_steps_tokens_per_second_per_gpu_avg: 7110.095
         peak_allocated_memory_gib: 68.547
         peak_reserved_memory_gib: 73.893
       expected_result: >
@@ -218,6 +219,7 @@ items:
         last_10_steps_step_time_ms_avg: 21483.630
         # Real RP2 convergence-verification run, not a mock-data benchmark.
         last_10_steps_model_tflops_per_gpu_avg: 686.920
+        last_10_steps_tokens_per_second_per_gpu_avg: 24404.070
         peak_allocated_memory_gib: 158.220
         peak_reserved_memory_gib: 162.290
       expected_result: >
@@ -265,6 +267,7 @@ items:
             last_10_steps_step_time_ms_avg: 26665.830
             # Real RP2 convergence-verification run, not a mock-data benchmark.
             last_10_steps_model_tflops_per_gpu_avg: 553.430
+            last_10_steps_tokens_per_second_per_gpu_avg: 19661.417
             peak_allocated_memory_gib: 160.760
             peak_reserved_memory_gib: 166.230
           expected_result: >
@@ -302,6 +305,7 @@ items:
             last_10_steps_step_time_ms_avg: 13917.000
             # Mock-data performance run; not a convergence measurement.
             last_10_steps_model_tflops_per_gpu_avg: 795.390
+            last_10_steps_tokens_per_second_per_gpu_avg: 28254.365
             peak_allocated_memory_gib: 169.54
             peak_reserved_memory_gib: 173.86
           expected_result: >
@@ -334,6 +338,7 @@ items:
         final_loss: 0.2757806
         last_10_steps_step_time_ms_avg: 9887.800
         last_10_steps_model_tflops_per_gpu_avg: 79.240
+        last_10_steps_tokens_per_second_per_gpu_avg: 3313.983
       expected_result: >
         Packed OpenMathInstruct-2 full SFT completes 100 finite-loss steps with
         active MTP gradients, LM loss 0.4406566 -> 0.2757806, finite MTP-1
@@ -361,6 +366,7 @@ items:
         final_loss: 0.2762039
         last_10_steps_step_time_ms_avg: 6795.830
         last_10_steps_model_tflops_per_gpu_avg: 256.990
+        last_10_steps_tokens_per_second_per_gpu_avg: 9643.561
         peak_allocated_memory_gib: 101.510
         peak_reserved_memory_gib: 103.960
       expected_result: >
@@ -456,6 +462,7 @@ items:
         final_loss: 0.2650192
         last_10_steps_step_time_ms_avg: 40863.010
         last_10_steps_model_tflops_per_gpu_avg: 188.950
+        last_10_steps_tokens_per_second_per_gpu_avg: 6415.191
       expected_result: >
         Packed OpenMathInstruct-2 CP2 SFT completes exactly 100 finite-loss 32K
         steps with LM loss 0.4268321 -> 0.2650192 and MTP-1 loss 0.7322379 ->
@@ -502,6 +509,7 @@ items:
         final_loss: 0.2649925
         last_10_steps_step_time_ms_avg: 129692.530
         last_10_steps_model_tflops_per_gpu_avg: 119.030
+        last_10_steps_tokens_per_second_per_gpu_avg: 4042.546
       expected_result: >
         Packed OpenMathInstruct-2 CP2 SFT completes exactly 100 finite-loss 32K
         steps with LM loss 0.4268995 -> 0.2649925 and MTP-1 loss 0.7322624 ->
@@ -542,6 +550,7 @@ items:
         final_loss: 0.2854756
         last_10_steps_step_time_ms_avg: 16900.360
         last_10_steps_model_tflops_per_gpu_avg: 92.890
+        last_10_steps_tokens_per_second_per_gpu_avg: 3877.787
       expected_result: >
         Packed rank-32, alpha-32, zero-dropout LoRA completes 100 finite-loss
         steps with adapters on the MTP layers, LM loss 0.4406696 -> 0.2854756,
@@ -580,6 +589,7 @@ items:
         final_loss: 0.2855029
         last_10_steps_step_time_ms_avg: 19230.400
         last_10_steps_model_tflops_per_gpu_avg: 81.780
+        last_10_steps_tokens_per_second_per_gpu_avg: 3407.937
       expected_result: >
         Packed rank-32, alpha-32, zero-dropout LoRA completes 100 finite-loss
         steps with 48 rank-local adapter attachment records covering MTP
@@ -615,6 +625,7 @@ items:
         final_loss: 7.238846
         last_10_steps_step_time_ms_avg: 56671.640
         last_10_steps_model_tflops_per_gpu_avg: 176.630
+        last_10_steps_tokens_per_second_per_gpu_avg: 4625.665
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [11, 20]
@@ -658,6 +669,7 @@ items:
         final_loss: 5.796845
         last_10_steps_step_time_ms_avg: 22233.450
         last_10_steps_model_tflops_per_gpu_avg: 663.860
+        last_10_steps_tokens_per_second_per_gpu_avg: 23581.046
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -688,6 +700,7 @@ items:
         final_loss: 0.01217863
         last_10_steps_step_time_ms_avg: 18467.280
         last_10_steps_model_tflops_per_gpu_avg: 399.580
+        last_10_steps_tokens_per_second_per_gpu_avg: 14195.052
         peak_allocated_memory_gib: 72.066
         peak_reserved_memory_gib: 75.340
       expected_result: >
@@ -714,6 +727,7 @@ items:
         final_loss: 0.03325584
         last_10_steps_step_time_ms_avg: 18236.060
         last_10_steps_model_tflops_per_gpu_avg: 809.220
+        last_10_steps_tokens_per_second_per_gpu_avg: 28750.070
         peak_allocated_memory_gib: 156.850
         peak_reserved_memory_gib: 161.260
       expected_result: >

--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -170,13 +170,14 @@ items:
         final_loss: 6.139116
         last_10_steps_step_time_ms_avg: 30289.550
         last_10_steps_model_tflops_per_gpu_avg: 199.120
+        last_10_steps_tokens_per_second_per_gpu_avg: 8654.602
       expected_result: >
         On 16x H100, the public alias resolves to the 16-GPU recipe and completes
         exactly 100 bounded RP2 optimizer steps with TP1/PP1/CP1/EP16/ETP1,
         DP16, SP off, GBS/MBS 1024/1, and 64-way gradient accumulation. Natural
         routing, HybridEP, and Transformer Engine CUDA graphs for moe_router and
         moe_preprocess remain active. Loss is finite from 12.41145 to 6.139116
-        with no skipped or NaN iterations, all four metrics are recorded, and
+        with no skipped or NaN iterations, all five metrics are recorded, and
         complete iter_0000050 and iter_0000100 checkpoints are saved.
 
     GB200:
@@ -215,6 +216,7 @@ items:
         final_loss: 6.183484
         last_10_steps_step_time_ms_avg: 12362.340
         last_10_steps_model_tflops_per_gpu_avg: 487.880
+        last_10_steps_tokens_per_second_per_gpu_avg: 21205.047
       expected_result: >
         On 8x GB200, this support-verification workload completes exactly 100
         bounded RP2 optimizer steps with TP1/PP1/CP1/EP8/ETP1, DP8, SP off,
@@ -222,7 +224,7 @@ items:
         routing, HybridEP, Transformer Engine CUDA graphs for moe_router and
         moe_preprocess, communication overlap, functional safety checks, and
         MXFP8 parameter all-gather remain active. Loss is finite from 12.41293
-        to 6.183484 with no skipped or NaN iterations, all four metrics are
+        to 6.183484 with no skipped or NaN iterations, all five metrics are
         recorded, and complete eight-shard iter_0000050 and iter_0000100
         checkpoints are saved. Timing and throughput are support sanity checks,
         not cross-model convergence or tuned performance claims.
@@ -262,13 +264,14 @@ items:
         final_loss: 0.9030643
         last_10_steps_step_time_ms_avg: 1206.320
         last_10_steps_model_tflops_per_gpu_avg: 64.020
+        last_10_steps_tokens_per_second_per_gpu_avg: 3395.451
       expected_result: >
         The immutable-revision 16-GPU run completes exactly 100 full-SFT steps
         at TP1/PP1/CP1/EP16/ETP1, DP16, SP off, GBS/MBS 32/1, and two-way
         gradient accumulation with natural routing. Pad-1 offline packing is
         99.30% efficient, and the sampled 6,553,600 token slots contain
         4,350,004 supervised tokens after label masking. LM loss is finite from
-        1.704380 to 0.9030643 with no skipped or NaN iterations, all four metrics
+        1.704380 to 0.9030643 with no skipped or NaN iterations, all five metrics
         are recorded, and the complete sixteen-shard iter_0000100 full-model
         checkpoint reloads successfully.
 
@@ -342,6 +345,7 @@ items:
         final_loss: 1.468103
         last_10_steps_step_time_ms_avg: 142663.710
         last_10_steps_model_tflops_per_gpu_avg: 26.120
+        last_10_steps_tokens_per_second_per_gpu_avg: 459.374
       expected_result: >
         The immutable-revision 16-GPU run completes exactly 20 Tulu3 SFT steps at
         sequence length 32768 with TP8/PP1/CP2/EP8/SP-on, DeepEP, and explicit
@@ -387,6 +391,7 @@ items:
         final_loss: 1.113119
         last_10_steps_step_time_ms_avg: 22347.640
         last_10_steps_model_tflops_per_gpu_avg: 13.840
+        last_10_steps_tokens_per_second_per_gpu_avg: 733.142
       expected_result: >
         The immutable-revision 4-GPU run completes exactly 100 PEFT steps at
         TP4/PP1/CP1/EP4/ETP1, DP1, SP on, GBS/MBS 32/1, and 32-way gradient
@@ -395,7 +400,7 @@ items:
         4,332,480 supervised tokens after label masking. Only rank-8, alpha-16,
         zero-dropout LoRA on linear_qkv and linear_proj is trainable. LM loss is
         finite from 1.575987 to 1.113119 with no skipped or NaN iterations, all
-        four metrics are recorded, and the complete four-shard iter_0000100
+        five metrics are recorded, and the complete four-shard iter_0000100
         adapter checkpoint covers all 192 expected adapter entries.
 
   checkpoint_resume:
@@ -432,6 +437,7 @@ items:
         final_loss: 6.145390
         last_10_steps_step_time_ms_avg: 31142.650
         last_10_steps_model_tflops_per_gpu_avg: 193.640
+        last_10_steps_tokens_per_second_per_gpu_avg: 8417.524
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -445,7 +451,7 @@ items:
         unused cached memory after optimizer steps is execution-only. Step-51 loss
         6.989006 matches the uninterrupted reference exactly; step-100 loss
         6.145390 differs from reference 6.139116 by 0.102197%, within the declared
-        one-percent gate, so both sentinels match and all four metrics are recorded.
+        one-percent gate, so both sentinels match and all five metrics are recorded.
 
     GB200:
       status: verified
@@ -482,6 +488,7 @@ items:
         final_loss: 6.187264
         last_10_steps_step_time_ms_avg: 18694.970
         last_10_steps_model_tflops_per_gpu_avg: 322.620
+        last_10_steps_tokens_per_second_per_gpu_avg: 14022.167
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -496,7 +503,7 @@ items:
         iterations. Step-51 loss 6.774675 matches the uninterrupted reference
         exactly; step-100 loss 6.187264 differs from reference 6.183484 by
         0.061131%, within the declared one-percent gate. Both sentinels match,
-        all four metrics are recorded, and a complete iter_0000100 checkpoint
+        all five metrics are recorded, and a complete iter_0000100 checkpoint
         is saved.
 
   pretrain_performance:
@@ -514,10 +521,11 @@ items:
         final_loss: 8.145514
         last_10_steps_step_time_ms_avg: 20147.290
         last_10_steps_model_tflops_per_gpu_avg: 299.352
+        last_10_steps_tokens_per_second_per_gpu_avg: 13011.378
       expected_result: >
         On two nodes with 16x H100, the exact mock-data performance recipe
         completes exactly 50 steps with finite losses, no skipped or NaN
-        iterations, and all four metrics recorded. HybridEP permute fusion uses
+        iterations, and all five metrics recorded. HybridEP permute fusion uses
         32 SMs and 64-token combine chunks, expert-parallel communication
         overlap is active with delayed weight-gradient compute disabled, and
         Transformer Engine CUDA graph capture completes for all 48 graphable
@@ -538,10 +546,11 @@ items:
         final_loss: 8.112733
         last_10_steps_step_time_ms_avg: 6501.120
         last_10_steps_model_tflops_per_gpu_avg: 927.680
+        last_10_steps_tokens_per_second_per_gpu_avg: 40322.898
       expected_result: >
         On two nodes with 8x GB200, the exact mock-data performance recipe
         completes exactly 50 steps with finite losses, no skipped or NaN
-        iterations, and all four metrics recorded. The benchmark uses forced
+        iterations, and all five metrics recorded. The benchmark uses forced
         load balancing, HybridEP, MXFP8, and full-iteration CUDA graphs. Over
         steps 41-50, the run averages at most 7 seconds per step and at least
         900 model TFLOP/s/GPU.

--- a/examples/model_verification_cards/qwen3-8b/card.yaml
+++ b/examples/model_verification_cards/qwen3-8b/card.yaml
@@ -157,12 +157,13 @@ items:
         final_loss: 6.190218
         last_10_steps_step_time_ms_avg: 25070.320
         last_10_steps_model_tflops_per_gpu_avg: 512.700
+        last_10_steps_tokens_per_second_per_gpu_avg: 10456.348
       expected_result: >
         The uninterrupted 16-GPU bounded RP2 run completes exactly 100 steps at
         TP1/PP1/CP1, DP16, GBS/MBS 1024/1, and 64-way gradient accumulation. It
         reaches peak learning rate at step 40 and completes cosine decay at step
         100. LM loss is finite from 12.73617 to 6.190218 with no skipped or NaN
-        iterations, all four metrics are recorded, the post-setup configuration
+        iterations, all five metrics are recorded, the post-setup configuration
         persists, and complete 16-shard iter_0000050 and iter_0000100 checkpoints
         are saved.
 
@@ -197,6 +198,7 @@ items:
         final_loss: 0.9733383
         last_10_steps_step_time_ms_avg: 7424.240
         last_10_steps_model_tflops_per_gpu_avg: 101.630
+        last_10_steps_tokens_per_second_per_gpu_avg: 2206.825
       expected_result: >
         Immutable Tulu3 pad-1 offline packing is 99.30% efficient. Full SFT uses
         DP=1 with 32 gradient-accumulation steps and reaches step 100 with the four
@@ -268,6 +270,7 @@ items:
         final_loss: 1.490618
         last_10_steps_step_time_ms_avg: 71668.780
         last_10_steps_model_tflops_per_gpu_avg: 34.080
+        last_10_steps_tokens_per_second_per_gpu_avg: 457.214
       expected_result: >
         The immutable-revision 8-GPU run completes exactly 20 Tulu3 SFT steps at
         sequence length 32768 with recipe-owned TP4/PP1/CP2/SP-on, GBS/MBS 8/1,
@@ -307,10 +310,11 @@ items:
         final_loss: 1.170038
         last_10_steps_step_time_ms_avg: 7774.790
         last_10_steps_model_tflops_per_gpu_avg: 387.430
+        last_10_steps_tokens_per_second_per_gpu_avg: 8429.295
       expected_result: >
         Immutable Tulu3 pad-4 offline packing is 99.39% efficient. The 100 LoRA
         steps use DP=1 with 32 gradient-accumulation steps and complete with the
-        four recorded metrics, finite loss, and no skipped or NaN iterations.
+        five recorded metrics, finite loss, and no skipped or NaN iterations.
         Across 6,553,600 token slots, the sampled assistant-only loss masks
         contain 4,332,480 supervised tokens. The complete single-shard
         iter_0000100 adapter checkpoint is saved.
@@ -346,6 +350,7 @@ items:
         final_loss: 6.190785
         last_10_steps_step_time_ms_avg: 24995.610
         last_10_steps_model_tflops_per_gpu_avg: 514.240
+        last_10_steps_tokens_per_second_per_gpu_avg: 10487.602
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]
@@ -357,7 +362,7 @@ items:
         data-order, and RNG state from iter_0000050, begins at step 51, and
         finishes exactly at step 100 in a distinct output root at TP1/PP1/CP1,
         DP16, GBS/MBS 1024/1, and 64-way gradient accumulation. All 50 losses
-        are finite with no skipped or NaN iterations, all four metrics are
+        are finite with no skipped or NaN iterations, all five metrics are
         recorded, the post-setup configuration persists, and a complete
         16-shard iter_0000100 checkpoint is saved. Step-51 resumed/reference
         loss is 7.015641/7.015641. Step-100 resumed/reference loss is

--- a/examples/model_verification_cards/qwen3.6-35b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3.6-35b-a3b/card.yaml
@@ -204,6 +204,7 @@ items:
         final_loss: 2.261159
         last_10_steps_step_time_ms_avg: 330730.470
         last_10_steps_model_tflops_per_gpu_avg: 18.090
+        last_10_steps_tokens_per_second_per_gpu_avg: 792.621
       expected_result: >
         At the recorded bridge commit, this bounded projection-pretraining
         support run used the official DataComp download pipeline at repository
@@ -258,6 +259,7 @@ items:
         final_loss: 1.006886
         last_10_steps_step_time_ms_avg: 3268.140
         last_10_steps_model_tflops_per_gpu_avg: 57.690
+        last_10_steps_tokens_per_second_per_gpu_avg: 2506.625
       expected_result: >
         The exact 16-H100 command completed all 100 MedPix SFT steps at
         TP1/PP2/CP1/EP8/ETP1, MBS1/GBS32, natural expert routing, HybridEP,
@@ -295,6 +297,7 @@ items:
         final_loss: 0.9978729
         last_10_steps_step_time_ms_avg: 9899.640
         last_10_steps_model_tflops_per_gpu_avg: 38.180
+        last_10_steps_tokens_per_second_per_gpu_avg: 1655.010
       expected_result: >
         On 8x GB200, the shared Qwen3.5/Qwen3.6-VL functional recipe completed
         exactly 100 MedPix SFT steps at TP1/PP1/CP1/EP8/ETP1, MBS1/GBS32,
@@ -375,6 +378,7 @@ items:
         final_loss: 0.997894
         last_10_steps_step_time_ms_avg: 36847.110
         last_10_steps_model_tflops_per_gpu_avg: 84.830
+        last_10_steps_tokens_per_second_per_gpu_avg: 3557.185
       expected_result: >
         The pinned 32-H100 run completed exactly 20 full-SFT steps at
         TP1/PP4/CP2/EP8/ETP1, dense DP4 and expert DP1, MBS2/GBS512, and 64-way
@@ -422,6 +426,7 @@ items:
         final_loss: 1.270382
         last_10_steps_step_time_ms_avg: 1714.300
         last_10_steps_model_tflops_per_gpu_avg: 109.940
+        last_10_steps_tokens_per_second_per_gpu_avg: 4778.627
       expected_result: >
         The exact 16-H100 command completed all 100 MedPix LoRA steps at
         TP1/PP2/CP1/EP8/ETP1, MBS1/GBS32, natural expert routing, HybridEP,
@@ -459,6 +464,7 @@ items:
         final_loss: 1.254138
         last_10_steps_step_time_ms_avg: 5511.530
         last_10_steps_model_tflops_per_gpu_avg: 68.410
+        last_10_steps_tokens_per_second_per_gpu_avg: 2972.677
       expected_result: >
         On the same 8x GB200 topology and MedPix schedule as the controlled SFT
         item, LoRA completed exactly 100 finite steps with zero skipped or NaN
@@ -506,6 +512,7 @@ items:
         final_loss: 2.262711
         last_10_steps_step_time_ms_avg: 339600.710
         last_10_steps_model_tflops_per_gpu_avg: 17.650
+        last_10_steps_tokens_per_second_per_gpu_avg: 771.918
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [11, 20]
@@ -554,6 +561,7 @@ items:
         final_loss: 3.458849
         last_10_steps_step_time_ms_avg: 22271.220
         last_10_steps_model_tflops_per_gpu_avg: 135.610
+        last_10_steps_tokens_per_second_per_gpu_avg: 5885.264
       expected_result: >
         The exact 16-H100 command completed all 50 DataComp Energon steps at
         TP1/PP2/CP1/EP8/ETP1, a 16/24 language-layer pipeline split, and
@@ -583,6 +591,7 @@ items:
         final_loss: 3.166235
         last_10_steps_step_time_ms_avg: 26880.420
         last_10_steps_model_tflops_per_gpu_avg: 210.360
+        last_10_steps_tokens_per_second_per_gpu_avg: 9142.714
       expected_result: >
         On 8x GB200, the exact architecture-shared Qwen3.5/Qwen3.6-VL
         fixed-shape mock-data recipe completed 50 steps at

--- a/examples/model_verification_cards/step35-flash/card.yaml
+++ b/examples/model_verification_cards/step35-flash/card.yaml
@@ -180,9 +180,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         The public Step-3.5-Flash H100 recipe must complete a bounded 100-step
-        run with finite loss, no skipped or NaN iterations, all four metrics,
+        run with finite loss, no skipped or NaN iterations, all five metrics,
         and a reloadable final checkpoint. Training is deferred by this card.
 
   sft:
@@ -197,9 +198,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A pinned-data 100-step full-SFT run must finish with finite loss, no
-        skipped or NaN iterations, all four metrics, and a reloadable final
+        skipped or NaN iterations, all five metrics, and a reloadable final
         checkpoint. Training is deferred by this card.
 
   sft_export_inference:
@@ -226,9 +228,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A dedicated packed long-context SFT run must complete 100 steps with
-        finite loss, no skipped or NaN iterations, all four metrics, and a
+        finite loss, no skipped or NaN iterations, all five metrics, and a
         reloadable checkpoint. Training is deferred by this card.
 
   peft:
@@ -243,9 +246,10 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       expected_result: >
         A Step-3.5-Flash PEFT recipe with an audited adapter target set must
-        complete 100 steps with finite loss, all four metrics, and a reloadable
+        complete 100 steps with finite loss, all five metrics, and a reloadable
         adapter checkpoint. Training is deferred by this card.
 
   checkpoint_resume:
@@ -260,6 +264,7 @@ items:
         final_loss: null
         last_10_steps_step_time_ms_avg: null
         last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
       resume_comparison:
         reference_item: pretrain
         sentinel_steps: [51, 100]

--- a/skills/create-model-verification-card/SKILL.md
+++ b/skills/create-model-verification-card/SKILL.md
@@ -700,7 +700,18 @@ For every verified training item, record:
 - `final_loss`: loss at its final optimizer step;
 - `last_10_steps_step_time_ms_avg`: arithmetic mean over the final 10 executed
   optimizer steps;
-- `last_10_steps_model_tflops_per_gpu_avg`: arithmetic mean over the same rows.
+- `last_10_steps_model_tflops_per_gpu_avg`: arithmetic mean over the same rows;
+- `last_10_steps_tokens_per_second_per_gpu_avg`: token-slot throughput derived
+  from the same final-10-step average. Compute token slots per optimizer step as
+  `packed_sequence_size * global_batch_size` for packed training, or
+  `effective_seq_length * global_batch_size` otherwise, then divide by
+  `(last_10_steps_step_time_ms_avg / 1000) * total_gpus`.
+
+Use recipe-owned batch size and the resolved sequence or pack length, and
+derive `total_gpus` from the public command's positive node and GPU counts.
+Count total token slots, not supervised or loss-bearing tokens. This metric is
+training-only; do not add it to inference results. When a training leaf is not
+verified, record this metric as `null` alongside its other training metrics.
 
 Optionally record `peak_allocated_memory_gib` and
 `peak_reserved_memory_gib`. They are required on verified `pretrain_fsdp`
@@ -797,7 +808,7 @@ an item verified merely to make validation pass.
 - Keep private executor wiring out of commands: no mounts, environment
   forwarding, concrete accounts/partitions/images, or remote-launch setup.
 - Put every training result under its canonical public hardware key and include
-  all four metrics for each verified training leaf; never record a private
+  all five metrics for each verified training leaf; never record a private
   cluster name or retain the old `gpu_type` field.
 - Keep `verification_index` synchronized with `items`, omit empty status
   buckets, list every item name explicitly, and never use the scalar `all` in

--- a/skills/create-model-verification-card/scripts/validate_card.py
+++ b/skills/create-model-verification-card/scripts/validate_card.py
@@ -106,6 +106,7 @@ REQUIRED_METRIC_NAMES = frozenset(
         "final_loss",
         "last_10_steps_step_time_ms_avg",
         "last_10_steps_model_tflops_per_gpu_avg",
+        "last_10_steps_tokens_per_second_per_gpu_avg",
     }
 )
 OPTIONAL_METRIC_NAMES = frozenset({"peak_allocated_memory_gib", "peak_reserved_memory_gib"})
@@ -681,6 +682,7 @@ def _validate_metrics(
                 in {
                     "last_10_steps_step_time_ms_avg",
                     "last_10_steps_model_tflops_per_gpu_avg",
+                    "last_10_steps_tokens_per_second_per_gpu_avg",
                     "peak_allocated_memory_gib",
                     "peak_reserved_memory_gib",
                 }

--- a/tests/unit_tests/scripts/test_validate_model_verification_card.py
+++ b/tests/unit_tests/scripts/test_validate_model_verification_card.py
@@ -52,6 +52,7 @@ def _fsdp_metrics():
         "final_loss": 3.913218,
         "last_10_steps_step_time_ms_avg": 13917.0,
         "last_10_steps_model_tflops_per_gpu_avg": 795.39,
+        "last_10_steps_tokens_per_second_per_gpu_avg": 28254.365,
         "peak_allocated_memory_gib": 169.54,
         "peak_reserved_memory_gib": 173.86,
     }
@@ -227,6 +228,45 @@ def test_verified_fsdp_metrics_are_valid():
     )
 
     assert errors == []
+
+
+def test_verified_training_metrics_require_tps_per_gpu():
+    module = _load_validator()
+    item = {"metrics": _fsdp_metrics()}
+    del item["metrics"]["last_10_steps_tokens_per_second_per_gpu_avg"]
+    errors = []
+
+    module._validate_metrics(
+        item,
+        item_name="pretrain",
+        item_path=("items", "pretrain", "GB200"),
+        status="verified",
+        errors=errors,
+    )
+
+    assert (
+        "/items/pretrain/GB200/metrics/last_10_steps_tokens_per_second_per_gpu_avg: required key is missing" in errors
+    )
+
+
+def test_verified_fsdp_variant_requires_positive_tps_per_gpu():
+    module = _load_validator()
+    metrics = _fsdp_metrics()
+    metrics["last_10_steps_tokens_per_second_per_gpu_avg"] = 0
+    errors = []
+
+    module._validate_metrics(
+        {"metrics": metrics},
+        item_name="pretrain_fsdp",
+        item_path=("items", "pretrain_fsdp", "GB200", "variants", "fp8_mx"),
+        status="verified",
+        errors=errors,
+    )
+
+    assert (
+        "/items/pretrain_fsdp/GB200/variants/fp8_mx/metrics/"
+        "last_10_steps_tokens_per_second_per_gpu_avg: verified performance metrics must be positive"
+    ) in errors
 
 
 def test_fsdp_hardware_leaf_accepts_multiple_precision_variants():

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -8,11 +8,88 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 VALIDATOR_PATH = REPO_ROOT / "skills" / "create-model-verification-card" / "scripts" / "validate_card.py"
 pytestmark = pytest.mark.unit
+
+# Audited from recipe-owned GBS, the resolved card sequence or pack length, and
+# the public command topology: (sequence_or_pack_length, global_batch_size, GPUs).
+TRAINING_THROUGHPUT_INPUTS = {
+    ("gemma-4-26b-a4b-it", "sft", "H100"): (4096, 32, 8),
+    ("gemma-4-26b-a4b-it", "peft", "H100"): (4096, 32, 4),
+    ("glm5-2", "pretrain", "H100"): (2048, 1024, 352),
+    ("glm5-2", "pretrain", "GB200"): (4096, 1024, 192),
+    ("glm5-2", "sft", "H100"): (2048, 32, 416),
+    ("glm5-2", "sft", "GB200"): (8192, 8, 192),
+    ("glm5-2", "sft_long_context", "H100"): (200000, 13, 608),
+    ("glm5-2", "sft_long_context", "GB200"): (131072, 56, 192),
+    ("glm5-2", "peft", "H100"): (2048, 32, 208),
+    ("glm5-2", "peft", "GB200"): (2048, 32, 192),
+    ("glm5-2", "checkpoint_resume", "H100"): (2048, 1024, 352),
+    ("glm5-2", "checkpoint_resume", "GB200"): (4096, 1024, 192),
+    ("gpt-oss-20b", "pretrain", "H100"): (4096, 512, 16),
+    ("gpt-oss-20b", "sft", "H100"): (2048, 128, 8),
+    ("gpt-oss-20b", "sft_long_context", "H100"): (32768, 32, 8),
+    ("gpt-oss-20b", "peft", "H100"): (2048, 128, 1),
+    ("gpt-oss-20b", "checkpoint_resume", "H100"): (4096, 512, 16),
+    ("moonlight-16b-a3b", "pretrain", "H100"): (4096, 1024, 16),
+    ("moonlight-16b-a3b", "sft", "H100"): (8192, 8, 8),
+    ("moonlight-16b-a3b", "sft_long_context", "H100"): (8192, 128, 8),
+    ("moonlight-16b-a3b", "peft", "H100"): (2048, 32, 4),
+    ("moonlight-16b-a3b", "checkpoint_resume", "H100"): (4096, 1024, 16),
+    ("nemotron-3-nano-4b", "pretrain", "H100"): (4096, 1024, 8),
+    ("nemotron-3-nano-4b", "sft", "H100"): (2048, 32, 8),
+    ("nemotron-3-nano-4b", "sft_long_context", "H100"): (32768, 8, 8),
+    ("nemotron-3-nano-4b", "peft", "H100"): (2048, 32, 8),
+    ("nemotron-3-nano-4b", "checkpoint_resume", "H100"): (4096, 1024, 8),
+    ("nemotron-3-nano-omni-30b-a3b-reasoning", "sft", "H100"): (4096, 64, 16),
+    ("nemotron-3-nano-omni-30b-a3b-reasoning", "peft", "H100"): (4096, 64, 8),
+    ("nemotron-3-super-120b-a12b", "pretrain", "H100"): (4096, 1280, 64),
+    ("nemotron-3-super-120b-a12b", "sft_long_context", "H100"): (32768, 2, 16),
+    ("nemotron-3-super-120b-a12b", "peft", "GB200"): (8192, 16, 16),
+    ("nemotron-3-super-120b-a12b", "pretrain_performance", "H100"): (4096, 1280, 64),
+    ("nemotron-3-super-120b-a12b", "pretrain_performance", "GB200"): (4096, 512, 64),
+    ("nemotron-3.5-lightning", "pretrain", "H100"): (8192, 512, 16),
+    ("nemotron-3.5-lightning", "pretrain", "GB200"): (8192, 512, 8),
+    ("nemotron-3.5-lightning", "pretrain_fsdp", "GB200", "bf16"): (8192, 512, 8),
+    ("nemotron-3.5-lightning", "pretrain_fsdp", "GB200", "fp8_mx"): (8192, 384, 8),
+    ("nemotron-3.5-lightning", "sft", "H100"): (4096, 128, 16),
+    ("nemotron-3.5-lightning", "sft", "GB200"): (4096, 128, 8),
+    ("nemotron-3.5-lightning", "sft_long_context", "H100"): (32768, 128, 16),
+    ("nemotron-3.5-lightning", "sft_long_context", "GB200"): (32768, 128, 8),
+    ("nemotron-3.5-lightning", "peft", "H100"): (4096, 128, 8),
+    ("nemotron-3.5-lightning", "peft", "GB200"): (4096, 128, 8),
+    ("nemotron-3.5-lightning", "checkpoint_resume", "H100"): (8192, 512, 16),
+    ("nemotron-3.5-lightning", "checkpoint_resume", "GB200"): (8192, 512, 8),
+    ("nemotron-3.5-lightning", "pretrain_performance", "H100"): (8192, 512, 16),
+    ("nemotron-3.5-lightning", "pretrain_performance", "GB200"): (8192, 512, 8),
+    ("qwen3-30b-a3b", "pretrain", "H100"): (4096, 1024, 16),
+    ("qwen3-30b-a3b", "pretrain", "GB200"): (4096, 512, 8),
+    ("qwen3-30b-a3b", "sft", "H100"): (2048, 32, 16),
+    ("qwen3-30b-a3b", "sft_long_context", "H100"): (32768, 32, 16),
+    ("qwen3-30b-a3b", "peft", "H100"): (2048, 32, 4),
+    ("qwen3-30b-a3b", "checkpoint_resume", "H100"): (4096, 1024, 16),
+    ("qwen3-30b-a3b", "checkpoint_resume", "GB200"): (4096, 512, 8),
+    ("qwen3-30b-a3b", "pretrain_performance", "H100"): (4096, 1024, 16),
+    ("qwen3-30b-a3b", "pretrain_performance", "GB200"): (4096, 512, 8),
+    ("qwen3-8b", "pretrain", "H100"): (4096, 1024, 16),
+    ("qwen3-8b", "sft", "H100"): (2048, 32, 4),
+    ("qwen3-8b", "sft_long_context", "H100"): (32768, 8, 8),
+    ("qwen3-8b", "peft", "H100"): (2048, 32, 1),
+    ("qwen3-8b", "checkpoint_resume", "H100"): (4096, 1024, 16),
+    ("qwen3.6-35b-a3b", "pretrain", "H100"): (4096, 512, 8),
+    ("qwen3.6-35b-a3b", "sft", "H100"): (4096, 32, 16),
+    ("qwen3.6-35b-a3b", "sft", "GB200"): (4096, 32, 8),
+    ("qwen3.6-35b-a3b", "sft_long_context", "H100"): (8192, 512, 32),
+    ("qwen3.6-35b-a3b", "peft", "H100"): (4096, 32, 16),
+    ("qwen3.6-35b-a3b", "peft", "GB200"): (4096, 32, 8),
+    ("qwen3.6-35b-a3b", "checkpoint_resume", "H100"): (4096, 512, 8),
+    ("qwen3.6-35b-a3b", "pretrain_performance", "H100"): (4096, 512, 16),
+    ("qwen3.6-35b-a3b", "pretrain_performance", "GB200"): (4096, 480, 8),
+}
 
 
 def _load_validator():
@@ -21,6 +98,39 @@ def _load_validator():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_shipped_training_tps_matches_audited_token_slot_inputs():
+    validator = _load_validator()
+    verified_leaves = {}
+
+    for card_path in sorted((REPO_ROOT / "examples" / "model_verification_cards").glob("*/card.yaml")):
+        card = yaml.safe_load(card_path.read_text())
+        slug = card_path.parent.name
+        for item_name in validator.TRAINING_ITEMS:
+            for hardware, leaf in card["items"].get(item_name, {}).items():
+                if not isinstance(leaf, dict):
+                    continue
+                if "metrics" in leaf:
+                    if leaf.get("status") == "verified":
+                        verified_leaves[(slug, item_name, hardware)] = leaf
+                    else:
+                        assert leaf["metrics"]["last_10_steps_tokens_per_second_per_gpu_avg"] is None
+                for variant_name, variant in leaf.get("variants", {}).items():
+                    if variant.get("status") == "verified":
+                        verified_leaves[(slug, item_name, hardware, variant_name)] = variant
+                    else:
+                        assert variant["metrics"]["last_10_steps_tokens_per_second_per_gpu_avg"] is None
+
+    assert verified_leaves.keys() == TRAINING_THROUGHPUT_INPUTS.keys()
+    for leaf_key, (sequence_or_pack_length, global_batch_size, total_gpus) in TRAINING_THROUGHPUT_INPUTS.items():
+        metrics = verified_leaves[leaf_key]["metrics"]
+        token_slots_per_step = sequence_or_pack_length * global_batch_size
+        expected_tps_per_gpu = token_slots_per_step / (metrics["last_10_steps_step_time_ms_avg"] / 1000) / total_gpus
+
+        assert metrics["last_10_steps_tokens_per_second_per_gpu_avg"] == pytest.approx(
+            expected_tps_per_gpu, abs=0.0005
+        )
 
 
 def test_shipped_greedy_inference_cards_validate():


### PR DESCRIPTION
# What does this PR do ?

Add schema-consistent tokens-per-second-per-GPU metrics to every model verification card using existing card and recipe evidence only.

# Changelog

- Add `last_10_steps_tokens_per_second_per_gpu_avg` to all 17 model verification cards: derived positive values for 71 verified training leaves and `null` for 43 non-verified leaves.
- Document the token-slot formula and training-only constraints in the verification-card skill.
- Require finite positive TPS/GPU for verified training leaves in the validator, including FSDP precision variants.
- Add focused schema tests and a 71-leaf audited input table that recomputes TPS/GPU from sequence or pack length, recipe GBS, total GPUs, and recorded step time.

No workloads were rerun. Commands, statuses, losses, inference metrics, and evidence payloads are unchanged.

# GitHub Actions CI

CI should run after the exact-SHA `/ok to test` comment.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed Contributor guidelines
- [x] Added focused validator and arithmetic coverage
- [x] Updated the verification-card skill contract
- [x] Optional install components are unaffected

# Validation

- All 17 cards pass the bundled validator and parse as YAML.
- 19 skill-validator tests pass.
- 17 focused validator tests pass.
- `pre-commit run --all-files` passes all hooks.