### PR TITLE
fix(model): preserve masked placeholder embeddings

### DIFF
--- a/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
+++ b/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
@@ -686,7 +686,15 @@ class NemotronOmniModel(MegatronModule):
             # Match LLaVAModel's execution order. Besides keeping the two
             # implementations directly comparable, this ensures that RADIO's
             # first distributed forward sees the same runtime/collective state.
-            input_ids_text = input_ids.masked_fill(input_ids == self.image_token_index, 0)
+            image_anchor_mask = input_ids == self.image_token_index
+            if media_token_validity_mask is not None:
+                if media_token_validity_mask.shape != input_ids.shape:
+                    raise ValueError(
+                        "The media token-validity mask must have the same shape as input_ids: "
+                        f"got mask={tuple(media_token_validity_mask.shape)}, input_ids={tuple(input_ids.shape)}."
+                    )
+                image_anchor_mask = image_anchor_mask & media_token_validity_mask.bool()
+            input_ids_text = input_ids.masked_fill(image_anchor_mask, 0)
             combined_embeddings = self.language_model.embedding(input_ids=input_ids_text, position_ids=position_ids)
 
             if image_embeddings is None:

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
@@ -581,10 +581,8 @@ def test_text_containing_the_placeholder_trains_with_a_caller_mask():
         media_token_validity_mask=torch.tensor([[True, False, True]]),
     )
 
-    # The spared placeholder keeps the language embedding the forward gave it.
-    # That embedding is of token id 0, because the forward masks media tokens
-    # out of the text before embedding regardless of the validity mask.
-    assert torch.equal(output, torch.tensor([[[7.0] * 3], [[0.0] * 3], [[9.0] * 3]]))
+    # The spared placeholder is ordinary text, so it keeps its vocabulary embedding.
+    assert torch.equal(output, torch.tensor([[[7.0] * 3], [[18.0] * 3], [[9.0] * 3]]))
 
 
 def test_caller_mask_takes_precedence_over_the_derived_one():


### PR DESCRIPTION
## What changed

When a direct or external caller supplies `media_token_validity_mask`, a literal Nemotron Omni `<image>` token excluded by that mask is ordinary text and must retain its vocabulary embedding. The forward path instead replaced every placeholder ID with token ID 0 before embedding, so excluded placeholders silently received the wrong language embedding.

This path was introduced by #5573. The merge logic correctly respected the caller mask, but the earlier text-embedding preparation did not.

The fix applies the same explicit caller mask when selecting placeholder IDs to zero before language embedding. It also rejects a differently shaped mask before boolean combination, avoiding accidental broadcasting. Calls without an explicit mask preserve their prior behavior.

## User impact

Direct/external users of `NemotronOmniModel.forward` who pass a caller validity mask can include literal placeholder tokens as ordinary text. Before this change, those tokens silently trained or inferred with token 0's embedding instead of the configured placeholder token's embedding.

## Verification

Deterministic method-level reproducer against the unmodified base:

```text
uv run --no-sync python reproduce_masked_placeholder.py src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
exit 1: actual=[7.0, 0.0, 9.0], expected=[7.0, 18.0, 9.0]
```

The unchanged reproducer after the fix:

```text
uv run --no-sync python reproduce_masked_placeholder.py src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
exit 0: actual=[7.0, 18.0, 9.0], expected=[7.0, 18.0, 9.0]
```

Focused and adjacent Nemotron Omni model tests in a CUDA-capable environment:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py -k "caller_mask or validity_mask or placeholder or text_only or media_alignment or collapsed" -q
9 passed, 25 deselected
```

Repository checks:

```text
git diff --check
passed

uv run --no-sync pre-commit run --all-files
passed
```

## Scope

This is limited to the explicit caller-mask path in Nemotron Omni's public model forward. It does not change the bundled training collator/step, derived-mask behavior, conversion APIs, checkpoint handling, or other model families.
