### PR TITLE
fix(misc): correct Nemotron 3 Super GB200 training TPS per GPU

### DIFF
--- a/examples/model_verification_cards/nemotron-3-super-120b-a12b/card.yaml
+++ b/examples/model_verification_cards/nemotron-3-super-120b-a12b/card.yaml
@@ -691,7 +691,7 @@ items:
         final_loss: 0.01120061
         last_10_steps_step_time_ms_avg: 9926.350
         last_10_steps_model_tflops_per_gpu_avg: 559.390
-        last_10_steps_tokens_per_second_per_gpu_avg: 3301.113
+        last_10_steps_tokens_per_second_per_gpu_avg: 6602.225
       expected_result: >
         On exactly 64 GB200s, the canonical BF16 performance recipe completes
         50 mock-data steps at TP2/PP1/CP1/EP64, GBS/MBS 512/1, HybridEP flex

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -51,7 +51,7 @@ TRAINING_THROUGHPUT_INPUTS = {
     ("nemotron-3-super-120b-a12b", "sft_long_context", "H100"): (32768, 2, 16),
     ("nemotron-3-super-120b-a12b", "peft", "GB200"): (8192, 16, 16),
     ("nemotron-3-super-120b-a12b", "pretrain_performance", "H100"): (4096, 1280, 64),
-    ("nemotron-3-super-120b-a12b", "pretrain_performance", "GB200"): (4096, 512, 64),
+    ("nemotron-3-super-120b-a12b", "pretrain_performance", "GB200"): (8192, 512, 64),
     ("nemotron-3.5-lightning", "pretrain", "H100"): (8192, 512, 16),
     ("nemotron-3.5-lightning", "pretrain", "GB200"): (8192, 512, 8),
     ("nemotron-3.5-lightning", "pretrain_fsdp", "GB200", "bf16"): (8192, 512, 8),


### PR DESCRIPTION
# What does this PR do ?

Fixes the Nemotron 3 Super 120B-A12B verification card understating its verified GB200 training throughput by 2x, by correcting a TPS/GPU value derived on 128 GPUs instead of the 64 its own command allocates.

# Changelog

- `examples/model_verification_cards/nemotron-3-super-120b-a12b/card.yaml`: `pretrain_performance.GB200` TPS/GPU 3301.113 -> 6602.225.
- `tests/unit_tests/skills/create_model_verification_card/test_validate_card.py`: audited token-slot sequence length for that leaf 4096 -> 8192, the recipe-owned value.

# Additional Information

- **Root cause:** SKILL.md defines the metric as `seq * gbs / step_s / total_gpus` with a recipe-owned batch size and `total_gpus` from the leaf's own command. `nemotron_3_super_pretrain_64gpu_gb200_bf16_config` resolves to gbs=512, seq=8192 (identical in the library and benchmark definitions), the command allocates `--nodes 16 --gpus-per-node 4` = 64, and the leaf records step_time 9926.350 ms, giving 6602.225. The shipped 3301.113 is that formula halved.
- **Blast radius:** card data only, no product code path. The sibling H100 leaf reproduces exactly (4096 * 1280 / 27.58858 / 64 = 2969.345), so only this leaf was wrong.
- **Independent check:** TFLOPS/TPS is the model's FLOPs per token. As shipped this leaf implied 169.45 GFLOPs/token for a 12B-active model; patched it implies 84.73, against the H100 sibling's 83.73.
- **Why the audit missed it:** `_validate_metrics` only checks presence, positivity and finiteness, and `TRAINING_THROUGHPUT_INPUTS` transcribed 4096 for this leaf, so the recomputation agreed with the card's own error.
- **Regression?** No - the key has only ever been touched by `79308d0d feat(verification): add training TPS per GPU (#5584)`, so it has never been correct on this leaf.
- **Verification:** red-green in `nvcr.io/nvidian/nemo:nightly` on EOS (job 5858930) against `/opt/Megatron-Bridge` at `origin/main` - RED: audit test failed, `Obtained: 3301.113, Expected: 6602.225389997329` (1 failed, 18 passed); GREEN: 19 passed. Directory-level discovery collected 24 passed; `validate_card.py` on the patched card exits 0; the real loader in the same container resolved gbs=512 seq=8192.
- Related to # (issue)