### PR TITLE
[recipe] fix: make Ministral3 defaults runnable

### DIFF
--- a/src/megatron/bridge/recipes/ministral3/h100/ministral3.py
+++ b/src/megatron/bridge/recipes/ministral3/h100/ministral3.py
@@ -110,6 +110,7 @@ def ministral3_3b_sft_1gpu_h100_bf16_config() -> ConfigContainer:
     # Dataset configuration
     cfg.dataset.seq_length = 4096
     cfg.dataset.hf_processor_path = hf_path
+    cfg.dataset.enable_in_batch_packing = False
 
     # DDP settings
     cfg.ddp.overlap_grad_reduce = False
@@ -225,6 +226,7 @@ def ministral3_8b_sft_2gpu_h100_bf16_config() -> ConfigContainer:
     # Dataset configuration
     cfg.dataset.seq_length = 4096
     cfg.dataset.hf_processor_path = hf_path
+    cfg.dataset.enable_in_batch_packing = False
 
     # DDP settings
     cfg.ddp.overlap_grad_reduce = False
@@ -340,6 +342,7 @@ def ministral3_14b_sft_4gpu_h100_bf16_config() -> ConfigContainer:
     # Dataset configuration
     cfg.dataset.seq_length = 4096
     cfg.dataset.hf_processor_path = hf_path
+    cfg.dataset.enable_in_batch_packing = False
 
     # DDP settings
     cfg.ddp.overlap_grad_reduce = False
@@ -464,6 +467,7 @@ def ministral3_3b_peft_1gpu_h100_bf16_config(peft_scheme: str | PEFT = "lora") -
     # Dataset configuration
     cfg.dataset.seq_length = 4096
     cfg.dataset.hf_processor_path = hf_path
+    cfg.dataset.enable_in_batch_packing = False
 
     # DDP settings
     cfg.ddp.overlap_grad_reduce = False
@@ -588,6 +592,7 @@ def ministral3_8b_peft_1gpu_h100_bf16_config(peft_scheme: str | PEFT = "lora") -
     # Dataset configuration
     cfg.dataset.seq_length = 4096
     cfg.dataset.hf_processor_path = hf_path
+    cfg.dataset.enable_in_batch_packing = False
 
     # DDP settings
     cfg.ddp.overlap_grad_reduce = False
@@ -712,6 +717,7 @@ def ministral3_14b_peft_2gpu_h100_bf16_config(peft_scheme: str | PEFT = "lora") 
     # Dataset configuration
     cfg.dataset.seq_length = 4096
     cfg.dataset.hf_processor_path = hf_path
+    cfg.dataset.enable_in_batch_packing = False
 
     # DDP settings
     cfg.ddp.overlap_grad_reduce = False

--- a/tests/unit_tests/recipes/test_ministral3_recipes.py
+++ b/tests/unit_tests/recipes/test_ministral3_recipes.py
@@ -44,6 +44,8 @@ _MINISTRAL3_PEFT_FUNCS = [
     _ministral3_module.ministral3_14b_peft_config,
 ]
 
+_MINISTRAL3_FUNCS = _MINISTRAL3_SFT_FUNCS + _MINISTRAL3_PEFT_FUNCS
+
 
 class _FakeModelCfg:
     """Fake model configuration for testing."""
@@ -136,6 +138,16 @@ def test_each_ministral3_sft_recipe_uses_recommended_learning_rate(
 
     assert cfg.optimizer.lr == pytest.approx(5e-6)
     assert cfg.optimizer.min_lr == pytest.approx(5e-7)
+
+
+@pytest.mark.parametrize("recipe_func", _MINISTRAL3_FUNCS)
+def test_each_ministral3_recipe_defaults_validate(recipe_func: Callable, monkeypatch: pytest.MonkeyPatch):
+    """Test that every Ministral3 recipe has runnable default batch settings."""
+    patch_recipe_module_global(monkeypatch, _ministral3_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = recipe_func()
+
+    assert not cfg.dataset.enable_in_batch_packing or cfg.train.micro_batch_size > 1
 
 
 @pytest.mark.parametrize("recipe_func", _MINISTRAL3_PEFT_FUNCS)


### PR DESCRIPTION
## What does this PR do?

Makes all six public Ministral3 H100 SFT and PEFT recipe defaults pass Bridge's supported batch-configuration contract.

The shared VLM helpers enable in-batch packing, while these GPU-sized recipes deliberately set `micro_batch_size=1`. The normal runner therefore rejects each default during runtime configuration because in-batch packing requires a micro-batch greater than one.

This patch disables in-batch packing only in the affected Ministral3 constructors. That preserves their documented GPU counts and memory-sized micro-batch defaults; users can still opt into packing together with an explicit micro-batch greater than one.

## User impact

Before this change, invoking any of the six canonical defaults (or their direct compatibility aliases) fails before training begins. The regression test covers the full SFT/PEFT constructor set and asserts the public packing/batch invariant.

## Validation

Fail-before on unmodified `main`:

```bash
uv run python -m pytest tests/unit_tests/recipes/test_ministral3_recipes.py -k defaults_validate -q
# 6 failed, 28 deselected
```

Pass-after with the unchanged regression test:

```bash
uv run python -m pytest tests/unit_tests/recipes/test_ministral3_recipes.py -k defaults_validate -q
# 6 passed, 28 deselected
```

Adjacent coverage:

```bash
uv run python -m pytest tests/unit_tests/recipes/test_ministral3_recipes.py -q
# 34 passed

uv run python -m pytest tests/unit_tests/training/test_config.py -k in_batch_packing -q
# 6 passed, 261 deselected

uv run pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

Scope is limited to recipe construction and CPU unit coverage. No GPU, convergence, performance, or full-suite validation was run.
