### PR TITLE
fix(ckpt): skip export of parameters no PP rank owns

### DIFF
--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -432,7 +432,9 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
 
         return tensor
 
-    def broadcast_obj_from_pp_rank(self, obj: Optional[Any], cache_key: Optional[str] = None) -> Any:
+    def broadcast_obj_from_pp_rank(
+        self, obj: Optional[Any], cache_key: Optional[str] = None, allow_missing: bool = False
+    ) -> Any:
         """Broadcast any Python object from the PP rank that owns it.
 
         This method is useful for broadcasting configuration objects or
@@ -443,12 +445,16 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
             obj (Optional[Any]): Object to broadcast (None on non-owning ranks).
             cache_key (Optional[str]): Optional cache key. If not provided,
                 no caching will be performed.
+            allow_missing (bool): Return None instead of raising when no PP rank
+                owns the object. Must be passed by every rank of the PP group.
 
         Returns:
-            Any: Broadcasted object on all ranks.
+            Any: Broadcasted object on all ranks, or None if no rank owns it and
+            ``allow_missing`` is set.
 
         Raises:
-            ValueError: If object does not exist on any rank.
+            ValueError: If object does not exist on any rank and ``allow_missing``
+                is not set.
         """
         if self.pp_size == 1:
             return obj
@@ -476,6 +482,8 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
                 break
 
         if src_rank is None:
+            if allow_missing:
+                return None
             raise ValueError("Object must exist on at least one PP rank")
 
         # ------------------------------------------------------------------
@@ -1581,11 +1589,8 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
                 # Broadcast to other ranks
                 self._detected_type = self.broadcast_obj_from_pp_rank(self._detected_type, "detected_type")
             else:
-                # Receive from owning rank
-                self._detected_type = self.broadcast_obj_from_pp_rank(None, "detected_type")
-                if self._detected_type is None:
-                    # PP group likely has 1 member - skipping.
-                    return {}
+                # Receive from owning rank, or None when no PP rank owns the module
+                self._detected_type = self.broadcast_obj_from_pp_rank(None, "detected_type", allow_missing=True)
 
             # If no PP rank detected a type (e.g. Megatron parameter without an
             # HF counterpart, such as MoE modules on dense layers created by

--- a/tests/unit_tests/models/test_param_mapping.py
+++ b/tests/unit_tests/models/test_param_mapping.py
@@ -301,6 +301,52 @@ class TestAutoMapping:
         finally:
             AutoMapping._MODULE_TYPE_REGISTRY["column"].discard("Linear")
 
+    def test_megatron_to_hf_skips_param_no_pp_rank_owns(self, mock_distributed_env):
+        """A parameter whose module is absent from every PP rank exports as no weights."""
+        _, mock_dist = mock_distributed_env(pp_size=2, pp_rank=1)
+        mapping = AutoMapping(megatron_param="some.weight", hf_param="hf.weight")
+
+        mock_dist.all_gather_object.side_effect = lambda output, obj, group: output.__setitem__(
+            slice(None), [False, False]
+        )
+
+        result = mapping.megatron_to_hf(None, None)
+
+        assert result == {}, f"expected an empty export for an unowned parameter, got {result}"
+        assert mock_dist.broadcast_object_list.call_count == 0, "nothing should be broadcast when no rank owns it"
+
+    def test_megatron_to_hf_uses_type_broadcast_by_owning_pp_rank(self, mock_distributed_env):
+        """Regression: a non-owning rank still receives the parallelism type from the owner."""
+        _, mock_dist = mock_distributed_env(pp_size=2, pp_rank=1)
+        mapping = AutoMapping(megatron_param="some.weight", hf_param="hf.weight")
+
+        mock_dist.all_gather_object.side_effect = lambda output, obj, group: output.__setitem__(
+            slice(None), [True, False]
+        )
+        mock_dist.broadcast_object_list.side_effect = lambda obj_list, src, group: obj_list.__setitem__(
+            0, "replicated"
+        )
+
+        with patch.object(AutoMapping, "_get_or_create_mapping") as mock_get_mapping:
+            mock_get_mapping.return_value.megatron_to_hf.return_value = {"hf.weight": torch.zeros(2)}
+            result = mapping.megatron_to_hf(None, None)
+
+        assert mapping._detected_type == "replicated"
+        assert mock_get_mapping.call_args[0][0] == "replicated"
+        assert set(result) == {"hf.weight"}
+
+    def test_broadcast_obj_from_pp_rank_raises_when_unowned_by_default(self, mock_distributed_env):
+        """Without allow_missing, an object owned by no PP rank is still an error."""
+        _, mock_dist = mock_distributed_env(pp_size=2, pp_rank=1)
+        mapping = AutoMapping(megatron_param="some.weight", hf_param="hf.weight")
+
+        mock_dist.all_gather_object.side_effect = lambda output, obj, group: output.__setitem__(
+            slice(None), [False, False]
+        )
+
+        with pytest.raises(ValueError, match="Object must exist on at least one PP rank"):
+            mapping.broadcast_obj_from_pp_rank(None, "detected_type")
+
 
 class TestHelperFunctions:
     def test_qkv_merge_split(self, transformer_config):


### PR DESCRIPTION
# What does this PR do ?

Fixes every Megatron-to-HF export at `pipeline_model_parallel_size > 1` crashing with `ValueError: Object must exist on at least one PP rank` whenever a Megatron parameter has no HF counterpart, by letting the PP broadcast return `None` so the graceful-skip path that was already written can actually run.

# Changelog

- `src/megatron/bridge/models/conversion/param_mapping.py`: `broadcast_obj_from_pp_rank` gains an `allow_missing` flag that returns `None` instead of raising when no PP rank owns the object; `AutoMapping.megatron_to_hf` passes it on the receive path and drops its now-redundant local `None` check.
- `tests/unit_tests/models/test_param_mapping.py`: 3 tests covering the patched branch — no owner with `allow_missing` returns `None`, no owner without it still raises, and an owned object still broadcasts unchanged.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- **Root cause:** `AutoMapping.megatron_to_hf` (`param_mapping.py:1589-1602`) is written to skip a parameter that no PP rank detected a type for — the comment and the `if self._detected_type is None: return {}` guard are already there. That guard was unreachable at `pp_size > 1` because `broadcast_obj_from_pp_rank` (`param_mapping.py:472-479`) raised as soon as its all-gather found no owner, before the caller could inspect the result. At `pp_size == 1` the function short-circuits with `return obj`, `_detected_type` stays `None`, and the parameter is skipped correctly — which is why the same model exports at PP=1 and crashes at PP=2.

- **Blast radius:** any Megatron-to-HF export at `pp_size > 1` where a Megatron parameter has no HF counterpart. Reproduced on NemotronH, where a stale `backbone.embeddings.weight` mapping in the bridge leaves the embedding unmatched under transformers 5.12.1; the same shape is reachable for MoE modules on dense layers created by `moe_layer_freq`, which is the case the existing comment names.

- **Regression?** No — not introduced by any recent PR. The raising `broadcast_obj_from_pp_rank` and the unreachable guard are both pre-existing. Found while running coverage for #5367 (`perf(ckpt): cache config broadcasts for Mamba and GDN mappings`), but that PR is not implicated: the failing call is `AutoMapping`'s own `broadcast_obj_from_pp_rank(None, "detected_type")`, none of the four Mamba/GDN call sites #5367 touched, and #5367's own contract passes in the same run (12/12 `qwen3_5` and `qwen3_next` cases).

- **Verification:** red-green in `nvcr.io/nvidian/nemo:nightly`, EOS job 5850574 — RED 1 failed with the fix reverted, GREEN 16 passed with it applied. The failing e2e that found it is `test_pp_config_broadcast_cache_export` (2 GPU, `pp_size=2`, NemotronH `hybrid_override_pattern="M-M*"`, random weights, no Hub download), which goes 6 failed → passing with this change.

- **NVBug:** not filed at time of writing; report at `bugs/hermes/2026-08-14_test_pp_config_broadcast_cache_export_bug.md`. Add the `qa_rcca_done` label once it is filed.

- **Known adjacent defect, deliberately NOT fixed here:** `nemotron_h_bridge.py:421` maps `embedding.word_embeddings.weight` to `backbone.embeddings.weight`, a key transformers 5.12.1 does not produce, so the embedding is silently dropped from the export at *every* PP size. That is a wrong checkpoint rather than a crash and wants its own fix; this PR only stops the crash it triggers.

- Related to #5367 (context only — the defect is independent of it)