### PR TITLE
[misc] fix: Cap server requests by token budget

### DIFF
--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -320,8 +320,8 @@ def build_inference_config(
     one source of truth. Pure: never mutates caller state.
 
     ``max_requests`` resolves to ``max_batch_size`` if set, else ``num_prompts``. When both are
-    ``None`` (e.g. a server that should auto-size to the KV-cache memory buffer), ``max_requests``
-    is left as ``None`` for the engine to size.
+    ``None``, an explicit token budget caps server capacity; otherwise ``max_requests`` is left as
+    ``None`` for the engine to size from the KV-cache memory buffer.
     """
     effective_block_size = block_size_tokens
     if getattr(getattr(model, "config", None), "cache_mla_latents", False) and block_size_tokens != 64:
@@ -345,6 +345,10 @@ def build_inference_config(
         max_requests = rounded
 
     max_tokens_limit = max_tokens or DynamicInferenceContext.DEFAULT_MAX_TOKENS
+    if max_requests is None and max_tokens is not None:
+        max_requests = max_tokens_limit // tp * tp
+        if max_requests == 0:
+            raise ValueError(f"--max_tokens ({max_tokens_limit}) must be at least --tp ({tp}).")
     if max_requests is not None and max_requests > max_tokens_limit:
         if max_batch_size is not None:
             raise ValueError(f"--max_batch_size ({max_batch_size}) cannot exceed --max_tokens ({max_tokens_limit}).")

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -186,8 +186,28 @@ def test_build_inference_config_rounds_max_requests_up_to_tp(text_generation):
     assert config.kwargs["materialize_only_last_token_logits"] is True
 
 
-def test_build_inference_config_auto_sizes_max_requests_when_unset(text_generation):
-    """Server path: max_batch_size and num_prompts both None -> max_requests left as None."""
+def test_build_inference_config_caps_auto_sized_server_requests_at_token_budget(text_generation):
+    model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
+
+    config = text_generation.build_inference_config(
+        model=model,
+        max_sequence_length=4096,
+        max_batch_size=None,
+        num_prompts=None,
+        tp=2,
+        block_size_tokens=256,
+        kv_cache_buffer_size_gb=20.0,
+        max_tokens=128,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+    )
+
+    assert config.kwargs["max_requests"] is not None
+    assert config.kwargs["max_requests"] <= 128
+    assert config.kwargs["max_requests"] % 2 == 0
+
+
+def test_build_inference_config_preserves_kv_auto_sizing_without_token_limit(text_generation):
     model = types.SimpleNamespace(position_embedding_type="rope", max_sequence_length=8192)
 
     config = text_generation.build_inference_config(


### PR DESCRIPTION
## What changed

Cap OpenAI-server request capacity at an explicit active-token budget while preserving tensor-parallel divisibility. When neither `--max_batch_size` nor a prompt count supplies a request limit, Bridge now derives a request ceiling only if the user explicitly set `--max_tokens`; otherwise the existing KV-memory auto-sizing path remains unchanged.

## Supported trigger and user impact

The maintained OpenAI-server example supports `Qwen/Qwen2.5-1.5B` and exposes `--max_tokens`. With `--max_tokens 128` and the documented unset `--max_batch_size`, Bridge passed `max_requests=None` into pinned MCore. MCore independently auto-sized 2,924 requests from the default 20 GiB KV buffer, then aborted context construction because 128 active tokens cannot support 2,924 active requests. The HTTP server therefore failed before binding its port.

This is the server-side omitted sibling of the prompt-derived capacity invariant fixed in #5577.

## Root cause and minimal fix

`build_inference_config()` reconciled explicit and prompt-derived request counts with the effective token budget, but skipped the cap when both request inputs were unset. The shared builder is the owning Bridge-to-MCore boundary. It now selects the largest TP-divisible request ceiling within an explicitly supplied token budget. No-limit server startup still leaves `max_requests=None` for KV-based sizing.

## Regression evidence

Focused contract test:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_text_generation.py::test_build_inference_config_caps_auto_sized_server_requests_at_token_budget -q
```

- Before: 1 failed because `max_requests` remained `None` under an explicit 128-token server budget.
- After: 1 passed; request capacity is non-null, TP-divisible, and no greater than 128.

Adjacent validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_text_generation.py -k build_inference_config -q
# 8 passed, 12 deselected

uv run --no-sync python -m pytest --noconftest tests/unit_tests/scripts/test_openai_server_entrypoint.py tests/unit_tests/scripts/test_async_text_generation_entrypoint.py tests/unit_tests/scripts/test_text_generation_entrypoint.py -q
# 9 passed

uv run --no-sync pre-commit run --all-files
# passed

git diff --check
# passed
```

A CPU-only dependency preload was used locally to isolate the real shared helper from unrelated optional CUDA import initialization; no MCore behavior was mocked in the request/token contract itself.

## Scope

- No public API or CLI signature changes.
- No dependency, workflow, lockfile, or MCore submodule changes.
- Default server KV auto-sizing is preserved when `--max_tokens` is unset.
- No GPU execution, model-quality, convergence, performance, or full-suite validation is claimed.
