### PR TITLE
[ci] test: exercise release docs preparation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
     secrets: inherit  # pragma: allowlist secret
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@f7af92c4d1caea5a58577ce4ac5314f7de1bc5d4 # v1.4.3
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@dd5b4dcb2201e6db8f3656a3ac1e8490356e02c0 # PR NVIDIA-NeMo/FW-CI-templates#554
     needs: [pre-flight]
     if: |
       !cancelled() && !failure()
@@ -104,6 +104,7 @@ jobs:
       no-build-isolation: true
       app-id: ${{ vars.BOT_ID }}
       publish-docs: ${{ inputs.publish-docs || true }}
+      prepare-release-docs: true
       docs-target-path: nemo/megatron-bridge
       submodules: recursive
       container-options: "--gpus all --runtime=nvidia"


### PR DESCRIPTION
## Background

Companion validation for [NVIDIA-NeMo/FW-CI-templates#554](https://github.com/NVIDIA-NeMo/FW-CI-templates/pull/554). Megatron-Bridge `v0.5.1` contains package version `0.5.1` but docs metadata version `0.5.0`.

## What changed

- Pin `_release_library.yml` to the FW-CI-templates PR commit.
- Enable release docs metadata preparation.

## Details

```mermaid
flowchart LR
    A[v0.5.1 SHA] --> B[Dry-run release workflow]
    B --> C[Prepare docs as 0.5.1]
    C --> D[Validate conf, project, and picker]
    D --> E[No push or publication]
```

This PR must not merge with the temporary FW-CI commit pin. After FW-CI-templates#554 is released, replace the pin with the released immutable tag SHA.

## Tested

- `git diff --check`
- `actionlint .github/workflows/release.yaml` — workflow parsed; only pre-existing SC2086 findings remain in the untouched release-summary block.
- `uv run --no-sync pre-commit run --all-files` — passed all hooks. The initial sync attempt was blocked by the existing isolated `fast-hadamard-transform` build missing Torch.
- [Release dry-run 32137007085](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/32137007085) — `success`; bump job [95710720969](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/32137007085/job/95710720969) resolved `0.5.1`, prepared and validated `docs/conf.py`, `docs/project.json`, and `docs/versions1.json`, and skipped push/merge under `dry-run=true`; wheel validation, dry-run release finalization, docs build/linkcheck, and dry-run docs publication all succeeded.

