### PR TITLE
[peft] fix: support decentralized process groups in adapter export

### DIFF
--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -561,9 +561,9 @@ class MegatronPeftBridge:
         if not isinstance(megatron_model, list):
             megatron_model = [megatron_model]
 
-        from megatron.bridge.models.conversion.model_bridge import _megatron_local_name_to_global
+        from megatron.bridge.models.conversion.model_bridge import _get_pp_group, _megatron_local_name_to_global
 
-        pp_group = parallel_state.get_pipeline_model_parallel_group()
+        pp_group = _get_pp_group(megatron_model)
         pp_rank = get_pg_rank(pp_group)
         model_config = unwrap_model(megatron_model)[0].config
         global_param_objects: List[tuple[str, str, bool, bool, bool, int, int, int, int]] = []
@@ -676,11 +676,18 @@ class MegatronPeftBridge:
         tasks_by_base: Dict[str, List[AdapterWeightConversionTask]] = defaultdict(list)  # type: ignore[name-defined]
         excluded_prefixes = tuple(exclude_adapter_base_prefixes or ())
 
-        from megatron.bridge.models.conversion.model_bridge import WeightConversionTask
+        from megatron.bridge.models.conversion.model_bridge import (
+            WeightConversionTask,
+            _get_pg_collection_from_model,
+            _get_pp_rank,
+        )
 
         # `MegatronModelBridge` mixes in this class and provides `mapping_registry`.
         assert hasattr(self, "mapping_registry"), "MegatronModelBridge must define mapping_registry"
         mapping_registry = self.mapping_registry()  # type: ignore[attr-defined]
+        pg_collection = _get_pg_collection_from_model(megatron_model)
+        mapping_registry.set_process_groups_from_pg_collection(pg_collection)
+        current_pp_rank = None
 
         for (
             global_base_name,
@@ -724,7 +731,9 @@ class MegatronPeftBridge:
 
             linear_in_module, linear_in_weight = None, None
             linear_out_module, linear_out_weight = None, None
-            if parallel_state.get_pipeline_model_parallel_rank() == pp_rank:
+            if current_pp_rank is None:
+                current_pp_rank = _get_pp_rank(megatron_model)
+            if current_pp_rank == pp_rank:
                 adapter, _ = self._get_adapter_wrap_module(local_base_prefix, megatron_model, vp_stage)
                 if isinstance(adapter, ModuleDict):
                     adapter = adapter[adapter_key]
@@ -742,26 +751,30 @@ class MegatronPeftBridge:
                 linear_in_mapping_cls = ReplicatedMapping
                 linear_out_mapping_cls = ReplicatedMapping
 
+            linear_in_mapping = linear_in_mapping_cls(
+                megatron_param=local_linear_in_name,
+                hf_param=hf_linear_in_name,
+            )
+            linear_in_mapping.set_process_groups_from_pg_collection(pg_collection)
             linear_in_task = WeightConversionTask(
                 param_name=local_linear_in_name,
                 global_param_name=global_linear_in_name,
-                mapping=linear_in_mapping_cls(
-                    megatron_param=local_linear_in_name,
-                    hf_param=hf_linear_in_name,
-                ),
+                mapping=linear_in_mapping,
                 pp_rank=pp_rank,
                 vp_stage=vp_stage,
                 megatron_module=linear_in_module,
                 param_weight=linear_in_weight,
             )
 
+            linear_out_mapping = linear_out_mapping_cls(
+                megatron_param=local_linear_out_name,
+                hf_param=hf_linear_out_name,
+            )
+            linear_out_mapping.set_process_groups_from_pg_collection(pg_collection)
             linear_out_task = WeightConversionTask(
                 param_name=local_linear_out_name,
                 global_param_name=global_linear_out_name,
-                mapping=linear_out_mapping_cls(
-                    megatron_param=local_linear_out_name,
-                    hf_param=hf_linear_out_name,
-                ),
+                mapping=linear_out_mapping,
                 pp_rank=pp_rank,
                 vp_stage=vp_stage,
                 megatron_module=linear_out_module,

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -759,6 +759,97 @@ def test_megatron_global_adapters_info_all_pp_ranks(monkeypatch):
     assert alpha == 8 and dim == 2 and pp_rank == 0 and vp_stage == 0
 
 
+def test_build_adapter_conversion_tasks_uses_model_process_groups(monkeypatch):
+    bridge = DummyBridge()
+
+    class DummyGroup:
+        def size(self):
+            return 1
+
+        def rank(self):
+            return 0
+
+    pp_group = DummyGroup()
+    tp_group = object()
+    ep_group = object()
+    expert_tp_group = object()
+    pg_collection = SimpleNamespace(pp=pp_group, tp=tp_group, ep=ep_group, expt_tp=expert_tp_group)
+
+    class FakeAdapter:
+        def __init__(self):
+            self.linear_in = SimpleNamespace(weight=torch.ones(2, 2))
+            self.linear_out = SimpleNamespace(weight=torch.ones(2, 2))
+            self.input_is_parallel = True
+            self.base_linear_is_parallel = True
+            self.alpha = 8
+            self.dim = 2
+
+    class FakeModel:
+        def __init__(self):
+            self.config = SimpleNamespace()
+            self.pg_collection = pg_collection
+            param = torch.nn.Parameter(torch.zeros(2, 2))
+            self._params = [
+                ("decoder.layers.0.mlp.linear_fc1.adapter.linear_in.weight", param),
+                ("decoder.layers.0.mlp.linear_fc1.adapter.linear_out.weight", param),
+            ]
+
+        def named_parameters(self):
+            return self._params
+
+        def named_modules(self):
+            return []
+
+    def fail_global_lookup():
+        raise AssertionError("global process-group state must not be used")
+
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_pipeline_model_parallel_group",
+        fail_global_lookup,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_pipeline_model_parallel_rank",
+        fail_global_lookup,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.peft_bridge.persistent_buffers",
+        lambda *_: [],
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.model_bridge._megatron_local_name_to_global",
+        lambda *_args, **_kwargs: _args[2],
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.models.conversion.model_bridge.unwrap_model",
+        lambda model: model[0] if isinstance(model, list) else model,
+    )
+    monkeypatch.setattr(
+        "torch.distributed.all_gather_object",
+        lambda output, obj, group=None: output.__setitem__(0, obj),
+    )
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: group.rank())
+
+    adapter = FakeAdapter()
+    monkeypatch.setattr(bridge, "_get_adapter_wrap_module", lambda *_: (adapter, None))
+    monkeypatch.setattr(
+        bridge,
+        "mapping_registry",
+        lambda: MegatronMappingRegistry(
+            AutoMapping(
+                megatron_param="decoder.layers.*.mlp.linear_fc1.weight",
+                hf_param="model.layers.*.mlp.gate_proj.weight",
+            )
+        ),
+    )
+
+    tasks = bridge.build_adapter_conversion_tasks([FakeModel()])["decoder.layers.0.mlp.linear_fc1"]
+    for task in (tasks[0].linear_in_task, tasks[0].linear_out_task):
+        assert task.mapping.pp_group is pp_group
+        assert task.mapping._tp_group is tp_group
+        assert task.mapping.ep_group is ep_group
+        assert task.mapping._etp_group is expert_tp_group
+
+
 def test_construct_adapters_names():
     bridge = DummyBridge()
     linear_in, linear_out = bridge._construct_adapters_names("decoder.layers.0.mlp.linear_fc1", None)
@@ -838,7 +929,7 @@ def test_build_adapter_conversion_tasks(monkeypatch):
     )
     monkeypatch.setattr(bridge, "mapping_registry", lambda: registry)
 
-    tasks_by_base = bridge.build_adapter_conversion_tasks([Mock()])
+    tasks_by_base = bridge.build_adapter_conversion_tasks([SimpleNamespace(pg_collection=None)])
     assert "decoder.layers.0.mlp.linear_fc1" in tasks_by_base
     tasks = tasks_by_base["decoder.layers.0.mlp.linear_fc1"]
     assert len(tasks) == 1


### PR DESCRIPTION
## What changed

Dense PEFT adapter export now uses the `ProcessGroupCollection` attached to the Megatron model when decentralized process groups are enabled.

The supported trigger is a PEFT-enabled model constructed with model-owned process groups, followed by adapter task construction through `save_hf_adapter()` / `stream_adapter_weights_megatron_to_hf()`. Adapter discovery previously queried the global pipeline group, which is intentionally unset in this mode and causes an assertion. Fresh adapter mappings also retained constructor-time global groups instead of the model topology.

The fix reuses the existing model process-group helpers to:

- discover adapters and select the owning pipeline rank through the model's PP group;
- install the model collection on the temporary mapping registry; and
- install it on both generated adapter mappings before materialization.

When no model-owned collection exists, the existing global-state fallback is unchanged.

## Regression evidence

Fail-before on unmodified `main`:

```text
uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_model_bridge_lora.py::test_build_adapter_conversion_tasks_uses_model_process_groups
1 failed: global process-group state must not be used
```

Pass-after:

```text
uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_model_bridge_lora.py::test_build_adapter_conversion_tasks_uses_model_process_groups
1 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_model_bridge_lora.py
57 passed

uv run --no-sync pre-commit run --all-files
Passed
```

`git diff --check` also passes.

## Scope

This change covers dense adapter task discovery, ownership, and mapping collectives. It does not claim validation of decentralized grouped-expert/MoE adapter export or model-quality/convergence behavior.
