### PR TITLE
[ckpt] fix: Restore checkpoints without Energon state

### DIFF
--- a/docs/training/checkpointing.md
+++ b/docs/training/checkpointing.md
@@ -312,8 +312,8 @@ The load default follows the actual source because the checkpoint restored on re
 
 ### Restore Behavior and Failure Modes
 
-- If the dataloader state directory is **absent** (e.g. a checkpoint saved before this feature existed), the dataloader starts from the beginning and a message is logged.
-- If the directory **exists** but the current rank's per-DP-rank file is **missing**, restore **raises**. This almost always means the data-parallel size changed since the checkpoint was saved; resuming would silently change the data order, so it fails loudly instead.
+- If the dataloader state root or the selected `iter_N` directory is **absent** (e.g. the selected checkpoint was saved before this feature existed), the dataloader starts from the beginning and a message is logged. Other state generations under the same root do not change this behavior.
+- If the selected `iter_N` directory **exists** but the current rank's per-DP-rank file is **missing**, restore **raises**. This almost always means the data-parallel size changed since the checkpoint was saved; resuming would silently change the data order, so it fails loudly instead.
 
 ### Determinism Requirement
 

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1803,11 +1803,11 @@ def maybe_load_dataloader_state(
     on *every* rank: each tensor/pipeline/context rank pulls from its own data iterator (e.g.
     ``qwen3_vl`` ``get_batch``), so all of them must be rewound to the saved position.
 
-    Restore failure modes are deliberately loud. If the dataloader state directory is absent
-    entirely, the checkpoint predates dataloader-state saving and the dataloader starts fresh. But
-    if the directory exists while the current rank's state file does not, the data-parallel size
-    almost certainly changed since the checkpoint was saved; rather than silently resume with a
-    different data order, this raises.
+    Restore failure modes distinguish checkpoint generations. If the dataloader state root or the
+    selected iteration is absent, that checkpoint predates dataloader-state saving and the
+    dataloader starts fresh. If the selected iteration exists while the current rank's state file
+    does not, the data-parallel size almost certainly changed since the checkpoint was saved;
+    rather than silently resume with a different data order, this raises.
 
     Restoring is only correct when the task encoder is deterministic per sample (Energon replays the
     samples since the last checkpoint by re-running the pipeline) — see
@@ -1843,8 +1843,13 @@ def maybe_load_dataloader_state(
         print_rank_0(f"no dataloader state under {dataloader_load_path}; dataloader starts from the beginning")
         return
 
-    dp_rank = get_pg_rank(pg_collection.dp)
     iter_dir = get_checkpoint_name(dataloader_load_path, iteration)
+    if not is_dir(iter_dir):
+        # This checkpoint generation predates dataloader-state saving. Start from scratch.
+        print_rank_0(f"no dataloader state for iteration {iteration}; dataloader starts from the beginning")
+        return
+
+    dp_rank = get_pg_rank(pg_collection.dp)
     data_state_load_path = join_paths(iter_dir, f"train_dataloader_dprank{dp_rank:03d}.pt")
     if not is_file(data_state_load_path):
         raise RuntimeError(

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5052,10 +5052,20 @@ class TestMaybeLoadDataloaderState:
         maybe_load_dataloader_state(train_iterator, 10, str(missing), pg_collection=self._pg())
         train_iterator.iterable.restore_state.assert_not_called()
 
+    def test_missing_selected_iteration_warns_and_skips(self, tmp_path):
+        """An unrelated state generation does not prevent an older checkpoint from resuming."""
+        train_iterator = Mock()
+        os.makedirs(get_checkpoint_name(str(tmp_path), 20))
+
+        maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
+
+        train_iterator.iterable.restore_state.assert_not_called()
+
     def test_existing_dir_missing_file_raises(self, tmp_path):
         """If the state dir exists but this rank's file does not, fail loudly (likely a DP-size change)."""
         train_iterator = Mock()
-        # tmp_path exists (the energon root) but contains no per-rank file for this iteration.
+        os.makedirs(get_checkpoint_name(str(tmp_path), 10))
+        # The selected iteration exists but contains no state file for this data-parallel rank.
         with pytest.raises(RuntimeError, match="data-parallel size"):
             maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
 


### PR DESCRIPTION
## Problem

Selecting an older model checkpoint that predates Energon dataloader-state saving can fail if the same checkpoint root contains state for a newer generation.

For example, a supported `checkpoint.ckpt_step=10` resume may select `iter_0000010` while `energon/iter_0000020` exists. The restore path checked only the shared `energon` root, then treated the missing `energon/iter_0000010/train_dataloader_dprank000.pt` as a data-parallel-size mismatch and aborted. This prevents otherwise valid older model-only checkpoints from resuming.

## Root cause and fix

The loader did not distinguish two different conditions:

- the selected checkpoint has no Energon generation because it predates state saving;
- the selected generation exists but its current DP-rank file is missing.

Check the selected `iter_N` directory before resolving the DP-rank file. A missing selected generation now follows the existing pre-feature compatibility behavior and starts the dataloader fresh. A missing rank file inside an existing selected generation remains a hard error to avoid silently changing data order. The checkpointing documentation now describes this boundary.

## Validation

Fail before, on the unmodified `fbb7570cf7eec94fd2e6064454d84f7fad07fbfa` base:

```text
uv run python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py::TestMaybeLoadDataloaderState::test_missing_selected_iteration_warns_and_skips -q --tb=short
1 failed: RuntimeError claimed a data-parallel-size change for an absent selected generation
```

Pass after:

```text
uv run python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py::TestMaybeLoadDataloaderState::test_missing_selected_iteration_warns_and_skips -q --tb=short
1 passed

uv run python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py::TestRecordDataloaderStateDir tests/unit_tests/training/test_checkpointing.py::TestMaybeLoadDataloaderState tests/unit_tests/training/test_checkpointing.py::TestMaybeSaveDataloaderState -q --tb=short
24 passed

uv run pre-commit run --all-files
passed

git diff --check
passed
```

The adjacent set includes a negative control proving that an existing selected generation with a missing DP-rank file still raises. This is a focused CPU path; no GPU, distributed, full-suite, convergence, or performance validation was run.
