### PR TITLE
fix(peft): support hybrid-stack activation recompute

### DIFF
--- a/src/megatron/bridge/peft/recompute.py
+++ b/src/megatron/bridge/peft/recompute.py
@@ -41,7 +41,7 @@ def _iter_unwrapped_models(model) -> Iterable[torch.nn.Module]:
 
 
 def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] | None = None) -> Set[int]:
-    """Enable grad on TransformerBlock inputs when only adapters are trainable.
+    """Enable grad on recompute-block inputs when only adapters are trainable.
 
     Root cause analysis:
 
@@ -53,15 +53,19 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
       This means CheckpointFunction.backward() is never called, and LoRA gradients
       inside the checkpoint are never computed.
 
-    Solution: Hook TransformerBlock.forward to ensure hidden_states.requires_grad=True
-    before it enters checkpointed computation. This doesn't unfreeze any parameters;
-    it just ensures the autograd machinery calls checkpoint's backward.
+    Solution: Hook TransformerBlock.forward and HybridStack.forward to ensure
+    hidden_states.requires_grad=True before it enters checkpointed computation.
+    This doesn't unfreeze any parameters; it just ensures the autograd machinery
+    calls checkpoint's backward.
 
     Borrowed (with modifications) from
     https://github.com/HollowMan6/verl/blob/4285f0601028aee7ddcb9ec5a15198ebfc69bba3/verl/utils/megatron_peft_utils.py
     """
 
+    from megatron.core.models.hybrid.hybrid_block import HybridStack
     from megatron.core.transformer.transformer_block import TransformerBlock
+
+    recompute_block_types = (TransformerBlock, HybridStack)
 
     patched_registry = peft_recompute_patched or PEFT_RECOMPUTE_PATCHED
 
@@ -83,8 +87,8 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
             if not (trainable_adapter and not trainable_base):
                 continue  # Not adapter-only training, no fix needed
 
-            def _patch_transformer_block(module: torch.nn.Module) -> bool:
-                if isinstance(module, TransformerBlock):
+            def _patch_recompute_block(module: torch.nn.Module) -> bool:
+                if isinstance(module, recompute_block_types):
                     original_forward = module.forward
 
                     @wraps(original_forward)
@@ -104,18 +108,18 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
 
             patched = False
             for module in unwrapped_model.modules():
-                if _patch_transformer_block(module):
+                if _patch_recompute_block(module):
                     patched = True
             if patched:
                 patched_registry.add(id(unwrapped_model))
                 print_rank_0(
-                    "[PEFT+Recompute] Patched TransformerBlock.forward to enable grad on "
+                    "[PEFT+Recompute] Patched recompute-block forward to enable grad on "
                     "hidden_states input. This ensures checkpoint backward is called when "
                     "only adapters are trainable (PP=1 with frozen base model).",
                 )
     except Exception as exc:  # pragma: no cover - best effort logging
         # Log but don't fail - user will see grad_norm=0 and can debug
-        print_rank_0(f"[PEFT+Recompute] Warning: Failed to patch TransformerBlock: {exc}")
+        print_rank_0(f"[PEFT+Recompute] Warning: Failed to patch recompute block: {exc}")
 
     return patched_registry
 

--- a/tests/unit_tests/peft/test_recompute.py
+++ b/tests/unit_tests/peft/test_recompute.py
@@ -16,6 +16,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from megatron.bridge.peft import recompute as recompute_mod
@@ -38,11 +39,15 @@ class DummyTransformerBlock(torch.nn.Module):
         return hidden_states
 
 
+class DummyHybridStack(DummyTransformerBlock):
+    pass
+
+
 class DummyModel(torch.nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, block_cls=DummyTransformerBlock) -> None:
         super().__init__()
         self.config = SimpleNamespace(recompute_method="uniform")
-        self.block = DummyTransformerBlock()
+        self.block = block_cls()
 
         # Frozen base parameter (not trainable)
         self.base = torch.nn.Linear(1, 1, bias=False)
@@ -59,9 +64,11 @@ class DummyModel(torch.nn.Module):
             yield module
 
 
-def _patch_transformer_block(monkeypatch):
+def _patch_recompute_blocks(monkeypatch):
+    import megatron.core.models.hybrid.hybrid_block as hybrid_block
     import megatron.core.transformer.transformer_block as transformer_block
 
+    monkeypatch.setattr(hybrid_block, "HybridStack", DummyHybridStack, raising=False)
     monkeypatch.setattr(
         transformer_block,
         "TransformerBlock",
@@ -70,11 +77,12 @@ def _patch_transformer_block(monkeypatch):
     )
 
 
-def test_maybe_enable_recompute_inputs_grad_patches_block(monkeypatch):
-    _patch_transformer_block(monkeypatch)
+@pytest.mark.parametrize("block_cls", [DummyTransformerBlock, DummyHybridStack])
+def test_maybe_enable_recompute_inputs_grad_patches_block(monkeypatch, block_cls):
+    _patch_recompute_blocks(monkeypatch)
     recompute_mod.PEFT_RECOMPUTE_PATCHED.clear()
 
-    model = DummyModel()
+    model = DummyModel(block_cls)
     patched_registry = maybe_enable_recompute_inputs_grad(model, set())
 
     assert id(model) in patched_registry


### PR DESCRIPTION
## Summary

- mark frozen-model `HybridStack` inputs differentiable before full activation recompute
- preserve the existing `TransformerBlock` behavior for GPT models
- cover both recompute containers with parameterized unit tests

## Bug

With PP=1, PEFT, and full activation recompute, the frozen model's embedding output does not require gradients. The existing workaround patched `TransformerBlock`, but Nemotron 3.5 Lightning is an MCore `HybridModel` whose checkpoint container is `HybridStack`. Autograd therefore never invoked checkpoint backward, returning a finite loss with zero adapter gradients.

## Live validation

| case | XID | evidence |
| --- | --- | --- |
| broken full recompute | [1044606](https://xmanager.trajectory.ai/experiments/1044606) | grad norm `0.0` for two updates; loss stayed `29.1419`; sampler logprobs bit-identical |
| no-recompute control | [1044620](https://xmanager.trajectory.ai/experiments/1044620) | grad norms `42.76 → 162.41`; both updates changed vLLM sampling |
| this patch + full recompute | [1044623](https://xmanager.trajectory.ai/experiments/1044623) | live `HybridStack` hook logged; grad norms `49.54 → 17249.23`; both updates changed vLLM sampling |
| standard 10-step GSM8K | [1044624](https://xmanager.trajectory.ai/experiments/1044624) | completed 10/10 at 32×16; nonzero grad on every reward-contrast update; full eval every step |

The two-update repro deliberately uses LR `1e-2` to make stale sampler weights obvious; it is not a quality/loss benchmark. In the standard run, eval was 100% at steps 0–2, 90% at step 3, and 100% at steps 4–9. Steps with zero gradients had zero advantage and zero trainable tokens, confirming expected all-pass no-ops rather than a recurrence of the bug.

GSM8K plots and complete metrics are embedded in [Trajectory #3500](https://github.com/Trajectorylabs/trajectory/pull/3500).

Runtime image digest: `sha256:1fe4af917ad6d2e07b5ea967fbd3ef64eaecab867b55d7091259c6e02f713f4d`

## Testing

- Ruff check and format pass
- parameterized unit tests pass for `TransformerBlock` and `HybridStack`
- final runtime container: 4 focused Bridge/SkyRL recompute + LoRA export tests passed
- live patched full-recompute two-update LoRA/sampler probe passes
- standard 10-step GSM8K run completed; step 0 621.9s and steady steps averaged 215.3s
