### PR TITLE
[training] fix: Refresh GDN2 metadata for eval CP

### DIFF
--- a/src/megatron/bridge/training/eval_context_parallel_rebinding.py
+++ b/src/megatron/bridge/training/eval_context_parallel_rebinding.py
@@ -80,9 +80,14 @@ def install_pg_collection(
     try:
         from megatron.core.ssm.gated_delta_net import GatedDeltaNet as _GDN
 
-        _gdn_cls: type | None = _GDN
+        try:
+            from megatron.core.ssm.gated_delta_net import GatedDeltaNet2 as _GDN2
+
+            _gdn_classes: tuple[type, ...] = (_GDN, _GDN2)
+        except (ImportError, AttributeError):
+            _gdn_classes = (_GDN,)
     except (ImportError, AttributeError):
-        _gdn_cls = None
+        _gdn_classes = ()
 
     cp_group = target.cp
     cp_size = cp_group.size()
@@ -120,7 +125,7 @@ def install_pg_collection(
 
         # GDN caches the construction-time CP size and derives its post-A2A
         # split metadata from it. Refresh both when the live CP group changes.
-        if _gdn_cls is not None and isinstance(module, _gdn_cls):
+        if _gdn_classes and isinstance(module, _gdn_classes):
             module.cp_size = cp_size
             module._setup_variant_attrs()
 

--- a/tests/unit_tests/training/test_eval_context_parallel_rebinding.py
+++ b/tests/unit_tests/training/test_eval_context_parallel_rebinding.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
 from types import SimpleNamespace
 
 import pytest
@@ -75,6 +76,38 @@ def test_eval_cp_context_refreshes_gdn_runtime_shape_metadata(monkeypatch: pytes
         assert gdn.cp_size == 2
         live_feature_width = sum(gdn.in_proj_split_sections) // gdn.cp_size
         torch.split(torch.empty(live_feature_width), gdn.feat_dim_split)
+
+    assert gdn.cp_size == 1
+    assert gdn.config.context_parallel_size == 1
+
+
+@pytest.mark.unit
+def test_eval_cp_context_supports_mcore_without_gdn2(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def _import_without_gdn2(
+        name: str,
+        globals_: dict[str, object] | None = None,
+        locals_: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "megatron.core.ssm.gated_delta_net" and "GatedDeltaNet2" in fromlist:
+            raise ImportError("GatedDeltaNet2 unavailable")
+        return original_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _import_without_gdn2)
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_process_group_ranks",
+        lambda group: list(range(group.size())),
+    )
+    gdn = _make_gdn(cp_size=1)
+    train_pgs = gdn.pg_collection
+    eval_pgs = SimpleNamespace(cp=_FakeProcessGroup(2))
+
+    with eval_cp_context(gdn, eval_pgs, train_pgs):
+        assert gdn.cp_size == 2
 
     assert gdn.cp_size == 1
     assert gdn.config.context_parallel_size == 1

--- a/tests/unit_tests/training/test_eval_context_parallel_rebinding.py
+++ b/tests/unit_tests/training/test_eval_context_parallel_rebinding.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from megatron.core.ssm.gated_delta_net import GatedDeltaNet
+from megatron.core.ssm.gated_delta_net import GatedDeltaNet, GatedDeltaNet2
 
 from megatron.bridge.training.eval_context_parallel_rebinding import eval_cp_context
 
@@ -44,6 +44,22 @@ def _make_gdn(cp_size: int) -> GatedDeltaNet:
     return gdn
 
 
+def _make_gdn2(cp_size: int) -> GatedDeltaNet2:
+    gdn = GatedDeltaNet2.__new__(GatedDeltaNet2)
+    torch.nn.Module.__init__(gdn)
+    gdn.config = SimpleNamespace(context_parallel_size=cp_size, deterministic_mode=True)
+    gdn.pg_collection = SimpleNamespace(cp=_FakeProcessGroup(cp_size))
+    gdn.cp_size = cp_size
+    gdn.tp_size = 1
+    gdn.qk_dim = 256
+    gdn.v_dim = 256
+    gdn.qk_dim_local_tp = 256
+    gdn.v_dim_local_tp = 256
+    gdn.num_k_heads_local_tp = 8
+    gdn._setup_variant_attrs()
+    return gdn
+
+
 @pytest.mark.unit
 def test_eval_cp_context_refreshes_gdn_runtime_shape_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
@@ -52,6 +68,26 @@ def test_eval_cp_context_refreshes_gdn_runtime_shape_metadata(monkeypatch: pytes
         lambda group: list(range(group.size())),
     )
     gdn = _make_gdn(cp_size=1)
+    train_pgs = gdn.pg_collection
+    eval_pgs = SimpleNamespace(cp=_FakeProcessGroup(2))
+
+    with eval_cp_context(gdn, eval_pgs, train_pgs):
+        assert gdn.cp_size == 2
+        live_feature_width = sum(gdn.in_proj_split_sections) // gdn.cp_size
+        torch.split(torch.empty(live_feature_width), gdn.feat_dim_split)
+
+    assert gdn.cp_size == 1
+    assert gdn.config.context_parallel_size == 1
+
+
+@pytest.mark.unit
+def test_eval_cp_context_refreshes_gdn2_runtime_shape_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_process_group_ranks",
+        lambda group: list(range(group.size())),
+    )
+    gdn = _make_gdn2(cp_size=1)
     train_pgs = gdn.pg_collection
     eval_pgs = SimpleNamespace(cp=_FakeProcessGroup(2))
 


### PR DESCRIPTION
## Problem

A public generic `GPTModelProvider` can select MCore's typed `gdn2` experimental attention variant and evaluate it with a different context-parallel degree through `eval_cp_context`. The eval-CP rebinder refreshed cached runtime shape metadata for `GatedDeltaNet` only. Because `GatedDeltaNet2` is a sibling rather than a subclass, it retained its construction-time CP degree and split table.

With train CP=1 and eval CP=2, the live all-to-all returns a 640-wide tensor while GDN2 still requests CP=1 split sections totaling 1280. Validation crashes in `torch.split` before producing metrics.

This is an omitted supported sibling boundary from #5624.

## Root cause and fix

`install_pg_collection()` matched only `GatedDeltaNet` before assigning the live CP size and rerunning the existing variant-attribute initializer.

The fix adds the immediate pinned `GatedDeltaNet2` sibling to that guarded class tuple. The fallback retains GDN-only behavior when an older MCore build does not expose GDN2. No public API, configuration, dependency, workflow, or MCore source changes.

## Regression evidence

The new focused contract test was run unchanged against unmodified base production code and then after the fix:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/test_eval_context_parallel_rebinding.py::test_eval_cp_context_refreshes_gdn2_runtime_shape_metadata \
  -q --tb=short
```

- Before: failed because cached GDN2 CP remained 1 inside eval CP=2.
- After: `1 passed`.

A standalone real two-rank GDN2 forward was also run unchanged:

```bash
uv run --no-sync python -m torch.distributed.run \
  --standalone --nproc_per_node=2 reproduce_gdn2_eval_cp.py
```

- Before: both ranks failed at `split_with_sizes`; live width 640, cached split width 1280.
- After: passed; live and cached CP were both 2 and both widths were 640.

Adjacent validation:

```bash
uv run --no-sync python -m pytest \
  tests/unit_tests/training/test_eval_context_parallel_rebinding.py \
  tests/unit_tests/training/test_eval.py \
  tests/unit_tests/models/qwen/test_qwen3_next_bridge.py \
  -q --tb=short
# 32 passed

git diff --check
uv run --no-sync pre-commit run --all-files
# passed
```

## Scope

This changes only eval-time CP metadata refresh and restoration for the GDN2 sibling. It does not change static training CP, model-family defaults, conversion mappings, packed-sequence behavior, process-group construction, or MCore. No full-suite, convergence, model-quality, or performance validation was run.
