### PR TITLE
[training] fix: refresh GDN metadata for eval CP

### DIFF
--- a/src/megatron/bridge/training/eval_context_parallel_rebinding.py
+++ b/src/megatron/bridge/training/eval_context_parallel_rebinding.py
@@ -77,6 +77,13 @@ def install_pg_collection(
     except (ImportError, AttributeError):
         _rotary_cls = ()
 
+    try:
+        from megatron.core.ssm.gated_delta_net import GatedDeltaNet as _GDN
+
+        _gdn_cls: type | None = _GDN
+    except (ImportError, AttributeError):
+        _gdn_cls = None
+
     cp_group = target.cp
     cp_size = cp_group.size()
     cp_ranks = torch.distributed.get_process_group_ranks(cp_group)
@@ -110,6 +117,12 @@ def install_pg_collection(
         if _rotary_cls and isinstance(module, _rotary_cls):
             if hasattr(module, "forward") and hasattr(module.forward, "cache_clear"):
                 module.forward.cache_clear()
+
+        # GDN caches the construction-time CP size and derives its post-A2A
+        # split metadata from it. Refresh both when the live CP group changes.
+        if _gdn_cls is not None and isinstance(module, _gdn_cls):
+            module.cp_size = cp_size
+            module._setup_variant_attrs()
 
         if _te_dpa_cls is not None and isinstance(module, _te_dpa_cls):
             # Lazily create the class-level CP stream if needed (created by TE the

--- a/tests/unit_tests/training/test_eval_context_parallel_rebinding.py
+++ b/tests/unit_tests/training/test_eval_context_parallel_rebinding.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from megatron.core.ssm.gated_delta_net import GatedDeltaNet
+
+from megatron.bridge.training.eval_context_parallel_rebinding import eval_cp_context
+
+
+class _FakeProcessGroup:
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+def _make_gdn(cp_size: int) -> GatedDeltaNet:
+    gdn = GatedDeltaNet.__new__(GatedDeltaNet)
+    torch.nn.Module.__init__(gdn)
+    gdn.config = SimpleNamespace(context_parallel_size=cp_size, deterministic_mode=False)
+    gdn.pg_collection = SimpleNamespace(cp=_FakeProcessGroup(cp_size))
+    gdn.cp_size = cp_size
+    gdn.tp_size = 1
+    gdn.qk_dim_local_tp = 256
+    gdn.v_dim_local_tp = 256
+    gdn.num_value_heads = 8
+    gdn.num_v_heads_local_tp = 8
+    gdn._setup_variant_attrs()
+    return gdn
+
+
+@pytest.mark.unit
+def test_eval_cp_context_refreshes_gdn_runtime_shape_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_process_group_ranks",
+        lambda group: list(range(group.size())),
+    )
+    gdn = _make_gdn(cp_size=1)
+    train_pgs = gdn.pg_collection
+    eval_pgs = SimpleNamespace(cp=_FakeProcessGroup(2))
+
+    with eval_cp_context(gdn, eval_pgs, train_pgs):
+        assert gdn.cp_size == 2
+        live_feature_width = sum(gdn.in_proj_split_sections) // gdn.cp_size
+        torch.split(torch.empty(live_feature_width), gdn.feat_dim_split)
+
+    assert gdn.cp_size == 1
+    assert gdn.config.context_parallel_size == 1


### PR DESCRIPTION
## Problem

Eval-time context-parallel rebinding updates each module's live process-group collection, but `GatedDeltaNet` also caches `cp_size` and CP-derived projection split metadata at construction time. A supported Qwen3-Next model built with training CP=1 and evaluated with CP=2 therefore performs a two-rank all-to-all and then attempts to split the resulting 392-wide tensor with stale CP=1 widths totaling 784. Evaluation crashes before producing metrics.

This is an omitted GDN boundary case in the eval-CP feature introduced by #3755.

## Root cause and fix

`eval_cp_context()` installs the eval process groups but previously left GDN's cached runtime shape metadata unchanged. Refresh `GatedDeltaNet.cp_size` from the installed CP group and regenerate its derived attributes through the existing MCore initializer. The same path restores the training values when the context exits.

The change is limited to GDN modules during existing eval-CP rebinding. It does not change static training CP, add model support, alter public APIs, or modify MCore.

## Validation

Fail-before, using a two-rank standalone reproducer against unmodified `main`:

```text
uv run --no-sync python -m torch.distributed.run --standalone --nproc_per_node=2 reproduce_eval_cp_gdn.py
```

Result: failed on both ranks at `torch.split`: input width 392, requested split widths `[512, 256, 8, 8]` totaling 784.

The unchanged reproducer passes after this fix.

Focused regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_eval_context_parallel_rebinding.py -q --tb=short
```

Result: `1 passed`.

Adjacent tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_eval.py tests/unit_tests/models/qwen/test_qwen3_next_bridge.py -q --tb=short
```

Result: `30 passed`.

Repository checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

Result: passed.
