### PR TITLE
[data] fix: use eval batch size for MegatronMIMO loaders

### DIFF
--- a/src/megatron/bridge/data/megatron_mimo/loaders.py
+++ b/src/megatron/bridge/data/megatron_mimo/loaders.py
@@ -90,6 +90,16 @@ def build_megatron_mimo_data_loaders(
                 f"slice_batch_for_megatron_mimo requires an evenly divisible micro-batch."
             )
 
+    eval_micro_batch_size = cfg.validation.eval_micro_batch_size
+    for mod_name, mod_cfg in cfg.model.megatron_mimo_parallelism_config.module_parallelisms.items():
+        dp = mod_cfg.data_parallel_size
+        if eval_micro_batch_size % dp != 0:
+            raise ValueError(
+                f"eval_micro_batch_size ({eval_micro_batch_size}) must be divisible by "
+                f"data_parallel_size ({dp}) of module '{mod_name}'. "
+                "slice_batch_for_megatron_mimo requires an evenly divisible micro-batch."
+            )
+
     print_rank_0("> building MegatronMIMO train, validation, and test datasets ...")
 
     # Use cached grids from build_model()
@@ -125,12 +135,12 @@ def build_megatron_mimo_data_loaders(
     collate_fn = megatron_mimo_provider.get_collate_fn()
     micro_batch_size = cfg.train.micro_batch_size
 
-    def _make_loader(dataset, consumed_samples: int) -> Optional[DataLoader]:
+    def _make_loader(dataset, consumed_samples: int, split_micro_batch_size: int) -> Optional[DataLoader]:
         return build_pretraining_data_loader(
             dataset=dataset,
             consumed_samples=consumed_samples,
             dataloader_type=megatron_mimo_provider.dataloader_type,
-            micro_batch_size=micro_batch_size,
+            micro_batch_size=split_micro_batch_size,
             num_workers=megatron_mimo_provider.num_workers,
             data_sharding=megatron_mimo_provider.data_sharding,
             collate_fn=collate_fn,
@@ -141,8 +151,12 @@ def build_megatron_mimo_data_loaders(
             drop_last=megatron_mimo_provider.drop_last,
         )
 
-    train_loader = _make_loader(train_ds, consumed_samples=train_state.consumed_train_samples)
-    valid_loader = _make_loader(valid_ds, consumed_samples=0)
-    test_loader = _make_loader(test_ds, consumed_samples=0)
+    train_loader = _make_loader(
+        train_ds,
+        consumed_samples=train_state.consumed_train_samples,
+        split_micro_batch_size=micro_batch_size,
+    )
+    valid_loader = _make_loader(valid_ds, consumed_samples=0, split_micro_batch_size=eval_micro_batch_size)
+    test_loader = _make_loader(test_ds, consumed_samples=0, split_micro_batch_size=eval_micro_batch_size)
 
     return train_loader, valid_loader, test_loader

--- a/tests/unit_tests/data/megatron_mimo/test_loaders.py
+++ b/tests/unit_tests/data/megatron_mimo/test_loaders.py
@@ -128,6 +128,7 @@ def _make_happy_cfg(micro_batch_size: int = 3):
     return SimpleNamespace(
         model=FakeMegatronMIMOProvider(megatron_mimo_parallelism_config=fake_parallelism_config, grids=fake_grids),
         train=SimpleNamespace(micro_batch_size=micro_batch_size),
+        validation=SimpleNamespace(eval_micro_batch_size=micro_batch_size),
     )
 
 
@@ -158,6 +159,23 @@ def test_build_megatron_mimo_data_loaders_happy_path(monkeypatch):
     assert all(c["drop_last"] is True for c in builder_calls)
     assert all(c["num_workers"] == 0 for c in builder_calls)
     assert all(c["pin_memory"] is False for c in builder_calls)
+
+
+def test_build_megatron_mimo_data_loaders_uses_eval_micro_batch_size_for_eval_splits(monkeypatch):
+    builder_calls = _patch_happy_path_dependencies(monkeypatch)
+    cfg = _make_happy_cfg(micro_batch_size=3)
+    cfg.validation = SimpleNamespace(eval_micro_batch_size=2)
+
+    build_megatron_mimo_data_loaders(
+        cfg,
+        train_state=SimpleNamespace(consumed_train_samples=0),
+        megatron_mimo_provider=FakeProvider(),
+        train_samples=10,
+        valid_samples=4,
+        test_samples=2,
+    )
+
+    assert [call["micro_batch_size"] for call in builder_calls] == [3, 2, 2]
 
 
 def test_build_megatron_mimo_data_loaders_wires_consumed_samples_for_resume(monkeypatch):
@@ -248,6 +266,7 @@ def _make_real_loader_cfg(monkeypatch, *, micro_batch_size: int, sampler_dp_rank
     return SimpleNamespace(
         model=FakeMegatronMIMOProvider(megatron_mimo_parallelism_config=parallelism_config, grids={"llm": object()}),
         train=SimpleNamespace(micro_batch_size=micro_batch_size),
+        validation=SimpleNamespace(eval_micro_batch_size=micro_batch_size),
     )
 
 
@@ -337,6 +356,7 @@ def test_build_megatron_mimo_data_loaders_skips_non_data_ranks(monkeypatch):
             grids={"llm": object()},
         ),
         train=SimpleNamespace(micro_batch_size=2),
+        validation=SimpleNamespace(eval_micro_batch_size=2),
     )
     provider = FakeProvider()
     monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Fixes MegatronMIMO validation and test loaders to use the independently configured evaluation micro-batch size.

MegatronMIMO runtime configuration accepts `validation.eval_micro_batch_size` independently from `train.micro_batch_size`, and the evaluator derives its forward count and consumed-sample accounting from the evaluation value. The canonical MIMO loader nevertheless built all three splits with the training value. When the values differed, validation loss covered too few or too many examples while accounting advanced by the configured eval global batch size; exact-sized drop-last datasets could also exhaust before evaluation.

The MIMO interval-evaluation path is supported by #5409.

## Root cause and fix

`build_megatron_mimo_data_loaders()` captured `cfg.train.micro_batch_size` once and passed it to the train, validation, and test sampler builders.

This change:

- passes training MBS only to the training loader;
- passes evaluation MBS to validation and test loaders; and
- validates evaluation MBS against every module's DP degree, matching the existing training-MBS slicing invariant.

## Regression evidence

The same focused test was run before and after the production change:

```bash
uv run python -m pytest tests/unit_tests/data/megatron_mimo/test_loaders.py::test_build_megatron_mimo_data_loaders_uses_eval_micro_batch_size_for_eval_splits -q --tb=short
```

- Before: failed because loader MBS calls were `[3, 3, 3]` instead of `[3, 2, 2]`.
- After: `1 passed`.

Adjacent validation:

```bash
uv run python -m pytest tests/unit_tests/data/megatron_mimo/test_loaders.py -q --tb=short
# 10 passed

uv run python -m pytest \
  tests/unit_tests/training/test_eval.py \
  tests/unit_tests/training/megatron_mimo/test_pretrain_megatron_mimo.py \
  tests/unit_tests/data/megatron_mimo/test_dp_utils.py \
  -q --tb=short
# 37 passed

git diff --check
uv run pre-commit run --all-files
# passed
```

## Scope

This changes only canonical MegatronMIMO train/validation/test loader batch sizing and its module-DP divisibility guard. It does not change sampler order, schedule behavior, accounting code, MCore, dependencies, or public APIs. No full-suite, GPU integration, convergence, model-quality, or performance validation was run.
