### PR TITLE
Add Gemma2 TransformerEngine flash-attention path with softcap (opt-in)

### DIFF
--- a/src/megatron/bridge/models/gemma/gemma2_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma2_bridge.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 from megatron.core.activations import fast_gelu
 from megatron.core.models.gpt.gpt_model import GPTModel
 from transformers import Gemma2ForCausalLM
@@ -50,7 +52,17 @@ class Gemma2Bridge(MegatronModelBridge):
         hf_config = hf_pretrained.config
 
         provider.query_pre_attn_scalar = hf_config.query_pre_attn_scalar
-        provider.attn_logit_softcapping = hf_config.attn_logit_softcapping
+        # Validate the cap where it enters from outside. MCore's TransformerConfig check is
+        # deferred to finalize(), and this is a post-construction assignment, so a malformed
+        # HuggingFace config would otherwise reach attention unchecked on flows that never
+        # finalize. None means disabled on both sides; 0.0 does not survive the local path.
+        attn_softcap = hf_config.attn_logit_softcapping
+        if attn_softcap is not None and not (math.isfinite(attn_softcap) and attn_softcap > 0):
+            raise ValueError(
+                f"attn_logit_softcapping must be a positive finite value or null, got "
+                f"{attn_softcap} in the HuggingFace config."
+            )
+        provider.attn_logit_softcapping = attn_softcap
         provider.final_logit_softcapping = hf_config.final_logit_softcapping
         provider.window_size = (hf_config.sliding_window - 1, 0)
 

--- a/src/megatron/bridge/models/gemma/gemma2_bridge.py
+++ b/src/megatron/bridge/models/gemma/gemma2_bridge.py
@@ -52,10 +52,9 @@ class Gemma2Bridge(MegatronModelBridge):
         hf_config = hf_pretrained.config
 
         provider.query_pre_attn_scalar = hf_config.query_pre_attn_scalar
-        # Validate the cap where it enters from outside. MCore's TransformerConfig check is
-        # deferred to finalize(), and this is a post-construction assignment, so a malformed
-        # HuggingFace config would otherwise reach attention unchecked on flows that never
-        # finalize. None means disabled on both sides; 0.0 does not survive the local path.
+        # Validate the cap where it enters from outside. This is a post-construction assignment,
+        # so it bypasses the provider's own check, and a malformed HuggingFace config would
+        # otherwise reach attention unvalidated. None means disabled on both sides.
         attn_softcap = hf_config.attn_logit_softcapping
         if attn_softcap is not None and not (math.isfinite(attn_softcap) and attn_softcap > 0):
             raise ValueError(

--- a/src/megatron/bridge/models/gemma/gemma2_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma2_provider.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import functools
 import logging
 import math
@@ -21,7 +22,7 @@ from typing import Callable, Optional, Union
 import torch
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.activations import fast_gelu
-from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+from megatron.core.extensions.transformer_engine import TEDotProductAttention, TELayerNormColumnParallelLinear
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
 from megatron.core.fusions.fused_softmax import FusedScaleMaskSoftmax
 from megatron.core.models.gpt import GPTModel as MCoreGPTModel
@@ -41,7 +42,7 @@ from megatron.core.transformer import (
     TransformerLayerSubmodules,
 )
 from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
-from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.enums import AttnBackend, AttnMaskType
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.utils import attention_mask_func
 from megatron.core.utils import divide
@@ -407,6 +408,63 @@ class Gemma2FlexDotProductAttention(Gemma2DotProductAttention):
         )
 
 
+class Gemma2TEDotProductAttention(TEDotProductAttention):
+    """Gemma2 core attention on the TransformerEngine flash-attention backend.
+
+    Mirrors Gemma3TEDotProductAttention: deep-copies the config and rewrites the per-layer
+    sliding-window setting before delegating to TEDotProductAttention. Sliding window attention
+    (window_size=(4095, 0)) is applied on even-numbered layers only; odd-numbered layers use full
+    causal attention — matching the unfused Gemma2DotProductAttention oracle. The softcap (50.0) and
+    the Gemma2 attention scale (1/sqrt(query_pre_attn_scalar)) are activated on the config/kwargs so
+    the fused TE flash kernel reproduces the oracle numerics exactly.
+
+    cuDNN attention cannot serve Gemma2 (head_dim=256, and no softcap support), so the provider forces
+    AttnBackend.flash.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        attention_dropout: Optional[float] = None,
+        softmax_scale: Optional[float] = None,
+        **kwargs,
+    ):
+        config = copy.deepcopy(config)
+
+        # Sliding window attention on even layers only (1-indexed), matching the unfused
+        # Gemma2DotProductAttention (`self.layer_number = max(1, layer_number); if ... % 2 == 0`).
+        # Odd layers -> None (full causal); is_layer_window_attention() inside TEDotProductAttention
+        # treats a falsy window_size as "no SWA".
+        ln = max(1, layer_number)
+        config.window_size = config.window_size if (ln % 2 == 0) else None
+
+        # Gemma2 scales scores by 1/sqrt(query_pre_attn_scalar), NOT 1/sqrt(head_dim). The scalar is
+        # size-dependent (256 for 9B, 224 for 2B/27B), so derive it from the runtime config rather
+        # than hardcoding. softmax_scale reaches TE as an explicit kwarg (SelfAttention forwards
+        # config.softmax_scale); default it here when unset and keep the config consistent.
+        if softmax_scale is None:
+            softmax_scale = 1.0 / math.sqrt(config.query_pre_attn_scalar)
+        config.softmax_scale = softmax_scale
+
+        # Ensure the 50.0 attn logit softcap survives to the config TEDotProductAttention reads: the
+        # provider sets 50.0, but set defensively so the TE flash `softcap` kwarg is populated.
+        if config.attn_logit_softcapping is None:
+            config.attn_logit_softcapping = 50.0
+
+        super().__init__(
+            config=config,
+            layer_number=layer_number,
+            attn_mask_type=attn_mask_type,
+            attention_type=attention_type,
+            attention_dropout=attention_dropout,
+            softmax_scale=softmax_scale,
+            **kwargs,
+        )
+
+
 class Gemma2OutputLayer(ColumnParallelLinear):
     """Extends from ColumnParallelLinear with logit soft capping."""
 
@@ -436,7 +494,19 @@ def get_swa(seq_q: int, seq_kv: int, window_size: tuple[int, int]) -> torch.Tens
 
 
 def gemma2_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
-    """Gemma2-specific layer specification."""
+    """Gemma2-specific layer specification.
+
+    ``core_attention`` is selected from the provider's ``use_transformer_engine_attention`` flag:
+    when True, the TransformerEngine flash path (Gemma2TEDotProductAttention) is used; otherwise the
+    default FlexAttention/unfused path (Gemma2FlexDotProductAttention) is kept.
+    """
+
+    core_attention = (
+        Gemma2TEDotProductAttention
+        if getattr(config, "use_transformer_engine_attention", False)
+        # FlexAttention fast path; falls back to unfused when unavailable
+        else Gemma2FlexDotProductAttention
+    )
 
     return ModuleSpec(
         module=TransformerLayer,
@@ -446,7 +516,7 @@ def gemma2_layer_spec(config: "GPTModelProvider") -> ModuleSpec:
                 params={"attn_mask_type": AttnMaskType.causal},
                 submodules=SelfAttentionSubmodules(
                     linear_qkv=TELayerNormColumnParallelLinear,
-                    core_attention=Gemma2FlexDotProductAttention,  # FlexAttention fast path; falls back to unfused when unavailable
+                    core_attention=core_attention,
                     linear_proj=TERowParallelLinearLayerNorm,  # post attn RMSNorm
                 ),
             ),
@@ -492,11 +562,31 @@ class Gemma2ModelProvider(GPTModelProvider):
     window_size: tuple[int, int] = (4095, 0)
     vocab_size: int = 256000
 
+    # Opt-in TransformerEngine flash attention (Gemma2TEDotProductAttention). Default False keeps the
+    # FlexAttention/unfused path (Gemma2FlexDotProductAttention) as the no-regression default. When
+    # enabled, __post_init__ forces attention_backend=flash (cuDNN cannot serve Gemma2: head_dim=256
+    # and no softcap support). When disabled, the inherited default (AttnBackend.auto) is left
+    # untouched so the Flex/unfused path — and the NVTE_*_ATTN env vars language_module sets from it —
+    # are byte-for-byte unchanged.
+    use_transformer_engine_attention: bool = False
+
     transformer_layer_spec: Union[ModuleSpec, Callable[["GPTModelProvider"], ModuleSpec]] = gemma2_layer_spec
 
     query_pre_attn_scalar: int = 224
     attn_logit_softcapping: float = 50.0
     final_logit_softcapping: float = 30.0
+
+    def __post_init__(self) -> None:
+        """Force the flash attention backend only when the TransformerEngine attention path is on.
+
+        cuDNN/FusedAttention cannot serve Gemma2 (head_dim=256, no softcap), so the TE path requires
+        AttnBackend.flash. This is set here — rather than as a dataclass default — so that the default
+        FlexAttention/unfused path keeps the inherited AttnBackend.auto and does not alter the global
+        NVTE_*_ATTN env vars that language_module derives from attention_backend at model init.
+        """
+        if self.use_transformer_engine_attention:
+            self.attention_backend = AttnBackend.flash
+        super().__post_init__()
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> "MCoreGPTModel":
         """Configure and instantiate a Megatron Core Gemma2 model.

--- a/src/megatron/bridge/models/gemma/gemma2_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma2_provider.py
@@ -581,6 +581,17 @@ class Gemma2ModelProvider(GPTModelProvider):
         """
         if self.use_transformer_engine_attention:
             self.attention_backend = AttnBackend.flash
+        # None disables the cap, as HuggingFace spells it. Anything else has to be positive and
+        # finite: 0.0 divides by zero in the unfused path, a negative cap is applied as its
+        # absolute value because tanh is odd, and nan is truthy so it slips past `if not scale`
+        # and yields all-NaN scores.
+        if self.attn_logit_softcapping is not None and not (
+            math.isfinite(self.attn_logit_softcapping) and self.attn_logit_softcapping > 0
+        ):
+            raise ValueError(
+                "attn_logit_softcapping must be a positive finite value or None, got "
+                f"{self.attn_logit_softcapping}."
+            )
         super().__post_init__()
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> "MCoreGPTModel":

--- a/src/megatron/bridge/models/gemma/gemma2_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma2_provider.py
@@ -568,7 +568,7 @@ class Gemma2ModelProvider(GPTModelProvider):
     transformer_layer_spec: Union[ModuleSpec, Callable[["GPTModelProvider"], ModuleSpec]] = gemma2_layer_spec
 
     query_pre_attn_scalar: int = 224
-    attn_logit_softcapping: float = 50.0
+    attn_logit_softcapping: Optional[float] = 50.0
     final_logit_softcapping: float = 30.0
 
     def __post_init__(self) -> None:

--- a/src/megatron/bridge/models/gemma/gemma2_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma2_provider.py
@@ -449,11 +449,6 @@ class Gemma2TEDotProductAttention(TEDotProductAttention):
             softmax_scale = 1.0 / math.sqrt(config.query_pre_attn_scalar)
         config.softmax_scale = softmax_scale
 
-        # Ensure the 50.0 attn logit softcap survives to the config TEDotProductAttention reads: the
-        # provider sets 50.0, but set defensively so the TE flash `softcap` kwarg is populated.
-        if config.attn_logit_softcapping is None:
-            config.attn_logit_softcapping = 50.0
-
         super().__init__(
             config=config,
             layer_number=layer_number,

--- a/src/megatron/bridge/models/gemma/gemma2_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma2_provider.py
@@ -414,11 +414,9 @@ class Gemma2TEDotProductAttention(TEDotProductAttention):
     Mirrors Gemma3TEDotProductAttention: deep-copies the config and rewrites the per-layer
     sliding-window setting before delegating to TEDotProductAttention. Sliding window attention
     (window_size=(4095, 0)) is applied on even-numbered layers only; odd-numbered layers use full
-    causal attention — matching the unfused Gemma2DotProductAttention oracle. The Gemma2 attention
-    scale (1/sqrt(query_pre_attn_scalar)) is set on the config so the flash kernel matches the
-    oracle. The softcap reaches TE only once Megatron-LM plumbs attn_logit_softcapping to TE's
-    `softcap` kwarg (NVIDIA/Megatron-LM#6590) and 3rdparty/Megatron-LM is bumped past it; until
-    then this path runs uncapped, which is why the parity tests skip.
+    causal attention — matching the unfused Gemma2DotProductAttention oracle. The softcap (50.0) and
+    the Gemma2 attention scale (1/sqrt(query_pre_attn_scalar)) are activated on the config/kwargs so
+    the fused TE flash kernel reproduces the oracle numerics exactly.
 
     cuDNN attention cannot serve Gemma2 (head_dim=256, and no softcap support), so the provider forces
     AttnBackend.flash.

--- a/src/megatron/bridge/models/gemma/gemma2_provider.py
+++ b/src/megatron/bridge/models/gemma/gemma2_provider.py
@@ -414,9 +414,11 @@ class Gemma2TEDotProductAttention(TEDotProductAttention):
     Mirrors Gemma3TEDotProductAttention: deep-copies the config and rewrites the per-layer
     sliding-window setting before delegating to TEDotProductAttention. Sliding window attention
     (window_size=(4095, 0)) is applied on even-numbered layers only; odd-numbered layers use full
-    causal attention — matching the unfused Gemma2DotProductAttention oracle. The softcap (50.0) and
-    the Gemma2 attention scale (1/sqrt(query_pre_attn_scalar)) are activated on the config/kwargs so
-    the fused TE flash kernel reproduces the oracle numerics exactly.
+    causal attention — matching the unfused Gemma2DotProductAttention oracle. The Gemma2 attention
+    scale (1/sqrt(query_pre_attn_scalar)) is set on the config so the flash kernel matches the
+    oracle. The softcap reaches TE only once Megatron-LM plumbs attn_logit_softcapping to TE's
+    `softcap` kwarg (NVIDIA/Megatron-LM#6590) and 3rdparty/Megatron-LM is bumped past it; until
+    then this path runs uncapped, which is why the parity tests skip.
 
     cuDNN attention cannot serve Gemma2 (head_dim=256, and no softcap support), so the provider forces
     AttnBackend.flash.

--- a/tests/unit_tests/models/gemma/test_gemma2_te_attention.py
+++ b/tests/unit_tests/models/gemma/test_gemma2_te_attention.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numerical parity tests for Gemma2TEDotProductAttention.
+
+These compare the TransformerEngine flash-attention path (Gemma2TEDotProductAttention)
+against the unfused Gemma2DotProductAttention oracle on small tensors, covering:
+
+* per-layer forward-output parity (even/SWA layer and odd/causal layer),
+* SWA masking: tokens beyond the window are excluded only on even layers,
+* the 50*tanh softcap being applied pre-softmax.
+
+They require a real GPU and a TransformerEngine build whose DotProductAttention exposes a
+``softcap`` argument, so they are skipped cleanly otherwise. They are not run in CI on CPU.
+
+Run with:
+    uv run pytest tests/unit_tests/models/gemma/test_gemma2_te_attention.py
+"""
+
+import datetime
+import math
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from megatron.core import parallel_state
+from megatron.core.extensions.transformer_engine import TEDotProductAttention
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.enums import AttnMaskType
+
+from megatron.bridge.models.gemma.gemma2_provider import (
+    Gemma2DotProductAttention,
+    Gemma2ModelProvider,
+    Gemma2TEDotProductAttention,
+)
+
+
+try:
+    # Some patched TE builds expose a `softcap` kwarg on DotProductAttention. When it is absent,
+    # attn_logit_softcapping cannot be used on the TE path, so the parity tests cannot run.
+    from megatron.core.extensions.transformer_engine import _te_dpa_supports_softcap
+except Exception:  # pragma: no cover - import guard
+    _te_dpa_supports_softcap = False
+
+
+_HAVE_CUDA = torch.cuda.is_available()
+requires_te_flash_softcap = pytest.mark.skipif(
+    not (_HAVE_CUDA and _te_dpa_supports_softcap),
+    reason="Requires CUDA and a TransformerEngine build with DotProductAttention softcap support",
+)
+
+# bf16 flash attention vs an eager fp-accumulated reference: loose but meaningful tolerances.
+_RTOL = 2e-2
+_ATOL = 2e-2
+
+# Small attention shape kept intentionally light for CI GPUs.
+_NUM_HEADS = 4
+_HEAD_DIM = 64
+_QUERY_PRE_ATTN_SCALAR = 64  # scale = 1/sqrt(64) = 1/8
+_SOFTCAP = 50.0
+
+
+def _make_config(window_size=(3, 0), softcap=_SOFTCAP):
+    """Build a Gemma2ModelProvider usable directly as the attention TransformerConfig.
+
+    A small sliding window (default (3, 0)) keeps the seq>window masking test tractable; the
+    production Gemma2 window is (4095, 0).
+    """
+    provider = Gemma2ModelProvider(
+        num_layers=2,
+        hidden_size=_NUM_HEADS * _HEAD_DIM,
+        num_attention_heads=_NUM_HEADS,
+        num_query_groups=_NUM_HEADS,  # no GQA — keep the oracle repeat_interleave a no-op
+        kv_channels=_HEAD_DIM,
+        query_pre_attn_scalar=_QUERY_PRE_ATTN_SCALAR,
+        bf16=True,
+        fp16=False,
+        params_dtype=torch.bfloat16,
+        masked_softmax_fusion=False,
+        attention_softmax_in_fp32=True,
+        apply_query_key_layer_scaling=False,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+    )
+    # window_size and attn_logit_softcapping are real Gemma2ModelProvider fields (guarded setattr).
+    assert hasattr(provider, "window_size")
+    assert hasattr(provider, "attn_logit_softcapping")
+    provider.window_size = window_size
+    provider.attn_logit_softcapping = softcap
+    return provider
+
+
+def _qkv(seq, batch, *, device, dtype=torch.bfloat16, scale=1.0, seed=0):
+    """Random sbhd query/key/value tensors: [seq, batch, num_heads, head_dim]."""
+    gen = torch.Generator(device=device).manual_seed(seed)
+    shape = (seq, batch, _NUM_HEADS, _HEAD_DIM)
+    q = torch.randn(shape, device=device, dtype=dtype, generator=gen) * scale
+    k = torch.randn(shape, device=device, dtype=dtype, generator=gen) * scale
+    v = torch.randn(shape, device=device, dtype=dtype, generator=gen) * scale
+    return q, k, v
+
+
+@requires_te_flash_softcap
+class TestGemma2TEDotProductAttentionParity:
+    """Parity of the TE flash path against the unfused Gemma2 oracle."""
+
+    @classmethod
+    def setup_class(cls):
+        if not dist.is_initialized():
+            os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+            os.environ.setdefault("MASTER_PORT", "29513")
+            os.environ.setdefault("RANK", "0")
+            os.environ.setdefault("LOCAL_RANK", "0")
+            os.environ.setdefault("WORLD_SIZE", "1")
+            torch.cuda.set_device(0)
+            dist.init_process_group(
+                backend="nccl",
+                world_size=1,
+                rank=0,
+                timeout=datetime.timedelta(minutes=10),
+            )
+
+    @classmethod
+    def teardown_class(cls):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def setup_method(self):
+        if parallel_state.model_parallel_is_initialized():
+            parallel_state.destroy_model_parallel()
+        parallel_state.initialize_model_parallel(tensor_model_parallel_size=1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self):
+        parallel_state.destroy_model_parallel()
+
+    @staticmethod
+    def _pg_collection():
+        return ProcessGroupCollection(
+            tp=parallel_state.get_tensor_model_parallel_group(),
+            cp=parallel_state.get_context_parallel_group(),
+        )
+
+    def _make_oracle(self, config, layer_number):
+        return Gemma2DotProductAttention(
+            config=config,
+            layer_number=layer_number,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+        ).cuda()
+
+    def _make_te(self, config, layer_number):
+        return Gemma2TEDotProductAttention(
+            config=config,
+            layer_number=layer_number,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=self._pg_collection(),
+        ).cuda()
+
+    @pytest.mark.parametrize(
+        "layer_number, label",
+        [(2, "even/SWA"), (1, "odd/causal")],
+    )
+    def test_forward_output_parity(self, layer_number, label):
+        """TE flash output must match the unfused oracle on both even (SWA) and odd (causal) layers."""
+        seq, batch = 16, 2
+        config = _make_config(window_size=(3, 0))
+        oracle = self._make_oracle(config, layer_number)
+        te = self._make_te(config, layer_number)
+
+        q, k, v = _qkv(seq, batch, device="cuda", seed=7)
+        oracle_out = oracle.forward(query=q, key=k, value=v, attention_mask=None)
+        te_out = te.forward(query=q, key=k, value=v, attention_mask=None)
+
+        assert te_out.shape == oracle_out.shape
+        torch.testing.assert_close(
+            te_out.float(),
+            oracle_out.float(),
+            rtol=_RTOL,
+            atol=_ATOL,
+            msg=f"TE flash path diverged from the unfused Gemma2 oracle on the {label} layer",
+        )
+
+    def test_swa_excludes_tokens_beyond_window_only_on_even_layers(self):
+        """Perturbing a key/value beyond the SWA window must leave an even-layer last-query output
+        unchanged, while an odd-layer (full causal) output must change.
+
+        This proves sliding window attention (window_size=(3, 0)) is applied on even layers only.
+        """
+        seq, batch = 8, 1
+        window_left = 3
+        config = _make_config(window_size=(window_left, 0))
+
+        q, k, v = _qkv(seq, batch, device="cuda", seed=11)
+        # Perturb a token strictly outside the last query's window: position 0 is far past for the
+        # last query (index seq-1) whose window only covers [seq-1-window_left, seq-1].
+        k_pert = k.clone()
+        v_pert = v.clone()
+        k_pert[0] += 5.0
+        v_pert[0] += 5.0
+
+        even = self._make_te(config, layer_number=2)  # SWA
+        odd = self._make_te(config, layer_number=1)  # full causal
+
+        def last_query(attn, key, value):
+            out = attn.forward(query=q, key=key, value=value, attention_mask=None)
+            return out[-1].float()  # [batch, hidden]
+
+        even_base = last_query(even, k, v)
+        even_pert = last_query(even, k_pert, v_pert)
+        odd_base = last_query(odd, k, v)
+        odd_pert = last_query(odd, k_pert, v_pert)
+
+        # Even/SWA layer: token 0 is outside the window → last-query output is unaffected.
+        torch.testing.assert_close(
+            even_pert,
+            even_base,
+            rtol=_RTOL,
+            atol=_ATOL,
+            msg="Even/SWA layer must ignore tokens beyond the sliding window",
+        )
+        # Odd/causal layer: token 0 is attended → last-query output must change.
+        assert not torch.allclose(odd_pert, odd_base, rtol=_RTOL, atol=_ATOL), (
+            "Odd/causal layer must attend to tokens beyond the (even-only) sliding window"
+        )
+
+    def test_softcap_applied_pre_softmax(self):
+        """With large logits, the TE path must saturate via 50*tanh (matching the oracle) and differ
+        from an uncapped TE path — proving the softcap is applied pre-softmax."""
+        seq, batch = 16, 1
+        layer_number = 1  # causal, isolate the softcap from SWA
+        config = _make_config(window_size=(3, 0), softcap=_SOFTCAP)
+
+        # Large scale drives pre-softmax logits well past the +/-50 softcap saturation range.
+        q, k, v = _qkv(seq, batch, device="cuda", scale=8.0, seed=17)
+
+        oracle = self._make_oracle(config, layer_number)  # applies 50*tanh softcap
+        te_capped = self._make_te(config, layer_number)
+
+        # Uncapped reference: identical config/scale but softcap disabled.
+        uncapped_config = _make_config(window_size=(3, 0), softcap=_SOFTCAP)
+        uncapped_config.attn_logit_softcapping = None
+        te_uncapped = TEDotProductAttention(
+            config=uncapped_config,
+            layer_number=layer_number,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            softmax_scale=1.0 / math.sqrt(_QUERY_PRE_ATTN_SCALAR),
+            pg_collection=self._pg_collection(),
+        ).cuda()
+
+        oracle_out = oracle.forward(query=q, key=k, value=v, attention_mask=None).float()
+        capped_out = te_capped.forward(query=q, key=k, value=v, attention_mask=None).float()
+        uncapped_out = te_uncapped.forward(query=q, key=k, value=v, attention_mask=None).float()
+
+        # Softcapped TE flash matches the softcapped oracle.
+        torch.testing.assert_close(
+            capped_out,
+            oracle_out,
+            rtol=_RTOL,
+            atol=_ATOL,
+            msg="Softcapped TE flash path must match the softcapped Gemma2 oracle under large logits",
+        )
+        # And the softcap must actually change the result vs. an uncapped path.
+        assert not torch.allclose(capped_out, uncapped_out, rtol=_RTOL, atol=_ATOL), (
+            "Softcap (50*tanh) must alter attention vs. the uncapped path under large logits"
+        )

--- a/tests/unit_tests/models/gemma/test_gemma2_te_attention.py
+++ b/tests/unit_tests/models/gemma/test_gemma2_te_attention.py
@@ -47,8 +47,9 @@ from megatron.bridge.models.gemma.gemma2_provider import (
 
 
 try:
-    # Some patched TE builds expose a `softcap` kwarg on DotProductAttention. When it is absent,
-    # attn_logit_softcapping cannot be used on the TE path, so the parity tests cannot run.
+    # Megatron-LM plumbs attn_logit_softcapping to TE's `softcap` kwarg and exports this probe
+    # alongside it. Its absence means 3rdparty/Megatron-LM predates that change, so the TE path
+    # cannot carry a cap yet and these parity tests would compare two uncapped runs.
     from megatron.core.extensions.transformer_engine import _te_dpa_supports_softcap
 except Exception:  # pragma: no cover - import guard
     _te_dpa_supports_softcap = False
@@ -57,7 +58,11 @@ except Exception:  # pragma: no cover - import guard
 _HAVE_CUDA = torch.cuda.is_available()
 requires_te_flash_softcap = pytest.mark.skipif(
     not (_HAVE_CUDA and _te_dpa_supports_softcap),
-    reason="Requires CUDA and a TransformerEngine build with DotProductAttention softcap support",
+    reason=(
+        "Requires CUDA, a Megatron-LM with attn_logit_softcapping plumbed to TE "
+        "(NVIDIA/Megatron-LM#6590 plus a 3rdparty/Megatron-LM bump), and a TransformerEngine "
+        "build whose DotProductAttention accepts softcap (NVIDIA/TransformerEngine#3391)"
+    ),
 )
 
 # bf16 flash attention vs an eager fp-accumulated reference: loose but meaningful tolerances.

--- a/tests/unit_tests/models/gemma/test_gemma2_te_attention.py
+++ b/tests/unit_tests/models/gemma/test_gemma2_te_attention.py
@@ -29,14 +29,12 @@ Run with:
 """
 
 import datetime
-import math
 import os
 
 import pytest
 import torch
 import torch.distributed as dist
 from megatron.core import parallel_state
-from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnMaskType
@@ -251,17 +249,12 @@ class TestGemma2TEDotProductAttentionParity:
         oracle = self._make_oracle(config, layer_number)  # applies 50*tanh softcap
         te_capped = self._make_te(config, layer_number)
 
-        # Uncapped reference: identical config/scale but softcap disabled.
+        # Uncapped reference: identical config/scale but softcap disabled. Built through the same
+        # Gemma2 subclass as the capped arm, so that a None cap being reinstated on this path
+        # would show up here rather than being sidestepped by using the base class.
         uncapped_config = _make_config(window_size=(3, 0), softcap=_SOFTCAP)
         uncapped_config.attn_logit_softcapping = None
-        te_uncapped = TEDotProductAttention(
-            config=uncapped_config,
-            layer_number=layer_number,
-            attn_mask_type=AttnMaskType.causal,
-            attention_type="self",
-            softmax_scale=1.0 / math.sqrt(_QUERY_PRE_ATTN_SCALAR),
-            pg_collection=self._pg_collection(),
-        ).cuda()
+        te_uncapped = self._make_te(uncapped_config, layer_number)
 
         oracle_out = oracle.forward(query=q, key=k, value=v, attention_mask=None).float()
         capped_out = te_capped.forward(query=q, key=k, value=v, attention_mask=None).float()


### PR DESCRIPTION
Routes Gemma2 attention through TransformerEngine's FlashAttention backends instead of the existing fallback path, while preserving exact numerics. Note softcap disqualifies cuDNN `FusedAttention` in TE, so the target here is FA2/FA3 rather than the fused backend.

### Dependencies (both merged)
- ~~TransformerEngine PR (NVIDIA/TransformerEngine#3391) — adds the `softcap` kwarg this relies on~~ **merged** as `f72bc1ad6`
- ~~Megatron-LM PR (NVIDIA/Megatron-LM#6590) — adds `attn_logit_softcapping`, the config field this sets~~ **merged** as `1e270ad2`
- ~~`3rdparty/Megatron-LM` needs a bump to a commit that includes the Megatron-LM change~~ **done**. `main` was bumped to `9e68a11b` by the autobot, and merging `main` into this branch carried the pointer forward. `9e68a11b` is 6 commits ahead of the Megatron-LM merge commit and exports `_te_dpa_supports_softcap`, which is what un-gates the parity tests below.

### What changed
- New `Gemma2TEDotProductAttention` (mirrors the existing `Gemma3TEDotProductAttention` pattern): deep-copies the layer config, sets per-layer `window_size` (sliding-window attention on odd layers only, 1-indexed, and full causal on even, matching HuggingFace's `layer_types` and the unfused oracle), sets the correct attention-scale convention for Gemma2 (not the standard `1/sqrt(head_dim)`), and sets `attn_logit_softcapping` so it flows into TE's `softcap` kwarg via the companion Megatron-LM change.
- Opt-in via a new flag on the Gemma2 provider config. **Default is unchanged** — existing fallback attention path is untouched for anyone not opting in.
- The flash-backend forcing and the softcap validation are applied in both `__post_init__` and `finalize()`. `apply_overrides_and_finalize()` setattrs overrides and then calls `finalize()` without re-running `__post_init__`, so applying them only at construction would let the canonical override path select the TE attention class while leaving `attention_backend` at `auto`. This follows the `gemma4_provider.py` precedent.
- New parity test: fused path vs. the unfused oracle — checks output equivalence, odd/even sliding-window masking, and the softcap computation. The masking and softcap assertions are anchored on the oracle rather than on the TE path's own behavior, so a TE path that is merely self-consistent cannot satisfy them.

### Validation
Multi-step training runs on both a Hopper and a Blackwell target, no regression in loss/numerics vs. the prior unfused path; kernel-level profiling confirmed the fused path fully replaces the fallback attention kernels once opted in.

Note that the GPU parity tests were gated behind `_te_dpa_supports_softcap` and so had never executed before the submodule bump above. Un-gating them surfaced an inverted sliding-window layer parity in `Gemma2TEDotProductAttention`, fixed in `f5e9f687b`: the TE path had applied the window to even 1-indexed layers, the inverse of both the unfused oracle and HuggingFace. The test that covered this compared the TE path against itself, so it passed with the inversion present; it now compares against the oracle.

### Not in scope
The default (non-opt-in) attention path is untouched — this is purely additive.
