### PR TITLE
fix(training): persist fault-tolerance state atomically

### DIFF
--- a/src/megatron/bridge/training/fault_tolerance.py
+++ b/src/megatron/bridge/training/fault_tolerance.py
@@ -50,6 +50,7 @@ import os
 import random
 import signal
 import sys
+import tempfile
 import threading
 import time
 from typing import List
@@ -345,8 +346,26 @@ def _update_timeouts(selected_sections: List[str], calc_out_of_section: bool, gl
     )
     if get_rank_safe() == 0:
         rmon_state = rmon_cli.state_dict()
-        with open(ft_state.ft_state_path, "w") as f:
-            json.dump(rmon_state, f)
+        temp_state_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=os.path.dirname(ft_state.ft_state_path),
+                prefix=".ft_state.",
+                delete=False,
+            ) as f:
+                temp_state_path = f.name
+                json.dump(rmon_state, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_state_path, ft_state.ft_state_path)
+            temp_state_path = None
+        finally:
+            if temp_state_path is not None:
+                try:
+                    os.unlink(temp_state_path)
+                except FileNotFoundError:
+                    pass
         print_rank_0(f"FT: updated timeouts saved to {ft_state.ft_state_path}. {rmon_cli.section_timeouts}")
 
 

--- a/tests/unit_tests/training/test_fault_tolerance.py
+++ b/tests/unit_tests/training/test_fault_tolerance.py
@@ -595,8 +595,9 @@ class TestPrivateFunctions:
             # Should not attempt to load
             mock_rank_monitor_client.load_state_dict.assert_not_called()
 
-    def test_update_timeouts(self):
+    def test_update_timeouts(self, tmp_path):
         """Test _update_timeouts function."""
+        state_path = tmp_path / "ft_state.json"
         mock_global_state = MagicMock(spec=GlobalState)
         mock_rank_monitor_client = MagicMock()
         mock_rank_monitor_client.state_dict.return_value = {"timeouts": "data"}
@@ -604,14 +605,12 @@ class TestPrivateFunctions:
         mock_global_state.rank_monitor_client = mock_rank_monitor_client
 
         mock_ft_state = MagicMock(spec=FaultToleranceState)
-        mock_ft_state.ft_state_path = "/tmp/ft_state.json"
+        mock_ft_state.ft_state_path = str(state_path)
         mock_global_state.fault_tolerance_state = mock_ft_state
 
         with (
             patch("megatron.bridge.training.fault_tolerance.print_rank_0"),
             patch("megatron.bridge.training.fault_tolerance.get_rank_safe", return_value=0),
-            patch("builtins.open", mock_open()) as mock_file,
-            patch("json.dump") as mock_json_dump,
         ):
             fault_tolerance._update_timeouts(
                 selected_sections=["setup", "step"], calc_out_of_section=True, global_state=mock_global_state
@@ -620,7 +619,44 @@ class TestPrivateFunctions:
             mock_rank_monitor_client.calculate_and_set_section_timeouts.assert_called_once_with(
                 selected_sections=["setup", "step"], calc_out_of_section=True
             )
-            mock_json_dump.assert_called_once_with({"timeouts": "data"}, mock_file())
+            assert json.loads(state_path.read_text()) == {"timeouts": "data"}
+
+    def test_update_timeouts_preserves_previous_state_if_write_is_interrupted(self, tmp_path):
+        """A failed timeout-state write must not corrupt the state used by a restart."""
+        state_path = tmp_path / "ft_state.json"
+        previous_state = {"section_timeouts": {"setup": 600, "step": 180}}
+        state_path.write_text(json.dumps(previous_state))
+
+        mock_global_state = MagicMock(spec=GlobalState)
+        mock_rank_monitor_client = MagicMock()
+        mock_rank_monitor_client.state_dict.return_value = {"section_timeouts": {"setup": 300, "step": 90}}
+        mock_rank_monitor_client.section_timeouts = {"setup": 300, "step": 90}
+        mock_global_state.rank_monitor_client = mock_rank_monitor_client
+
+        mock_ft_state = MagicMock(spec=FaultToleranceState)
+        mock_ft_state.ft_state_path = str(state_path)
+        mock_global_state.fault_tolerance_state = mock_ft_state
+
+        def interrupt_dump(state, output_file):
+            output_file.write("{")
+            output_file.flush()
+            raise OSError("simulated interrupted write")
+
+        with (
+            patch("megatron.bridge.training.fault_tolerance.print_rank_0"),
+            patch("megatron.bridge.training.fault_tolerance.get_rank_safe", return_value=0),
+            patch("megatron.bridge.training.fault_tolerance.json.dump", side_effect=interrupt_dump),
+            pytest.raises(OSError, match="simulated interrupted write"),
+        ):
+            fault_tolerance._update_timeouts(
+                selected_sections=["setup", "step"], calc_out_of_section=True, global_state=mock_global_state
+            )
+
+        restart_client = MagicMock()
+        mock_global_state.rank_monitor_client = restart_client
+        fault_tolerance._load_state_if_exists(mock_global_state)
+
+        restart_client.load_state_dict.assert_called_once_with(previous_state)
 
 
 class TestMaybeUpdateTimeouts:


### PR DESCRIPTION
## Problem

With fault tolerance enabled and timeout calculation active, rank 0 rewrites `ft_state.json` directly. If the process is interrupted after the file is truncated but before `json.dump` completes, the next launcher retry reads partial JSON and fails with `JSONDecodeError`. This can prevent recovery and exhaust launcher retries for an otherwise supported training configuration.

## Root cause and fix

`_update_timeouts` opened the canonical state file with `"w"`, while `_load_state_if_exists` assumes that any existing state file contains complete JSON.

Write the new state to a temporary file in the same directory, flush and sync it, then atomically replace the canonical path. Clean up an unpublished temporary file on failure. This preserves the last valid state without changing the public API or configuration contract.

## Validation

Fail-before, using the unmodified production source and a deterministic interruption during `json.dump`:

```text
uv run --no-sync python reproducer.py src/megatron/bridge/training/fault_tolerance.py
# exit 1: json.decoder.JSONDecodeError while the production loader reads the partial state
```

Pass-after with the same reproducer:

```text
uv run --no-sync python reproducer.py src/megatron/bridge/training/fault_tolerance.py
# exit 0
```

Focused and adjacent tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_fault_tolerance.py::TestPrivateFunctions::test_update_timeouts_preserves_previous_state_if_write_is_interrupted -q
# 1 passed

uv run --no-sync python -m pytest tests/unit_tests/training/test_fault_tolerance.py -q
# 41 passed

uv run --no-sync pre-commit run --all-files
# passed

git diff --check
# passed
```

## Scope

This change covers local fault-tolerance timeout-state publication and recovery from an interrupted write. It does not change timeout calculation, launcher behavior, distributed ownership, public APIs, dependencies, or CI configuration. It does not claim full-suite, convergence, or performance validation.
