### PR TITLE
perf(nemotron): enable CuteDSL fusion for GB MXFP8

### DIFF
--- a/src/megatron/bridge/perf_recipes/nemotronh/common.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/common.py
@@ -70,12 +70,6 @@ def _nemotron_3_super_nvfp4_precision() -> MixedPrecisionConfig:
     return cfg
 
 
-def _enable_cutedsl_fused_grouped_mlp(cfg: ConfigContainer) -> None:
-    """Enable the CuTeDSL fused grouped MLP independently of MoE A2A overlap."""
-    cfg.model.use_transformer_engine_op_fuser = True
-    cfg.model.moe_mlp_glu_interleave_size = 32
-
-
 def _apply_nemotron_3_super_perf_defaults(cfg: ConfigContainer) -> None:
     """Apply shared Nemotron 3 Super perf defaults after recipe-specific overrides."""
     cfg.mixed_precision.grad_reduce_in_fp32 = False

--- a/src/megatron/bridge/perf_recipes/nemotronh/common.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/common.py
@@ -28,6 +28,7 @@ from megatron.bridge.recipes.nemotronh.nemotron_3_ultra import nemotron_3_ultra_
 from megatron.bridge.recipes.nemotronh.nemotronh import nemotronh_56b_pretrain_config
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig, nemotron_3_super_bf16_with_nvfp4_mixed
+from megatron.bridge.utils.cuda_graph import set_full_iteration_cuda_graph
 
 
 _TE_QUANT_CFG_PATH = Path(__file__).with_name("te_quant.cfg")
@@ -74,6 +75,16 @@ def _enable_cutedsl_fused_grouped_mlp(cfg: ConfigContainer) -> None:
     """Enable the CuTeDSL fused grouped MLP independently of MoE A2A overlap."""
     cfg.model.use_transformer_engine_op_fuser = True
     cfg.model.moe_mlp_glu_interleave_size = 32
+
+
+def _enable_full_iteration_cuda_graph(cfg: ConfigContainer) -> None:
+    """Enable full-iteration CUDA graphs and their required safety settings."""
+    set_full_iteration_cuda_graph(cfg.model)
+    cfg.model.cuda_graph_warmup_steps = 3
+    cfg.model.use_te_rng_tracker = True
+    cfg.rng.te_rng_tracker = True
+    cfg.rerun_state_machine.check_for_nan_in_loss = False
+    cfg.ddp.check_for_nan_in_grad = False
 
 
 def _apply_nemotron_3_super_perf_defaults(cfg: ConfigContainer) -> None:

--- a/src/megatron/bridge/perf_recipes/nemotronh/common.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/common.py
@@ -26,7 +26,6 @@ from megatron.bridge.recipes.nemotronh.h100.nemotron_3_super import (
 from megatron.bridge.recipes.nemotronh.nemotron_3_nano import nemotron_3_nano_pretrain_config
 from megatron.bridge.recipes.nemotronh.nemotron_3_ultra import nemotron_3_ultra_pretrain_config
 from megatron.bridge.recipes.nemotronh.nemotronh import nemotronh_56b_pretrain_config
-from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig, nemotron_3_super_bf16_with_nvfp4_mixed
 
@@ -71,21 +70,10 @@ def _nemotron_3_super_nvfp4_precision() -> MixedPrecisionConfig:
     return cfg
 
 
-def _enable_hybridep_mxfp8_cutedsl_fusion(cfg: ConfigContainer) -> None:
-    """Enable the CuteDSL fused grouped MLP path for HybridEP MXFP8 benchmarks."""
+def _enable_cutedsl_fused_grouped_mlp(cfg: ConfigContainer) -> None:
+    """Enable the CuTeDSL fused grouped MLP independently of MoE A2A overlap."""
     cfg.model.use_transformer_engine_op_fuser = True
     cfg.model.moe_mlp_glu_interleave_size = 32
-    cfg.model.high_priority_a2a_comm_stream = True
-    cfg.model.moe_hybridep_num_sms_preprocessing = 32
-    cfg.model.moe_shared_expert_overlap = False
-    cfg.mixed_precision.fp8_dot_product_attention = True
-
-    if cfg.comm_overlap is None:
-        cfg.comm_overlap = CommOverlapConfig(
-            tp_comm_overlap=cfg.model.tensor_model_parallel_size > 1,
-        )
-    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
-    cfg.comm_overlap.delay_wgrad_compute = True
 
 
 def _apply_nemotron_3_super_perf_defaults(cfg: ConfigContainer) -> None:

--- a/src/megatron/bridge/perf_recipes/nemotronh/common.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/common.py
@@ -28,7 +28,6 @@ from megatron.bridge.recipes.nemotronh.nemotron_3_ultra import nemotron_3_ultra_
 from megatron.bridge.recipes.nemotronh.nemotronh import nemotronh_56b_pretrain_config
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig, nemotron_3_super_bf16_with_nvfp4_mixed
-from megatron.bridge.utils.cuda_graph import set_full_iteration_cuda_graph
 
 
 _TE_QUANT_CFG_PATH = Path(__file__).with_name("te_quant.cfg")
@@ -75,16 +74,6 @@ def _enable_cutedsl_fused_grouped_mlp(cfg: ConfigContainer) -> None:
     """Enable the CuTeDSL fused grouped MLP independently of MoE A2A overlap."""
     cfg.model.use_transformer_engine_op_fuser = True
     cfg.model.moe_mlp_glu_interleave_size = 32
-
-
-def _enable_full_iteration_cuda_graph(cfg: ConfigContainer) -> None:
-    """Enable full-iteration CUDA graphs and their required safety settings."""
-    set_full_iteration_cuda_graph(cfg.model)
-    cfg.model.cuda_graph_warmup_steps = 3
-    cfg.model.use_te_rng_tracker = True
-    cfg.rng.te_rng_tracker = True
-    cfg.rerun_state_machine.check_for_nan_in_loss = False
-    cfg.ddp.check_for_nan_in_grad = False
 
 
 def _apply_nemotron_3_super_perf_defaults(cfg: ConfigContainer) -> None:

--- a/src/megatron/bridge/perf_recipes/nemotronh/common.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/common.py
@@ -26,6 +26,7 @@ from megatron.bridge.recipes.nemotronh.h100.nemotron_3_super import (
 from megatron.bridge.recipes.nemotronh.nemotron_3_nano import nemotron_3_nano_pretrain_config
 from megatron.bridge.recipes.nemotronh.nemotron_3_ultra import nemotron_3_ultra_pretrain_config
 from megatron.bridge.recipes.nemotronh.nemotronh import nemotronh_56b_pretrain_config
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig, nemotron_3_super_bf16_with_nvfp4_mixed
 
@@ -68,6 +69,23 @@ def _nemotron_3_super_nvfp4_precision() -> MixedPrecisionConfig:
     # Disabled until MCore PR 4358 lands.
     cfg.fp4_param_gather = False
     return cfg
+
+
+def _enable_hybridep_mxfp8_cutedsl_fusion(cfg: ConfigContainer) -> None:
+    """Enable the CuteDSL fused grouped MLP path for HybridEP MXFP8 benchmarks."""
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.model.high_priority_a2a_comm_stream = True
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.mixed_precision.fp8_dot_product_attention = True
+
+    if cfg.comm_overlap is None:
+        cfg.comm_overlap = CommOverlapConfig(
+            tp_comm_overlap=cfg.model.tensor_model_parallel_size > 1,
+        )
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
+    cfg.comm_overlap.delay_wgrad_compute = True
 
 
 def _apply_nemotron_3_super_perf_defaults(cfg: ConfigContainer) -> None:

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -22,7 +22,7 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_fsdp_hsdp,
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
-    _enable_hybridep_mxfp8_cutedsl_fusion,
+    _enable_cutedsl_fused_grouped_mlp,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     load_quantization_recipe,
@@ -144,7 +144,8 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
 
     _apply_nemotron_3_super_perf_defaults(cfg)
-    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
+    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -388,7 +389,8 @@ def _build_nemotron_3_nano_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_nano_gb200_mxfp8()
-    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
+    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -519,7 +521,8 @@ def _build_nemotron_3_5_lightning_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_5_lightning_gb200_mxfp8()
-    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
+    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.mixed_precision.fp8_dot_product_attention = True
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -501,8 +501,7 @@ def nemotron_3_5_lightning_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
-    """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8."""
+def _build_nemotron_3_5_lightning_gb200_mxfp8() -> ConfigContainer:
     cfg = _build_nemotron_3_nano_gb200_mxfp8()
     cfg.model.moe_hybridep_num_sms = 16
     cfg.model.mtp_num_layers = 2
@@ -514,6 +513,13 @@ def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer
     cfg.model.hf_model_revision = _NEMOTRON_3_5_LIGHTNING_MODEL_REVISION
     cfg.tokenizer.tokenizer_model = _NEMOTRON_3_5_LIGHTNING_MODEL_ID
     cfg.tokenizer.hf_tokenizer_kwargs = {"revision": _NEMOTRON_3_5_LIGHTNING_MODEL_REVISION}
+    return cfg
+
+
+def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
+    """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8."""
+    cfg = _build_nemotron_3_5_lightning_gb200_mxfp8()
+    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
@@ -525,7 +531,9 @@ def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_NORM_BWD_USE_CUDNN": 1,
         "NVTE_NORM_FWD_USE_CUDNN": 1,
@@ -535,7 +543,7 @@ def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer
 
 def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_fsdp_config() -> ConfigContainer:
     """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8, Megatron FSDP."""
-    cfg = nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config()
+    cfg = _build_nemotron_3_5_lightning_gb200_mxfp8()
 
     # FSDP reduces the model-state footprint enough to use the larger measured
     # microbatch. Megatron FSDP registers module hooks that Transformer Engine

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -22,6 +22,7 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_fsdp_hsdp,
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
+    _enable_hybridep_mxfp8_cutedsl_fusion,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     load_quantization_recipe,
@@ -143,6 +144,7 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
 
     _apply_nemotron_3_super_perf_defaults(cfg)
+    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -160,7 +162,9 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         # Transformer Engine overlap settings for this model.
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
     }
     return cfg
@@ -354,8 +358,7 @@ def nemotron_3_nano_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
-    """Nemotron 3 Nano pretrain: 8× GB200, MXFP8."""
+def _build_nemotron_3_nano_gb200_mxfp8() -> ConfigContainer:
     cfg = nemotron_3_nano_pretrain_config()
     _apply_nemotron_3_nano_perf_defaults(cfg)
     cfg.mixed_precision = _perf_precision("fp8_mx")
@@ -379,6 +382,13 @@ def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
 
     _benchmark_common(cfg)
     cfg.model.moe_hybridep_num_sms = 32
+    return cfg
+
+
+def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
+    """Nemotron 3 Nano pretrain: 8× GB200, MXFP8."""
+    cfg = _build_nemotron_3_nano_gb200_mxfp8()
+    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -396,7 +406,9 @@ def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         # Transformer Engine overlap settings for this model.
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
         # Use cuDNN LayerNorm for this measured baseline.
         "NVTE_NORM_BWD_USE_CUDNN": 1,
@@ -491,7 +503,7 @@ def nemotron_3_5_lightning_pretrain_8gpu_gb200_bf16_config() -> ConfigContainer:
 
 def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8."""
-    cfg = nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config()
+    cfg = _build_nemotron_3_nano_gb200_mxfp8()
     cfg.model.moe_hybridep_num_sms = 16
     cfg.model.mtp_num_layers = 2
     cfg.model.mtp_hybrid_override_pattern = "*E"

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -23,7 +23,6 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
     _enable_cutedsl_fused_grouped_mlp,
-    _enable_full_iteration_cuda_graph,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     load_quantization_recipe,
@@ -145,7 +144,6 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
 
     _apply_nemotron_3_super_perf_defaults(cfg)
-    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -155,8 +153,8 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
@@ -391,7 +389,6 @@ def _build_nemotron_3_nano_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_nano_gb200_mxfp8()
-    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -401,8 +398,8 @@ def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
@@ -524,15 +521,14 @@ def _build_nemotron_3_5_lightning_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_5_lightning_gb200_mxfp8()
-    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         "NCCL_NVLS_ENABLE": 0,
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -23,6 +23,7 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
     _enable_cutedsl_fused_grouped_mlp,
+    _enable_full_iteration_cuda_graph,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     load_quantization_recipe,
@@ -144,6 +145,7 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
 
     _apply_nemotron_3_super_perf_defaults(cfg)
+    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -153,8 +155,8 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
@@ -389,6 +391,7 @@ def _build_nemotron_3_nano_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_nano_gb200_mxfp8()
+    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -398,8 +401,8 @@ def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
@@ -521,14 +524,15 @@ def _build_nemotron_3_5_lightning_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_5_lightning_gb200_mxfp8()
+    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
         "NCCL_NVLS_ENABLE": 0,
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb200/nemotronh.py
@@ -22,7 +22,6 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_fsdp_hsdp,
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
-    _enable_cutedsl_fused_grouped_mlp,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     load_quantization_recipe,
@@ -144,7 +143,8 @@ def nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
 
     _apply_nemotron_3_super_perf_defaults(cfg)
-    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
@@ -389,7 +389,8 @@ def _build_nemotron_3_nano_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_nano_gb200_mxfp8()
-    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
@@ -521,7 +522,8 @@ def _build_nemotron_3_5_lightning_gb200_mxfp8() -> ConfigContainer:
 def nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3.5 Lightning pretrain: 8× GB200, MXFP8."""
     cfg = _build_nemotron_3_5_lightning_gb200_mxfp8()
-    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
     cfg.mixed_precision.fp8_dot_product_attention = True
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
@@ -23,7 +23,6 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
     _enable_cutedsl_fused_grouped_mlp,
-    _enable_full_iteration_cuda_graph,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     _with_global_batch_size,
@@ -146,7 +145,6 @@ def _build_nemotron_3_super_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Super pretrain: 64× GB300, MXFP8."""
     cfg = _build_nemotron_3_super_gb300_mxfp8()
-    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -156,8 +154,8 @@ def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
@@ -401,7 +399,6 @@ def _build_nemotron_3_nano_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB300, MXFP8."""
     cfg = _build_nemotron_3_nano_gb300_mxfp8()
-    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -411,8 +408,8 @@ def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
@@ -22,6 +22,7 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_fsdp_hsdp,
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
+    _enable_hybridep_mxfp8_cutedsl_fusion,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     _with_global_batch_size,
@@ -115,8 +116,7 @@ def nemotron_3_super_pretrain_64gpu_gb300_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
-    """Nemotron 3 Super pretrain: 64× GB300, MXFP8."""
+def _build_nemotron_3_super_gb300_mxfp8() -> ConfigContainer:
     cfg = nemotron_3_super_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_mx")
 
@@ -139,6 +139,13 @@ def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.model.cuda_graph_scope = ["attn", "mamba", "moe_router", "moe_preprocess"]
 
     _apply_nemotron_3_super_perf_defaults(cfg)
+    return cfg
+
+
+def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
+    """Nemotron 3 Super pretrain: 64× GB300, MXFP8."""
+    cfg = _build_nemotron_3_super_gb300_mxfp8()
+    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -156,7 +163,9 @@ def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         # Transformer Engine overlap settings for this model.
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
     }
     return cfg
@@ -359,8 +368,7 @@ def nemotron_3_nano_pretrain_8gpu_gb300_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
-    """Nemotron 3 Nano pretrain: 8× GB300, MXFP8."""
+def _build_nemotron_3_nano_gb300_mxfp8() -> ConfigContainer:
     cfg = nemotron_3_nano_pretrain_config()
     _apply_nemotron_3_nano_perf_defaults(cfg)
     cfg.mixed_precision = _perf_precision("fp8_mx")
@@ -384,6 +392,13 @@ def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
 
     _benchmark_common(cfg)
     cfg.model.moe_hybridep_num_sms = 16
+    return cfg
+
+
+def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
+    """Nemotron 3 Nano pretrain: 8× GB300, MXFP8."""
+    cfg = _build_nemotron_3_nano_gb300_mxfp8()
+    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -401,7 +416,9 @@ def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         # Transformer Engine overlap settings for this model.
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
         # Use cuDNN LayerNorm for this measured baseline.
         "NVTE_NORM_BWD_USE_CUDNN": 1,

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
@@ -22,7 +22,7 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_fsdp_hsdp,
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
-    _enable_hybridep_mxfp8_cutedsl_fusion,
+    _enable_cutedsl_fused_grouped_mlp,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     _with_global_batch_size,
@@ -145,7 +145,8 @@ def _build_nemotron_3_super_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Super pretrain: 64× GB300, MXFP8."""
     cfg = _build_nemotron_3_super_gb300_mxfp8()
-    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
+    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -398,7 +399,8 @@ def _build_nemotron_3_nano_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB300, MXFP8."""
     cfg = _build_nemotron_3_nano_gb300_mxfp8()
-    _enable_hybridep_mxfp8_cutedsl_fusion(cfg)
+    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
@@ -23,6 +23,7 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
     _enable_cutedsl_fused_grouped_mlp,
+    _enable_full_iteration_cuda_graph,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     _with_global_batch_size,
@@ -145,6 +146,7 @@ def _build_nemotron_3_super_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Super pretrain: 64× GB300, MXFP8."""
     cfg = _build_nemotron_3_super_gb300_mxfp8()
+    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -154,8 +156,8 @@ def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
@@ -399,6 +401,7 @@ def _build_nemotron_3_nano_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB300, MXFP8."""
     cfg = _build_nemotron_3_nano_gb300_mxfp8()
+    _enable_full_iteration_cuda_graph(cfg)
     _enable_cutedsl_fused_grouped_mlp(cfg)
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
@@ -408,8 +411,8 @@ def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
         "CUDA_DEVICE_MAX_CONNECTIONS": 32,
         # CUDA graph and allocator behavior for this recipe.
         "NCCL_GRAPH_REGISTER": 0,
-        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
@@ -22,7 +22,6 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_fsdp_hsdp,
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
-    _enable_cutedsl_fused_grouped_mlp,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     _with_global_batch_size,
@@ -145,7 +144,8 @@ def _build_nemotron_3_super_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Super pretrain: 64× GB300, MXFP8."""
     cfg = _build_nemotron_3_super_gb300_mxfp8()
-    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
@@ -399,7 +399,8 @@ def _build_nemotron_3_nano_gb300_mxfp8() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× GB300, MXFP8."""
     cfg = _build_nemotron_3_nano_gb300_mxfp8()
-    _enable_cutedsl_fused_grouped_mlp(cfg)
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
     cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {

--- a/src/megatron/bridge/perf_recipes/nemotronh/vr200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/vr200/nemotronh.py
@@ -18,11 +18,11 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     ConfigContainer,
 )
 from megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh import (
+    _build_nemotron_3_nano_gb300_mxfp8,
+    _build_nemotron_3_super_gb300_mxfp8,
     nemotron_3_nano_pretrain_8gpu_gb300_bf16_config,
-    nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config,
     nemotron_3_nano_pretrain_8gpu_gb300_nvfp4_config,
     nemotron_3_super_pretrain_64gpu_gb300_bf16_config,
-    nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config,
     nemotron_3_super_pretrain_64gpu_gb300_nvfp4_config,
 )
 
@@ -58,7 +58,7 @@ def nemotron_3_nano_pretrain_8gpu_vr200_bf16_config() -> ConfigContainer:
 
 def nemotron_3_nano_pretrain_8gpu_vr200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× VR200, FP8-MX (alias of GB300)."""
-    cfg = nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config()
+    cfg = _build_nemotron_3_nano_gb300_mxfp8()
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -144,7 +144,7 @@ def nemotron_3_super_pretrain_64gpu_vr200_bf16_config() -> ConfigContainer:
 
 def nemotron_3_super_pretrain_64gpu_vr200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Super pretrain: 64× VR200, FP8-MX (alias of GB300)."""
-    cfg = nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config()
+    cfg = _build_nemotron_3_super_gb300_mxfp8()
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,

--- a/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
@@ -181,25 +181,41 @@ def test_nemotron_3_5_perf_recipes_inherit_nemotron_3_policy(
     cfg = recipe_factory()
     base_cfg = base_recipe_factory()
 
-    if recipe_factory is nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config:
-        base_env_vars = {
-            name: value
-            for name, value in base_cfg.env_vars.items()
-            if name not in {"CUDNNFE_CLUSTER_OVERLAP_MARGIN", "NVTE_CUTEDSL_FUSED_GROUPED_MLP"}
-        }
-        assert cfg.env_vars == base_env_vars
-        assert getattr(cfg.model, "use_transformer_engine_op_fuser", False) is False
-        assert getattr(cfg.model, "moe_mlp_glu_interleave_size", None) is None
-        assert getattr(cfg.model, "high_priority_a2a_comm_stream", False) is False
-        assert getattr(cfg.model, "moe_hybridep_num_sms_preprocessing", None) != 32
-        assert cfg.mixed_precision.fp8_dot_product_attention is False
-        assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
-        assert cfg.comm_overlap.delay_wgrad_compute is False
-    elif recipe_factory is not nemotron_3_5_lightning_pretrain_16gpu_h100_bf16_config:
+    if recipe_factory is not nemotron_3_5_lightning_pretrain_16gpu_h100_bf16_config:
         assert cfg.env_vars == base_cfg.env_vars
     assert cfg.model.calculate_per_token_loss == base_cfg.model.calculate_per_token_loss
     assert cfg.model.use_te_rng_tracker == base_cfg.model.use_te_rng_tracker
     assert cfg.tokenizer.tokenizer_model != base_cfg.tokenizer.tokenizer_model
+
+
+def test_gb200_mxfp8_enables_cutedsl_fusion() -> None:
+    """The non-FSDP Lightning MXFP8 recipe enables the complete CutDSL contract."""
+    cfg = nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config()
+
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
+    assert cfg.env_vars["CUDNNFE_CLUSTER_OVERLAP_MARGIN"] == 8
+    assert cfg.model.use_transformer_engine_op_fuser is True
+    assert cfg.model.moe_mlp_glu_interleave_size == 32
+    assert cfg.model.high_priority_a2a_comm_stream is True
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.mixed_precision.fp8_dot_product_attention is True
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+    assert cfg.comm_overlap.delay_wgrad_compute is True
+
+
+def test_gb200_mxfp8_fsdp_skips_cutedsl_fusion() -> None:
+    """The Lightning MXFP8 FSDP variant remains outside the CutDSL tuning scope."""
+    cfg = nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_fsdp_config()
+
+    assert "NVTE_CUTEDSL_FUSED_GROUPED_MLP" not in cfg.env_vars
+    assert "CUDNNFE_CLUSTER_OVERLAP_MARGIN" not in cfg.env_vars
+    assert getattr(cfg.model, "use_transformer_engine_op_fuser", False) is False
+    assert getattr(cfg.model, "moe_mlp_glu_interleave_size", None) is None
+    assert getattr(cfg.model, "high_priority_a2a_comm_stream", False) is False
+    assert getattr(cfg.model, "moe_hybridep_num_sms_preprocessing", None) != 32
+    assert cfg.mixed_precision.fp8_dot_product_attention is False
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+    assert cfg.comm_overlap.delay_wgrad_compute is False
 
 
 @pytest.mark.parametrize("recipe_factory", _H100_RECIPES, ids=lambda recipe: recipe.__name__)

--- a/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
@@ -35,7 +35,6 @@ from megatron.bridge.perf_recipes.nemotronh import (
     nemotron_3_nano_pretrain_16gpu_h100_fp8cs_config,
 )
 from megatron.bridge.training.config import ConfigContainer
-from megatron.bridge.utils.cuda_graph import cuda_graph_module_names, is_full_iteration_cuda_graph
 
 
 pytestmark = pytest.mark.unit
@@ -189,8 +188,8 @@ def test_nemotron_3_5_perf_recipes_inherit_nemotron_3_policy(
     assert cfg.tokenizer.tokenizer_model != base_cfg.tokenizer.tokenizer_model
 
 
-def test_gb200_mxfp8_enables_cutedsl_and_full_iteration_graphs() -> None:
-    """The non-FSDP Lightning recipe uses CutDSL and full-iteration graphs without MoE A2A overlap."""
+def test_gb200_mxfp8_enables_cutedsl_fusion() -> None:
+    """The non-FSDP Lightning recipe enables CutDSL without MoE A2A overlap."""
     cfg = nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config()
 
     assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
@@ -202,18 +201,6 @@ def test_gb200_mxfp8_enables_cutedsl_and_full_iteration_graphs() -> None:
     assert cfg.mixed_precision.fp8_dot_product_attention is True
     assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
     assert cfg.comm_overlap.delay_wgrad_compute is not True
-    assert is_full_iteration_cuda_graph(cfg.model)
-    assert cuda_graph_module_names(cfg.model) == []
-    assert cfg.model.cuda_graph_warmup_steps == 3
-    assert cfg.model.use_te_rng_tracker is True
-    assert cfg.rng.te_rng_tracker is True
-    assert cfg.rerun_state_machine.check_for_nan_in_loss is False
-    assert cfg.ddp.check_for_nan_in_grad is False
-    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == (
-        "expandable_segments:True,graph_capture_record_stream_reuse:True"
-    )
-    assert cfg.env_vars["NCCL_GRAPH_REGISTER"] == 0
-    assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
 
 
 def test_gb200_mxfp8_fsdp_skips_cutedsl_fusion() -> None:
@@ -229,7 +216,6 @@ def test_gb200_mxfp8_fsdp_skips_cutedsl_fusion() -> None:
     assert cfg.mixed_precision.fp8_dot_product_attention is False
     assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
     assert cfg.comm_overlap.delay_wgrad_compute is False
-    assert not is_full_iteration_cuda_graph(cfg.model)
 
 
 @pytest.mark.parametrize("recipe_factory", _H100_RECIPES, ids=lambda recipe: recipe.__name__)

--- a/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
@@ -197,10 +197,10 @@ def test_gb200_mxfp8_enables_cutedsl_fusion() -> None:
     assert cfg.model.use_transformer_engine_op_fuser is True
     assert cfg.model.moe_mlp_glu_interleave_size == 32
     assert cfg.model.high_priority_a2a_comm_stream is False
-    assert cfg.model.moe_hybridep_num_sms_preprocessing != 32
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 108
     assert cfg.mixed_precision.fp8_dot_product_attention is True
-    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
-    assert cfg.comm_overlap.delay_wgrad_compute is not True
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+    assert cfg.comm_overlap.delay_wgrad_compute is False
 
 
 def test_gb200_mxfp8_fsdp_skips_cutedsl_fusion() -> None:

--- a/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
@@ -181,7 +181,21 @@ def test_nemotron_3_5_perf_recipes_inherit_nemotron_3_policy(
     cfg = recipe_factory()
     base_cfg = base_recipe_factory()
 
-    if recipe_factory is not nemotron_3_5_lightning_pretrain_16gpu_h100_bf16_config:
+    if recipe_factory is nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config:
+        base_env_vars = {
+            name: value
+            for name, value in base_cfg.env_vars.items()
+            if name not in {"CUDNNFE_CLUSTER_OVERLAP_MARGIN", "NVTE_CUTEDSL_FUSED_GROUPED_MLP"}
+        }
+        assert cfg.env_vars == base_env_vars
+        assert getattr(cfg.model, "use_transformer_engine_op_fuser", False) is False
+        assert getattr(cfg.model, "moe_mlp_glu_interleave_size", None) is None
+        assert getattr(cfg.model, "high_priority_a2a_comm_stream", False) is False
+        assert getattr(cfg.model, "moe_hybridep_num_sms_preprocessing", None) != 32
+        assert cfg.mixed_precision.fp8_dot_product_attention is False
+        assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+        assert cfg.comm_overlap.delay_wgrad_compute is False
+    elif recipe_factory is not nemotron_3_5_lightning_pretrain_16gpu_h100_bf16_config:
         assert cfg.env_vars == base_cfg.env_vars
     assert cfg.model.calculate_per_token_loss == base_cfg.model.calculate_per_token_loss
     assert cfg.model.use_te_rng_tracker == base_cfg.model.use_te_rng_tracker

--- a/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
@@ -35,6 +35,7 @@ from megatron.bridge.perf_recipes.nemotronh import (
     nemotron_3_nano_pretrain_16gpu_h100_fp8cs_config,
 )
 from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.utils.cuda_graph import cuda_graph_module_names, is_full_iteration_cuda_graph
 
 
 pytestmark = pytest.mark.unit
@@ -188,8 +189,8 @@ def test_nemotron_3_5_perf_recipes_inherit_nemotron_3_policy(
     assert cfg.tokenizer.tokenizer_model != base_cfg.tokenizer.tokenizer_model
 
 
-def test_gb200_mxfp8_enables_cutedsl_fusion() -> None:
-    """The non-FSDP Lightning recipe enables CutDSL without MoE A2A overlap."""
+def test_gb200_mxfp8_enables_cutedsl_and_full_iteration_graphs() -> None:
+    """The non-FSDP Lightning recipe uses CutDSL and full-iteration graphs without MoE A2A overlap."""
     cfg = nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config()
 
     assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
@@ -201,6 +202,18 @@ def test_gb200_mxfp8_enables_cutedsl_fusion() -> None:
     assert cfg.mixed_precision.fp8_dot_product_attention is True
     assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
     assert cfg.comm_overlap.delay_wgrad_compute is not True
+    assert is_full_iteration_cuda_graph(cfg.model)
+    assert cuda_graph_module_names(cfg.model) == []
+    assert cfg.model.cuda_graph_warmup_steps == 3
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+    assert cfg.rerun_state_machine.check_for_nan_in_loss is False
+    assert cfg.ddp.check_for_nan_in_grad is False
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == (
+        "expandable_segments:True,graph_capture_record_stream_reuse:True"
+    )
+    assert cfg.env_vars["NCCL_GRAPH_REGISTER"] == 0
+    assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
 
 
 def test_gb200_mxfp8_fsdp_skips_cutedsl_fusion() -> None:
@@ -216,6 +229,7 @@ def test_gb200_mxfp8_fsdp_skips_cutedsl_fusion() -> None:
     assert cfg.mixed_precision.fp8_dot_product_attention is False
     assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
     assert cfg.comm_overlap.delay_wgrad_compute is False
+    assert not is_full_iteration_cuda_graph(cfg.model)
 
 
 @pytest.mark.parametrize("recipe_factory", _H100_RECIPES, ids=lambda recipe: recipe.__name__)

--- a/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
@@ -189,18 +189,18 @@ def test_nemotron_3_5_perf_recipes_inherit_nemotron_3_policy(
 
 
 def test_gb200_mxfp8_enables_cutedsl_fusion() -> None:
-    """The non-FSDP Lightning MXFP8 recipe enables the complete CutDSL contract."""
+    """The non-FSDP Lightning recipe enables CutDSL without MoE A2A overlap."""
     cfg = nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_config()
 
     assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
     assert cfg.env_vars["CUDNNFE_CLUSTER_OVERLAP_MARGIN"] == 8
     assert cfg.model.use_transformer_engine_op_fuser is True
     assert cfg.model.moe_mlp_glu_interleave_size == 32
-    assert cfg.model.high_priority_a2a_comm_stream is True
-    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.model.high_priority_a2a_comm_stream is False
+    assert cfg.model.moe_hybridep_num_sms_preprocessing != 32
     assert cfg.mixed_precision.fp8_dot_product_attention is True
-    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
-    assert cfg.comm_overlap.delay_wgrad_compute is True
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
+    assert cfg.comm_overlap.delay_wgrad_compute is not True
 
 
 def test_gb200_mxfp8_fsdp_skips_cutedsl_fusion() -> None:

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -188,7 +188,7 @@ def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
     module_name: str,
     factory_name: str,
 ) -> None:
-    """GB200 and GB300 MXFP8 recipes enable the complete CutDSL fusion contract."""
+    """GB200 and GB300 MXFP8 recipes enable CutDSL without MoE A2A overlap."""
     module = importlib.import_module(module_name)
     cfg = getattr(module, factory_name)()
 
@@ -196,11 +196,11 @@ def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
     assert cfg.env_vars["CUDNNFE_CLUSTER_OVERLAP_MARGIN"] == 8
     assert cfg.model.use_transformer_engine_op_fuser is True
     assert cfg.model.moe_mlp_glu_interleave_size == 32
-    assert cfg.model.high_priority_a2a_comm_stream is True
-    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.model.high_priority_a2a_comm_stream is False
+    assert cfg.model.moe_hybridep_num_sms_preprocessing != 32
     assert cfg.mixed_precision.fp8_dot_product_attention is True
-    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
-    assert cfg.comm_overlap.delay_wgrad_compute is True
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
+    assert cfg.comm_overlap.delay_wgrad_compute is not True
 
 
 def test_nemotron_3_super_64gpu_gb200_matches_benchmark_hardware_configuration():

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -54,6 +54,8 @@ class _FakeModelProvider:
 
     def __init__(self) -> None:
         self.vocab_size = 256
+        self.high_priority_a2a_comm_stream = False
+        self.moe_hybridep_num_sms_preprocessing = 108
 
     def finalize(self) -> None:
         return None
@@ -163,32 +165,40 @@ def test_nemotron_3_nano_gb200_defers_vocab_size_to_training_tokenizer():
 
 
 @pytest.mark.parametrize(
-    ("module_name", "factory_name"),
+    ("module_name", "factory_name", "has_comm_overlap"),
     [
-        (
+        pytest.param(
             "megatron.bridge.perf_recipes.nemotronh.gb200.nemotronh",
             "nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config",
+            True,
+            id="nano-gb200",
         ),
-        (
+        pytest.param(
             "megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh",
             "nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config",
+            True,
+            id="nano-gb300",
         ),
-        (
+        pytest.param(
             "megatron.bridge.perf_recipes.nemotronh.gb200.nemotronh",
             "nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config",
+            False,
+            id="super-gb200",
         ),
-        (
+        pytest.param(
             "megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh",
             "nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config",
+            False,
+            id="super-gb300",
         ),
     ],
-    ids=lambda recipe: recipe.rsplit(".", 1)[-1],
 )
 def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
     module_name: str,
     factory_name: str,
+    has_comm_overlap: bool,
 ) -> None:
-    """GB200 and GB300 MXFP8 recipes enable CutDSL without MoE A2A overlap."""
+    """GB MXFP8 recipes match the measured CutDSL and MoE overlap settings."""
     module = importlib.import_module(module_name)
     cfg = getattr(module, factory_name)()
 
@@ -197,10 +207,14 @@ def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
     assert cfg.model.use_transformer_engine_op_fuser is True
     assert cfg.model.moe_mlp_glu_interleave_size == 32
     assert cfg.model.high_priority_a2a_comm_stream is False
-    assert cfg.model.moe_hybridep_num_sms_preprocessing != 32
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 108
     assert cfg.mixed_precision.fp8_dot_product_attention is True
-    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
-    assert cfg.comm_overlap.delay_wgrad_compute is not True
+    if has_comm_overlap:
+        assert cfg.comm_overlap is not None
+        assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+        assert cfg.comm_overlap.delay_wgrad_compute is False
+    else:
+        assert cfg.comm_overlap is None
 
 
 def test_nemotron_3_super_64gpu_gb200_matches_benchmark_hardware_configuration():

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -162,6 +162,47 @@ def test_nemotron_3_nano_gb200_defers_vocab_size_to_training_tokenizer():
     assert cfg.model.vocab_size is None
 
 
+@pytest.mark.parametrize(
+    ("module_name", "factory_name"),
+    [
+        (
+            "megatron.bridge.perf_recipes.nemotronh.gb200.nemotronh",
+            "nemotron_3_nano_pretrain_8gpu_gb200_fp8mx_config",
+        ),
+        (
+            "megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh",
+            "nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config",
+        ),
+        (
+            "megatron.bridge.perf_recipes.nemotronh.gb200.nemotronh",
+            "nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config",
+        ),
+        (
+            "megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh",
+            "nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config",
+        ),
+    ],
+    ids=lambda recipe: recipe.rsplit(".", 1)[-1],
+)
+def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
+    module_name: str,
+    factory_name: str,
+) -> None:
+    """GB200 and GB300 MXFP8 recipes enable the complete CutDSL fusion contract."""
+    module = importlib.import_module(module_name)
+    cfg = getattr(module, factory_name)()
+
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
+    assert cfg.env_vars["CUDNNFE_CLUSTER_OVERLAP_MARGIN"] == 8
+    assert cfg.model.use_transformer_engine_op_fuser is True
+    assert cfg.model.moe_mlp_glu_interleave_size == 32
+    assert cfg.model.high_priority_a2a_comm_stream is True
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.mixed_precision.fp8_dot_product_attention is True
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+    assert cfg.comm_overlap.delay_wgrad_compute is True
+
+
 def test_nemotron_3_super_64gpu_gb200_matches_benchmark_hardware_configuration():
     """The training recipe should share the tuned GB200 layout without benchmark-only behavior."""
     from megatron.bridge.perf_recipes.nemotronh.gb200.nemotronh import (

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -27,6 +27,7 @@ import pytest
 import torch
 
 from megatron.bridge.training.utils.omegaconf_utils import OverridesError, process_config_with_overrides
+from megatron.bridge.utils.cuda_graph import cuda_graph_module_names, is_full_iteration_cuda_graph
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
 
 
@@ -184,11 +185,11 @@ def test_nemotron_3_nano_gb200_defers_vocab_size_to_training_tokenizer():
     ],
     ids=lambda recipe: recipe.rsplit(".", 1)[-1],
 )
-def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
+def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_and_full_iteration_graphs(
     module_name: str,
     factory_name: str,
 ) -> None:
-    """GB200 and GB300 MXFP8 recipes enable CutDSL without MoE A2A overlap."""
+    """GB200 and GB300 MXFP8 recipes use CutDSL and full-iteration graphs without MoE A2A overlap."""
     module = importlib.import_module(module_name)
     cfg = getattr(module, factory_name)()
 
@@ -201,6 +202,18 @@ def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
     assert cfg.mixed_precision.fp8_dot_product_attention is True
     assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
     assert cfg.comm_overlap.delay_wgrad_compute is not True
+    assert is_full_iteration_cuda_graph(cfg.model)
+    assert cuda_graph_module_names(cfg.model) == []
+    assert cfg.model.cuda_graph_warmup_steps == 3
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+    assert cfg.rerun_state_machine.check_for_nan_in_loss is False
+    assert cfg.ddp.check_for_nan_in_grad is False
+    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == (
+        "expandable_segments:True,graph_capture_record_stream_reuse:True"
+    )
+    assert cfg.env_vars["NCCL_GRAPH_REGISTER"] == 0
+    assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
 
 
 def test_nemotron_3_super_64gpu_gb200_matches_benchmark_hardware_configuration():

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -27,7 +27,6 @@ import pytest
 import torch
 
 from megatron.bridge.training.utils.omegaconf_utils import OverridesError, process_config_with_overrides
-from megatron.bridge.utils.cuda_graph import cuda_graph_module_names, is_full_iteration_cuda_graph
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
 
 
@@ -185,11 +184,11 @@ def test_nemotron_3_nano_gb200_defers_vocab_size_to_training_tokenizer():
     ],
     ids=lambda recipe: recipe.rsplit(".", 1)[-1],
 )
-def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_and_full_iteration_graphs(
+def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
     module_name: str,
     factory_name: str,
 ) -> None:
-    """GB200 and GB300 MXFP8 recipes use CutDSL and full-iteration graphs without MoE A2A overlap."""
+    """GB200 and GB300 MXFP8 recipes enable CutDSL without MoE A2A overlap."""
     module = importlib.import_module(module_name)
     cfg = getattr(module, factory_name)()
 
@@ -202,18 +201,6 @@ def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_and_full_iteration_grap
     assert cfg.mixed_precision.fp8_dot_product_attention is True
     assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is not True
     assert cfg.comm_overlap.delay_wgrad_compute is not True
-    assert is_full_iteration_cuda_graph(cfg.model)
-    assert cuda_graph_module_names(cfg.model) == []
-    assert cfg.model.cuda_graph_warmup_steps == 3
-    assert cfg.model.use_te_rng_tracker is True
-    assert cfg.rng.te_rng_tracker is True
-    assert cfg.rerun_state_machine.check_for_nan_in_loss is False
-    assert cfg.ddp.check_for_nan_in_grad is False
-    assert cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"] == (
-        "expandable_segments:True,graph_capture_record_stream_reuse:True"
-    )
-    assert cfg.env_vars["NCCL_GRAPH_REGISTER"] == 0
-    assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == 0
 
 
 def test_nemotron_3_super_64gpu_gb200_matches_benchmark_hardware_configuration():


### PR DESCRIPTION
## Summary

- enable the CuteDSL fused grouped MLP environment and cuDNN cluster overlap margin for Nemotron 3 Nano and Super MXFP8 benchmarks on GB200 and GB300, plus the non-FSDP Nemotron 3.5 Lightning MXFP8 benchmark on GB200
- mirror `set_workload_base_configs` by keeping the CutDSL TE op fuser and GLU interleave controls independent from MoE A2A overlap, and enable FP8 dot-product attention separately
- leave high-priority A2A, HybridEP preprocessing SMs, expert-parallel communication overlap, and delayed wgrad compute disabled for these recipes
- replace the target recipes' Transformer Engine scoped graphs with full-iteration CUDA graphs, including three warmup steps, TE RNG tracking, disabled NaN checks, and graph-compatible allocator/NCCL recording settings
- keep the Nemotron 3.5 Lightning FSDP variant and VR200 aliases on their existing untuned base configuration

These are benchmark execution/performance settings; batch size, parallelism, and precision selection are unchanged.

Pipeline 63094776 showed why the separation is required: Nano entered the combined 1F1B schedule and failed to find `build_schedule_plan` on the hybrid model wrapper, while Lightning rejected expert-parallel overlap with `mtp_num_layers=2` because that path supports at most one MTP layer.

## Validation

- `uv run --no-project --with pre-commit pre-commit run --all-files`
- focused Nemotron recipe pytest was attempted but could not collect locally: project synchronization fails while building `fast-hadamard-transform` because its isolated build cannot import undeclared `torch`; the project explicitly excludes PyTorch from the macOS uv environment
