### PR TITLE
[perf] fix: Gather only final VLM token logits

### DIFF
--- a/scripts/inference/vlm_generation.py
+++ b/scripts/inference/vlm_generation.py
@@ -148,6 +148,19 @@ def _hf_revision_kwargs(revision: str | None) -> dict[str, str]:
     return {"revision": revision} if revision is not None else {}
 
 
+def _gather_last_token_logits(output: torch.Tensor, real_seq_len: int) -> torch.Tensor:
+    """Gather only the last real token's tensor-parallel vocabulary shards."""
+    local_logits = output[:, real_seq_len - 1]
+    world_size = parallel_state.get_tensor_model_parallel_world_size()
+    gathered_logits = [torch.zeros_like(local_logits) for _ in range(world_size)]
+    dist.all_gather(
+        gathered_logits,
+        local_logits,
+        group=parallel_state.get_tensor_model_parallel_group(),
+    )
+    return torch.cat(gathered_logits, dim=-1)
+
+
 def main(args) -> None:
     """Run VLM inference with HuggingFace or Megatron checkpoints."""
     maybe_initialize_distributed()
@@ -352,26 +365,22 @@ def main(args) -> None:
                 output = output[0]
 
             if parallel_state.is_pipeline_last_stage():
-                world_size = parallel_state.get_tensor_model_parallel_world_size()
-                gathered_tensors = [torch.zeros_like(output) for _ in range(world_size)]
-                dist.all_gather(gathered_tensors, output, group=parallel_state.get_tensor_model_parallel_group())
-                output = torch.cat(gathered_tensors, dim=2)
-
-                last_pos = real_seq_len - 1
-                next_token_ids = torch.argmax(output[:, last_pos], dim=-1, keepdim=True)
+                last_token_logits = _gather_last_token_logits(output, real_seq_len)
+                del output
+                next_token_ids = torch.argmax(last_token_logits, dim=-1, keepdim=True)
 
                 if step < 5:
                     print_rank_last(
-                        f"Step {step}: output shape={output.shape}, "
-                        f"real_seq_len={real_seq_len}, var={output.var():.4f}"
+                        f"Step {step}: last-token logits shape={last_token_logits.shape}, "
+                        f"real_seq_len={real_seq_len}, last-token var={last_token_logits.var():.4f}"
                     )
-                    logits = output[0, last_pos, :]
-                    top5_vals, top5_ids = torch.topk(logits, 5)
+                    top5_vals, top5_ids = torch.topk(last_token_logits[0], 5)
                     top5_tokens = [tokenizer.decode([idx]) for idx in top5_ids]
                     print_rank_last(f"Top 5: {list(zip(top5_tokens, top5_vals.tolist()))}")
                     print_rank_last(
                         f"Selected: '{tokenizer.decode([next_token_ids.item()])}' (id={next_token_ids.item()})"
                     )
+                del last_token_logits
             else:
                 next_token_ids = torch.ones((1, 1), device=generated_ids.device, dtype=generated_ids.dtype)
 

--- a/tests/unit_tests/scripts/inference/test_vlm_generation.py
+++ b/tests/unit_tests/scripts/inference/test_vlm_generation.py
@@ -1,0 +1,175 @@
+import gc
+import runpy
+import sys
+import types
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+_SCRIPT = Path(__file__).parents[4] / "scripts" / "inference" / "vlm_generation.py"
+_parallel_state = MagicMock()
+_import_stubs = {
+    "megatron": types.ModuleType("megatron"),
+    "megatron.core": types.ModuleType("megatron.core"),
+    "megatron.core.pipeline_parallel": types.ModuleType("megatron.core.pipeline_parallel"),
+    "megatron.core.pipeline_parallel.schedules": types.ModuleType("megatron.core.pipeline_parallel.schedules"),
+    "megatron.bridge": types.ModuleType("megatron.bridge"),
+    "megatron.bridge.models": types.ModuleType("megatron.bridge.models"),
+    "megatron.bridge.models.hf_pretrained": types.ModuleType("megatron.bridge.models.hf_pretrained"),
+    "megatron.bridge.models.hf_pretrained.utils": types.ModuleType("megatron.bridge.models.hf_pretrained.utils"),
+    "megatron.bridge.utils": types.ModuleType("megatron.bridge.utils"),
+    "megatron.bridge.utils.common_utils": types.ModuleType("megatron.bridge.utils.common_utils"),
+    "transformers": types.ModuleType("transformers"),
+    "vlm_generation_utils": types.ModuleType("vlm_generation_utils"),
+}
+_import_stubs["megatron.core"].parallel_state = _parallel_state
+_import_stubs["megatron.core.pipeline_parallel.schedules"].get_forward_backward_func = MagicMock()
+_import_stubs["megatron.bridge"].AutoBridge = MagicMock()
+_import_stubs["megatron.bridge.models.hf_pretrained.utils"].is_safe_repo = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].get_last_rank = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].maybe_initialize_distributed = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].print_rank_0 = MagicMock()
+_import_stubs["megatron.bridge.utils.common_utils"].print_rank_last = MagicMock()
+for name in ("AutoConfig", "AutoProcessor", "AutoTokenizer"):
+    setattr(_import_stubs["transformers"], name, MagicMock())
+for name in (
+    "decode_generated_tokens",
+    "pad_input_ids_to_tp_multiple",
+    "patch_kimi_vision_processor",
+    "process_image_inputs",
+    "process_multi_image_inputs",
+    "process_video_inputs",
+    "to_cuda",
+):
+    setattr(_import_stubs["vlm_generation_utils"], name, MagicMock())
+
+with patch.dict(sys.modules, _import_stubs):
+    _script_globals = runpy.run_path(_SCRIPT)
+_gather_last_token_logits = _script_globals.get("_gather_last_token_logits")
+_main = _script_globals["main"]
+
+
+@pytest.mark.unit
+def test_generation_gathers_only_last_real_token_logits() -> None:
+    """TP gathering must reconstruct vocabulary logits only for the consumed token."""
+    args = SimpleNamespace(
+        ep=1,
+        etp=1,
+        hf_model_path="org/model",
+        hf_revision="revision",
+        image_path=None,
+        image_paths=None,
+        max_new_tokens=2,
+        megatron_model_path=None,
+        pp=1,
+        pp_layout=None,
+        prompt="prompt",
+        tp=2,
+        trust_remote_code=False,
+        video_fps=2.0,
+        video_path=None,
+    )
+
+    model = MagicMock()
+    model.cuda.return_value = model
+    model.config = SimpleNamespace(mtp_num_layers=None, grad_scale_func=None)
+    provider = MagicMock()
+    provider.provide_distributed_model.return_value = [model]
+    bridge = MagicMock()
+    bridge.to_megatron_provider.return_value = provider
+
+    tokenizer = MagicMock(eos_token_id=99, eos_token="<eos>", pad_token_id=0, pad_token="<pad>")
+    tokenizer.decode.return_value = "decoded"
+
+    output_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+    last_token_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+    collective_result_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+
+    def run_forward(**kwargs):
+        gc.collect()
+        assert all(ref() is None for ref in output_refs)
+        assert all(ref() is None for ref in last_token_refs)
+        assert all(ref() is None for ref in collective_result_refs)
+        seq_length = kwargs["seq_length"]
+        logits = torch.arange(seq_length * 4, dtype=torch.float32).view(1, seq_length, 4)
+        output_refs.append(weakref.ref(logits))
+        return [logits]
+
+    gathered_shapes: list[torch.Size] = []
+    gathered_refs: list[weakref.ReferenceType[torch.Tensor]] = []
+
+    def fake_all_gather(gathered, local_logits, group):
+        gathered_shapes.append(local_logits.shape)
+        gathered_refs.extend(weakref.ref(tensor) for tensor in gathered)
+        gathered[0].copy_(local_logits)
+        gathered[1].copy_(local_logits + 100)
+
+    def pad_to_tp_multiple(input_ids, tp_size, pad_token_id=0):
+        remainder = input_ids.shape[1] % tp_size
+        if remainder == 0:
+            return input_ids
+        padding = torch.full((1, tp_size - remainder), pad_token_id, dtype=input_ids.dtype)
+        return torch.cat([input_ids, padding], dim=1)
+
+    original_cat = torch.cat
+
+    def recording_cat(tensors, *args, **kwargs):
+        result = original_cat(tensors, *args, **kwargs)
+        if tensors and tensors[0].dtype.is_floating_point:
+            collective_result_refs.append(weakref.ref(result))
+        return result
+
+    def gather_last_token_logits(output, real_seq_len):
+        assert _gather_last_token_logits is not None
+        last_token_logits = _gather_last_token_logits(output, real_seq_len)
+        last_token_refs.append(weakref.ref(last_token_logits))
+        return last_token_logits
+
+    selected_tokens: list[int] = []
+
+    def capture_broadcast(tensor, src):
+        selected_tokens.append(tensor.item())
+
+    script_globals = {
+        "AutoBridge": SimpleNamespace(from_hf_pretrained=MagicMock(return_value=bridge)),
+        "AutoConfig": SimpleNamespace(
+            from_pretrained=MagicMock(return_value=SimpleNamespace(model_type="qwen2_5_vl"))
+        ),
+        "AutoProcessor": SimpleNamespace(from_pretrained=MagicMock(return_value=MagicMock())),
+        "AutoTokenizer": SimpleNamespace(from_pretrained=MagicMock(return_value=tokenizer)),
+        "_gather_last_token_logits": gather_last_token_logits,
+        "decode_generated_tokens": MagicMock(return_value="decoded"),
+        "get_forward_backward_func": MagicMock(return_value=run_forward),
+        "get_last_rank": MagicMock(return_value=0),
+        "is_safe_repo": MagicMock(return_value=False),
+        "maybe_initialize_distributed": MagicMock(),
+        "pad_input_ids_to_tp_multiple": pad_to_tp_multiple,
+        "print_rank_0": MagicMock(),
+        "print_rank_last": MagicMock(),
+        "process_image_inputs": MagicMock(return_value=(torch.tensor([[7, 8, 9]]), None, None, None, None, None)),
+        "to_cuda": lambda value: value,
+    }
+
+    with (
+        patch.dict(_main.__globals__, script_globals),
+        patch.object(torch.Tensor, "cuda", lambda self: self),
+        patch.object(torch, "cat", new=recording_cat),
+        patch.object(torch.distributed, "all_gather", new=fake_all_gather),
+        patch.object(torch.distributed, "broadcast", new=capture_broadcast),
+        patch.object(_main.__globals__["parallel_state"], "is_pipeline_last_stage", return_value=True),
+        patch.object(_main.__globals__["parallel_state"], "get_tensor_model_parallel_group", return_value=None),
+        patch.object(_main.__globals__["parallel_state"], "get_tensor_model_parallel_world_size", return_value=2),
+    ):
+        _main(args)
+
+    assert gathered_shapes == [torch.Size([1, 4]), torch.Size([1, 4])]
+    assert selected_tokens == [7, 7]
+    assert all(ref() is None for ref in gathered_refs)
+    assert all(ref() is None for ref in output_refs)
+    assert all(ref() is None for ref in last_token_refs)
+    assert all(ref() is None for ref in collective_result_refs)


### PR DESCRIPTION
## What changed

The canonical VLM generation path now selects the last real sequence position before gathering tensor-parallel vocabulary shards. It also releases the full schedule output and gathered last-token logits as soon as each is no longer needed.

## Why

`scripts/inference/vlm_generation.py` previously all-gathered the complete `[batch, sequence, vocab/TP]` output and only then selected `real_seq_len - 1`. The documented tensor-parallel VLM path therefore materialized full-prefix vocabulary logits on every TP rank even though decoding consumes one position.

For a two-rank BF16 probe with sequence length 4096 and vocabulary size 151936, the old collective added 2.320 GiB per rank, while gathering only the final position added 0.000568 GiB. Both paths selected the same token.

## Validation

The regression test runs two generation steps and checks the user-visible token, collective input shape, and tensor lifetimes.

- Unmodified base: `uv run python -m pytest --confcutdir=tests/unit_tests/scripts/inference tests/unit_tests/scripts/inference/test_vlm_generation.py -q --tb=short` — fails because the first step's full gathered result remains live at the next forward (and the collective receives `[1, 4, 4]` rather than `[1, 4]`).
- Fixed branch: same command — 1 passed.
- `uv run python -m pytest --confcutdir=tests/unit_tests/scripts/inference tests/unit_tests/scripts/inference/test_setup_inference.py -q` — 32 passed.
- `uv run python -m pytest --confcutdir=tests/unit_tests/examples tests/unit_tests/examples/test_hf_to_megatron_generate_vlm.py -q` — 3 passed.
- `uv run python -m pytest --confcutdir=tests/unit_tests/utils tests/unit_tests/utils/test_vlm_generate_utils.py -q` — 13 passed.
- `uv run pre-commit run --all-files` — passed.
- Two-rank H100 NCCL probe — same selected token; 2.320 GiB versus 0.000568 GiB peak collective allocation delta per rank.

## Scope

This changes only the canonical VLM generation script's TP logit gathering. It does not change model outputs, sampling policy, public APIs, checkpoints, training code, or supported model/configuration scope.
