### PR TITLE
fix(model): default multi_latent_attention to True on the MLA config

### DIFF
--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -230,6 +230,9 @@ class MLATransformerConfig(TransformerConfig, MCoreMLATransformerConfig):
         config.finalize()
     """
 
+    # Redeclared so the reverse-MRO dataclass field walk cannot revert MCore's MLA default to False.
+    multi_latent_attention: bool = True
+
     def __post_init__(self) -> None:
         """Skip MCore post_init during initial construction.
 

--- a/tests/unit_tests/models/test_transformer_config.py
+++ b/tests/unit_tests/models/test_transformer_config.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
+from megatron.bridge.models.mla_provider import MLAModelProvider
 from megatron.bridge.models.transformer_config import (
     _HYBRIDEP_PADDING_FIELDS,
     HeterogeneousTransformerConfig,
@@ -331,6 +332,43 @@ class TestMLATransformerConfigFinalize:
             cfg.finalize()
 
         assert getattr(cfg, padding_field) is True
+
+
+# ---------------------------------------------------------------------------
+# MLATransformerConfig.multi_latent_attention
+# ---------------------------------------------------------------------------
+
+
+class TestMLATransformerConfigMultiLatentAttention:
+    """Tests for the multi_latent_attention default on MLATransformerConfig."""
+
+    def _make_mla(self, **kwargs) -> MLATransformerConfig:
+        defaults = dict(
+            num_layers=2,
+            hidden_size=256,
+            ffn_hidden_size=512,
+            num_attention_heads=8,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        defaults.update(kwargs)
+        return MLATransformerConfig(**defaults)
+
+    def test_mla_config_and_provider_default_to_multi_latent_attention(self):
+        assert MLATransformerConfig.__dataclass_fields__["multi_latent_attention"].default is True
+        assert MLAModelProvider.__dataclass_fields__["multi_latent_attention"].default is True
+        assert self._make_mla().multi_latent_attention is True
+
+    def test_selective_mla_up_proj_recompute_is_accepted(self):
+        cfg = self._make_mla(recompute_granularity="selective", recompute_modules=["mla_up_proj"])
+
+        cfg.finalize()
+
+        assert cfg.recompute_modules == ["mla_up_proj"]
+
+    def test_explicit_non_mla_value_and_plain_config_are_unchanged(self):
+        assert self._make_mla(multi_latent_attention=False).multi_latent_attention is False
+        assert TransformerConfig.__dataclass_fields__["multi_latent_attention"].default is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Fixes directly constructed Bridge MLA configs not being MLA — every MLA-gated Megatron Core path, including `recompute_modules=["mla_up_proj"]`, is rejected — by declaring `multi_latent_attention = True` on `MLATransformerConfig` instead of relying on dataclass base order.

# Changelog

- `src/megatron/bridge/models/transformer_config.py`: redeclare `multi_latent_attention: bool = True` on `MLATransformerConfig`.
- `tests/unit_tests/models/test_transformer_config.py`: 3 tests covering the default on config and provider, `mla_up_proj` selective recompute finalizing, and the explicit-`False` / plain-`TransformerConfig` regression.

# Additional Information

- **Root cause:** `dataclasses` builds `__dataclass_fields__` in reverse MRO, so Bridge's `TransformerConfig` (inherited `False` from MCore `TransformerConfig:281`) overwrote MCore `MLATransformerConfig`'s `True` (`:2906`). `finalize()` validates the field, it does not set it.
- **Blast radius:** shipped models are unaffected — eight bridges assign `provider.multi_latent_attention = True` after construction and `sarvam_provider.py:200` redeclares it. Direct `MLATransformerConfig` / `MLAModelProvider` construction, which the class docstring documents, was affected.
- **Scope:** redeclaring on the parent is sufficient; `MLAModelProvider` picks it up because `MLATransformerConfig` is last in its reverse-MRO walk. Verified, so `mla_provider.py` is unchanged.
- **Regression?** No — broken since `b1623586` (#2268, 2026-02-26), the only commit touching this class declaration. Found while testing #5570, which is docs-only and merely published the decision table that exposed it.
- **Verification:** red-green in `nvcr.io/nvidian/nemo:nightly` (EOS job 5858950, repo at `fbb7570cf`, MCore `f9cc5444b`) — RED 2 failed / 44 passed, GREEN 46 passed. Product path in the same job: pre-fix `ValueError: mla_up_proj in recompute_modules is only supported with multi_latent_attention.`, post-fix accepted. `pytest tests/unit_tests/models/ --collect-only` collects the new class.
- Related to # (issue)