### PR TITLE
[ckpt] fix: Keep FSDP optimizer fresh when state is omitted

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2771,6 +2771,7 @@ def _load_checkpoint_from_path(
     # Step 2: Initialize scaffolding
     load_kwargs = {}
     ignore_rng_state = False
+    ignore_optimizer_state = False
     ignore_rerun_state = True
     run_config = None  # Initialize for later use
 
@@ -2973,9 +2974,13 @@ def _load_checkpoint_from_path(
                     f"(TP, PP) mismatch after resume ({run_tp_pp} vs {ckpt_tp_pp} from checkpoint): "
                     "RNG state will be ignored"
                 )
-            if cfg.checkpoint.load_optim:
+            checkpoint_saved_optimizer = run_config is None or run_config.get("checkpoint", {}).get("save_optim", True)
+            if cfg.checkpoint.load_optim and checkpoint_saved_optimizer:
                 gen_sd_optim = optimizer
                 gen_sd_opt_param_scheduler = opt_param_scheduler
+            elif cfg.checkpoint.load_optim:
+                ignore_optimizer_state = True
+                print_rank_0("Optimizer state was not saved in the FSDP checkpoint; using a fresh optimizer")
 
         optim_sd_kwargs = dict(
             metadata=_build_sharded_state_dict_metadata(cfg.optimizer.use_distributed_optimizer, cfg.checkpoint),
@@ -3127,7 +3132,7 @@ def _load_checkpoint_from_path(
     print_rank_0(f" checkpoint version {checkpoint_version}")
 
     # Load optimizer and scheduler
-    if not release and not cfg.checkpoint.finetune and cfg.checkpoint.load_optim:
+    if not release and not cfg.checkpoint.finetune and cfg.checkpoint.load_optim and not ignore_optimizer_state:
         try:
             if (
                 not skip_load_to_model_and_opt

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -1571,6 +1571,63 @@ class TestLoadCheckpoint:
         mock_get_rng_state.assert_not_called()
         assert mock_generate.call_args.kwargs["rng_state"] is None
 
+    def test_fsdp_omitted_optimizer_does_not_materialize_load_state(self, load_checkpoint_fixtures):
+        """An FSDP checkpoint saved without optimizer state must leave the optimizer fresh."""
+        cfg = load_checkpoint_fixtures["mock_cfg"]
+        cfg.checkpoint.ckpt_format = "fsdp_dtensor"
+        cfg.checkpoint.load_rng = False
+        cfg.peft = None
+
+        pg_collection = Mock()
+        reader = Mock()
+        reader.read_metadata.return_value.state_dict_metadata = {"model.weight": Mock()}
+
+        optimizer = load_checkpoint_fixtures["mock_optimizer"]
+        optimizer.is_stub_optimizer = False
+        optimizer.materialized_step = 0
+
+        def materialize_optimizer_state(*_args, **_kwargs):
+            optimizer.materialized_step += 1
+            return {"state": {"step": optimizer.materialized_step}}
+
+        optimizer.sharded_state_dict.side_effect = materialize_optimizer_state
+        load_checkpoint_fixtures["mock_model"][0].state_dict_for_save_checkpoint.return_value = {"weight": Mock()}
+
+        with (
+            patch("megatron.bridge.training.checkpointing.is_hf_checkpoint_dir", return_value=False),
+            patch("megatron.bridge.training.checkpointing.is_checkpoint_iteration_directory", return_value=True),
+            patch("megatron.bridge.training.checkpointing.file_exists", return_value=True),
+            patch(
+                "megatron.bridge.training.checkpointing.read_run_config",
+                return_value={
+                    "model": {
+                        "tensor_model_parallel_size": 1,
+                        "pipeline_model_parallel_size": 1,
+                    },
+                    "checkpoint": {"save_optim": False},
+                },
+            ),
+            patch("megatron.bridge.training.checkpointing._get_filesystem_reader", return_value=reader),
+            patch(
+                "megatron.bridge.training.checkpointing._load_base_checkpoint",
+                side_effect=[
+                    ({}, "/checkpoints/iter_0000003", False, CheckpointType.FSDP_DTENSOR),
+                    (None, "", False, None),
+                ],
+            ),
+        ):
+            result = _load_checkpoint_from_path(
+                "/checkpoints/iter_0000003",
+                load_checkpoint_fixtures["mock_state"],
+                load_checkpoint_fixtures["mock_model"],
+                optimizer,
+                None,
+                pg_collection=pg_collection,
+            )
+
+        assert result == (0, 0)
+        assert optimizer.materialized_step == 0
+
     @patch("torch.distributed.is_initialized")
     @patch("megatron.bridge.training.checkpointing._build_auto_bridge_for_save")
     def test_load_hf_pretrained_checkpoint_initializes_from_hf_source(


### PR DESCRIPTION
## Summary

Loading an `fsdp_dtensor` checkpoint saved with `save_optim=False` while leaving the supported `load_optim=True` default could silently advance the fresh optimizer before training resumed.

The FSDP load path built optimizer state scaffolding even though the checkpoint contained no optimizer section. Megatron-Core materializes that scaffold with a dummy optimizer step, and partial DCP loading leaves its values untouched because no optimizer keys exist. Bridge then restored the scaffold as checkpoint state, so the first real update used advanced step semantics.

This change consults the saved run configuration before building the FSDP optimizer scaffold. If optimizer state was intentionally omitted, Bridge leaves the optimizer and scheduler fresh and skips the later optimizer restore. Legacy checkpoints without saved run configuration and checkpoints with `save_optim=True` preserve the existing behavior.

## Validation

The new focused test was run unchanged against audited base `0480586879f2513958fd8634fc529693ae13e536` before applying the production fix:

```
uv run python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint::test_fsdp_omitted_optimizer_does_not_materialize_load_state -q
1 failed
```

The failure showed optimizer scaffolding materialized step 1 instead of leaving the optimizer at step 0.

After the fix:

```
uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint -q
7 passed
```

Additional checks:

```
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This only changes FSDP checkpoint loading when the saved run configuration explicitly records `save_optim=False`. It does not change checkpoint formats, public APIs, strictness defaults, non-FSDP loading, or legacy checkpoint behavior.