### PR TITLE
[data] fix: Handle repeated prompt truncation fields

### DIFF
--- a/src/megatron/bridge/data/datasets/gpt_sft.py
+++ b/src/megatron/bridge/data/datasets/gpt_sft.py
@@ -408,7 +408,7 @@ class GPTSFTDataset(Dataset):
 
         if total_ids > self.max_seq_length:
             truncation_length_total = total_ids - self.max_seq_length
-            num_fields = len(self.truncation_fields)
+            num_fields = sum(key in self.truncation_fields for key in template_ids_keys)
             if num_fields > 0:
                 # sorted equal divide length to each field
                 # examples:

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -219,6 +219,25 @@ class TestDataGPTSFTDataset:
         assert context_ids == [101, 102, 103, 104, 201, 202, 203]
         assert label_ids == [301, 302]
 
+    def test_repeated_truncation_field_placeholder_handles_overflow(self, tmp_path):
+        dataset_path = tmp_path / "repeated_prompt.jsonl"
+        dataset_path.write_text(json.dumps({"input": "one two three four five", "output": "answer"}) + "\n")
+        dataset = GPTSFTDataset(
+            file_path=str(dataset_path),
+            tokenizer=create_mock_tokenizer(),
+            max_seq_length=8,
+            max_num_samples=None,
+            label_key="output",
+            prompt_template="{input} Again: {input} {output}",
+            truncation_field="input",
+            memmap_workers=1,
+        )
+
+        processed = dataset[0]
+
+        assert len(processed["input_ids"]) <= dataset.max_seq_length
+        assert processed["answer_ids"]
+
     def test_utils_func(self, tmp_path):
         dataset, _ = get_gpt_sft(tmp_path)
 


### PR DESCRIPTION
## What does this PR do?

Fixes legacy GPT SFT prompt templates that repeat a configured truncation field.

An accepted template such as `{input} Again: {input} {output}` crashes on an overlength row. This compatibility path remains supported by `GPTSFTDatasetConfig`, so the crash can stop ordinary SFT loading or offline packing preparation.

## Root cause and fix

`GPTSFTDataset._multiple_truncation()` allocated one truncation share per configured field name, but consumed one share per matching placeholder occurrence. A repeated placeholder therefore exhausted the allocation list and raised `IndexError: pop from empty list`.

The fix counts matching prompt-template occurrences, which is the same unit consumed by the existing truncation loop. No public API or configuration behavior changes.

## Regression evidence

The same focused test was run before and after the production change:

```bash
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/data/datasets/test_gpt_sft.py::TestDataGPTSFTDataset::test_repeated_truncation_field_placeholder_handles_overflow -q --tb=short
```

- Before: `1 failed` at `gpt_sft.py:425` with `IndexError: pop from empty list`.
- After: `1 passed`.

Focused adjacent validation:

```bash
uv run --no-sync python -m pytest -p no:cacheprovider \
  tests/unit_tests/data/datasets/test_gpt_sft.py::TestDataGPTSFTDataset::test_multiple_truncation \
  tests/unit_tests/data/datasets/test_gpt_sft.py::TestDataGPTSFTDataset::test_repeated_truncation_field_placeholder_handles_overflow \
  tests/unit_tests/data/test_sft_processing.py::test_prompt_completion_full_loss_and_truncation_preserve_special_tokens \
  tests/unit_tests/data/test_sft_processing.py::test_prompt_completion_preserves_gpt_generation_reserve_truncation \
  -q --tb=short
# 5 passed

git diff --check
uv run --no-sync pre-commit run --all-files
# passed
```

## Scope

This is limited to repeated placeholders in the legacy-compatible GPT SFT prompt-template truncation path. It does not change declarative prompt/completion preprocessing, chat-template masking, packed-sequence layout, dependencies, CI, MCore, or public APIs. No full-suite, convergence, model-quality, or performance validation was run.
