### PR TITLE
[data] fix: handle nullable SFT union columns

### DIFF
--- a/src/megatron/bridge/data/sft_processing.py
+++ b/src/megatron/bridge/data/sft_processing.py
@@ -169,6 +169,8 @@ def _canonical_prompt_completion_values(example: Mapping[str, Any]) -> tuple[str
         return None
     prompt = example[_CANONICAL_PROMPT_KEY]
     completion = example[_CANONICAL_COMPLETION_KEY]
+    if prompt is None and completion is None:
+        return None
     if not isinstance(prompt, str) or not isinstance(completion, str):
         raise ValueError("Canonical prompt and completion values must be strings.")
     return prompt, completion
@@ -199,7 +201,7 @@ def normalize_sft_example(
             metadata = {
                 key: value
                 for key, value in row.items()
-                if key not in {_CANONICAL_PROMPT_KEY, _CANONICAL_COMPLETION_KEY}
+                if key not in {*_CONVERSATION_KEYS, _CANONICAL_PROMPT_KEY, _CANONICAL_COMPLETION_KEY}
             }
             return {
                 "conversation": [
@@ -209,7 +211,11 @@ def normalize_sft_example(
                 **metadata,
             }
         conversation = normalize_chat_conversation(row)
-        metadata = {key: value for key, value in row.items() if key not in _CONVERSATION_KEYS}
+        metadata = {
+            key: value
+            for key, value in row.items()
+            if key not in {*_CONVERSATION_KEYS, _CANONICAL_PROMPT_KEY, _CANONICAL_COMPLETION_KEY}
+        }
         # Keep the canonical singular key expected by registered VLM/audio
         # collators; shared text preprocessing accepts it as well.
         return {"conversation": conversation, **metadata}

--- a/tests/unit_tests/data/test_sft_processing.py
+++ b/tests/unit_tests/data/test_sft_processing.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 import sentencepiece
+from datasets import Dataset, concatenate_datasets
 from megatron.core.tokenizers.megatron_tokenizer import MegatronTokenizer
 
 from megatron.bridge.data.base import DatasetBuildContext
@@ -23,6 +24,7 @@ from megatron.bridge.data.sft_processing import (
     ChatSFTPreprocessingConfig,
     PromptCompletionSFTPreprocessingConfig,
     normalize_sft_example,
+    normalize_sft_examples,
     tokenize_prompt_completion_example,
 )
 from megatron.bridge.data.sources.hf import HFDatasetSourceConfig
@@ -189,6 +191,24 @@ def test_chat_preprocessing_promotes_canonical_pair():
         ],
         "id": 7,
     }
+
+
+def test_chat_preprocessing_accepts_nullable_union_columns():
+    paired = Dataset.from_list([{"prompt": "question", "completion": "answer"}])
+    chat = Dataset.from_list([{"conversation": [{"role": "assistant", "content": "response"}]}])
+    rows = adapt_hf_dataset(concatenate_datasets([paired, chat]), adapter_name=None)
+
+    normalized = normalize_sft_examples(rows, ChatSFTPreprocessingConfig())
+
+    assert normalized == [
+        {
+            "conversation": [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ]
+        },
+        {"conversation": [{"role": "assistant", "content": "response"}]},
+    ]
 
 
 def test_prompt_completion_rejects_structured_conversation():


### PR DESCRIPTION
## Problem

The supported Direct-HF SFT path accepts a list of dataset subsets and combines them with Hugging Face `concatenate_datasets()`. When one subset uses canonical `prompt`/`completion` rows and another uses structured `conversation` rows, Hugging Face represents the absent union columns as `None`.

Chat normalization currently treats the null `prompt`/`completion` pair as a selected canonical pair and raises, so dataset construction fails. On the paired row, the nullable `conversation` metadata can also overwrite the generated two-turn conversation with `None`, silently discarding the example content.

## Fix

Treat only an all-null canonical pair as absent, while retaining existing rejection for partial-null or non-string pairs. Exclude alternate schema keys from normalized metadata so nullable union sentinels cannot overwrite or leak into the canonical row.

The regression test exercises the real `Dataset` -> native HF adapter -> batch normalizer boundary with one row of each supported schema.

## Validation

Fail-before:

```text
uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_sft_processing.py -k nullable_union_columns
# 1 failed, 19 deselected: ValueError: Canonical prompt and completion values must be strings.
```

Pass-after:

```text
uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_sft_processing.py -k nullable_union_columns
# 1 passed, 19 deselected

uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_sft_processing.py tests/unit_tests/data/sources/test_hf_adapters.py
# 41 passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# all hooks passed
```

The pytest commands were run in CPU-only import isolation; environment-only path prefixes are intentionally omitted.

## Scope

This changes only Chat SFT normalization for nullable alternate-schema columns produced by HF dataset concatenation. It does not alter loading, tokenization, public APIs, dependencies, or behavior for genuinely invalid mixed schemas.
