### PR TITLE
[data] fix: Handle Gemma 4 tool call boundaries

### DIFF
--- a/src/megatron/bridge/data/conversation_processing.py
+++ b/src/megatron/bridge/data/conversation_processing.py
@@ -750,6 +750,7 @@ def _infer_terminal_assistant_content_start(
 
     empty_conversation = [dict(turn) for turn in conversation]
     empty_conversation[-1]["content"] = ""
+    empty_conversation[-1].pop("tool_calls", None)
     empty_chat = _apply_tokenized_chat_template(template_owner, empty_conversation, untruncated_kwargs)
     empty_ids = _chat_template_input_ids(empty_chat)
     untruncated_content_start = _common_token_prefix_length(empty_ids, full_ids)
@@ -1058,7 +1059,7 @@ def infer_assistant_mask_boundary_config(processor: Any) -> AssistantMaskBoundar
                 "user": "<|im_user|>user<|im_middle|>",
             },
         ),
-        (("<|turn>model", "<turn|>"), "<|turn>model\n", "<turn|>", (), {}),
+        (("<|turn>model", "<turn|>"), "<|turn>model\n", "<turn|>", ("<|tool_response>",), {}),
         (("<start_of_turn>model", "<end_of_turn>"), "<start_of_turn>model\n", "<end_of_turn>", (), {}),
         (
             ("<|start_header_id|>", "<|end_header_id|>", "<|eot_id|>"),
@@ -1348,7 +1349,15 @@ def _assistant_mask_from_conversation_turns(
             return None
 
         role_start, content_start = find_token_span(rendered_ids, start_tokens, turn_search_start)
-        if role_start < 0 or content_start > turn_limit:
+        matched_start_length = len(start_tokens)
+        if role_start < 0:
+            if turn_index == 0 or conversation[turn_index - 1].get("role") != "tool":
+                return None
+            # Some tool templates continue the same model turn after an inline tool response,
+            # so the next assistant payload begins at the prefix boundary without another role header.
+            role_start = content_start = turn_search_start
+            matched_start_length = 0
+        if content_start > turn_limit:
             return None
 
         candidate_ends: list[tuple[int, int, int, list[int]]] = []
@@ -1381,7 +1390,7 @@ def _assistant_mask_from_conversation_turns(
         if include_content:
             rendered_mask[loss_start:content_end] = 1.0
         if role in include_start_roles:
-            rendered_mask[role_start : role_start + len(start_tokens)] = 1.0
+            rendered_mask[role_start : role_start + matched_start_length] = 1.0
         if role in include_end_roles:
             rendered_mask[content_end:after_end] = 1.0
 

--- a/tests/unit_tests/data/test_conversation_processing.py
+++ b/tests/unit_tests/data/test_conversation_processing.py
@@ -1310,6 +1310,106 @@ def test_gpt_oss_harmony_assistant_mask_covers_analysis_and_final_channels():
     assert all(mask[position] for position in reasoning_positions + answer_positions)
 
 
+class _Gemma4ToolCallBoundaryTokenizer(_Tokenizer):
+    chat_template = (
+        "{% if add_generation_prompt %}<|turn>model\n{% endif %}"
+        "{% for message in messages %}<|turn>{{ message.role }}{{ message.content }}"
+        "{% if message.tool_calls %}<|tool_call>{{ message.tool_calls }}<tool_call|><|tool_response>{% endif %}"
+        "<turn|>{% endfor %}"
+    )
+
+    def __call__(self, text, add_special_tokens=False):
+        mapping = {
+            "<|turn>model\n": [10],
+            "<turn|>": [11],
+            "<|tool_response>": [12],
+            "<tool_response|>": [13],
+        }
+        return {"input_ids": mapping.get(text, [42])}
+
+    def apply_chat_template(
+        self,
+        conversation,
+        tokenize=True,
+        add_generation_prompt=False,
+        return_dict=False,
+        **kwargs,
+    ):
+        assert tokenize is True
+        assert add_generation_prompt is False
+        assert return_dict is True
+        input_ids = []
+        previous_non_tool_role = None
+        for turn_index, turn in enumerate(conversation):
+            role = turn["role"]
+            if role == "user":
+                input_ids.extend([20, 21, 11])
+            elif role == "assistant":
+                if previous_non_tool_role != "assistant":
+                    input_ids.append(10)
+                if turn.get("tool_calls"):
+                    input_ids.append(30)
+                    following_turn = conversation[turn_index + 1] if turn_index + 1 < len(conversation) else None
+                    if following_turn is not None and following_turn["role"] == "tool":
+                        input_ids.extend([12, 40, 13])
+                    else:
+                        input_ids.append(12)
+                if turn.get("content"):
+                    input_ids.append(50)
+                if not turn.get("tool_calls"):
+                    input_ids.append(11)
+                previous_non_tool_role = role
+        return {"input_ids": input_ids}
+
+
+@pytest.mark.parametrize(
+    ("trailing_messages", "expected_input_ids", "expected_mask", "expected_final_start"),
+    [
+        ([], [20, 21, 11, 10, 30, 12], [False, False, False, False, True, True], 4),
+        (
+            [
+                {"role": "tool", "tool_call_id": "call-1", "content": '{"temperature":"72F"}'},
+                {"role": "assistant", "content": "It is 72F."},
+            ],
+            [20, 21, 11, 10, 30, 12, 40, 13, 50, 11],
+            [False, False, False, False, True, True, False, False, True, True],
+            8,
+        ),
+    ],
+)
+def test_gemma4_tool_call_assistant_mask_and_generation_boundary(
+    trailing_messages,
+    expected_input_ids,
+    expected_mask,
+    expected_final_start,
+):
+    messages = [
+        {"role": "user", "content": "Weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"city":"Denver"}'},
+                }
+            ],
+        },
+        *trailing_messages,
+    ]
+
+    tokenized = tokenize_chat_example(
+        {"messages": messages},
+        _Gemma4ToolCallBoundaryTokenizer(),
+        return_final_assistant_start=True,
+    )
+
+    assert tokenized.input_ids.tolist() == expected_input_ids
+    assert tokenized.assistant_mask.tolist() == expected_mask
+    assert tokenized.final_assistant_start == expected_final_start
+
+
 @pytest.mark.parametrize("column", ["messages", "conversation", "conversations"])
 def test_shared_chat_preprocessing_supports_all_declared_conversation_columns(column):
     turns = [


### PR DESCRIPTION
## What does this PR do?

Fixes shared chat preprocessing for supported Gemma 4 instruction-tokenizer conversations containing OpenAI-style assistant `tool_calls`.

A Gemma 4 tool call ends its generated assistant span with `<|tool_response>` rather than the ordinary `<turn|>` marker. Completed tool exchanges can also continue with a final assistant payload without emitting another model header. The shared boundary scanner previously handled neither case, so both GPT SFT and direct-HF text SFT aborted with:

```text
ValueError: AssistantMaskBoundaryConfig did not match any loss-contributing spans in input_ids.
```

## Root cause and fix

`infer_assistant_mask_boundary_config` only recognized `<turn|>` as the Gemma assistant terminator. The conversation-aware scanner also required every assistant message to begin with a model header, even when a tool response remained inside the same model turn. Finally, terminal-generation boundary inference retained `tool_calls` while clearing only `content`, so the generated tool payload remained in the comparison render.

This change:

- accepts `<|tool_response>` as the Gemma tool-call assistant terminator;
- permits a headerless assistant continuation only immediately after a tool message;
- removes `tool_calls` when deriving the terminal assistant payload boundary.

The behavior remains limited to the existing supported chat schema and inferred Gemma boundary family. It does not add models, configuration, dependencies, or public API surface.

## Validation

Fail-before on unmodified `main`, using the unchanged focused regression:

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/data/test_conversation_processing.py::test_gemma4_tool_call_assistant_mask_and_generation_boundary -q --tb=short
# 2 failed at the claimed AssistantMaskBoundaryConfig ValueError
```

Pass-after:

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/data/test_conversation_processing.py::test_gemma4_tool_call_assistant_mask_and_generation_boundary -q --tb=short
# 2 passed

uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/data/test_conversation_processing.py -q --tb=short
# 108 passed

uv run --no-sync pre-commit run --all-files
# passed

git diff --check
# passed
```

A cached official Gemma 4 instruction tokenizer was also checked for terminal and completed tool-call exchanges: assistant tool-call/final-answer tokens are supervised, tool-response tokens remain unsupervised, and the final assistant split is correct.

No full test suite, convergence, model-quality, or performance validation was run.
