### PR TITLE
fix(recipe): match hybridep chunk sizes in nemotron_3_5_lightning fp8cs H100 recipe

### DIFF
--- a/src/megatron/bridge/perf_recipes/nemotronh/h100/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/h100/nemotronh.py
@@ -287,7 +287,10 @@ def nemotron_3_5_lightning_pretrain_16gpu_h100_fp8cs_config() -> ConfigContainer
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         "NCCL_NVLS_ENABLE": 0,
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        # Fuse mode (inherited moe_permute_fusion_into_hybridep=True) needs matching chunk sizes.
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NUM_OF_TOKENS_PER_CHUNK_DISPATCH_API": 128,
+        "NUM_OF_TOKENS_PER_CHUNK_PREPROCESSING_API": 128,
         "NVLINK_DOMAIN_SIZE": 8,
         "USE_MNNVL": 0,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,


### PR DESCRIPTION
## Summary

`nemotron_3_5_lightning_pretrain_16gpu_h100_fp8cs_config()` builds on `nemotron_3_nano_pretrain_16gpu_h100_fp8cs_config()`, inheriting `moe_permute_fusion_into_hybridep=True`, but replaces `cfg.env_vars` wholesale with `NUM_OF_TOKENS_PER_CHUNK_COMBINE_API=128` and no matching `DISPATCH_API`/`PREPROCESSING_API` override.

deep_ep's `fuse_permute_dispatch` mode requires `dispatch`/`combine`/`preprocessing` chunk sizes to all match (`config.cuh`'s `is_valid(fuse_permute_dispatch=True)`). Dispatch and preprocessing fall back to deep_ep's default of 64 when unset, so this recipe currently produces a mismatched config (`dispatch=64, combine=128, preprocessing=64`) and crashes on the very first training step:

```
[Error] Fuse mode requires identical chunk sizes: dispatch=64, combine=128, preprocessing=64
AssertionError: The config is not valid.
```

This is the same interaction already handled correctly elsewhere:
- `nemotron_3_nano_pretrain_16gpu_h100_fp8cs_config` (same file) pairs the fusion flag with `COMBINE_API=64`.
- `qwen/h100/qwen3_moe.py`'s `qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config` pairs it with `COMBINE_API=64`.

This recipe's own `COMBINE_API=128` choice is kept as-is; `DISPATCH_API`/`PREPROCESSING_API` are set to `128` to match it, rather than disabling fusion.

## Test plan

- [x] Diffed against the two recipes above that already pair these correctly — same fix shape.
- [x] `ast.parse` syntax check on the edited file.
- [ ] Not run: the repo's own test suite (`tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py`) only constructs `ConfigContainer` objects and checks field values — it doesn't invoke deep_ep, so it can't catch this class of bug either way. Local environment has no GPU / deep_ep install to run this recipe end-to-end.
- [x] The identical fix shape (adding `NUM_OF_TOKENS_PER_CHUNK_DISPATCH_API`/`PREPROCESSING_API` to match `COMBINE_API` when fuse mode is on) was independently verified fixing this exact crash on real H100 hardware, across multiple configs and precisions (fp8 and bf16), with and without other perf levers stacked.