### PR TITLE
fix(recipe): add library aliases for the colliding GLM-5.2 SFT recipes

### DIFF
--- a/examples/model_verification_cards/glm5-2/card.yaml
+++ b/examples/model_verification_cards/glm5-2/card.yaml
@@ -240,7 +240,7 @@ items:
         moe_dispatcher: deepep
       command: >
         ./scripts/training/train.sh --nodes 52 --gpus-per-node 8
-        --recipe glm52_sft_416gpu_h100_bf16_config --mode sft
+        --recipe glm52_h100_sft_config --mode sft
         --pretrained_checkpoint work/model-verification/glm5-2/gpu-megatron/iter_0000000
         --max_steps 100 --seq_length 2048
         dataset.hf_output_root=work/data/glm5-2/tulu3-full-sft-pad32
@@ -275,7 +275,7 @@ items:
         moe_dispatcher: hybridep
       command: >
         ./scripts/training/train.sh --nodes 48 --gpus-per-node 4
-        --recipe glm52_sft_192gpu_gb200_bf16_config --mode sft
+        --recipe glm52_gb200_sft_config --mode sft
         --pretrained_checkpoint
         work/model-verification/glm5-2/hf-4d67f66cc64d3219133b767c253b2ad1425c6c88
         --max_steps 100

--- a/src/megatron/bridge/recipes/glm/__init__.py
+++ b/src/megatron/bridge/recipes/glm/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .gb200.glm5 import (
+    glm52_gb200_sft_config,
     glm52_peft_192gpu_gb200_bf16_config,
     glm52_pretrain_192gpu_gb200_bf16_config,
     glm52_sft_192gpu_gb200_bf16_128k_config,
@@ -35,6 +36,7 @@ __all__ = [
     "glm45_air_106b_sft_config",
     "glm45_355b_peft_config",
     "glm45_air_106b_peft_config",
+    "glm52_gb200_sft_config",
     "glm52_peft_192gpu_gb200_bf16_config",
     "glm52_pretrain_192gpu_gb200_bf16_config",
     "glm52_sft_192gpu_gb200_bf16_128k_config",

--- a/src/megatron/bridge/recipes/glm/gb200/__init__.py
+++ b/src/megatron/bridge/recipes/glm/gb200/__init__.py
@@ -16,6 +16,7 @@ from megatron.bridge.recipes.glm.gb200.glm5 import *  # noqa: F403
 
 
 __all__ = [
+    "glm52_gb200_sft_config",
     "glm52_peft_192gpu_gb200_bf16_config",
     "glm52_pretrain_192gpu_gb200_bf16_config",
     "glm52_sft_192gpu_gb200_bf16_128k_config",

--- a/src/megatron/bridge/recipes/glm/gb200/glm5.py
+++ b/src/megatron/bridge/recipes/glm/gb200/glm5.py
@@ -419,7 +419,12 @@ def glm52_peft_192gpu_gb200_bf16_config(peft_scheme: str | PEFT = "lora") -> Con
     return cfg
 
 
+# Bare launcher lookup binds the same-named benchmark recipe; this alias keeps the library workload selectable.
+glm52_gb200_sft_config = glm52_sft_192gpu_gb200_bf16_config
+
+
 __all__ = [
+    "glm52_gb200_sft_config",
     "glm52_peft_192gpu_gb200_bf16_config",
     "glm52_pretrain_192gpu_gb200_bf16_config",
     "glm52_sft_192gpu_gb200_bf16_128k_config",

--- a/src/megatron/bridge/recipes/glm/h100/__init__.py
+++ b/src/megatron/bridge/recipes/glm/h100/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "glm45_air_106b_peft_8gpu_h100_bf16_config",
     "glm45_air_106b_pretrain_32gpu_h100_bf16_config",
     "glm45_air_106b_sft_32gpu_h100_bf16_config",
+    "glm52_h100_sft_config",
     "glm52_peft_208gpu_h100_bf16_config",
     "glm52_pretrain_416gpu_h100_bf16_config",
     "glm52_sft_416gpu_h100_bf16_config",

--- a/src/megatron/bridge/recipes/glm/h100/glm5.py
+++ b/src/megatron/bridge/recipes/glm/h100/glm5.py
@@ -360,7 +360,12 @@ def glm52_peft_208gpu_h100_bf16_config(peft_scheme: str | PEFT = "lora") -> Conf
     return cfg
 
 
+# Bare launcher lookup binds the same-named benchmark recipe; this alias keeps the library workload selectable.
+glm52_h100_sft_config = glm52_sft_416gpu_h100_bf16_config
+
+
 __all__ = [
+    "glm52_h100_sft_config",
     "glm52_peft_208gpu_h100_bf16_config",
     "glm52_pretrain_416gpu_h100_bf16_config",
     "glm52_sft_416gpu_h100_bf16_config",

--- a/tests/unit_tests/recipes/test_glm5_recipes.py
+++ b/tests/unit_tests/recipes/test_glm5_recipes.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 from megatron.bridge.data.builders import ChatSFTPreprocessingConfig
 from megatron.bridge.recipes.glm import gb200
@@ -345,3 +346,40 @@ def test_glm52_platform_recipes_are_exported() -> None:
         assert getattr(h100, recipe_name) is getattr(glm5, recipe_name)
         assert getattr(recipes, recipe_name) is getattr(glm5, recipe_name)
         assert recipe_name in h100.__all__
+
+
+def _glm52_card_sft_command(hardware: str) -> str:
+    card_path = Path(__file__).resolve().parents[3] / "examples/model_verification_cards/glm5-2/card.yaml"
+    card = yaml.safe_load(card_path.read_text(encoding="utf-8"))
+    return card["items"]["sft"][hardware]["command"]
+
+
+@pytest.mark.parametrize(
+    ("hardware", "alias_name", "alias", "target"),
+    [
+        ("H100", "glm52_h100_sft_config", glm5.glm52_h100_sft_config, glm5.glm52_sft_416gpu_h100_bf16_config),
+        (
+            "GB200",
+            "glm52_gb200_sft_config",
+            gb200_glm5.glm52_gb200_sft_config,
+            gb200_glm5.glm52_sft_192gpu_gb200_bf16_config,
+        ),
+    ],
+)
+def test_glm52_sft_card_command_names_the_library_alias(hardware, alias_name, alias, target) -> None:
+    assert alias is target
+    assert f"--recipe {alias_name} " in _glm52_card_sft_command(hardware)
+
+
+@pytest.mark.parametrize(
+    ("alias", "gbs", "seq_length"),
+    [
+        (glm5.glm52_h100_sft_config, 32, 2048),
+        (gb200_glm5.glm52_gb200_sft_config, 8, 8192),
+    ],
+)
+def test_glm52_sft_alias_keeps_the_documented_batch_shape(alias, gbs, seq_length) -> None:
+    cfg = alias()
+
+    assert cfg.train.global_batch_size == gbs
+    assert cfg.model.seq_length == seq_length


### PR DESCRIPTION
# What does this PR do ?

Fixes the GLM-5.2 verification card's two SFT reproduction commands launching a 131,072-token benchmark job instead of the library configuration their published metrics were measured on, by giving those library recipes a distinct name.

# Changelog

- `recipes/glm/h100/glm5.py`: add `glm52_h100_sft_config` alias.
- `recipes/glm/gb200/glm5.py`: add `glm52_gb200_sft_config` alias.
- `recipes/glm/{__init__,h100/__init__,gb200/__init__}.py`: export the aliases.
- `examples/model_verification_cards/glm5-2/card.yaml`: both SFT commands name the alias.
- `tests/unit_tests/recipes/test_glm5_recipes.py`: 4 parametrized cases over the aliases and the shipped card commands.

# Additional Information

- **Root cause:** both SFT names are exported by `megatron.bridge.recipes` and `megatron.bridge.perf_recipes`; `load_recipe` binds the benchmark definition and the library workloads had no other name.
- **Blast radius:** card only. Purely additive — the colliding names still resolve to the benchmark recipes.
- **Regression?** Yes. The SFT leaves were verified 2026-07-22 / 2026-08-04; the collision registry that changed what those names mean landed later. Found while testing #5583, not caused by it.
- **Verification:** red-green in `nvcr.io/nvidian/nemo:nightly` — RED is a collection `AttributeError` without the aliases and `2 failed` with the card unchanged; GREEN is `20 passed`. On the patched tree `load_recipe` returns gbs=32/seq=2048 (H100) and gbs=8/seq=8192 (GB200), matching the card.
- **Not included:** the other 7 `BENCHMARK_RECIPE_PRECEDENCE_COLLISIONS` entries still lack a library alias, and `validate_card.py` still does not check `--recipe`.