### PR TITLE
[ckpt] fix: Reject Energon resume after DP changes

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1857,6 +1857,20 @@ def maybe_load_dataloader_state(
         print_rank_0(f"no dataloader state for iteration {iteration}; dataloader starts from the beginning")
         return
 
+    state_file_pattern = join_paths(iter_dir, "train_dataloader_dprank*.pt")
+    saved_dp_size = (
+        len(msc.glob(state_file_pattern))
+        if msc is not None
+        else len(list(Path(iter_dir).glob("train_dataloader_dprank*.pt")))
+    )
+    current_dp_size = get_pg_size(pg_collection.dp)
+    if saved_dp_size != current_dp_size:
+        raise RuntimeError(
+            f"Dataloader state at {iter_dir} was saved for data-parallel size {saved_dp_size}, but the current "
+            f"data-parallel size is {current_dp_size}. Resuming would silently change the training data order; "
+            "refusing to continue."
+        )
+
     dp_rank = get_pg_rank(pg_collection.dp)
     data_state_load_path = join_paths(iter_dir, f"train_dataloader_dprank{dp_rank:03d}.pt")
     if not is_file(data_state_load_path):

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -5011,7 +5011,7 @@ class TestMaybeLoadDataloaderState:
             yield
 
     @staticmethod
-    def _pg(cp: int | None = 0, pp: int = 0, tp: int = 0, dp: int = 0):
+    def _pg(cp: int | None = 0, pp: int = 0, tp: int = 0, dp: int = 0, dp_size: int = 1):
         """Mock a ProcessGroupCollection with the given per-dimension ranks. Only cp may be None —
         modeling a collection configured without context parallelism (tp/pp/dp are always
         populated); the real get_pg_rank then reads the absent cp group as rank 0."""
@@ -5023,6 +5023,7 @@ class TestMaybeLoadDataloaderState:
         pg.pp.rank.return_value = pp
         pg.tp.rank.return_value = tp
         pg.dp.rank.return_value = dp
+        pg.dp.size.return_value = dp_size
         return pg
 
     def test_noop_when_no_path(self):
@@ -5068,6 +5069,27 @@ class TestMaybeLoadDataloaderState:
         # The selected iteration exists but contains no state file for this data-parallel rank.
         with pytest.raises(RuntimeError, match="data-parallel size"):
             maybe_load_dataloader_state(train_iterator, 10, str(tmp_path), pg_collection=self._pg())
+
+    @patch("megatron.bridge.training.checkpointing.energon_torch_load")
+    def test_extra_saved_dp_rank_file_raises(self, mock_load, tmp_path):
+        """A smaller current DP size must not silently discard saved rank state."""
+        train_iterator = Mock()
+        iter_dir = Path(get_checkpoint_name(str(tmp_path), 10))
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "train_dataloader_dprank000.pt").touch()
+        (iter_dir / "train_dataloader_dprank001.pt").touch()
+        pg_collection = self._pg(dp=0, dp_size=1)
+
+        with pytest.raises(RuntimeError, match="data-parallel size"):
+            maybe_load_dataloader_state(
+                train_iterator,
+                10,
+                str(tmp_path),
+                pg_collection=pg_collection,
+            )
+
+        mock_load.assert_not_called()
+        train_iterator.iterable.restore_state.assert_not_called()
 
     @patch("megatron.bridge.training.checkpointing.energon_torch_load")
     def test_restores_on_every_cp_tp_pp_rank(self, mock_load, tmp_path):


### PR DESCRIPTION
## Summary

Reject Energon dataloader-state restoration when the saved and current data-parallel sizes differ.

## Supported trigger and impact

Native distributed checkpoints can be resharded across a changed DP size. Energon rank-local state cannot be restored that way without redistribution, so Bridge documents that direct Energon restore requires the same DP size.

When a DP=2 checkpoint was resumed at DP=1, the existing guard saw rank 0's old file and restored it. The extra rank-1 state was silently dropped. Energon then rebuilt dataset sharding for the new world size, so continuing from only rank 0's old position could skip or repeat samples and change the training stream while checkpoint load reported success.

Expansion already failed when a current rank file was missing; shrinkage bypassed that asymmetric check.

## Root cause and minimal fix

`maybe_load_dataloader_state()` validated only the current rank's filename. A completed Energon generation contains exactly one deterministic file per saved pure-DP rank, so the rank-file cardinality identifies the saved DP size.

Before deserializing state, the loader now counts those files through the existing local `Path.glob` or MSC `glob` path and compares the count with the current DP process-group size. Any mismatch raises with the existing fail-loud data-order rationale. The per-rank file check remains as a malformed-generation guard.

## Regression evidence

An exact-function deterministic reproducer executes the maintained helper with a completed two-file generation and current DP size 1.

Fail before on `d0debd0bd308f3b4aef6aa0904952d655cb31eb5`:

```text
uv run --no-sync python reproduce_energon_dp_shrink.py src/megatron/bridge/training/checkpointing.py
exit 1: DP-shrink restore did not fail; restore_calls=[{'position': 25}]
```

Pass after, including unchanged DP=1 local and MSC-shaped restore controls:

```text
uv run --no-sync python reproduce_energon_dp_shrink.py src/megatron/bridge/training/checkpointing.py
exit 0
```

The focused repository unit test was also added. Local collection was attempted but the CPU workstation stops before collection on unavailable pinned GPU import dependencies; that environment failure is not claimed as passing evidence.

Additional validation:

```text
uv run --no-sync ruff check src/megatron/bridge/training/checkpointing.py tests/unit_tests/training/test_checkpointing.py
passed

uv run --project "$BRIDGE_PROJECT" --no-sync pre-commit run --all-files
passed

git diff --check
passed
```

## Scope

This patch changes only Energon dataloader-state restore validation and adds one focused CPU regression test. It does not redistribute dataloader state across DP sizes, change native model/optimizer resharding, add configuration or dependencies, or claim GPU, convergence, performance, model-quality, or full-suite validation.
