### PR TITLE
fix(model): use yarn provider fields for Mistral rope scaling

### DIFF
--- a/src/megatron/bridge/models/mistral/mistral_bridge.py
+++ b/src/megatron/bridge/models/mistral/mistral_bridge.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
+from typing import Any
 
 import torch
 from megatron.core.models.gpt.gpt_model import GPTModel
@@ -47,18 +47,33 @@ class MistralBridge(MegatronModelBridge):
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MistralModelProvider:
         hf_config = hf_pretrained.config
 
-        if getattr(hf_config, "rope_scaling", None) is not None and hf_config.rope_scaling.get("rope_type") == "yarn":
-            # Apply Mistral customize rope scaling
-            cls = partial(MistralModelProvider, scale_factor=rope_scaling_factor_from_hf(hf_config, default=8.0))
-        else:
-            cls = MistralModelProvider
+        # Mirrors the generic yarn handling in
+        # MegatronModelBridge._hf_config_to_megatron_kwargs; YARN_ROPE_SCALING_MAPPING
+        # is the source of truth for the hf-key -> provider-field pairs.
+        yarn_kwargs: dict[str, Any] = {}
+        rope_scaling = getattr(hf_config, "rope_scaling", None)
+        rope_type = None
+        if isinstance(rope_scaling, dict) and rope_scaling:
+            rope_type = rope_scaling.get("type") or rope_scaling.get("rope_type")
+        if rope_type == "yarn":
+            yarn_kwargs["position_embedding_type"] = "yarn"
+            yarn_kwargs["yarn_rotary_scaling_factor"] = rope_scaling_factor_from_hf(hf_config, default=8.0)
+            for hf_key, megatron_key in self.YARN_ROPE_SCALING_MAPPING:
+                if hf_key == "factor":
+                    continue
+                value = rope_scaling.get(hf_key)
+                if value is not None:
+                    yarn_kwargs[megatron_key] = value
+            if "truncate" in rope_scaling:
+                yarn_kwargs["yarn_correction_range_round_to_int"] = rope_scaling["truncate"]
 
         window_size, cp_comm_type = (None, None)
         if getattr(hf_config, "sliding_window", None) is not None:
             window_size = [hf_config.sliding_window - 1, 0]
             cp_comm_type = "a2a"
 
-        provider = cls(
+        provider = MistralModelProvider(
+            **yarn_kwargs,
             num_layers=hf_config.num_hidden_layers,
             hidden_size=hf_config.hidden_size,
             ffn_hidden_size=hf_config.intermediate_size,

--- a/tests/unit_tests/models/mistral/test_mistral_bridge.py
+++ b/tests/unit_tests/models/mistral/test_mistral_bridge.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+import torch.nn.functional as F
+from transformers import MistralConfig
+
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+from megatron.bridge.models.mistral.mistral_bridge import MistralBridge
+from megatron.bridge.models.mistral.mistral_provider import MistralModelProvider
+
+
+pytestmark = pytest.mark.unit
+
+
+def _hf_config(**overrides):
+    kwargs = dict(
+        num_hidden_layers=2,
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=1024,
+        vocab_size=512,
+        rms_norm_eps=1e-6,
+        initializer_range=0.02,
+        rope_theta=100000.0,
+        torch_dtype=torch.bfloat16,
+    )
+    kwargs.update(overrides)
+    return MistralConfig(**kwargs)
+
+
+def _pretrained(config):
+    pretrained = Mock(spec=PreTrainedCausalLM)
+    pretrained.config = config
+    return pretrained
+
+
+@pytest.fixture
+def bridge():
+    return MistralBridge()
+
+
+class TestMistralProviderBridge:
+    def test_basic_config_fields(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config()))
+
+        assert isinstance(provider, MistralModelProvider)
+        assert provider.num_layers == 2
+        assert provider.hidden_size == 64
+        assert provider.ffn_hidden_size == 128
+        assert provider.num_attention_heads == 4
+        assert provider.num_query_groups == 2
+        assert provider.seq_length == 1024
+        assert provider.vocab_size == 512
+        assert provider.layernorm_epsilon == 1e-6
+        assert provider.init_method_std == 0.02
+        assert provider.rotary_base == 100000.0
+        assert provider.gated_linear_unit is True
+
+    def test_dtype_from_hf_config(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config(torch_dtype=torch.bfloat16)))
+
+        assert provider.bf16 is True
+        assert provider.fp16 is False
+        assert provider.params_dtype == torch.bfloat16
+
+    def test_kv_channels_from_head_dim(self, bridge):
+        config = _hf_config()
+        provider = bridge.provider_bridge(_pretrained(config))
+
+        assert provider.kv_channels == config.head_dim
+
+    def test_sliding_window_maps_to_window_size(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config(sliding_window=4096)))
+
+        assert provider.window_size == [4095, 0]
+        assert provider.cp_comm_type == "a2a"
+
+    def test_no_sliding_window(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config(sliding_window=None)))
+
+        assert provider.window_size is None
+        assert provider.cp_comm_type is None
+
+    @pytest.mark.parametrize("tie_word_embeddings", [True, False])
+    def test_tied_embeddings(self, bridge, tie_word_embeddings):
+        provider = bridge.provider_bridge(_pretrained(_hf_config(tie_word_embeddings=tie_word_embeddings)))
+
+        assert provider.share_embeddings_and_output_weights is tie_word_embeddings
+
+    def test_default_rope_is_not_treated_as_yarn(self, bridge):
+        # transformers 5.x always exposes rope_scaling as a dict with rope_type "default"
+        provider = bridge.provider_bridge(_pretrained(_hf_config()))
+
+        assert provider.position_embedding_type == "rope"
+        assert provider.yarn_rotary_scaling_factor is None
+
+    def test_yarn_rope_scaling_sets_yarn_fields(self, bridge):
+        config = _hf_config(
+            rope_scaling={
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "original_max_position_embeddings": 256,
+            }
+        )
+        provider = bridge.provider_bridge(_pretrained(config))
+
+        assert provider.position_embedding_type == "yarn"
+        assert provider.yarn_rotary_scaling_factor == 4.0
+        assert provider.yarn_original_max_position_embeddings == 256
+
+    def test_yarn_truncate_maps_to_correction_range_rounding(self, bridge):
+        config = _hf_config(
+            rope_scaling={
+                "rope_type": "yarn",
+                "factor": 4.0,
+                "truncate": True,
+            }
+        )
+        provider = bridge.provider_bridge(_pretrained(config))
+
+        assert provider.yarn_correction_range_round_to_int is True
+
+    def test_yarn_rope_scaling_with_legacy_type_key(self, bridge):
+        config = _hf_config()
+        # Legacy checkpoints use "type" instead of "rope_type".
+        config.rope_scaling = {"type": "yarn", "factor": 2.0}
+        provider = bridge.provider_bridge(_pretrained(config))
+
+        assert provider.position_embedding_type == "yarn"
+        assert provider.yarn_rotary_scaling_factor == 2.0
+
+    def test_provider_defaults(self):
+        provider = MistralModelProvider(num_layers=2, hidden_size=64, num_attention_heads=4)
+
+        assert provider.normalization == "RMSNorm"
+        assert provider.activation_func is F.silu
+        assert provider.position_embedding_type == "rope"
+        assert provider.add_bias_linear is False
+        assert provider.gated_linear_unit is True
+        assert provider.share_embeddings_and_output_weights is False
+
+
+class TestMistralMappingRegistry:
+    def test_registry_type_and_size(self, bridge):
+        registry = bridge.mapping_registry()
+
+        assert isinstance(registry, MegatronMappingRegistry)
+        # 7 direct mappings + QKV + GatedMLP, plus any registry-added derived mappings.
+        assert len(registry) >= 9
+
+    @pytest.mark.parametrize(
+        "megatron_param",
+        [
+            "embedding.word_embeddings.weight",
+            "output_layer.weight",
+            "decoder.final_layernorm.weight",
+            "decoder.layers.*.self_attention.linear_qkv.weight",
+            "decoder.layers.*.mlp.linear_fc1.weight",
+            "decoder.layers.*.mlp.linear_fc2.weight",
+        ],
+    )
+    def test_expected_megatron_params_are_mapped(self, bridge, megatron_param):
+        registry = bridge.mapping_registry()
+        mapped = {mapping.megatron_param for mapping in registry.get_all_mappings()}
+
+        assert megatron_param in mapped


### PR DESCRIPTION
# What does this PR do ?

Fixes a `TypeError` that crashes `MistralBridge.provider_bridge` for any YaRN rope-scaled Mistral checkpoint, and adds unit tests for the Mistral bridge and provider (previously untested).

# Changelog

- `MistralBridge.provider_bridge` passed `scale_factor=` to `MistralModelProvider`, which defines no such dataclass field, so the constructor raised `TypeError: MistralModelProvider.__init__() got an unexpected keyword argument 'scale_factor'`. On transformers 5.x this path always triggers for yarn checkpoints because `rope_scaling` is normalized to a dict aliasing `rope_parameters`.
- Route yarn parameters through the established `GPTModelProvider` fields instead (`position_embedding_type="yarn"`, `yarn_rotary_scaling_factor`, the `YARN_ROPE_SCALING_MAPPING` extras, and `truncate` → `yarn_correction_range_round_to_int`), mirroring the generic `MegatronModelBridge._hf_config_to_megatron_kwargs` yarn path.
- Accept both the legacy `"type"` and current `"rope_type"` keys, matching the generic path.
- Add `tests/unit_tests/models/mistral/test_mistral_bridge.py`: 19 unit tests covering config mapping, yarn handling, sliding window, dtype plumbing, tied embeddings, and the parameter mapping registry.

# Verification (contributor-run)

Reproduction is CPU-only — no GPU needed; the crash happens at provider construction, before any model build.

On current `main` (`11e43b1da`), with the new test file applied:

```
$ python -m pytest tests/unit_tests/models/mistral/test_mistral_bridge.py::TestMistralProviderBridge::test_yarn_rope_scaling_sets_yarn_fields -q
E       TypeError: MistralModelProvider.__init__() got an unexpected keyword argument 'scale_factor'
src/megatron/bridge/models/mistral/mistral_bridge.py:61: TypeError
1 failed
```

On this branch:

```
$ python -m pytest tests/unit_tests/models/mistral/ -q
19 passed
```

Also equivalent to: `MistralConfig(rope_scaling={"rope_type": "yarn", "factor": 4.0, ...})` → `MistralBridge().provider_bridge(...)` raises on main, returns a provider with `position_embedding_type="yarn"` / `yarn_rotary_scaling_factor=4.0` on this branch.

Ruff check and format pass on the changed files. Tests were run on a CPU-only environment (torch 2.x, transformers 5.15); none of the added tests require CUDA, network access, or checkpoint downloads.

# GitHub Actions CI

External contribution — needs `/ok to test <commit-SHA>` from an NVIDIA developer.

# Before your PR is "Ready for review"

- [x] Read and followed Contributor guidelines
- [x] New tests added (19 unit tests)
- [ ] Documentation — not needed (bug fix, no API change)

# Additional Information

- This was found while writing coverage for the previously untested `mistral_bridge.py`. There is no pre-existing issue for it.
- Authored with AI assistance; all reproduction steps and test runs above were executed and verified locally by the contributor account submitting this PR.
- Suggested labels: `bug`, `area:model`
