### PR TITLE
[ckpt] fix: Replace reused Energon generations

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1769,6 +1769,14 @@ def maybe_save_dataloader_state(
     torch.distributed.barrier(group=pg_collection.dp)
 
     if get_pg_rank(pg_collection.dp) == 0:
+        # A retained Energon generation may outlive its model checkpoint. Replace the generation
+        # before reusing an iteration so rank files from a previous, larger DP world cannot survive.
+        if MultiStorageClientFeature.is_enabled():
+            msc = MultiStorageClientFeature.import_package()
+            if msc.os.path.isdir(iter_dir):
+                msc.delete(iter_dir, recursive=True)
+        elif os.path.isdir(iter_dir):
+            shutil.rmtree(iter_dir)
         ensure_directory_exists(data_state_save_path)
 
     torch.distributed.barrier(group=pg_collection.dp)

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5372,6 +5372,32 @@ class TestMaybeSaveDataloaderState:
             "dataloader_state_dict": {"dummy_energon_state": "xyz"}
         }
 
+    def test_reused_iteration_rejects_stale_dp_rank_state(self, tmp_path):
+        """Reusing an iteration at smaller DP must not retain rank files from its previous owner."""
+        iter_dir = Path(get_checkpoint_name(str(tmp_path), 10))
+        iter_dir.mkdir(parents=True)
+        torch.save(
+            {"dataloader_state_dict": {"generation": "old"}},
+            iter_dir / "train_dataloader_dprank001.pt",
+        )
+
+        with patch("megatron.bridge.training.checkpointing.torch.distributed.barrier"):
+            maybe_save_dataloader_state(
+                Mock(),
+                self._iterator(),
+                10,
+                str(tmp_path),
+                pg_collection=self._pg(dp=0),
+            )
+
+        with pytest.raises(RuntimeError, match="data-parallel size"):
+            maybe_load_dataloader_state(
+                Mock(),
+                10,
+                str(tmp_path),
+                pg_collection=self._pg(dp=1),
+            )
+
     @patch("megatron.bridge.training.checkpointing.torch.save")
     @patch("megatron.bridge.training.checkpointing.ensure_directory_exists")
     @patch("megatron.bridge.training.checkpointing.get_checkpoint_name")


### PR DESCRIPTION
## What changed

When an Energon checkpoint root and iteration are reused, replace the existing iteration generation before current data-parallel ranks write their state.

## User impact

A supported fresh run can reuse an existing checkpoint root after model retention has removed an old model iteration. If that run saves the same iteration at a smaller data-parallel size, the previous implementation overwrote only the current rank files and left higher-rank files from the old generation. A later resume at the larger data-parallel size could silently restore a mixture of old and new dataloader state instead of raising the documented DP-size mismatch.

The root cause is the path from retained `energon/iter_N` generations through `maybe_save_dataloader_state`: save reused the directory without clearing it, while load treats every existing per-rank file as belonging to the selected generation.

The fix is deliberately narrow: DP rank zero removes only the reused Energon iteration directory, for both local and multi-storage backends, between the existing distributed barriers. All current ranks then write a fresh generation.

## Validation

Fail-before (unmodified production code with the regression test present):

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py::TestMaybeSaveDataloaderState::test_reused_iteration_rejects_stale_dp_rank_state -q --tb=short
```

Result: `1 failed` with `DID NOT RAISE RuntimeError`; the stale higher-rank file was restored.

Pass-after: the same command passes (`1 passed`).

Adjacent coverage:

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/training/test_checkpointing.py::TestMaybeLoadDataloaderState tests/unit_tests/training/test_checkpointing.py::TestMaybeSaveDataloaderState tests/unit_tests/training/test_checkpointing.py::TestCleanupNonPersistentCheckpoints::test_cleanup_keeps_complete_checkpoint_generation_with_energon_state -q --tb=short
```

Result: `23 passed`.

```text
uv run --no-sync pre-commit run --all-files
git diff --check
```

Both passed.

Scope is limited to replacing a reused Energon generation. This does not add cross-DP Energon resume support or change checkpoint APIs, retention policy, dependencies, or CI.
