### PR TITLE
perf(nemotron): enable CuteDSL fusion for VR200 MXFP8

### DIFF
--- a/src/megatron/bridge/perf_recipes/nemotronh/vr200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/vr200/nemotronh.py
@@ -59,6 +59,9 @@ def nemotron_3_nano_pretrain_8gpu_vr200_bf16_config() -> ConfigContainer:
 def nemotron_3_nano_pretrain_8gpu_vr200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Nano pretrain: 8× VR200, FP8-MX (alias of GB300)."""
     cfg = _build_nemotron_3_nano_gb300_mxfp8()
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -76,7 +79,9 @@ def nemotron_3_nano_pretrain_8gpu_vr200_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         # Transformer Engine overlap settings for this model.
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
         # Use cuDNN LayerNorm for this measured baseline.
         "NVTE_NORM_BWD_USE_CUDNN": 1,
@@ -145,6 +150,9 @@ def nemotron_3_super_pretrain_64gpu_vr200_bf16_config() -> ConfigContainer:
 def nemotron_3_super_pretrain_64gpu_vr200_fp8mx_config() -> ConfigContainer:
     """Nemotron 3 Super pretrain: 64× VR200, FP8-MX (alias of GB300)."""
     cfg = _build_nemotron_3_super_gb300_mxfp8()
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.mixed_precision.fp8_dot_product_attention = True
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -162,7 +170,9 @@ def nemotron_3_super_pretrain_64gpu_vr200_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         # Transformer Engine overlap settings for this model.
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
     }
     return cfg

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -180,6 +180,12 @@ def test_nemotron_3_nano_gb200_defers_vocab_size_to_training_tokenizer():
             id="nano-gb300",
         ),
         pytest.param(
+            "megatron.bridge.perf_recipes.nemotronh.vr200.nemotronh",
+            "nemotron_3_nano_pretrain_8gpu_vr200_fp8mx_config",
+            True,
+            id="nano-vr200",
+        ),
+        pytest.param(
             "megatron.bridge.perf_recipes.nemotronh.gb200.nemotronh",
             "nemotron_3_super_pretrain_64gpu_gb200_fp8mx_config",
             False,
@@ -191,14 +197,20 @@ def test_nemotron_3_nano_gb200_defers_vocab_size_to_training_tokenizer():
             False,
             id="super-gb300",
         ),
+        pytest.param(
+            "megatron.bridge.perf_recipes.nemotronh.vr200.nemotronh",
+            "nemotron_3_super_pretrain_64gpu_vr200_fp8mx_config",
+            False,
+            id="super-vr200",
+        ),
     ],
 )
-def test_nemotron_3_gb_mxfp8_perf_recipes_enable_cutedsl_fusion(
+def test_nemotron_3_mxfp8_perf_recipes_enable_cutedsl_fusion(
     module_name: str,
     factory_name: str,
     has_comm_overlap: bool,
 ) -> None:
-    """GB MXFP8 recipes match the measured CutDSL and MoE overlap settings."""
+    """Selected MXFP8 recipes match the measured CutDSL and MoE overlap settings."""
     module = importlib.import_module(module_name)
     cfg = getattr(module, factory_name)()
 


### PR DESCRIPTION
## Summary

- enable the CutDSL fused grouped MLP environment for Nemotron 3 Nano and Super VR200 FP8_MX benchmarks
- mirror the GB MXFP8 Transformer Engine op fuser, GLU interleave size, cuDNN FE overlap margin, and FP8 dot-product attention settings
- extend the existing MXFP8 recipe unit-test matrix with VR200 Nano and Super coverage

## Scope

This changes benchmark execution/performance settings only. BF16 and NVFP4 recipes are unchanged, and there is no FSDP variant in scope.

## Validation

- `uv run --no-sync --with pre-commit pre-commit run --all-files`
- `uv run --no-sync python -m py_compile src/megatron/bridge/perf_recipes/nemotronh/vr200/nemotronh.py tests/unit_tests/recipes/test_nemotronh_recipes.py`
- targeted pytest collection was attempted locally, but the available macOS environment lacks PyTorch and failed while importing `tests/unit_tests/conftest.py` before collecting the test
