### PR TITLE
fix(test): avoid singleton rendezvous port races

### DIFF
--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -14,8 +14,6 @@
 
 import argparse
 import logging
-import os
-import socket
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator, Literal, Optional, Union
@@ -128,16 +126,11 @@ def temporary_distributed_context(backend: str = "gloo") -> Generator[None, None
     Yields:
         None.
     """
-    if "MASTER_ADDR" in os.environ and "MASTER_PORT" in os.environ:
-        init_method = None
-    else:
-        # Find an available port dynamically
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("localhost", 0))
-            addr, port = s.getsockname()
-        init_method = f"tcp://{addr}:{port}"
-
-    dist.init_process_group(backend=backend, init_method=init_method, world_size=1, rank=0)
+    # This context is intentionally single-process, so an in-process store is
+    # sufficient and avoids reserving a TCP port or inheriting rendezvous
+    # settings from the caller's environment.
+    store = dist.HashStore()
+    dist.init_process_group(backend=backend, store=store, world_size=1, rank=0)
     parallel_state.initialize_model_parallel()
 
     # Initialize RNG tracker for model initialization

--- a/tests/functional_tests/test_groups/models/qwen/test_qwen3_peft_verify.py
+++ b/tests/functional_tests/test_groups/models/qwen/test_qwen3_peft_verify.py
@@ -22,7 +22,6 @@ Tests the full adapter verification pipeline:
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -37,15 +36,6 @@ from megatron.bridge.training.model_load_save import temporary_distributed_conte
 
 
 peft = pytest.importorskip("peft", reason="peft library not installed")
-
-
-def _find_free_port() -> int:
-    """Return a port that is currently free on localhost."""
-    import socket
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
 
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent.parent
@@ -177,8 +167,7 @@ class TestVerifyAdapter:
             "--cpu",
         ]
 
-        env = {**os.environ, "MASTER_PORT": str(_find_free_port())}
-        result = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT)
         print(result.stdout)
         if result.returncode != 0:
             print(result.stderr)
@@ -201,8 +190,7 @@ class TestVerifyAdapter:
             "--cpu",
         ]
 
-        env = {**os.environ, "MASTER_PORT": str(_find_free_port())}
-        result = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT)
         print(result.stdout)
         if result.returncode != 0:
             print(result.stderr)
@@ -225,6 +213,7 @@ class TestVerifyAdapter:
             sys.executable,
             "-m",
             "torch.distributed.run",
+            "--standalone",
             "--nproc_per_node=2",
             "--nnodes=1",
             "examples/conversion/adapter/verify_adapter.py",
@@ -240,8 +229,7 @@ class TestVerifyAdapter:
             str(pp),
         ]
 
-        env = {**os.environ, "MASTER_PORT": str(_find_free_port())}
-        result = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT)
         print(result.stdout)
         if result.returncode != 0:
             print(result.stderr)

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -183,17 +183,9 @@ class TestTemporaryDistributedContext:
 
     @patch("megatron.bridge.training.model_load_save.dist")
     @patch("megatron.bridge.training.model_load_save.parallel_state")
-    @patch("megatron.bridge.training.model_load_save.socket")
-    @patch("megatron.bridge.training.model_load_save.os")
-    def test_temporary_distributed_context_gloo(self, mock_os, mock_socket, mock_parallel_state, mock_dist):
+    def test_temporary_distributed_context_gloo(self, mock_parallel_state, mock_dist):
         """Test temporary distributed context with gloo backend."""
-        # Mock environment to not have MASTER_ADDR and MASTER_PORT
-        mock_os.environ = {}
-
-        # Mock socket for port selection
-        mock_socket_instance = Mock()
-        mock_socket_instance.getsockname.return_value = ("localhost", 12345)
-        mock_socket.socket.return_value.__enter__.return_value = mock_socket_instance
+        mock_store = mock_dist.HashStore.return_value
 
         with (
             patch("megatron.bridge.training.model_load_save.torch.cuda.is_available", return_value=False),
@@ -202,9 +194,8 @@ class TestTemporaryDistributedContext:
         ):
             pass
 
-        mock_dist.init_process_group.assert_called_once_with(
-            backend="gloo", init_method="tcp://localhost:12345", world_size=1, rank=0
-        )
+        mock_dist.HashStore.assert_called_once_with()
+        mock_dist.init_process_group.assert_called_once_with(backend="gloo", store=mock_store, world_size=1, rank=0)
         mock_parallel_state.initialize_model_parallel.assert_called_once()
         mock_parallel_state.destroy_model_parallel.assert_called_once()
         mock_dist.destroy_process_group.assert_called_once()
@@ -212,37 +203,16 @@ class TestTemporaryDistributedContext:
 
     @patch("megatron.bridge.training.model_load_save.dist")
     @patch("megatron.bridge.training.model_load_save.parallel_state")
-    @patch("megatron.bridge.training.model_load_save.os")
-    def test_temporary_distributed_context_with_env_vars(self, mock_os, mock_parallel_state, mock_dist):
-        """Test temporary distributed context when env vars are already set."""
-        mock_os.environ = {"MASTER_ADDR": "localhost", "MASTER_PORT": "12345"}
-
-        with temporary_distributed_context(backend="gloo"):
-            pass
-
-        mock_dist.init_process_group.assert_called_once_with(backend="gloo", init_method=None, world_size=1, rank=0)
-
-    @patch("megatron.bridge.training.model_load_save.dist")
-    @patch("megatron.bridge.training.model_load_save.parallel_state")
-    @patch("megatron.bridge.training.model_load_save.socket")
-    @patch("megatron.bridge.training.model_load_save.os")
     @patch("megatron.core.tensor_parallel.model_parallel_cuda_manual_seed")
-    def test_temporary_distributed_context_nccl(self, mock_seed, mock_os, mock_socket, mock_parallel_state, mock_dist):
+    def test_temporary_distributed_context_nccl(self, mock_seed, mock_parallel_state, mock_dist):
         """Test temporary distributed context with nccl backend."""
-        # Mock environment to not have MASTER_ADDR and MASTER_PORT
-        mock_os.environ = {}
-
-        # Mock socket for port selection
-        mock_socket_instance = Mock()
-        mock_socket_instance.getsockname.return_value = ("localhost", 12345)
-        mock_socket.socket.return_value.__enter__.return_value = mock_socket_instance
+        mock_store = mock_dist.HashStore.return_value
 
         with temporary_distributed_context(backend="nccl"):
             pass
 
-        mock_dist.init_process_group.assert_called_once_with(
-            backend="nccl", init_method="tcp://localhost:12345", world_size=1, rank=0
-        )
+        mock_dist.HashStore.assert_called_once_with()
+        mock_dist.init_process_group.assert_called_once_with(backend="nccl", store=mock_store, world_size=1, rank=0)
         mock_seed.assert_called_once_with(0)
         mock_parallel_state.initialize_model_parallel.assert_called_once()
         mock_parallel_state.destroy_model_parallel.assert_called_once()


### PR DESCRIPTION
## Summary

- use an in-process `torch.distributed.HashStore` for singleton temporary process groups, avoiding TCP rendezvous ports and inherited distributed environment settings
- use `torchrun --standalone` for the Qwen3 adapter TP/PP verification subprocesses
- update focused unit coverage for both gloo and NCCL singleton initialization

## Root cause

Main CI job https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/31846107309/job/94940794151 failed in `TestVerifyAdapter.test_cpu_full_verification` with `EADDRINUSE` on port 43963.

The test selected a free port in the parent process, released it, and then launched a child that spent about 20 seconds loading models before binding that port. Another socket could claim the port during that gap.

## Testing

- `uvx --from pre-commit pre-commit run --all-files` — passed
- focused ruff check/format, Python compile, and `git diff --check` — passed
- runtime probe initialized and destroyed a gloo process group through `HashStore` while `MASTER_PORT` pointed to an occupied socket — passed
- `uv run python -m pytest tests/unit_tests/training/test_model_load_save.py -k temporary_distributed_context -vv` — not runnable on macOS ARM because `nvidia-resiliency-ext==0.6.0` publishes Linux-only wheels; CI will run the focused coverage on Linux
