### PR TITLE
fix(training): abort fault tolerance on pretrain failure

### DIFF
--- a/src/megatron/bridge/training/fault_tolerance.py
+++ b/src/megatron/bridge/training/fault_tolerance.py
@@ -256,6 +256,23 @@ def shutdown(global_state: GlobalState) -> None:
     global_state.rank_monitor_client = None
 
 
+def abort(global_state: GlobalState) -> None:
+    """Disconnect fault-tolerance monitoring after a failed workload.
+
+    Unlike :func:`shutdown`, this does not update timeouts because timeout
+    calculation synchronizes ranks and is unsafe while peers may be blocked.
+
+    Args:
+        global_state: Global training state.
+    """
+    rmon_cli = global_state.rank_monitor_client
+    try:
+        if rmon_cli is not None:
+            rmon_cli.shutdown_workload_monitoring()
+    finally:
+        global_state.rank_monitor_client = None
+
+
 def maybe_setup_simulated_fault(config: FaultToleranceConfig) -> None:
     """Sets up a simulated fault for fault tolerance testing, if configured.
 

--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -19,6 +19,7 @@ import torch.distributed as dist
 from nvidia_resiliency_ext.inprocess import CallWrapper
 
 from megatron.bridge.data.utils import get_dataset_provider
+from megatron.bridge.training import fault_tolerance
 from megatron.bridge.training.callbacks import Callback, CallbackManager, normalize_callbacks
 from megatron.bridge.training.config import ConfigContainer, runtime_config_update
 from megatron.bridge.training.eval import evaluate_and_print_results
@@ -245,6 +246,11 @@ def _safe_distributed_rank() -> str:
 
 def _cleanup_after_pretrain_failure(state: GlobalState, should_destroy_process_group: bool) -> None:
     """Clean up framework-owned state after ordinary pretrain execution fails."""
+    try:
+        fault_tolerance.abort(state)
+    except Exception:
+        logger.exception("Failed to abort fault-tolerance monitoring after pretrain failure")
+
     try:
         _abort_async_checkpoint_worker(state)
     except Exception:

--- a/tests/unit_tests/training/test_pretrain.py
+++ b/tests/unit_tests/training/test_pretrain.py
@@ -184,6 +184,34 @@ class TestPretrainProcessGroupOwnership:
         assert cleanup_order == [("async_queue", True), ("process_group", "abort")]
         assert state._async_calls_queue is None
 
+    def test_framework_owned_failure_shuts_down_fault_tolerance_before_process_groups(self):
+        """Test failed setup disconnects fault-tolerance monitoring before distributed cleanup."""
+        state = MagicMock()
+        rank_monitor_client = MagicMock()
+        rank_monitor_client.is_initialized = True
+        cleanup_order = []
+
+        def setup_then_fail(*_args, **_kwargs):
+            state.rank_monitor_client = rank_monitor_client
+            raise RuntimeError("setup failed after fault-tolerance initialization")
+
+        rank_monitor_client.shutdown_workload_monitoring.side_effect = lambda: cleanup_order.append("fault_tolerance")
+
+        with (
+            patch("megatron.bridge.training.pretrain.dist") as mock_dist,
+            patch("megatron.bridge.training.pretrain.destroy_global_state"),
+            patch("megatron.bridge.training.pretrain.get_dataset_provider"),
+            patch("megatron.bridge.training.pretrain.setup", side_effect=setup_then_fail),
+        ):
+            mock_dist.is_initialized.side_effect = [False, True, True]
+            mock_dist.distributed_c10d._abort_process_group.side_effect = lambda: cleanup_order.append("process_group")
+
+            with pytest.raises(RuntimeError, match="setup failed after fault-tolerance initialization"):
+                _pretrain(state, MagicMock())
+
+        assert cleanup_order == ["fault_tolerance", "process_group"]
+        assert state.rank_monitor_client is None
+
     def test_caller_owned_process_group_is_preserved_when_setup_raises(self):
         """Test Bridge preserves a process group that existed before setup."""
         state = MagicMock()


### PR DESCRIPTION
## Summary

- disconnect the NVRx rank monitor during ordinary pretrain failure cleanup
- avoid collective timeout recalculation while peer ranks may be blocked
- cover the failure lifecycle with a focused regression test

## Problem

When fault tolerance is enabled and `pretrain()` raises after setup, a caller that catches the exception can retain the traceback and its `GlobalState`. The existing failure cleanup tears down other framework-owned resources but leaves the initialized rank-monitor client, socket, and active workload section live. The monitor can therefore report a timeout for a rank whose training call has already failed.

The reachable path is:

`pretrain()` -> `_pretrain()` setup/runtime failure -> `_cleanup_after_pretrain_failure()`

## Root cause and fix

The ordinary failure path did not release the fault-tolerance client. The normal `fault_tolerance.shutdown()` helper cannot safely be reused because it recalculates timeouts using rank synchronization, which is unsafe when peer ranks may already be blocked or failing.

This change adds a failure-only `fault_tolerance.abort()` helper that closes workload monitoring and clears the client without timeout synchronization, then calls it before process-group teardown. Normal successful shutdown and in-process-restart ownership are unchanged.

## Validation

Fail-before:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_pretrain.py::TestPretrainProcessGroupOwnership::test_framework_owned_failure_shuts_down_fault_tolerance_before_process_groups -q
```

Result: 1 failed; cleanup contained only `process_group`, so fault-tolerance monitoring was not disconnected.

Pass-after:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_pretrain.py::TestPretrainProcessGroupOwnership::test_framework_owned_failure_shuts_down_fault_tolerance_before_process_groups -q
```

Result: 1 passed.

Adjacent tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_pretrain.py tests/unit_tests/training/test_fault_tolerance.py -q
```

Result: 51 passed.

Also passed:

- `uv run --no-sync pre-commit run --all-files`
- `git diff --check`

## Scope

This does not change successful fault-tolerance shutdown, timeout selection, in-process restart behavior, configuration, dependencies, CI, or Megatron-Core.
