### PR TITLE
feat(training): expose LayerWise parameter layout

### DIFF
--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -204,6 +204,8 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
         post_wrap_hook: Callable[[list[MegatronModule]], list[MegatronModule]] | None = None,
         mixed_precision_wrapper: Callable[[Any, MegatronModule], MegatronModule] | None = Float16Module,
         pg_collection: ProcessGroupCollection | None = None,
+        use_layer_wise_distributed_optimizer: bool = False,
+        use_layer_wise_param_layout: bool = True,
     ) -> list[ModelT]:
         """Instantiate and wrap the model for distributed training.
 
@@ -216,6 +218,10 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             ddp_config: Configuration for distributed data parallel.
             model_type: Type of model (encoder, decoder, or both).
             overlap_param_gather_with_optimizer_step: Whether to overlap param gathering.
+            use_layer_wise_distributed_optimizer: Whether to enable LayerWise optimizer wiring.
+            use_layer_wise_param_layout: Whether LayerWise uses the precomputed shard-aligned layout.
+                Set to ``False`` for the legacy whole-parameter ping-pong layout. Ignored when
+                ``use_layer_wise_distributed_optimizer`` is disabled.
             fp16: Override FP16 setting.
             bf16: Override BF16 setting.
             use_megatron_fsdp: Use Megatron's Fully Sharded Data Parallel
@@ -283,6 +289,8 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             ddp_config=ddp_config,
             model_type=model_type,
             overlap_param_gather_with_optimizer_step=overlap_param_gather_with_optimizer_step,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=use_layer_wise_param_layout,
             fp16=fp16,
             bf16=bf16,
             use_megatron_fsdp=use_megatron_fsdp,
@@ -503,6 +511,8 @@ class GetModelKwargs(TypedDict, total=False):
         ddp_config: Configuration for distributed data parallel.
         model_type: Type of model (encoder, decoder, or both).
         overlap_param_gather_with_optimizer_step: Whether to overlap param gathering.
+        use_layer_wise_distributed_optimizer: Whether to enable LayerWise optimizer wiring.
+        use_layer_wise_param_layout: Whether LayerWise uses the precomputed shard-aligned layout.
         fp16: Override FP16 setting.
         bf16: Override BF16 setting.
         use_megatron_fsdp: Use Megatron's Fully Sharded Data Parallel
@@ -519,6 +529,8 @@ class GetModelKwargs(TypedDict, total=False):
     ddp_config: DistributedDataParallelConfig | None
     model_type: ModelType
     overlap_param_gather_with_optimizer_step: bool
+    use_layer_wise_distributed_optimizer: bool
+    use_layer_wise_param_layout: bool
     fp16: bool | None
     bf16: bool | None
     use_megatron_fsdp: bool
@@ -580,6 +592,8 @@ def get_model(
     mixed_precision_wrapper: Callable[[Any, MegatronModule], MegatronModule] | None = Float16Module,
     *,
     pg_collection: ProcessGroupCollection,
+    use_layer_wise_distributed_optimizer: bool = False,
+    use_layer_wise_param_layout: bool = True,
 ) -> list[MegatronModule]:
     """Create and configure a model for distributed training.
 
@@ -598,6 +612,10 @@ def get_model(
         model_type: Type of model (encoder, decoder)
         overlap_param_gather_with_optimizer_step: Whether to overlap parameter
             gathering with optimizer step for performance optimization
+        use_layer_wise_distributed_optimizer: Whether to enable LayerWise optimizer wiring.
+        use_layer_wise_param_layout: Whether LayerWise uses the precomputed shard-aligned layout.
+            Set to ``False`` for the legacy whole-parameter ping-pong layout. Ignored when
+            ``use_layer_wise_distributed_optimizer`` is disabled.
         fp16: Enable FP16 mixed precision training. If None, uses model config
         bf16: Enable BF16 mixed precision training. If None, uses model config
         use_megatron_fsdp: Use Megatron's Fully Sharded Data Parallel
@@ -703,6 +721,8 @@ def get_model(
             use_megatron_fsdp=use_megatron_fsdp,
             use_torch_fsdp2=use_torch_fsdp2,
             pg_collection=pg_collection,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=use_layer_wise_param_layout,
         )
 
     return model

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -126,6 +126,15 @@ class OptimizerConfig(MCoreOptimizerConfig):
     for field modifications after construction but before computed fields are calculated.
     """
 
+    use_layer_wise_param_layout: bool = True
+    """Use the precomputed shard-aligned layout for the LayerWise optimizer.
+
+    Set to ``False`` to opt out to the legacy LayerWise layout, where all parameters
+    share one LayerWise buffer and parameter synchronization uses whole-parameter
+    ping-pong ownership with ``allgather_params``. This setting has no effect unless
+    ``use_layer_wise_distributed_optimizer`` is enabled.
+    """
+
     def __post_init__(self) -> None:
         """Skip MCore post_init during initial construction.
 

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -159,9 +159,7 @@ def _should_load_checkpoint(cfg: ConfigContainer, checkpoint_manager: Checkpoint
         "local_checkpoint_manager" in checkpointing_context
         and checkpointing_context["local_checkpoint_manager"].find_latest() != -1
     )
-    has_global_non_persistent_checkpoint = _has_global_non_persistent_checkpoint(
-        cfg.checkpoint.load, cfg.checkpoint
-    )
+    has_global_non_persistent_checkpoint = _has_global_non_persistent_checkpoint(cfg.checkpoint.load, cfg.checkpoint)
 
     if cfg.peft is not None:
         load_checkpoint_exists = cfg.checkpoint.load is not None and (
@@ -388,9 +386,7 @@ def setup(
                 checkpoint_path = cfg.checkpoint.pretrained_checkpoint
                 ckpt_step = None
             else:
-                raise RuntimeError(
-                    "No checkpoint source is available for ModelOpt state restoration"
-                )
+                raise RuntimeError("No checkpoint source is available for ModelOpt state restoration")
 
             if not has_modelopt_state(checkpoint_path, ckpt_step=ckpt_step):
                 raise RuntimeError(f"No modelopt_state found in selected checkpoint={checkpoint_path}")
@@ -573,7 +569,9 @@ def _register_setup_pre_wrap_hook(
             ]
         else:
             model_cfg._pre_wrap_hooks[:] = [
-                registered_hook for registered_hook in model_cfg._pre_wrap_hooks if registered_hook is not previous_hook
+                registered_hook
+                for registered_hook in model_cfg._pre_wrap_hooks
+                if registered_hook is not previous_hook
             ]
 
     setup_hooks[setup_hook_name] = hook
@@ -594,6 +592,8 @@ def _build_distributed_model(cfg: ConfigContainer, pg_collection: ProcessGroupCo
             use_megatron_fsdp=cfg.dist.use_megatron_fsdp,
             use_torch_fsdp2=cfg.dist.use_torch_fsdp2,
             data_parallel_random_init=cfg.rng.data_parallel_random_init,
+            use_layer_wise_distributed_optimizer=cfg.optimizer.use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=cfg.optimizer.use_layer_wise_param_layout,
         )
     else:
         model_config.finalize()
@@ -604,6 +604,8 @@ def _build_distributed_model(cfg: ConfigContainer, pg_collection: ProcessGroupCo
             overlap_param_gather_with_optimizer_step=cfg.optimizer.overlap_param_gather_with_optimizer_step,
             data_parallel_random_init=cfg.rng.data_parallel_random_init,
             pg_collection=pg_collection,
+            use_layer_wise_distributed_optimizer=cfg.optimizer.use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=cfg.optimizer.use_layer_wise_param_layout,
         )
 
 

--- a/tests/unit_tests/models/test_model_instantiation.py
+++ b/tests/unit_tests/models/test_model_instantiation.py
@@ -395,7 +395,13 @@ class TestGetModel:
         ddp_config = DistributedDataParallelConfig()
 
         pg = _PG()
-        result = get_model(model_provider, ddp_config, pg_collection=pg)
+        result = get_model(
+            model_provider,
+            ddp_config,
+            pg_collection=pg,
+            use_layer_wise_distributed_optimizer=True,
+            use_layer_wise_param_layout=False,
+        )
 
         # Assertions
         assert len(result) == 1
@@ -404,6 +410,8 @@ class TestGetModel:
         assert "pg_collection" in mock_create_model.call_args.kwargs
         mock_print_params.assert_called_once()
         mock_ddp_wrap.assert_called_once()
+        assert mock_ddp_wrap.call_args.kwargs["use_layer_wise_distributed_optimizer"] is True
+        assert mock_ddp_wrap.call_args.kwargs["use_layer_wise_param_layout"] is False
 
     @patch("megatron.bridge.models.model_provider._create_model")
     @patch("megatron.bridge.models.model_provider._print_num_params")

--- a/tests/unit_tests/models/test_model_provider_mixin.py
+++ b/tests/unit_tests/models/test_model_provider_mixin.py
@@ -127,12 +127,19 @@ def test_provide_distributed_model_with_hooks_as_args(
     mock_use_pg.return_value = _PG()
 
     provider.provide_distributed_model(
-        ddp_config=ddp_config, pre_wrap_hook=pre_hook, post_wrap_hook=post_hook, wrap_with_ddp=False
+        ddp_config=ddp_config,
+        pre_wrap_hook=pre_hook,
+        post_wrap_hook=post_hook,
+        wrap_with_ddp=False,
+        use_layer_wise_distributed_optimizer=True,
+        use_layer_wise_param_layout=False,
     )
 
     mock_get_model.assert_called_once()
     # Check that the argument hook is passed directly to get_model
     assert mock_get_model.call_args.kwargs["pre_wrap_hook"] is pre_hook
+    assert mock_get_model.call_args.kwargs["use_layer_wise_distributed_optimizer"] is True
+    assert mock_get_model.call_args.kwargs["use_layer_wise_param_layout"] is False
     # Check that the argument hook is called after get_model
     post_hook.assert_called_once_with(mock_model)
 

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -3715,6 +3715,30 @@ class TestRuntimeConfigUpdate:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
+    def test_layer_wise_param_layout_is_serializable_and_overridable(self, tmp_path):
+        """The run_recipe override path should preserve the pinned MCore layout contract."""
+        from megatron.bridge.training.utils.omegaconf_utils import process_config_with_overrides
+
+        gpt_cfg = create_test_gpt_config()
+        full_cfg, og_ws, cfg_mod = create_test_config_container(world_size_override=1, model_config=gpt_cfg)
+        config_path = tmp_path / "recipe.yaml"
+
+        try:
+            assert full_cfg.optimizer.use_layer_wise_param_layout is True
+            assert full_cfg.to_dict()["optimizer"]["use_layer_wise_param_layout"] is True
+
+            process_config_with_overrides(
+                full_cfg,
+                cli_overrides=["optimizer.use_layer_wise_param_layout=false"],
+            )
+            assert full_cfg.optimizer.use_layer_wise_param_layout is False
+
+            full_cfg.to_yaml(str(config_path))
+            restored_cfg = ConfigContainer.from_yaml(str(config_path))
+            assert restored_cfg.optimizer.use_layer_wise_param_layout is False
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
     def test_hf_model_revision_round_trip_through_yaml(self, tmp_path):
         """Immutable Hugging Face model provenance should survive runtime config persistence."""
         revision = "b968826d9c46dd6066d109eabc6255188de91218"  # pragma: allowlist secret

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -508,22 +508,43 @@ class TestRegisterPreWrapHook:
 class TestBuildDistributedModel:
     """Test cases for the _build_distributed_model function."""
 
-    def _make_cfg_with_model_config(self):
+    def _make_cfg_with_model_config(
+        self,
+        *,
+        use_layer_wise_distributed_optimizer: bool,
+        use_layer_wise_param_layout: bool,
+    ):
         """Create a mock cfg whose .model is a real GPTModelConfig."""
         model_cfg = _make_gpt_model_config()
         cfg = MagicMock()
         cfg.model = model_cfg
         cfg.ddp = MagicMock()
-        cfg.optimizer.overlap_param_gather_with_optimizer_step = False
+        cfg.optimizer = SimpleNamespace(
+            overlap_param_gather_with_optimizer_step=False,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=use_layer_wise_param_layout,
+        )
         cfg.dist.use_megatron_fsdp = False
         cfg.dist.use_torch_fsdp2 = False
         cfg.rng.data_parallel_random_init = False
         return cfg, model_cfg
 
+    @pytest.mark.parametrize(
+        ("use_layer_wise_distributed_optimizer", "use_layer_wise_param_layout"),
+        [(True, True), (True, False), (False, True)],
+    )
     @patch("megatron.bridge.training.setup.GPTModelConfig")
-    def test_build_with_model_config(self, _mock_gpt_cls):
-        """Test that builder.build_distributed_models is called for ModelConfig."""
-        cfg, model_cfg = self._make_cfg_with_model_config()
+    def test_build_with_model_config(
+        self,
+        _mock_gpt_cls,
+        use_layer_wise_distributed_optimizer,
+        use_layer_wise_param_layout,
+    ):
+        """Test that ModelBuilder receives the exact LayerWise configuration."""
+        cfg, model_cfg = self._make_cfg_with_model_config(
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=use_layer_wise_param_layout,
+        )
         assert not hasattr(model_cfg, "provide_distributed_model")
 
         mock_builder_cls = MagicMock()
@@ -533,14 +554,32 @@ class TestBuildDistributedModel:
         mock_dist_model = [MagicMock()]
         mock_builder.build_distributed_models.return_value = mock_dist_model
 
+        pg_collection = MagicMock()
         with patch.object(type(model_cfg), "get_builder_cls", return_value=mock_builder_cls):
-            result = _build_distributed_model(cfg, pg_collection=MagicMock())
+            result = _build_distributed_model(cfg, pg_collection=pg_collection)
 
-        mock_builder.build_distributed_models.assert_called_once()
+        mock_builder.build_distributed_models.assert_called_once_with(
+            pg_collection=pg_collection,
+            ddp_config=cfg.ddp,
+            overlap_param_gather_with_optimizer_step=False,
+            use_megatron_fsdp=False,
+            use_torch_fsdp2=False,
+            data_parallel_random_init=False,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=use_layer_wise_param_layout,
+        )
         assert result == mock_dist_model
 
-    def test_build_with_provider(self):
-        """Test that provide_distributed_model is called for providers."""
+    @pytest.mark.parametrize(
+        ("use_layer_wise_distributed_optimizer", "use_layer_wise_param_layout"),
+        [(True, True), (True, False), (False, True)],
+    )
+    def test_build_with_provider(
+        self,
+        use_layer_wise_distributed_optimizer,
+        use_layer_wise_param_layout,
+    ):
+        """Test that the legacy provider receives the exact LayerWise configuration."""
         mock_provider = MagicMock()
         # Ensure isinstance(mock_provider, ModelConfig) is False
         mock_provider.__class__ = type("FakeProvider", (), {})
@@ -551,15 +590,29 @@ class TestBuildDistributedModel:
         cfg = MagicMock()
         cfg.model = mock_provider
         cfg.ddp = MagicMock()
-        cfg.optimizer.overlap_param_gather_with_optimizer_step = False
+        cfg.optimizer = SimpleNamespace(
+            overlap_param_gather_with_optimizer_step=False,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=use_layer_wise_param_layout,
+        )
         cfg.dist.use_megatron_fsdp = False
         cfg.dist.use_torch_fsdp2 = False
         cfg.rng.data_parallel_random_init = False
 
-        result = _build_distributed_model(cfg, pg_collection=MagicMock())
+        pg_collection = MagicMock()
+        result = _build_distributed_model(cfg, pg_collection=pg_collection)
 
         mock_provider.finalize.assert_called_once_with()
-        mock_provider.provide_distributed_model.assert_called_once()
+        mock_provider.provide_distributed_model.assert_called_once_with(
+            ddp_config=cfg.ddp,
+            use_megatron_fsdp=False,
+            use_torch_fsdp2=False,
+            overlap_param_gather_with_optimizer_step=False,
+            data_parallel_random_init=False,
+            pg_collection=pg_collection,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            use_layer_wise_param_layout=use_layer_wise_param_layout,
+        )
         assert result == mock_dist_model
 
     def test_finalizes_heterogeneous_provider_before_entering_distributed_model_build(self):
@@ -584,7 +637,11 @@ class TestBuildDistributedModel:
         cfg = SimpleNamespace(
             model=provider,
             ddp=MagicMock(),
-            optimizer=SimpleNamespace(overlap_param_gather_with_optimizer_step=False),
+            optimizer=SimpleNamespace(
+                overlap_param_gather_with_optimizer_step=False,
+                use_layer_wise_distributed_optimizer=False,
+                use_layer_wise_param_layout=True,
+            ),
             dist=SimpleNamespace(use_megatron_fsdp=False, use_torch_fsdp2=False),
             rng=SimpleNamespace(data_parallel_random_init=False),
         )


### PR DESCRIPTION
# What does this PR do ?

Expose and forward the LayerWise parameter-layout selector through Megatron Bridge training model construction.

This is a standalone Bridge follow-up to NVIDIA/Megatron-LM#5479. As rechecked at 2026-08-18 19:39 UTC, that upstream PR is **open and unmerged** at `098780bb9bb33775171dfc4a29d267b07c881d11`, is currently blocked, and has five unresolved current review threads. This draft must remain dependent on the upstream contract settling.

The Bridge base is exact `3f87ba60823a268b0c5102e9be3b3bd0012923cd`, whose Megatron-LM pin remains unchanged at `2a75ac12c54ba6a42b34024756820bf819a2e25f`. This PR deliberately does not bump the submodule. It preserves the API/default available at that pin and current Megatron-LM main: `use_layer_wise_param_layout=True` selects the precomputed shard-aligned layout, while `False` is the documented opt-out to the legacy whole-parameter ping-pong/`allgather_params` layout. The setting is inert when LayerWise distributed optimizer support is disabled. Revalidation against the final merged upstream contract is required before this PR leaves draft.

# Changelog

- Add serializable `OptimizerConfig.use_layer_wise_param_layout` with the upstream default and legacy opt-out documentation.
- Forward both LayerWise optimizer and layout controls through `ModelBuilder` construction.
- Forward both controls through supported legacy provider construction while preserving provider finalization order.
- Add focused coverage for default precomputed layout, explicit legacy layout, LayerWise-disabled behavior, exact builder/provider kwargs, serialization, YAML round-trip, and `run_recipe` CLI override handling.

# GitHub Actions CI

Draft opened after the minimal local evidence was clean, before GPU parity as requested.

- [x] Focused unit tests: 16 passed
- [x] `uv run pre-commit run --all-files`
- [x] 2-GPU LayerWise smoke with precomputed layout: 3/3 finite steps, zero skipped/NaN iterations
- [x] 2-GPU LayerWise smoke with legacy layout: 3/3 finite steps, zero skipped/NaN iterations
- [x] Matched Megatron-LM versus Bridge parity for each layout
- [x] Exact-SHA CI trigger for `fff9158001704ca19368125a5a24dda9c01cd098`

The matched BF16 DP=2 runs used the same 2-layer/256-hidden GPT, mock data, seed 1234, batch sizes, scheduler, Muon settings, and layout value. Displayed training losses were:

| Layout | Implementation | Step 1 | Step 2 | Step 3 |
| --- | --- | ---: | ---: | ---: |
| precomputed (`True`) | Bridge | 10.42688 | 10.42719 | 10.40060 |
| precomputed (`True`) | Megatron-LM | 10.41785 | 10.42496 | 10.39845 |
| legacy (`False`) | Bridge | 10.42688 | 10.42719 | 10.40077 |
| legacy (`False`) | Megatron-LM | 10.41785 | 10.42496 | 10.39845 |

The maximum same-layout displayed-loss delta is `0.00903` (`0.0867%`), within BF16-scale rounding for this smoke. This is loss-correlation evidence only; it does not claim tensor-level or bitwise parity. The logs also confirm the precomputed run generated the shard-aligned LayerWise layout, while the explicit `False` run retained LayerWise optimizer execution without generating that layout.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No.
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? Not applicable.

# Additional Information

- Upstream dependency: NVIDIA/Megatron-LM#5479
- No changes to checkpoint code, CI workflows, Megatron-LM submodule contents or pin, or GTP Stage 1 PR #5569.
