### PR TITLE
feat(data): add CoderForge SFT preset

### DIFF
--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -119,6 +119,7 @@ Benchmark recipes retain their recipe-owned dataset and reject `--dataset`.
 | `local-vlm` | Source selector | sft/lora/dora | Local VLM JSON/JSONL selected through `dataset.source` overrides |
 | `squad` | Named preset | sft/lora/dora | Hugging Face SQuAD preset |
 | `tulu3` | Named preset | sft/lora/dora | Ai2 Tulu 3 SFT mixture (`allenai/tulu-3-sft-mixture`) |
+| `coderforge` | Named preset | sft/lora/dora | CoderForge Preview `SWE_Rebench` agent-trajectory split |
 | `openmathinstruct2` | Named preset | sft/lora/dora | OpenMathInstruct-2 prompt/completion preset |
 | `openmathinstruct2-thinking` | Named preset | sft/lora/dora | OpenMathInstruct-2 analysis/final channel format |
 | `gsm8k` | Named preset | sft/lora/dora | GSM8K preset |
@@ -187,14 +188,23 @@ format: chain-of-thought goes to the analysis channel and the answer goes to the
 under ODC-BY-1.0, but individual subsets can carry additional terms, including non-commercial restrictions. Review the
 Hugging Face dataset card and its linked subset licenses before use.
 
+### CoderForge Preview
+
+`coderforge` selects the `trajectories` configuration and `SWE_Rebench` split of
+`togethercomputer/CoderForge-Preview`. The preset decodes the dataset's JSON-string `messages` and `tools` fields and
+uses assistant-only chat loss. Its `image` field identifies the execution environment and is retained as metadata; it
+is not treated as visual input. Use a Hugging Face split slice such as
+`'dataset.hf_dataset.split="SWE_Rebench[:64]"'` for bounded smoke runs; Hydra requires the quoted value to preserve
+the brackets.
+
 ### Offline packing
 
 Offline packing is a text SFT option, not a dataset name. Set `dataset.enable_offline_packing=true` for `squad`, either
-OpenMathInstruct-2 format, `tulu3`, `gsm8k`, or `local-jsonl`. The launcher aligns packed padding for the resolved CP/TP and
-sequence-parallel configuration. Packed training requires `train.micro_batch_size=1`. The builder materializes packed
-data automatically, so a separate packing Slurm job is not required. The selected recipe/model must support packed THD
-sequences; for example, GLM-4.5 and Qwen3-Next recipes currently do not. On multiple nodes, keep the dataset cache on
-shared mounted storage.
+OpenMathInstruct-2 format, `tulu3`, `coderforge`, `gsm8k`, or `local-jsonl`. The launcher aligns packed padding for the
+resolved CP/TP and sequence-parallel configuration. Packed training requires `train.micro_batch_size=1`. The builder
+materializes packed data automatically, so a separate packing Slurm job is not required. The selected recipe/model must
+support packed THD sequences; for example, GLM-4.5 and Qwen3-Next recipes currently do not. On multiple nodes, keep the
+dataset cache on shared mounted storage.
 
 ### In-batch packing for GPT SFT JSONL
 

--- a/src/megatron/bridge/data/packing/gpt_sft.py
+++ b/src/megatron/bridge/data/packing/gpt_sft.py
@@ -226,10 +226,19 @@ class GPTSFTPackedDataset(GPTSFTDataset):
                 for i in range(len(item["seq_boundaries"]) - 1):
                     current_seq = item["input_ids"][item["seq_boundaries"][i] : item["seq_boundaries"][i + 1] - 1]
 
-                    # Stop logical lengths at the last non-EOS token so alignment padding is excluded.
+                    # Alignment padding uses zero-loss EOS tokens. A supervised terminal EOS is part of
+                    # the logical sequence and must not be mistaken for a physical alignment gap.
                     current_seq_arr = np.array(current_seq)
-                    non_eos_positions = np.where(current_seq_arr != self.tokenizer.eos_id)[0]
-                    logical_seqlen = non_eos_positions[-1] + 1 if non_eos_positions.size > 0 else 0
+                    current_loss_mask = np.array(
+                        item["loss_mask"][item["seq_boundaries"][i] : item["seq_boundaries"][i + 1] - 1]
+                    )
+                    logical_seqlen = len(current_seq_arr)
+                    while (
+                        logical_seqlen > 0
+                        and current_seq_arr[logical_seqlen - 1] == self.tokenizer.eos_id
+                        and not current_loss_mask[logical_seqlen - 1]
+                    ):
+                        logical_seqlen -= 1
                     cu_seqlens[-1].append(cu_seqlens[-1][-1] + logical_seqlen)
 
                 # if extra paddings are added in the packed sequence, they can't be counted as
@@ -289,6 +298,8 @@ class GPTSFTPackedDataset(GPTSFTDataset):
             "loss_mask": loss_mask,
             "position_ids": torch.LongTensor(position_ids),
             "token_count": token_count,
+            "pad_between_seqs": cu_seqlens_padded is not None
+            and any(logical != padded for logical, padded in zip(cu_seqlens, cu_seqlens_padded)),
         }
         # Keep the key present for every offline-packed batch so mask handling
         # never depends on local padding contents. For fixed-width packing, this

--- a/src/megatron/bridge/data/packing/in_batch.py
+++ b/src/megatron/bridge/data/packing/in_batch.py
@@ -231,6 +231,9 @@ def build_mcore_thd_sequence_batch_from_rows(
         cu_seqlens_padded_t = torch.tensor(cu_seqlens_padded, dtype=torch.int32, device=first_tokens.device)
         packed["cu_seqlens_q_padded"] = cu_seqlens_padded_t
         packed["cu_seqlens_kv_padded"] = cu_seqlens_padded_t
+    # TE must retain physical alignment gaps in its output when the THD token
+    # stream contains padding between logical sequences (or in the final slot).
+    packed["pad_between_seqs"] = padded_lengths != unpadded_lengths
     packed["max_seqlen_q"] = torch.tensor(max(padded_lengths), dtype=torch.int32)
     packed["max_seqlen_kv"] = torch.tensor(max(padded_lengths), dtype=torch.int32)
     # MCore uses total_tokens together with the physical (padded) boundaries
@@ -341,6 +344,7 @@ def pack_right_padded_sequence_batch_to_mcore_thd(
         "cu_seqlens_kv",
         "cu_seqlens_q_padded",
         "cu_seqlens_kv_padded",
+        "pad_between_seqs",
         "max_seqlen_q",
         "max_seqlen_kv",
         "total_tokens",

--- a/src/megatron/bridge/data/sources/hf.py
+++ b/src/megatron/bridge/data/sources/hf.py
@@ -144,6 +144,13 @@ class _HFDatasetPreset:
 
 
 _HF_DATASET_PRESETS: dict[str, _HFDatasetPreset] = {
+    "coderforge": _HFDatasetPreset(
+        path_or_dataset="togethercomputer/CoderForge-Preview",
+        subset="trajectories",
+        split="SWE_Rebench",
+        schema_adapter="coderforge",
+        supported_splits=("SWE_Rebench",),
+    ),
     "cord_v2": _HFDatasetPreset(
         path_or_dataset="naver-clova-ix/cord-v2",
         schema_adapter="cord_v2",

--- a/src/megatron/bridge/data/sources/hf_adapters.py
+++ b/src/megatron/bridge/data/sources/hf_adapters.py
@@ -61,6 +61,29 @@ def _native_conversation_adapter(example: Mapping[str, Any], kwargs: Mapping[str
     return dict(example)
 
 
+def _coderforge_json_list(example: Mapping[str, Any], field_name: str) -> list[dict[str, Any]]:
+    value = example.get(field_name)
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"CoderForge {field_name} must contain valid JSON.") from error
+    if not isinstance(value, list) or not all(isinstance(item, Mapping) for item in value):
+        raise ValueError(f"CoderForge {field_name} must decode to a list of dictionaries.")
+    return [dict(item) for item in value]
+
+
+def _coderforge_adapter(example: Mapping[str, Any], _: Mapping[str, Any]) -> dict[str, Any]:
+    messages = _coderforge_json_list(example, "messages")
+    tools = _coderforge_json_list(example, "tools")
+    metadata = {key: value for key, value in example.items() if key not in {"messages", "tools", "image"}}
+    if example.get("image") is not None:
+        # CoderForge's image column names the trajectory's execution image; it
+        # is metadata, not visual input for a multimodal processor.
+        metadata["environment_image"] = example["image"]
+    return {"messages": messages, "tools": tools, **metadata}
+
+
 def _squad_adapter(example: Mapping[str, Any], _: Mapping[str, Any]) -> dict[str, Any]:
     answers = example["answers"]["text"]
     prompt = f"Context: {example['context']} Question: {example['question']} Answer:"
@@ -368,6 +391,7 @@ def prepare_hf_dataset_for_adapter(
 
 
 _ADAPTERS: dict[str, HFDatasetAdapter] = {
+    "coderforge": _coderforge_adapter,
     "squad": _squad_adapter,
     "gsm8k": _gsm8k_adapter,
     "openmathinstruct2": _openmathinstruct2_adapter,

--- a/src/megatron/bridge/recipes/utils/dataset_utils.py
+++ b/src/megatron/bridge/recipes/utils/dataset_utils.py
@@ -179,6 +179,37 @@ def default_tulu3_config(
     )
 
 
+def default_coderforge_config(
+    seq_length: int = 4096,
+    enable_offline_packing: bool = False,
+    pad_seq_to_mult: int = 1,
+) -> GPTSFTDatasetConfig:
+    """Create the default CoderForge Preview SWE-Rebench SFT dataset.
+
+    Args:
+        seq_length: Maximum sequence length.
+        enable_offline_packing: Whether to enable offline text SFT packing.
+        pad_seq_to_mult: Sequence-length multiple used by offline packing.
+
+    Returns:
+        A chat SFT configuration for the CoderForge Preview SWE-Rebench split.
+    """
+    offline_packing_specs = None
+    if enable_offline_packing:
+        offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=seq_length, pad_seq_to_mult=pad_seq_to_mult)
+
+    return _text_hf_dataset_config(
+        source=HFDatasetSourceConfig(dataset_name="coderforge"),
+        preprocessing=ChatSFTPreprocessingConfig(),
+        seq_length=seq_length,
+        do_validation=False,
+        do_test=False,
+        enable_offline_packing=enable_offline_packing,
+        offline_packing_specs=offline_packing_specs,
+        num_workers=2,
+    )
+
+
 def default_openmathinstruct2_config(
     seq_length: int = 4096,
     enable_offline_packing: bool = False,
@@ -452,6 +483,11 @@ def _tulu3_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
     return default_tulu3_config(seq_length=_resolve_seq_length(config))
 
 
+def _coderforge_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
+    """Build the CoderForge Preview SWE-Rebench chat SFT preset."""
+    return default_coderforge_config(seq_length=_resolve_seq_length(config))
+
+
 def _openmathinstruct2_dataset_config(config: ConfigContainer) -> GPTSFTDatasetConfig:
     """Build the OpenMathInstruct-2 prompt-completion preset."""
     return default_openmathinstruct2_config(seq_length=_resolve_seq_length(config))
@@ -544,6 +580,7 @@ DATASET_PRESETS: dict[str, DatasetPreset] = {
     "energon": _energon_dataset_config,
     "squad": _squad_dataset_config,
     "tulu3": _tulu3_dataset_config,
+    "coderforge": _coderforge_dataset_config,
     "openmathinstruct2": _openmathinstruct2_dataset_config,
     "openmathinstruct2-thinking": _openmathinstruct2_thinking_dataset_config,
     "gsm8k": _gsm8k_dataset_config,

--- a/src/megatron/bridge/training/gpt_step.py
+++ b/src/megatron/bridge/training/gpt_step.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 _CURRENT_PACKED_SEQ_DEVICE_KEYS = ("cu_seqlens_q", "cu_seqlens_kv", "cu_seqlens_q_padded", "cu_seqlens_kv_padded")
-_CURRENT_PACKED_SEQ_HOST_KEYS = ("max_seqlen_q", "max_seqlen_kv")
+_CURRENT_PACKED_SEQ_HOST_KEYS = ("max_seqlen_q", "max_seqlen_kv", "pad_between_seqs")
 _CURRENT_PACKED_SEQ_PARAM_KEYS = (*_CURRENT_PACKED_SEQ_DEVICE_KEYS, *_CURRENT_PACKED_SEQ_HOST_KEYS, "total_tokens")
 _LEGACY_PACKED_SEQ_DEVICE_KEYS = ("cu_seqlens", "cu_seqlens_unpadded")
 _LEGACY_PACKED_SEQ_HOST_KEYS = ("cu_seqlens_argmin", "max_seqlen", "cu_seqlens_unpadded_argmin")
@@ -330,6 +330,7 @@ def _partition_packed_batch_for_cp(
         "cu_seqlens_kv_padded",
         "max_seqlen_q",
         "max_seqlen_kv",
+        "pad_between_seqs",
         "token_count",
         # THD/packed attention is driven by cu_seqlens (PackedSeqParams), so the dense
         # attention_mask is unused here. It is also not sequence-partitionable: it is
@@ -404,7 +405,7 @@ def get_batch_from_iterator(
         if key in required_device_keys:
             _batch_required_keys[key] = val.cuda(non_blocking=True) if val is not None else None
         elif key in required_host_keys:
-            _batch_required_keys[key] = val.cpu() if val is not None else None
+            _batch_required_keys[key] = val.cpu() if isinstance(val, torch.Tensor) else val
         else:
             _batch_required_keys[key] = None
 

--- a/src/megatron/bridge/training/utils/omegaconf_utils.py
+++ b/src/megatron/bridge/training/utils/omegaconf_utils.py
@@ -495,6 +495,22 @@ def _apply_overrides(config_obj: DataclassInstance, overrides_dict: Dict[str, An
                 # Handle special case conversions if needed
                 final_value = value
 
+                # Hydra serializes Enum members to strings. Restore the original
+                # field's Enum type so downstream identity/equality checks keep
+                # working after CLI or YAML overrides.
+                if isinstance(current_attr, Enum) and not isinstance(value, type(current_attr)):
+                    enum_type = type(current_attr)
+                    try:
+                        final_value = enum_type[value] if isinstance(value, str) else enum_type(value)
+                    except (KeyError, ValueError):
+                        try:
+                            final_value = enum_type(value)
+                        except ValueError:
+                            logger.warning(
+                                f"Could not convert '{value}' back to {enum_type.__name__}; keeping provided value"
+                            )
+                            final_value = value
+
                 # If the original was a torch.dtype and value is a string, convert back
                 if isinstance(current_attr, torch.dtype) and isinstance(value, str):
                     from megatron.bridge.utils.activation_map import str_to_dtype

--- a/src/megatron/bridge/training/utils/packed_seq_utils.py
+++ b/src/megatron/bridge/training/utils/packed_seq_utils.py
@@ -244,6 +244,18 @@ def _as_python_int(value: PackedMetadataValue, *, field_name: str) -> int | None
     return int(value)
 
 
+def _as_python_bool(value: PackedMetadataValue, *, field_name: str) -> bool | None:
+    """Normalize scalar packed-sequence metadata to MCore's boolean contract."""
+    value = _squeeze_metadata(value)
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            raise ValueError(f"{field_name} must contain exactly one value, got shape {tuple(value.shape)}")
+        return bool(value.item())
+    return bool(value)
+
+
 def get_packed_seq_params(batch: dict[str, PackedMetadataValue]) -> PackedSeqParams:
     """Build packed sequence parameters from a batch dictionary.
 
@@ -277,6 +289,11 @@ def get_packed_seq_params(batch: dict[str, PackedMetadataValue]) -> PackedSeqPar
             max_seqlen_kv=max_seqlen_kv if max_seqlen_kv is not None else max_seqlen_q,
             total_tokens=batch.get("total_tokens"),
             qkv_format="thd",
+            **(
+                {"pad_between_seqs": _as_python_bool(batch.get("pad_between_seqs"), field_name="pad_between_seqs")}
+                if hasattr(PackedSeqParams, "pad_between_seqs")
+                else {}
+            ),
             # cp_partition_mode available in dev MCore only.
             **(
                 {

--- a/tests/unit_tests/data/datasets/test_chat_template.py
+++ b/tests/unit_tests/data/datasets/test_chat_template.py
@@ -1040,7 +1040,7 @@ class TestEOSIndexFixInPackedDataset:
             {
                 "input_ids": np.array([7, 0, 0, 0, 0], dtype=np.int64),
                 "seq_boundaries": [0, 5],
-                "loss_mask": np.ones(5, dtype=np.int64),
+                "loss_mask": np.array([1, 0, 0, 0, 0], dtype=np.int64),
             }
         ]
 
@@ -1069,7 +1069,7 @@ class TestEOSIndexFixInPackedDataset:
             {
                 "input_ids": np.array([7, 0, 0, 0, 0], dtype=np.int64),
                 "seq_boundaries": [0, 5],
-                "loss_mask": np.ones(5, dtype=np.int64),
+                "loss_mask": np.array([1, 0, 0, 0, 0], dtype=np.int64),
             }
         ]
 
@@ -1080,6 +1080,23 @@ class TestEOSIndexFixInPackedDataset:
         assert processed["cu_seqlens_kv"][0].tolist() == [0, 1, 1, 1, 1]
         assert processed["cu_seqlens_q_padded"][0].tolist() == [0, 4, 8, 8, 8]
         assert processed["cu_seqlens_kv_padded"][0].tolist() == [0, 4, 8, 8, 8]
+
+    def test_supervised_terminal_eos_precedes_zero_loss_padding(self):
+        """A supervised EOS remains logical while later zero-loss EOS tokens are padding."""
+        dataset = _create_minimal_packed_dataset()
+        batch = [
+            {
+                "input_ids": np.array([7, 0, 0, 0, 0], dtype=np.int64),
+                "seq_boundaries": [0, 5],
+                "loss_mask": np.array([1, 1, 0, 0, 0], dtype=np.int64),
+            }
+        ]
+
+        processed = dataset.collate_fn(batch)
+
+        assert processed["cu_seqlens_q"][0].tolist() == [0, 2]
+        assert processed["cu_seqlens_q_padded"][0].tolist() == [0, 4]
+        assert processed["padding_mask"].tolist() == [[False, False, True, True]]
 
     def test_without_alignment_padding_omits_physical_variants(self):
         """Identical logical and physical layouts use only the faster logical TE fields."""
@@ -1274,14 +1291,14 @@ class TestLogicalCuSeqlensCalculation:
                     dtype=np.int64,
                 ),
                 "seq_boundaries": [0, 5, 10],
-                "loss_mask": np.ones(10, dtype=np.int64),
+                "loss_mask": np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=np.int64),
             }
         ]
 
         processed = dataset.collate_fn(batch)
         cu_logical = processed["cu_seqlens_q"][0].tolist()
 
-        # Each non-EOS token contributes exactly once despite EOS padding.
+        # Each non-EOS token contributes exactly once despite zero-loss EOS padding.
         assert cu_logical == [0, 1, 2]
 
 

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -515,7 +515,7 @@ class TestDataGPTSFTPackedDataset:
             {
                 "input_ids": np.array([10, 11, 12, 2, 2, 20, 21, 2, 2, 2]),
                 "seq_boundaries": [0, 5, 10],
-                "loss_mask": np.ones(10, dtype=np.int64),
+                "loss_mask": np.array([1, 1, 1, 0, 0, 1, 1, 0, 0, 0]),
             }
         ]
 
@@ -524,8 +524,29 @@ class TestDataGPTSFTPackedDataset:
         assert processed["tokens"].tolist() == [[10, 11, 12, 2, 20, 21, 2, 2]]
         assert processed["cu_seqlens_q"].tolist() == [[0, 3, 5]]
         assert processed["cu_seqlens_q_padded"].tolist() == [[0, 4, 8]]
+        assert processed["pad_between_seqs"] is True
         assert processed["padding_mask"].dtype == torch.bool
         assert processed["padding_mask"].tolist() == [[False, False, False, True, False, False, True, True]]
+
+    def test_collate_fn_preserves_supervised_terminal_eos(self, tmp_path):
+        """A supervised chat EOS remains part of the logical sequence."""
+        dataset, _ = get_gpt_sft(tmp_path, dataset_type="packed")
+        dataset.max_seq_length = 4
+        dataset._pad_seq_to_mult = 4
+        batch = [
+            {
+                "input_ids": np.array([10, 11, 12, 2, 2]),
+                "seq_boundaries": [0, 5],
+                "loss_mask": np.array([1, 1, 1, 1, 0]),
+            }
+        ]
+
+        processed = dataset.collate_fn(batch)
+
+        assert processed["cu_seqlens_q"].tolist() == [[0, 4]]
+        assert processed["cu_seqlens_q_padded"].tolist() == [[0, 4]]
+        assert processed["pad_between_seqs"] is False
+        assert processed["padding_mask"].tolist() == [[False, False, False, False]]
 
     def test_collate_fn_marks_offline_trailing_padding_without_alignment(self, tmp_path):
         """Default offline packing masks padding added to reach the batch width."""

--- a/tests/unit_tests/data/packing/test_in_batch.py
+++ b/tests/unit_tests/data/packing/test_in_batch.py
@@ -152,6 +152,7 @@ class TestPackBatchSequences:
         assert packed["loss_mask"].tolist() == [[1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]]
         assert packed["cu_seqlens_q"].tolist() == [0, 3, 5]
         assert packed["cu_seqlens_q_padded"].tolist() == [0, 3, 8]
+        assert packed["pad_between_seqs"] is True
         assert packed["max_seqlen_q"].item() == 5
         assert packed["total_tokens"] == 8
 
@@ -231,6 +232,7 @@ class TestPackBatchSequences:
         assert batch["padding_mask"].tolist() == [[False, False, False, True, False, False, True, True]]
         assert batch["cu_seqlens_q"].tolist() == [0, 3, 5]
         assert batch["cu_seqlens_q_padded"].tolist() == [0, 4, 8]
+        assert batch["pad_between_seqs"] is True
 
     def test_packing_removes_stale_padding_mask_when_not_emitted(self):
         """Packing without mask emission removes an incompatible input mask."""

--- a/tests/unit_tests/data/sources/test_hf.py
+++ b/tests/unit_tests/data/sources/test_hf.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
+import json
+
 import pytest
 
 from megatron.bridge.data.sources import hf as source_module
@@ -229,6 +231,29 @@ def test_tulu3_preset_uses_current_native_chat_dataset(monkeypatch):
     assert resolved.schema_adapter is None
     assert calls == [("allenai/tulu-3-sft-mixture", "train", {})]
     assert adapted == rows
+
+
+def test_coderforge_preset_selects_swe_rebench_and_decodes_rows(monkeypatch):
+    messages = [{"role": "assistant", "content": "done"}]
+    tools = [{"type": "function", "function": {"name": "finish"}}]
+    calls = []
+
+    def _load_dataset(path, subset, *, split, **kwargs):
+        calls.append((path, subset, split, kwargs))
+        return [{"messages": json.dumps(messages), "tools": json.dumps(tools), "image": "runner/image"}]
+
+    monkeypatch.setattr(source_module, "load_dataset", _load_dataset)
+    source = HFDatasetSourceConfig(dataset_name="coderforge", split="SWE_Rebench[:64]")
+
+    resolved = resolve_hf_dataset_source(source)
+    adapted = load_and_adapt_hf_dataset(source)
+
+    assert resolved.path_or_dataset == "togethercomputer/CoderForge-Preview"
+    assert resolved.subset == "trajectories"
+    assert resolved.split == "SWE_Rebench[:64]"
+    assert resolved.schema_adapter == "coderforge"
+    assert calls == [("togethercomputer/CoderForge-Preview", "trajectories", "SWE_Rebench[:64]", {})]
+    assert adapted == [{"messages": messages, "tools": tools, "environment_image": "runner/image"}]
 
 
 def test_load_and_adapt_composes_source_loader_and_adapter(monkeypatch):

--- a/tests/unit_tests/data/sources/test_hf_adapters.py
+++ b/tests/unit_tests/data/sources/test_hf_adapters.py
@@ -61,6 +61,56 @@ def test_openmath_thinking_adapter_separates_reasoning_and_answer():
     ]
 
 
+def test_coderforge_adapter_decodes_messages_tools_and_execution_image():
+    messages = [
+        {"role": "user", "content": "Fix the bug."},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"type": "function", "function": {"name": "execute_bash", "arguments": "{}"}}],
+        },
+    ]
+    tools = [{"type": "function", "function": {"name": "execute_bash", "description": "Run a command"}}]
+
+    adapted = adapt_hf_dataset(
+        [
+            {
+                "trajectory_id": "example-run1",
+                "messages": json.dumps(messages),
+                "tools": json.dumps(tools),
+                "image": "example/eval-image",
+                "reward": 1.0,
+            }
+        ],
+        adapter_name="coderforge",
+    )
+
+    assert adapted == [
+        {
+            "messages": messages,
+            "tools": tools,
+            "trajectory_id": "example-run1",
+            "reward": 1.0,
+            "environment_image": "example/eval-image",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "error"),
+    [
+        ("messages", "not json", "must contain valid JSON"),
+        ("messages", json.dumps({"role": "user"}), "must decode to a list"),
+        ("tools", json.dumps(["not-a-tool"]), "must decode to a list"),
+    ],
+)
+def test_coderforge_adapter_rejects_invalid_json_lists(field_name, value, error):
+    row = {"messages": "[]", "tools": "[]", field_name: value}
+
+    with pytest.raises(ValueError, match=error):
+        adapt_hf_dataset([row], adapter_name="coderforge")
+
+
 @pytest.mark.parametrize(
     "ground_truth",
     [

--- a/tests/unit_tests/recipes/utils/test_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_dataset_utils.py
@@ -127,6 +127,7 @@ class TestDatasetPresets:
             "energon",
             "squad",
             "tulu3",
+            "coderforge",
             "openmathinstruct2",
             "openmathinstruct2-thinking",
             "gsm8k",
@@ -256,6 +257,7 @@ class TestDatasetPresets:
         [
             ("squad", "squad"),
             ("tulu3", "tulu3"),
+            ("coderforge", "coderforge"),
             ("openmathinstruct2", "openmathinstruct2"),
             ("openmathinstruct2-thinking", "openmathinstruct2_thinking"),
             ("gsm8k", "gsm8k"),

--- a/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
+++ b/tests/unit_tests/recipes/utils/test_sft_dataset_utils.py
@@ -23,6 +23,7 @@ from megatron.bridge.data.builders import (
 )
 from megatron.bridge.data.sft_processing import normalize_sft_example
 from megatron.bridge.recipes.utils.dataset_utils import (
+    default_coderforge_config,
     default_gsm8k_config,
     default_openmathinstruct2_config,
     default_openmathinstruct2_thinking_config,
@@ -52,6 +53,29 @@ class TestDefaultTulu3Config:
         assert cfg.offline_packing_specs is not None
         assert cfg.offline_packing_specs.packed_sequence_size == 8192
         assert cfg.offline_packing_specs.pad_seq_to_mult == 4
+
+
+@pytest.mark.unit
+class TestDefaultCoderForgeConfig:
+    def test_uses_swe_rebench_chat_preset_without_eval(self):
+        cfg = default_coderforge_config()
+
+        assert isinstance(cfg, GPTSFTDatasetConfig)
+        assert cfg.hf_dataset.dataset_name == "coderforge"
+        assert cfg.hf_dataset.split is None
+        assert isinstance(cfg.preprocessing, ChatSFTPreprocessingConfig)
+        assert cfg.do_validation is False
+        assert cfg.do_test is False
+        assert cfg.dataloader_type == "batch"
+
+    def test_custom_sequence_length_and_offline_packing(self):
+        cfg = default_coderforge_config(seq_length=131072, enable_offline_packing=True, pad_seq_to_mult=16)
+
+        assert cfg.seq_length == 131072
+        assert cfg.enable_offline_packing is True
+        assert cfg.offline_packing_specs is not None
+        assert cfg.offline_packing_specs.packed_sequence_size == 131072
+        assert cfg.offline_packing_specs.pad_seq_to_mult == 16
 
 
 @pytest.mark.unit

--- a/tests/unit_tests/scripts/training/test_run_recipe.py
+++ b/tests/unit_tests/scripts/training/test_run_recipe.py
@@ -69,6 +69,7 @@ def _load_module():
         "energon",
         "squad",
         "tulu3",
+        "coderforge",
         "openmathinstruct2",
         "openmathinstruct2-thinking",
         "gsm8k",
@@ -895,12 +896,13 @@ def test_named_finetuning_dataset_maps_to_internal_config():
     handles.recipe_runner.apply_cli_overrides.assert_called_once_with(config, [])
 
 
-def test_tulu3_dataset_is_listed_in_launcher_help():
+@pytest.mark.parametrize("dataset_name", ["tulu3", "coderforge"])
+def test_named_dataset_is_listed_in_launcher_help(dataset_name):
     module, _ = _load_module()
 
     help_text = module._build_parser().format_help()
 
-    assert "tulu3" in help_text
+    assert dataset_name in help_text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/training/test_gpt_step.py
+++ b/tests/unit_tests/training/test_gpt_step.py
@@ -223,6 +223,7 @@ class TestGetBatch:
             "cu_seqlens_kv_padded": torch.tensor([0, 4, 8], dtype=torch.int32),
             "max_seqlen_q": torch.tensor(4, dtype=torch.int32),
             "max_seqlen_kv": torch.tensor(4, dtype=torch.int32),
+            "pad_between_seqs": True,
         }
 
         out = _partition_packed_batch_for_cp(batch, cp_group)
@@ -234,6 +235,7 @@ class TestGetBatch:
         assert torch.equal(out["position_ids"], torch.tensor([[0, 1, 2, 3]]))
         assert torch.equal(out["loss_mask"], torch.ones(1, 4))
         assert torch.equal(out["padding_mask"], torch.tensor([[False, False, False, True]]))
+        assert out["pad_between_seqs"] is True
 
     def test_partition_packed_batch_trims_negative_sentinel_fallback(self, monkeypatch):
         """Packed CP slicing can trim CPU cu_seqlens without a precomputed argmin."""
@@ -328,6 +330,7 @@ class TestGetBatch:
             "cu_seqlens_kv_padded": cu_seqlens_kv_padded,
             "max_seqlen_q": max_seqlen_q,
             "max_seqlen_kv": max_seqlen_kv,
+            "pad_between_seqs": True,
         }
 
         (
@@ -356,6 +359,7 @@ class TestGetBatch:
         assert torch.equal(packed_seq_metadata["cu_seqlens_kv_padded"], cu_seqlens_kv_padded)
         assert torch.equal(packed_seq_metadata["max_seqlen_q"], max_seqlen_q)
         assert torch.equal(packed_seq_metadata["max_seqlen_kv"], max_seqlen_kv)
+        assert packed_seq_metadata["pad_between_seqs"] is True
         assert "cu_seqlens" not in packed_seq_metadata
         assert "cu_seqlens_argmin" not in packed_seq_metadata
 

--- a/tests/unit_tests/training/utils/test_omegaconf_utils.py
+++ b/tests/unit_tests/training/utils/test_omegaconf_utils.py
@@ -49,6 +49,20 @@ class SimpleConfig:
     value: int = 42
 
 
+class ExampleMode(Enum):
+    """Example enum for testing typed override restoration."""
+
+    FIRST = 1
+    SECOND = 2
+
+
+@dataclasses.dataclass
+class ConfigWithEnum:
+    """Config with an enum field."""
+
+    mode: ExampleMode = ExampleMode.FIRST
+
+
 @dataclasses.dataclass
 class ConfigWithCallable:
     """Config with callable fields for testing."""
@@ -500,6 +514,14 @@ class TestApplyOverrides:
 
         assert config.dtype == torch.float16
 
+    def test_enum_conversion(self):
+        """Test enum member-name conversion."""
+        config = ConfigWithEnum()
+
+        _apply_overrides(config, {"mode": "SECOND"})
+
+        assert config.mode is ExampleMode.SECOND
+
     def test_invalid_key_handling(self):
         """Test handling of invalid override keys."""
         config = SimpleConfig()
@@ -623,6 +645,14 @@ class TestProcessConfigWithOverrides:
         assert result.simple.name == "cli_updated"
         assert result.simple.value == 999
         assert result.with_callable.activation_func == original_func
+
+    def test_cli_override_preserves_enum_type(self):
+        """Test CLI overrides restore enum members instead of leaving strings."""
+        config = ConfigWithEnum()
+
+        result = process_config_with_overrides(config, cli_overrides=["mode=SECOND"])
+
+        assert result.mode is ExampleMode.SECOND
 
     def test_with_config_filepath(self, tmp_path):
         """Test processing config with YAML config file."""

--- a/tests/unit_tests/training/utils/test_packed_seq_utils.py
+++ b/tests/unit_tests/training/utils/test_packed_seq_utils.py
@@ -205,6 +205,7 @@ class TestGetPackedSeqParams:
             "cu_seqlens_kv_padded": torch.IntTensor([0, 128, 256, 384]),
             "max_seqlen_q": torch.tensor(128),
             "max_seqlen_kv": torch.tensor(128),
+            "pad_between_seqs": True,
         }
 
         result = get_packed_seq_params(batch)
@@ -215,6 +216,7 @@ class TestGetPackedSeqParams:
         torch.testing.assert_close(result.cu_seqlens_kv_padded, batch["cu_seqlens_kv_padded"])
         assert result.max_seqlen_q == 128
         assert result.max_seqlen_kv == 128
+        assert result.pad_between_seqs is True
         assert isinstance(result.max_seqlen_q, int)
         assert isinstance(result.max_seqlen_kv, int)
         assert result.qkv_format == "thd"


### PR DESCRIPTION
## Summary

- add a named CoderForge Preview `SWE_Rebench` SFT preset and JSON schema adapter
- restore enum types after Hydra overrides so typed selectors such as the attention backend remain valid
- propagate physical-gap metadata through packed batches and preserve supervised terminal EOS tokens during offline packing

Stacked on #5493.

## Validation

- focused unit suite: 438 passed, 5 deselected
- `uv run pre-commit run --all-files`
- Qwen3 0.6B 128K SFT smoke tests on 8 H100 GPUs (TP1/CP8), three optimizer steps each:
  - no packing: finite losses, zero skipped or NaN iterations
  - in-batch packing: 128K bins, finite losses, zero skipped or NaN iterations
  - offline packing: 128K bins with no single-sequence cap, finite losses, zero skipped or NaN iterations
