### PR TITLE
docs: fix preferred version and add 0.5.1 to the version picker

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -10,6 +10,11 @@
     "preferred": true
   },
   {
+    "name": "0.5.1 · 26.06.01",
+    "version": "0.5.1",
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.1/"
+  },
+  {
     "name": "0.5.0 · 26.06",
     "version": "0.5.0",
     "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.0/"
@@ -17,8 +22,7 @@
   {
     "name": "0.4.2 · 26.04.01",
     "version": "0.4.2",
-    "url": "https://docs.nvidia.com/nemo/megatron-bridge/latest/",
-    "preferred": true
+    "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.4.2/"
   },
   {
     "name": "0.4.0 · 26.04",


### PR DESCRIPTION
## Background / motivation

- `docs/versions1.json` on `r0.6.0` carries **two** `"preferred": true` entries — `0.6.0` and the stale `0.4.2`. `nvidia_sphinx_theme` resolves a single preferred entry, so the picker's "latest" is decided by list order, not intent.
- #5567 added the `0.6.0 (latest) · 26.08` entry and renamed `0.4.2 (latest) · 26.04.01` → `0.4.2 · 26.04.01`, but left that entry's `preferred` flag and its `/latest/` URL in place. Same miss as the 0.4.x line, fixed then by #4039 / #4040.
- `0.4.2`'s URL points at the `/latest/` alias, which `overwrite-latest-on-tag` repointed at the `v0.5.1` publish — so the entry labelled "0.4.2" serves 0.5.1 content.
- `0.5.1` (`26.06.01`) released after the `r0.6.0` code freeze and is missing from the picker. Companion PRs: #5621 (`r0.5.0`), #5622 (`main`).

## What changed

- `docs/versions1.json`: drop `preferred` from `0.4.2`, leaving `0.6.0` as the sole preferred entry.
- `docs/versions1.json`: repoint `0.4.2` from `/latest/` to `/0.4.2/`.
- `docs/versions1.json`: add `0.5.1 · 26.06.01`.

## Details

- `0.6.0` keeps `(latest)` + `preferred` — this is the release branch for `26.08`, and `docs/conf.py:40` (`release = "0.6.0"`) must match a picker entry via `html_theme_options.switcher.version_match`.
- `0.5.1` is added as a plain entry (no `(latest)`), inserted between `0.6.0` and `0.5.0` to keep the descending order the code-freeze automation produces (`sort_by(.version) | reverse` in `.github/workflows/release-freeze.yml`).
- `/0.4.2/` matches the same entry on `r0.5.0` and on `main` after #5622.
- No change to `docs/conf.py` or `docs/project.json` — both correctly pin `0.6.0`.

```json
// docs/versions1.json (excerpt)
{
  "name": "0.6.0 (latest) · 26.08",
  "version": "0.6.0",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.6.0/",
  "preferred": true
},
{
  "name": "0.5.1 · 26.06.01",
  "version": "0.5.1",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.5.1/"
},
{
  "name": "0.4.2 · 26.04.01",
  "version": "0.4.2",
  "url": "https://docs.nvidia.com/nemo/megatron-bridge/0.4.2/"
}
```

## Tested

- `json.load(open("docs/versions1.json"))` parses; entry/preferred audit prints `preferred count: 1` and the entry order `nightly, 0.6.0, 0.5.1, 0.5.0, 0.4.2, 0.4.0, 0.3.1, 0.3.0, 0.2.0, 0.1.0`.
- `git diff` confirms only `docs/versions1.json` is touched; `docs/conf.py` still reads `release = "0.6.0"`.
