### PR TITLE
perf(training): add NVTX ranges around training loop iterations

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -385,6 +385,9 @@ def train(
         if nvtx_ctx is not None:
             nsys_nvtx_context = nvtx_ctx
 
+        nvtx_step = global_state.train_state.step
+        nvtx_range_push(suffix=f"training_step_{nvtx_step}")
+
         fault_tolerance.on_checkpointing_start(global_state)
         checkpoint_manager.finalize_async_saves(state=global_state, blocking=False)
         fault_tolerance.on_checkpointing_end(global_state=global_state, is_async_finalization=True)
@@ -424,6 +427,7 @@ def train(
 
         # Completely skip iteration if needed.
         if _should_skip_and_handle_iteration(global_state, train_data_iterator, pg_collection):
+            nvtx_range_pop(suffix=f"training_step_{nvtx_step}")
             continue
 
         # Capture CUDA Graphs after warmup.
@@ -531,6 +535,7 @@ def train(
                 callback_manager=callback_manager,
             )
         if should_exit:
+            nvtx_range_pop(suffix=f"training_step_{nvtx_step}")
             break
 
         # Enable forward pre-hooks after first set of forward and backward passes.
@@ -720,6 +725,7 @@ def train(
             global_state.train_state.step,
             should_toggle_forward_pre_hook,
         )
+        nvtx_range_pop(suffix=f"training_step_{nvtx_step}")
         handle_profiling_stop(
             config.profiling,
             global_state.train_state.step,


### PR DESCRIPTION
# What does this PR do ?
Wrap each training iteration with named NVTX push/pop ranges so nsys timelines clearly show per-step boundaries, including skip and early-exit paths. This is mainly to enable analysis tools to easily identify step boundries.

# Changelog

1) Wrap each training loop iteration in train() with an NVTX range named training_step_<step> via nvtx_range_push / nvtx_range_pop
2) Push the range at the start of each iteration (after handle_profiling_step)
3) Pop the range on skip-iteration (continue), early exit from train_step (should_exit), and before handle_profiling_stop on the normal path
4) Improves nsys timeline readability by marking full per-iteration boundaries (imports / @nvtx_decorator() on train_step were already present)
<img width="2567" height="945" alt="image" src="https://github.com/user-attachments/assets/0f1766eb-f99c-4303-ba3a-a0aabb20e100" />
