### PR TITLE
[recipe] fix: Resync Kimi K2.5-VL pipeline layout

### DIFF
--- a/src/megatron/bridge/recipes/kimi_vl/h100/kimi_k25_vl.py
+++ b/src/megatron/bridge/recipes/kimi_vl/h100/kimi_k25_vl.py
@@ -84,6 +84,7 @@ def kimi_k25_vl_sft_512gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.num_layers_in_last_pipeline_stage = None
 
     # Set pipeline layout
+    cfg.model._pipeline_model_parallel_layout_builder = _get_kimi_k25_vl_pipeline_layout
     cfg.model.pipeline_model_parallel_layout = _get_kimi_k25_vl_pipeline_layout(16, 1)
 
     # Tokenizer - uses NullTokenizer with model vocab_size

--- a/tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py
+++ b/tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py
@@ -35,6 +35,7 @@ from megatron.bridge.recipes.kimi_vl.kimi_k25_vl import (
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
+from tests.unit_tests.training.test_run_recipe_qwen3_omni import _load_recipe_runner_module
 
 
 class _FakeKimiK25VLProvider:
@@ -183,6 +184,23 @@ class TestKimiK25VLSftConfig:
         cfg = kimi_k25_vl_sft_config()
 
         assert cfg.model.pipeline_model_parallel_layout == _get_kimi_k25_vl_pipeline_layout(16, 1)
+
+    def test_sft_config_pipeline_layout_tracks_supported_runner_override(self):
+        """Recipe-owned layouts must follow supported public pipeline overrides."""
+        cfg = kimi_k25_vl_sft_config()
+        recipe_runner, _ = _load_recipe_runner_module()
+
+        cfg.model.pipeline_model_parallel_size = 4
+        cfg.model.virtual_pipeline_model_parallel_size = 1
+        recipe_runner.sync_model_pipeline_layout(
+            cfg,
+            cli_overrides=[
+                "model.pipeline_model_parallel_size=4",
+                "model.virtual_pipeline_model_parallel_size=1",
+            ],
+        )
+
+        assert cfg.model.pipeline_model_parallel_layout == _get_kimi_k25_vl_pipeline_layout(4, 1)
 
     def test_sft_config_ddp_settings_for_muon(self):
         """DDP settings respect Muon's constraints (no dist optimizer, no param overlap)."""


### PR DESCRIPTION
## Problem

The Kimi K2.5-VL H100 recipe materializes a static PP=16, VP=1 pipeline layout but does not register its existing layout builder. A supported public runner override such as `--recipe kimi_k25_vl_sft_config -pp 4 -vp 1` therefore leaves the 16-stage layout unchanged. Megatron-Core derives VP=4 from that stale layout and rejects the explicit VP=1 setting; with only `-pp 4`, it can silently use VP=4 instead of the recipe's declared PP=4, VP=1 topology.

The path is `run_recipe` override application -> `sync_model_pipeline_layout` -> Kimi K2.5-VL recipe model config -> Megatron-Core pipeline-layout validation.

## Fix

Register the recipe's existing `_get_kimi_k25_vl_pipeline_layout` function as `_pipeline_model_parallel_layout_builder`. The shared runner then rebuilds recipe-owned layouts after supported PP/VP overrides while preserving explicit user-provided layouts.

This is the same ownership pattern already used by the Kimi K2 recipe. No public API, dependency, CI, or Megatron-Core changes are included.

## Validation

Regression test on the unmodified base revision:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/recipes/kimi_vl tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py -k pipeline_layout_tracks_supported_runner_override -q
1 failed, 31 deselected
```

The failure was the stale 16-entry layout instead of the expected four-entry PP=4, VP=1 layout.

The unchanged test after the fix:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/recipes/kimi_vl tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py -k pipeline_layout_tracks_supported_runner_override -q
1 passed, 31 deselected
```

Adjacent recipe tests:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/kimi/test_kimi_k2.py tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py -q
54 passed

uv run python -m pytest --confcutdir=tests/unit_tests/scripts/training tests/unit_tests/scripts/training/test_recipe_runner.py tests/unit_tests/scripts/training/test_run_recipe.py -k 'pipeline_layout or kimi_supported_pp_vp_override' -q
6 passed, 163 deselected
```

`git diff --check` and `uv run pre-commit run --all-files` also passed.

## Scope

This change only resynchronizes the Kimi K2.5-VL recipe-owned layout for the topologies already declared by its helper. It does not add new parallel configurations or claim GPU, convergence, performance, or full-suite validation.

Related prior Kimi K2 fix: #5008.
