### PR TITLE
fix(misc): map --max-position-embeddings onto model.seq_length

### DIFF
--- a/docs/megatron-lm-to-megatron-bridge.md
+++ b/docs/megatron-lm-to-megatron-bridge.md
@@ -365,7 +365,7 @@ Below is a concise mapping from common `megatron-lm/megatron/training/arguments.
 | `--num-query-groups` | `model.num_query_groups` | Number of query groups. |
 | `--qk-layernorm` | `model.qk_layernorm` | Enable QK LayerNorm. |
 | `--seq-length` | `model.seq_length` | Max model sequence length. |
-| `--max-position-embeddings` | `model.seq_length` | Alias used by HF conversions. |
+| `--max-position-embeddings` | `model.seq_length` | Alias used by HF conversions. A value differing from `--seq-length` is reported in the skipped section instead, since Bridge has no separate field for it. |
 | `--make-vocab-size-divisible-by` | `model.make_vocab_size_divisible_by` | TP padding multiple. |
 | `--disable-bias-linear` | `model.add_bias_linear=false` | Disable linear bias. |
 | `--use-flash-attn` | `model.attention_backend=flash` | Use FlashAttention backend. |

--- a/scripts/translate_mlm_to_bridge.py
+++ b/scripts/translate_mlm_to_bridge.py
@@ -95,7 +95,7 @@ ARG_MAP: dict[str, tuple[str, Any]] = {
     "num-attention-heads":               ("model.num_attention_heads",            None),
     "num-query-groups":                  ("model.num_query_groups",               None),
     "kv-channels":                       ("model.kv_channels",                    None),
-    "max-position-embeddings":           ("model.max_position_embeddings",        None),
+    "max-position-embeddings":           (None,                                   "max_position_embeddings"),
     "position-embedding-type":           ("model.position_embedding_type",        None),
     "rotary-base":                       ("model.rotary_base",                    None),
     "rotary-percent":                    ("model.rotary_percent",                 None),
@@ -541,6 +541,18 @@ def translate(args: dict[str, Any], env_vars: dict[str, str | int | float | bool
         elif transform == "seq_length":
             result.add_override("dataset.seq_length", arg_val)
             result.add_override("model.seq_length", arg_val)
+        elif transform == "max_position_embeddings":
+            # Bridge providers have no max_position_embeddings field; seq_length is the equivalent.
+            seq_length_arg = args.get("seq-length")
+            if seq_length_arg is None:
+                result.add_override("dataset.seq_length", arg_val)
+                result.add_override("model.seq_length", arg_val)
+            elif seq_length_arg != arg_val:
+                result.skipped.append((arg_name, arg_val))
+                result.add_note(
+                    f"max-position-embeddings ({arg_val}) differs from seq-length ({seq_length_arg}); "
+                    "Bridge has no separate field, review model.seq_length manually"
+                )
         elif transform == "vpp_from_layers":
             layers_per_vpp_stage = int(arg_val)
             num_layers = int(args.get("num-layers", 0))

--- a/tests/unit_tests/utils/test_translate_mlm_to_bridge.py
+++ b/tests/unit_tests/utils/test_translate_mlm_to_bridge.py
@@ -393,6 +393,41 @@ class TestTranslateSeqLength:
         assert r.overrides["model.seq_length"] == 4096
 
 
+class TestTranslateMaxPositionEmbeddings:
+    """Tests for max-position-embeddings translation."""
+
+    def test_never_emits_a_max_position_embeddings_path(self):
+        """--max-position-embeddings produces no model.max_position_embeddings override."""
+        r = translate({"seq-length": 4096, "max-position-embeddings": 4096})
+        assert "model.max_position_embeddings" not in r.overrides
+        assert r.overrides["model.seq_length"] == 4096
+        assert r.overrides["dataset.seq_length"] == 4096
+
+    def test_maps_to_seq_length_when_seq_length_absent(self):
+        """--max-position-embeddings alone supplies both seq_length fields."""
+        r = translate({"max-position-embeddings": 2048})
+        assert r.overrides["model.seq_length"] == 2048
+        assert r.overrides["dataset.seq_length"] == 2048
+
+    def test_divergent_value_is_skipped_not_translated(self):
+        """A max-position-embeddings that differs from seq-length is reported, not applied."""
+        r = translate({"seq-length": 512, "max-position-embeddings": 1024})
+        assert r.overrides["model.seq_length"] == 512
+        assert ("max-position-embeddings", 1024) in r.skipped
+        assert any("max-position-embeddings" in note for note in r.notes)
+
+    def test_emitted_recipe_has_no_unknown_provider_kwarg(self):
+        """The generated recipe passes no max_position_embeddings kwarg to the provider."""
+        args, env = parse_raw_args(
+            "--num-layers 4 --hidden-size 256 --ffn-hidden-size 512 --num-attention-heads 8 "
+            "--seq-length 512 --max-position-embeddings 512 --micro-batch-size 1 "
+            "--global-batch-size 4 --train-iters 6 --lr 3e-4 --mock-data"
+        )
+        code = emit_recipe(translate(args, env), "mlm_dense")
+        assert "max_position_embeddings=" not in code
+        assert "seq_length=512," in code
+
+
 class TestTranslateSkippedAndUnknown:
     """Tests for skipped and unknown arg handling."""
 


### PR DESCRIPTION
# What does this PR do ?

Fixes every recipe emitted by `translate_mlm_to_bridge.py` raising `TypeError` on its first `model_config()` call, by mapping `--max-position-embeddings` onto `model.seq_length` instead of `model.max_position_embeddings`, which is not a field on any Bridge provider.

# Changelog

- `scripts/translate_mlm_to_bridge.py`: `--max-position-embeddings` translates to `model.seq_length`/`dataset.seq_length`; a value diverging from `--seq-length` goes to the skipped section with a note.
- `tests/unit_tests/utils/test_translate_mlm_to_bridge.py`: 4 tests covering the new transform's three branches and the emitted recipe.

# Additional Information

- **Root cause:** `translate_mlm_to_bridge.py:98` mapped the flag to `model.max_position_embeddings`. `GPTModelProvider`/`HybridModelProvider` derive from `TransformerConfig`, which has no such field — only the YaRN `original_max_position_embeddings`. `docs/megatron-lm-to-megatron-bridge.md:368` already documents `model.seq_length` as the target. An audit of all 87 `model.*` mappings found it the only non-field.
- **Blast radius:** both output modes — `--emit recipe` writes a dead kwarg into the provider constructor, and the default overrides mode prints `model.max_position_embeddings=` into the block users paste onto a Bridge command line. The flag is effectively mandatory in Megatron-LM, so nearly every input was affected.
- **Divergent values:** Megatron-LM permits `max_position_embeddings > seq_length` and Bridge has no field for the difference, so that case is reported in the skipped section, not applied to `seq_length`.
- **Regression?** No — broken since `e5c7b8c2`, the commit that added the script. Found while testing #5354, which touches the same script but did not cause it.
- **Verification:** red-green in `nvcr.io/nvidian/nemo:nightly` on `origin/main` `fbb7570cf`. RED — dense and hybrid recipes fail with `TypeError: GPTModelProvider.__init__() got an unexpected keyword argument 'max_position_embeddings'`; 4 unit tests failed. GREEN — kwarg absent, both providers construct with `seq_length=512`; 154 passed (150 pre-existing + 4 new).
- **Not included:** `emit_recipe()` still writes `model.*` overrides without validating against `dataclasses.fields(provider_cls)`, and `docs/megatron-lm-to-megatron-bridge.md:121` documents the same invalid path. Both reported separately.