### PR TITLE
[training] fix: Synchronize MIMO loss scalers

### DIFF
--- a/src/megatron/bridge/training/setup_megatron_mimo.py
+++ b/src/megatron/bridge/training/setup_megatron_mimo.py
@@ -13,10 +13,14 @@ Key components:
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional
 
+import torch
 import torch.distributed as dist
+from megatron.core.models.mimo.optimizer import MimoOptimizer
+from megatron.core.optimizer.grad_scaler import DynamicGradScaler
 from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
 from megatron.core.utils import get_model_config
 
@@ -33,7 +37,6 @@ from megatron.bridge.training.utils.checkpoint_utils import checkpoint_exists, i
 
 if TYPE_CHECKING:
     from megatron.core.models.mimo import MimoModel
-    from megatron.core.models.mimo.optimizer import MimoOptimizer
     from megatron.core.optimizer.optimizer_param_scheduler import OptimizerParamScheduler
     from megatron.core.process_groups_config import MultiModuleProcessGroupCollection, ProcessGroupCollection
 
@@ -41,6 +44,42 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+class _WorldSyncedMimoOptimizer(MimoOptimizer):
+    """Keep loss-scaler state identical across disjoint module optimizers."""
+
+    def _grad_scalers(self) -> list[DynamicGradScaler]:
+        grad_scalers: dict[int, DynamicGradScaler] = {}
+        for optimizer in self._active_optimizers:
+            inner_optimizers = getattr(optimizer, "chained_optimizers", [optimizer])
+            for inner_optimizer in inner_optimizers:
+                grad_scaler = getattr(inner_optimizer, "grad_scaler", None)
+                if isinstance(grad_scaler, DynamicGradScaler):
+                    grad_scalers[id(grad_scaler)] = grad_scaler
+        return list(grad_scalers.values())
+
+    @torch.no_grad()
+    def prepare_grads(self) -> bool:
+        """Prepare gradients using one world-consistent loss-scaler update."""
+        grad_scalers = self._grad_scalers()
+        if not grad_scalers:
+            return super().prepare_grads()
+
+        scaler_states = [(grad_scaler, deepcopy(grad_scaler.state_dict())) for grad_scaler in grad_scalers]
+        found_inf = super().prepare_grads()
+
+        found_inf_tensor = torch.tensor([found_inf], dtype=torch.float32, device="cuda")
+        dist.all_reduce(found_inf_tensor, op=dist.ReduceOp.MAX)
+        found_inf = found_inf_tensor.item() > 0
+
+        # Inner optimizers update their scalers before MimoOptimizer reaches its
+        # world found-inf consensus. Replay that update with the global result.
+        for grad_scaler, state_dict in scaler_states:
+            grad_scaler.load_state_dict(state_dict)
+            grad_scaler.update(found_inf)
+
+        return found_inf
 
 
 @dataclass
@@ -223,7 +262,8 @@ def setup_megatron_mimo(
     from megatron.core.models.mimo.optimizer import get_mimo_optimizer
 
     # cfg.optimizer already finalized by megatron_mimo_runtime_config_update().
-    optimizer = get_mimo_optimizer(unwrapped_model, cfg.optimizer)
+    mcore_optimizer = get_mimo_optimizer(unwrapped_model, cfg.optimizer)
+    optimizer = _WorldSyncedMimoOptimizer(mcore_optimizer.module_infos, mcore_optimizer.config)
 
     # Auto-create per-module LR schedulers
     cfg._calculate_scheduler_steps()

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -16,6 +16,8 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+import torch
+from megatron.core.optimizer.grad_scaler import DynamicGradScaler
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +333,33 @@ class TestPretrainMegatronMIMOSetup:
         mock_get_mimo_optimizer.assert_called_once_with(unwrapped, cfg.optimizer)
         global_state.initialize_async_checkpoint_worker.assert_called_once()
         assert result.checkpoint_manager is mock_mgr_instance
+
+        grad_scaler = MagicMock(spec=DynamicGradScaler)
+        grad_scaler.scale = 8.0
+        grad_scaler.state_dict.side_effect = lambda: {"scale": grad_scaler.scale}
+        grad_scaler.load_state_dict.side_effect = lambda state: setattr(grad_scaler, "scale", state["scale"])
+        grad_scaler.update.side_effect = lambda found_inf: setattr(
+            grad_scaler, "scale", grad_scaler.scale * 0.5 if found_inf else grad_scaler.scale
+        )
+
+        inner_optimizer = MagicMock()
+        inner_optimizer.chained_optimizers = [inner_optimizer]
+        inner_optimizer.grad_scaler = grad_scaler
+        inner_optimizer.prepare_grads.return_value = False
+        result.optimizer._active_optimizers = [inner_optimizer]
+        mock_optimizer.prepare_grads.return_value = False
+        mock_dist.all_reduce.side_effect = lambda tensor, **_: tensor.fill_(1.0)
+
+        real_tensor = torch.tensor
+
+        def make_cpu_tensor(data, **kwargs):
+            kwargs.pop("device", None)
+            return real_tensor(data, **kwargs)
+
+        with patch("torch.tensor", side_effect=make_cpu_tensor):
+            result.optimizer.prepare_grads()
+
+        assert grad_scaler.scale == 4.0
 
     def test_pretrain_megatron_mimo_calls_runtime_config_update(self):
         """pretrain_megatron_mimo should call megatron_mimo_runtime_config_update before setup."""


### PR DESCRIPTION
## Problem

Non-colocated MegatronMIMO training supports FP16 dynamic loss scaling, but each disjoint module grid owns a separate inner optimizer and scaler. If only one module grid overflows, its inner `prepare_grads()` updates that scaler before the outer `MimoOptimizer` performs world-wide found-inf consensus. The global step is skipped, but the scaler states remain different.

On the next finite step, the terminal module scales the loss with its local value while upstream modules unscale the propagated gradients with different values. This silently changes effective gradient magnitudes across the connected model. With an initial scale of 8 and `hysteresis=1`, the two-rank reproducer observed `[4.0, 8.0]` after an encoder-only overflow.

Megatron-LM PR [#5331](https://github.com/NVIDIA/Megatron-LM/pull/5331) synchronizes update success after preparation; it does not reconcile the scaler mutation that already occurred.

## Fix

Bridge now wraps its MIMO optimizer so the dynamic scaler update uses the world-wide found-inf result:

1. snapshot each deduplicated dynamic scaler, including chained optimizers;
2. run the existing gradient preparation unchanged;
3. reduce found-inf across the world;
4. restore and replay one scaler update with the global result.

BF16 and constant-loss-scale paths delegate directly to MCore and add no extra collective. The wrapper reuses the same module infos and inner optimizers, preserving scheduler and checkpoint ownership.

## Validation

Fail before / pass after with the unchanged regression:

```bash
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestPretrainMegatronMIMOSetup::test_setup_megatron_mimo_initializes_checkpoint_manager -q --tb=short
```

- Before: failed; remote overflow left scale `8.0`, expected globally backed-off `4.0`.
- After: `1 passed`.

Real two-rank FP16 reproducer:

```bash
uv run --no-sync python -m torch.distributed.run --standalone --nproc_per_node=2 repro_bridge_mimo_scaler.py
```

- Before: module scalers `[4.0, 8.0]`.
- After: module scalers `[4.0, 4.0]`.

Adjacent tests:

```bash
uv run --no-sync python -m pytest -p no:cacheprovider \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_config.py \
  tests/unit_tests/training/megatron_mimo/test_megatron_mimo_parallel_utils.py \
  tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py \
  -q --tb=short
```

- `87 passed`.

```bash
uv run --no-sync pre-commit run --all-files
git diff --check
```

- All hooks passed; diff check passed.

## Scope

This changes only Bridge-created MIMO optimizers using dynamic FP16 scaling. It does not alter BF16/constant scaling, repair already-divergent scaler values in existing checkpoints, or change direct Megatron-LM users.