### PR TITLE
docs: update docs version for 0.5.1 (26.06.01)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ if os.path.isdir(_SKILLS_SRC):
 project = "Megatron Bridge"
 copyright = "2026, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "0.5.0"
+release = "0.5.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,4 +1,4 @@
 {
     "name": "megatron-bridge",
-    "version": "0.5.0"
+    "version": "0.5.1"
 }

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -4,10 +4,15 @@
     "url": "https://docs.nvidia.com/nemo/megatron-bridge/nightly/"
   },
   {
-    "name": "0.5.0 (latest) · 26.06",
-    "version": "0.5.0",
-    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.0/",
+    "name": "0.5.1 (latest) · 26.06.01",
+    "version": "0.5.1",
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.1/",
     "preferred": true
+  },
+  {
+    "name": "0.5.0 · 26.06",
+    "version": "0.5.0",
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.0/"
   },
   {
     "name": "0.4.2 · 26.04.01",


### PR DESCRIPTION
## Background / motivation

- `v0.5.1` (NeMo FW container `26.06.01`) is tagged and released off `r0.5.0`, but the docs on this branch still identify themselves as `0.5.0` / `26.06`.
- `docs/conf.py`'s `release` feeds `html_theme_options.switcher.version_match`, so a stale `release` makes the published `0.5.1` docs fail to highlight themselves in the version picker.
- Mirrors the equivalent bump done for `0.4.2` / `26.04.01` (#4037, #4040).

## What changed

- `docs/conf.py`: `release` `0.5.0` → `0.5.1`.
- `docs/project.json`: `version` `0.5.0` → `0.5.1`.
- `docs/versions1.json`: new preferred `0.5.1 (latest) · 26.06.01` entry; `0.5.0` demoted to a plain `0.5.0 · 26.06` entry.

## Details

- `docs/conf.py:40` — `release` is both the Sphinx version string and the switcher's `version_match`; it must equal the `version` field of the matching `versions1.json` entry.
- `docs/versions1.json:6-16` — entry URL uses the explicit versioned path (`/megatron-bridge/0.5.1/`), matching the convention used by the `0.5.0` and `0.6.0` entries. `preferred` moves to `0.5.1` and is dropped from `0.5.0`, per the fix in #4040.
- `docs/conf.py:135` ships `project.json` and `versions1.json` via `html_extra_path`, so both land in the published `0.5.1` tree.
- No `docs/releases/software-versions.md` section is added — patch releases (`26.02.01`, `26.04.01`) have never had one.

```json
// docs/versions1.json (excerpt)
{
  "name": "0.5.1 (latest) · 26.06.01",
  "version": "0.5.1",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.1/",
  "preferred": true
},
{
  "name": "0.5.0 · 26.06",
  "version": "0.5.0",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.0/"
}
```

## Tested

- `python -c "import json; [json.load(open(f)) for f in ['docs/versions1.json','docs/project.json']]"` → both parse.
- `git show v0.5.1` confirms the tag exists on `r0.5.0`, so the publish job resolves the versioned path `nemo/megatron-bridge/0.5.1`.
