### PR TITLE
test(model): add unit tests for Gemma2 provider and bridge

### DIFF
--- a/tests/unit_tests/models/gemma/test_gemma2_bridge.py
+++ b/tests/unit_tests/models/gemma/test_gemma2_bridge.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+from megatron.core.activations import fast_gelu
+from transformers import Gemma2Config
+
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.gemma.gemma2_bridge import Gemma2Bridge
+from megatron.bridge.models.gemma.gemma2_provider import Gemma2ModelProvider
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
+
+
+pytestmark = pytest.mark.unit
+
+
+def _hf_config(**overrides):
+    kwargs = dict(
+        num_hidden_layers=2,
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=1024,
+        vocab_size=512,
+        rms_norm_eps=1e-6,
+        initializer_range=0.02,
+        query_pre_attn_scalar=224,
+        attn_logit_softcapping=50.0,
+        final_logit_softcapping=30.0,
+        sliding_window=512,
+        torch_dtype=torch.bfloat16,
+    )
+    kwargs.update(overrides)
+    return Gemma2Config(**kwargs)
+
+
+def _pretrained(config):
+    pretrained = Mock(spec=PreTrainedCausalLM)
+    pretrained.config = config
+    return pretrained
+
+
+@pytest.fixture
+def bridge():
+    return Gemma2Bridge()
+
+
+class TestGemma2ProviderBridge:
+    def test_returns_gemma2_provider(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config()))
+
+        assert isinstance(provider, Gemma2ModelProvider)
+
+    def test_basic_dimensions(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config()))
+
+        assert provider.num_layers == 2
+        assert provider.hidden_size == 64
+        assert provider.ffn_hidden_size == 128
+        assert provider.num_attention_heads == 4
+        assert provider.vocab_size == 512
+
+    def test_softcapping_fields_from_hf_config(self, bridge):
+        config = _hf_config(attn_logit_softcapping=42.0, final_logit_softcapping=21.0, query_pre_attn_scalar=128)
+        provider = bridge.provider_bridge(_pretrained(config))
+
+        assert provider.attn_logit_softcapping == 42.0
+        assert provider.final_logit_softcapping == 21.0
+        assert provider.query_pre_attn_scalar == 128
+
+    def test_sliding_window_maps_to_window_size(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config(sliding_window=512)))
+
+        assert provider.window_size == (511, 0)
+
+    def test_gemma2_architecture_invariants(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config()))
+
+        assert provider.normalization == "RMSNorm"
+        assert provider.activation_func is fast_gelu
+        assert provider.gated_linear_unit is True
+        assert provider.add_bias_linear is False
+        assert provider.attention_dropout == 0.0
+        assert provider.hidden_dropout == 0.0
+        assert provider.share_embeddings_and_output_weights is True
+        assert provider.layernorm_zero_centered_gamma is True
+
+
+class TestGemma2MegatronToHfConfig:
+    def test_roundtrips_softcapping_and_window(self, bridge):
+        provider = bridge.provider_bridge(_pretrained(_hf_config(sliding_window=512)))
+
+        hf_config = Gemma2Bridge.megatron_to_hf_config(provider)
+
+        assert hf_config["query_pre_attn_scalar"] == 224
+        assert hf_config["attn_logit_softcapping"] == 50.0
+        assert hf_config["final_logit_softcapping"] == 30.0
+        assert hf_config["sliding_window"] == 512
+
+
+class TestGemma2MappingRegistry:
+    def test_registry_type(self, bridge):
+        assert isinstance(bridge.mapping_registry(), MegatronMappingRegistry)
+
+    @pytest.mark.parametrize(
+        "megatron_param",
+        [
+            "embedding.word_embeddings.weight",
+            "decoder.final_layernorm.weight",
+            "decoder.layers.*.self_attention.linear_qkv.weight",
+            "decoder.layers.*.mlp.linear_fc1.weight",
+            "decoder.layers.*.mlp.linear_fc2.weight",
+            # Gemma2-specific post-layernorm locations
+            "decoder.layers.*.mlp.linear_fc2.post_layernorm.weight",
+            "decoder.layers.*.self_attention.linear_proj.post_layernorm.weight",
+        ],
+    )
+    def test_expected_megatron_params_are_mapped(self, bridge, megatron_param):
+        mapped = {mapping.megatron_param for mapping in bridge.mapping_registry().get_all_mappings()}
+
+        assert megatron_param in mapped
+
+    def test_no_lm_head_mapping_for_tied_embeddings(self, bridge):
+        mapped = {mapping.megatron_param for mapping in bridge.mapping_registry().get_all_mappings()}
+
+        assert "output_layer.weight" not in mapped

--- a/tests/unit_tests/models/gemma/test_gemma2_provider.py
+++ b/tests/unit_tests/models/gemma/test_gemma2_provider.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from megatron.core.activations import fast_gelu
+
+from megatron.bridge.models.gemma.gemma2_provider import (
+    Gemma2ModelProvider,
+    _get_softcap_score_mod,
+    get_swa,
+    logit_softcapping,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestLogitSoftcapping:
+    def test_none_scale_returns_input_unchanged(self):
+        logits = torch.tensor([1.0, -2.0, 3.0])
+
+        assert logit_softcapping(logits, None) is logits
+
+    def test_zero_scale_returns_input_unchanged(self):
+        logits = torch.tensor([1.0, -2.0, 3.0])
+
+        assert logit_softcapping(logits, 0.0) is logits
+
+    def test_softcapping_applies_scaled_tanh(self):
+        logits = torch.tensor([0.0, 10.0, -10.0, 100.0])
+        scale = 30.0
+
+        capped = logit_softcapping(logits, scale)
+
+        expected = scale * torch.tanh(logits / scale)
+        assert torch.allclose(capped, expected)
+
+    def test_softcapping_bounds_output_by_scale(self):
+        logits = torch.linspace(-1e4, 1e4, steps=101)
+        scale = 50.0
+
+        capped = logit_softcapping(logits, scale)
+
+        assert capped.abs().max() <= scale
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="get_swa builds its mask on the CUDA device")
+class TestGetSwa:
+    def test_square_causal_window_mask(self):
+        window = (2, 0)
+        mask = get_swa(4, 4, window)
+
+        assert mask.shape == (4, 4)
+        # True marks masked-out positions: outside the sliding window or future tokens.
+        allowed = ~mask
+        for q in range(4):
+            for k in range(4):
+                inside_window = q - window[0] <= k <= q + window[1]
+                assert allowed[q, k].item() == inside_window
+
+    def test_rectangular_mask_offsets_by_key_length(self):
+        mask = get_swa(2, 4, (1, 0))
+
+        allowed = ~mask
+        # Query q attends keys aligned to the end of the key sequence.
+        offset = 4 - 2
+        for q in range(2):
+            for k in range(4):
+                inside_window = q + offset - 1 <= k <= q + offset
+                assert allowed[q, k].item() == inside_window
+
+
+class TestSoftcapScoreMod:
+    def test_score_mod_is_cached_per_softcap(self):
+        assert _get_softcap_score_mod(50.0) is _get_softcap_score_mod(50.0)
+
+    def test_distinct_softcaps_get_distinct_mods(self):
+        assert _get_softcap_score_mod(50.0) is not _get_softcap_score_mod(30.0)
+
+    def test_zero_softcap_is_identity(self):
+        score = torch.tensor(3.0)
+
+        assert _get_softcap_score_mod(0.0)(score, 0, 0, 0, 0) is score
+
+    def test_nonzero_softcap_applies_tanh(self):
+        score = torch.tensor(100.0)
+        softcap = 50.0
+
+        result = _get_softcap_score_mod(softcap)(score, 0, 0, 0, 0)
+
+        assert torch.allclose(result, softcap * torch.tanh(score / softcap))
+
+
+class TestGemma2ModelProvider:
+    def test_default_configuration(self):
+        provider = Gemma2ModelProvider(num_layers=2, hidden_size=64, num_attention_heads=4)
+
+        assert provider.normalization == "RMSNorm"
+        assert provider.activation_func is fast_gelu
+        assert provider.gated_linear_unit is True
+        assert provider.position_embedding_type == "rope"
+        assert provider.add_bias_linear is False
+        assert provider.share_embeddings_and_output_weights is True
+        assert provider.layernorm_zero_centered_gamma is True
+        assert provider.layernorm_epsilon == 1e-6
+        assert provider.rotary_base == 10000
+        assert provider.window_size == (4095, 0)
+        assert provider.vocab_size == 256000
+        assert provider.kv_channels == 256
+
+    def test_softcapping_defaults(self):
+        provider = Gemma2ModelProvider(num_layers=2, hidden_size=64, num_attention_heads=4)
+
+        assert provider.query_pre_attn_scalar == 224
+        assert provider.attn_logit_softcapping == 50.0
+        assert provider.final_logit_softcapping == 30.0
+
+    def test_query_pre_attn_scalar_override(self):
+        provider = Gemma2ModelProvider(num_layers=2, hidden_size=64, num_attention_heads=4, query_pre_attn_scalar=128)
+
+        assert provider.query_pre_attn_scalar == 128


### PR DESCRIPTION
# What does this PR do ?

Adds unit tests for `gemma2_provider.py` and `gemma2_bridge.py`. The gemma3/gemma4 siblings have provider and bridge tests; Gemma2 had none.

# Changelog

- Add `tests/unit_tests/models/gemma/test_gemma2_provider.py`:
  - `logit_softcapping`: identity on `None`/`0` scale, scaled-tanh formula, output bounded by scale
  - `_get_softcap_score_mod`: identity caching per softcap value (the documented torch.compile-guard contract), zero-softcap identity, tanh math
  - `get_swa`: sliding-window mask band semantics for square and rectangular shapes — `@pytest.mark.skipif` CUDA-guarded because the source hard-codes `device="cuda"`; these run in GPU CI
  - `Gemma2ModelProvider`: architecture defaults (RMSNorm, fast_gelu, zero-centered gamma, window `(4095, 0)`, softcapping values, `query_pre_attn_scalar` override)
- Add `tests/unit_tests/models/gemma/test_gemma2_bridge.py`:
  - `provider_bridge` mapping from a real `transformers.Gemma2Config` (dimensions, softcapping fields, `sliding_window` → `window_size`, architecture invariants)
  - `megatron_to_hf_config` round-trip of softcapping and sliding window
  - Parameter mapping registry: expected Megatron params including the Gemma2-specific post-layernorm locations; no `output_layer.weight` mapping (tied embeddings)

# Verification (contributor-run)

```
$ python -m pytest tests/unit_tests/models/gemma/test_gemma2_provider.py tests/unit_tests/models/gemma/test_gemma2_bridge.py -q
26 passed, 2 skipped
```

Run on a CPU-only environment (the 2 skips are the CUDA-guarded `get_swa` tests, whose band math was additionally verified against a CPU replica of the mask construction). No network, checkpoint, or tokenizer downloads. Ruff check and format pass.

# GitHub Actions CI

External contribution — needs `/ok to test <commit-SHA>` from an NVIDIA developer.

# Before your PR is "Ready for review"

- [x] Read and followed Contributor guidelines
- [x] New tests added
- [ ] Documentation — not applicable (tests only)

# Additional Information

- Authored with AI assistance; every assertion was verified against the source module and the suite was run locally by the submitting contributor.
- Suggested labels: `test` (`area:model`)
