### PR TITLE
docs: add 0.5.1 (26.06.01) to the docs version picker

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -8,10 +8,20 @@
     "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.6.0/"
   },
   {
-    "name": "0.4.2 (latest) · 26.04.01",
-    "version": "0.4.2",
-    "url": "https://docs.nvidia.com/nemo/megatron-bridge/latest/",
+    "name": "0.5.1 (latest) · 26.06.01",
+    "version": "0.5.1",
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.1/",
     "preferred": true
+  },
+  {
+    "name": "0.5.0 · 26.06",
+    "version": "0.5.0",
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.0/"
+  },
+  {
+    "name": "0.4.2 · 26.04.01",
+    "version": "0.4.2",
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.4.2/"
   },
   {
     "name": "0.4.0 · 26.04",


### PR DESCRIPTION
## Background / motivation

- Cherry-pick of #5621 (`r0.5.0`) into `main`, so the version picker served with the nightly docs lists the `0.5.1` / `26.06.01` release.
- `main` publishes the **nightly** docs, so `docs/conf.py` (`release = "nightly"`) and `docs/project.json` (`"version": "nightly"`) are deliberately **not** bumped — only `docs/versions1.json` carries over. See the note in `docs/documentation.md`.
- While in the file, two pre-existing defects: `0.5.0` was never added to `main`'s picker at all, and `0.4.2` was still flagged `preferred` with its URL pointing at the `/latest/` alias — which the `v0.5.1` publish (`overwrite-latest-on-tag`) now backs, so the "0.4.2" entry served 0.5.1 content.

## What changed

- `docs/versions1.json`: add `0.5.1 (latest) · 26.06.01` as the `preferred` entry.
- `docs/versions1.json`: add the missing `0.5.0 · 26.06` entry.
- `docs/versions1.json`: `0.4.2` demoted — `(latest)` dropped from the name, `preferred` removed, URL repointed from `/latest/` to `/0.4.2/`.

## Details

- Entry order stays descending by version (`nightly`, `0.6.0`, `0.5.1`, `0.5.0`, `0.4.2`, …), matching the `sort_by(.version) | reverse` the code-freeze automation applies in `.github/workflows/release-freeze.yml`.
- Exactly one `preferred: true` entry after this change. `v0.5.1` is tagged; `v0.6.0` is not yet, so `0.5.1` is the latest published release and the `0.6.0` entry is left untouched.
- `0.4.2`'s `/0.4.2/` URL matches the same entry on `r0.5.0`.

```json
// docs/versions1.json (excerpt)
{
  "version": "0.6.0",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.6.0/"
},
{
  "name": "0.5.1 (latest) · 26.06.01",
  "version": "0.5.1",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.1/",
  "preferred": true
},
{
  "name": "0.5.0 · 26.06",
  "version": "0.5.0",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.0/"
}
```

## Tested

- `json.load(open("docs/versions1.json"))` parses; entry/preferred audit prints `preferred count: 1`.
- `git diff HEAD -- docs/` confirms `docs/conf.py` and `docs/project.json` are untouched (both still `nightly`).

## Follow-up (not in this PR)

`r0.6.0` carries the same duplicate-`preferred` defect: #5567 renamed `0.4.2` but left `"preferred": true` and the `/latest/` URL on it alongside the new `0.6.0` entry, and `0.5.1` is missing there too. Happy to send that as a separate PR.
