### PR TITLE
[data] fix: align DeepSeek null-content test

### DIFF
--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_chat.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_chat.py
@@ -259,7 +259,7 @@ def test_deepseek_v4_tokenizer_accepts_tool_call_without_content():
 
     tokenized = tokenize_deepseek_v4_example(example, tokenizer)
 
-    assert tokenized.conversation[2]["content"] is None
+    assert tokenized.conversation[2]["content"] == ""
     assert f'<{DSML_TOKEN}invoke name="get_weather">' in _decode_character_ids(tokenized.input_ids.tolist())
 
 


### PR DESCRIPTION
## Summary

- align the DeepSeek-V4 tool-call-only test with the shared chat normalization contract
- preserve the existing token IDs and tool-call rendering behavior

## Root cause

Main CI run 32136508380 failed in `Launch_Unit_Tests_Core_0` because `normalize_chat_conversation()` now intentionally converts OpenAI `content: null` to an empty string before rendering, while the DeepSeek-V4 test still expected `None`. The DeepSeek renderer already treats both forms identically through `str(content or "")`; this updates only the stale post-normalization assertion.

## Validation

- `121 passed`: `tests/unit_tests/models/deepseek/test_deepseek_v4_chat.py` and `tests/unit_tests/data/test_conversation_processing.py`
- `uv run pre-commit run --all-files`

Fixes the main failure: https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/32136508380/job/95726900053