### PR TITLE
[model] fix: clamp the first CP chunk slice in preprocess_packed_seqs

### DIFF
--- a/src/megatron/bridge/models/exaone/exaone45/modelling_exaone45/utils.py
+++ b/src/megatron/bridge/models/exaone/exaone45/modelling_exaone45/utils.py
@@ -633,14 +633,24 @@ def preprocess_packed_seqs(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i, attention_mask[i]]
-            input_ids_rmpad[start_idx : start_idx + half_seqlen] = d[
-                half_seqlen * cp_rank : half_seqlen * (cp_rank + 1)
-            ]
+            # Chunk indices are computed in the *padded* coordinate space
+            # (seqlen_padded_i), while d holds only the *valid* tokens. When a row's
+            # valid length is shorter than the alignment padding, the first-chunk
+            # slice can start past the end of d and yield an empty tensor, which
+            # raises on assignment:
+            #   RuntimeError: The expanded size of the tensor (2) must match the
+            #   existing size (0) at non-singleton dimension 0
+            # Clamp it the same way the remaining chunk below already is.
+            first_start = half_seqlen * cp_rank
+            first_end = min(half_seqlen * (cp_rank + 1), d.shape[0])
+            first_len = max(first_end - first_start, 0)
+            if first_len > 0:
+                input_ids_rmpad[start_idx : start_idx + first_len] = d[first_start:first_end]
 
             remain_start = seqlen_padded_i - half_seqlen * (cp_rank + 1)
             remain_end = seqlen_padded_i - half_seqlen * cp_rank
             remain_end = min(remain_end, d.shape[0])
-            remain_len = remain_end - remain_start
+            remain_len = max(remain_end - remain_start, 0)
             if remain_len > 0:
                 input_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + remain_len] = d[
                     remain_start:remain_end

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py
@@ -767,14 +767,24 @@ def preprocess_packed_seqs(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i, attention_mask[i]]
-            input_ids_rmpad[start_idx : start_idx + half_seqlen] = d[
-                half_seqlen * cp_rank : half_seqlen * (cp_rank + 1)
-            ]
+            # Chunk indices are computed in the *padded* coordinate space
+            # (seqlen_padded_i), while d holds only the *valid* tokens. When a row's
+            # valid length is shorter than the alignment padding, the first-chunk
+            # slice can start past the end of d and yield an empty tensor, which
+            # raises on assignment:
+            #   RuntimeError: The expanded size of the tensor (2) must match the
+            #   existing size (0) at non-singleton dimension 0
+            # Clamp it the same way the remaining chunk below already is.
+            first_start = half_seqlen * cp_rank
+            first_end = min(half_seqlen * (cp_rank + 1), d.shape[0])
+            first_len = max(first_end - first_start, 0)
+            if first_len > 0:
+                input_ids_rmpad[start_idx : start_idx + first_len] = d[first_start:first_end]
 
             remain_start = seqlen_padded_i - half_seqlen * (cp_rank + 1)
             remain_end = seqlen_padded_i - half_seqlen * cp_rank
             remain_end = min(remain_end, d.shape[0])
-            remain_len = remain_end - remain_start
+            remain_len = max(remain_end - remain_start, 0)
             if remain_len > 0:
                 input_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + remain_len] = d[
                     remain_start:remain_end

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_utils.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_utils.py
@@ -511,6 +511,41 @@ class TestQwen3VLUtils:
         not torch.cuda.is_available() or int(os.environ.get("WORLD_SIZE", "1")) < 2,
         reason="Requires at least 2 GPUs",
     )
+    def test_preprocess_packed_seqs_row_shorter_than_alignment(self):
+        """A row whose valid length is below the alignment padding must not raise.
+
+        Chunk indices come from the alignment-padded length while ``d`` holds only the
+        valid tokens, so on the higher CP ranks the first-chunk slice can start past the
+        end of ``d``. Assigning that empty slice used to raise::
+
+            RuntimeError: The expanded size of the tensor (1) must match the existing
+            size (0) at non-singleton dimension 0
+
+        With tp=1/cp=2 the alignment is 4, so a single-token row is the smallest case
+        that reaches the out-of-range slice on cp_rank 1.
+        """
+        tp_size = 1
+        cp_size = 2
+        self._setup_parallel_state(tp_size=tp_size, cp_size=cp_size)
+
+        batch_size, seq_len = 2, 8
+        input_ids = torch.randint(0, 1000, (batch_size, seq_len))
+        attention_mask = torch.zeros(batch_size, seq_len, dtype=torch.bool)
+        attention_mask[0, :] = True  # a full-length row
+        attention_mask[1, 0] = True  # a single valid token
+
+        ids_out, packed = preprocess_packed_seqs(input_ids, attention_mask, pre_process=True)
+        assert packed.max_seqlen_q == packed.max_seqlen_kv
+        assert ids_out.shape[0] == 1
+        # 8 valid tokens need no padding; the 1-token row is padded to align_size = 4.
+        assert ids_out.shape[1] == (8 + 4) // cp_size
+
+        self.destroy_parallel_state()
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or int(os.environ.get("WORLD_SIZE", "1")) < 2,
+        reason="Requires at least 2 GPUs",
+    )
     def test_allgather_vision_embeddings(self):
         """Test AllGatherVisionEmbeddings forward/backward."""
         tp_size = 1


### PR DESCRIPTION
## Problem

In `preprocess_packed_seqs`, when `cp_size > 1`, the chunk indices are computed in the
**alignment-padded** coordinate space (`seqlen_padded_i`, aligned to `tp_size * cp_size * 2`),
while `d = input_ids[i, attention_mask[i]]` holds only the **valid** tokens.

When a row's valid length is shorter than the alignment padding, the first-chunk slice
`d[half_seqlen * cp_rank : half_seqlen * (cp_rank + 1)]` can start past the end of `d` and
yield an empty tensor, so the assignment raises:

```
RuntimeError: The expanded size of the tensor (2) must match the existing size (0)
at non-singleton dimension 0.  Target sizes: [2].  Tensor sizes: [0]
```

The remaining chunk immediately below is **already** clamped with
`min(remain_end, d.shape[0])` — only the first chunk was missed. The identical code in verl
was fixed in [verl-project/verl#6001](https://github.com/verl-project/verl/pull/6001).

The same function is vendored in two places here, both with the same gap; both are fixed:

- `src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/utils.py`
- `src/megatron/bridge/models/exaone/exaone45/modelling_exaone45/utils.py`

Measured thresholds for the unclamped path (largest valid length that still crashes):

| topology | `align_size` | crashes at valid length | safe from |
|---|---|---|---|
| TP1/CP2 | 4 | 1 | 2 |
| TP2/CP2 | 8 | 1, 2 | 3 |
| TP2/CP4 | 16 | 1–6 | 8 |
| TP4/CP4 | 32 | 1–8 | 16 |

Larger TP×CP grids are affected at larger valid lengths, so short prompts plus a wide
parallel grid is the general trigger.

## How we hit it

Qwen3.6-35B-A3B RL training on H20-141G, THD (`use_remove_padding`) + TP2/CP2, verl driving
Megatron through the bridge. Our trigger is verl's multi-trajectory divisibility padding row
— a deliberate 2-token no-op sample — but nothing about the crash is specific to that source.

The runtime module inspection was unambiguous: verl's own copy of the function carries the
clamp, both vendored copies here do not, and the traceback lands in the vendored copy.
Causality was established by single-variable isolation: with a longer padding row the same
config trains fine for 4 steps; reverting **only** the row length reproduces the crash.

## Fix

Clamp the first chunk exactly as the remaining chunk already is, and add the matching
`max(..., 0)` to `remain_len`. Plus a regression test.

## Test

`pre-commit run --files <the three changed files>` — all hooks pass (ruff, ruff-format,
trailing whitespace, end-of-file).

New unit test `test_preprocess_packed_seqs_row_shorter_than_alignment` in
`tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_utils.py`, following the existing
`test_preprocess_packed_seqs` (same 2-GPU `skipif`, same `_setup_parallel_state` helper): a
batch with one full-length row and one single-token row. With tp=1/cp=2 the alignment is 4,
so the single-token row is the smallest case that reaches the out-of-range slice on
cp_rank 1. It raises before this change and passes after.

Behaviour of the chunk assignment, reproduced for both variants at TP=CP=2, both CP ranks:

```
valid  rank  before          after
2      0     ok              ok
2      1     RuntimeError    ok      <- only behaviour change
8      0/1   ok              ok
38     0/1   ok              ok
128    0/1   ok              ok
14000  0/1   ok              ok
```

Rows long enough to be unaffected are **bit-identical**, i.e. this is a pure guard:

```
valid=128    rank=0/1  torch.equal(before, after) = True
valid=4096   rank=0/1  torch.equal(before, after) = True
valid=14000  rank=0/1  torch.equal(before, after) = True
```

End to end on the cluster: with the crash avoided, THD + CP=2 completes 4 training steps and
reward magnitude matches an otherwise identical CP=1 run (0.797/0.697/0.473/0.472 vs
0.847/0.415/0.483/0.457 — GRPO rollout is sampled, so only magnitude and trend are
comparable). Peak reserved memory 99.2 GB (CP=2) vs 113.9 GB (CP=1) of 141 GB.

Scope note: clamping prevents the crash; it does not make a very short row semantically
meaningful (some CP ranks end up holding only zeros for it). That matches the behaviour of
the already-clamped remaining chunk, and is harmless for the padding-row case that triggered
it here (no gradient, excluded from metrics).

## Not a duplicate

Searched this repo for `preprocess_packed_seqs`, `context parallel packed`, and
`expanded size` (PRs, all states). The closest open PR, #3869 ("Stabilize Qwen3-VL packed
SFT"), does touch `modelling_qwen3_vl/utils.py`, but its hunks are at lines ~200/230/636 and
do not touch the CP chunk assignment — no overlap and no conflict. #4304 is about adding
packed-sequence support for qwen3-omni. Also filed the same fix for the other vendored copy
of this function in ISEEKYAN/mbridge#157.

## AI assistance

This change was prepared with AI assistance (Claude). I reviewed every changed line, ran the
checks above myself, and can defend the change end-to-end.
