### PR TITLE
[data] fix: Preserve explicit split adapter ownership

### DIFF
--- a/src/megatron/bridge/data/builders/direct_hf_sft.py
+++ b/src/megatron/bridge/data/builders/direct_hf_sft.py
@@ -166,7 +166,12 @@ class DirectHFSFTDatasetConfig(DataloaderConfig):
     def _inherit_source_adapter_kwargs(self, split_source: HFDatasetSourceConfig) -> None:
         """Fill unset adapter arguments on another split of the training source."""
         source = self.split_source
-        if source is None or split_source.dataset_name != source.dataset_name or not source.adapter_kwargs:
+        if (
+            source is None
+            or split_source.dataset_name != source.dataset_name
+            or (source.dataset_name is None and split_source.path_or_dataset != source.path_or_dataset)
+            or not source.adapter_kwargs
+        ):
             return
         split_adapter_kwargs = dict(split_source.adapter_kwargs or {})
         for key, value in source.adapter_kwargs.items():

--- a/tests/unit_tests/data/builders/test_direct_hf_split_source_adapter.py
+++ b/tests/unit_tests/data/builders/test_direct_hf_split_source_adapter.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+import pytest
+
+from megatron.bridge.data.builders.direct_hf_sft import DirectHFSFTDatasetConfig
+from megatron.bridge.data.sources import hf_adapters as hf_adapter_module
+from megatron.bridge.data.sources.hf import HFDatasetSourceConfig
+from megatron.bridge.data.sources.hf_adapters import adapt_hf_dataset
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_explicit_custom_validation_source_keeps_own_adapter_columns(monkeypatch):
+    config = DirectHFSFTDatasetConfig(
+        seq_length=16,
+        source=HFDatasetSourceConfig(
+            path_or_dataset="org/train",
+            schema_adapter="default_audio",
+            adapter_kwargs={"audio_column": "train_audio", "text_column": "train_text"},
+        ),
+        validation_source=HFDatasetSourceConfig(
+            path_or_dataset="org/validation",
+            schema_adapter="default_audio",
+        ),
+        do_test=False,
+    )
+    config.validate()
+    monkeypatch.setattr(hf_adapter_module, "_decode_audio", lambda _audio: ([0.0], 16_000))
+
+    adapted = adapt_hf_dataset(
+        [{"audio": {}, "text": "validation"}],
+        adapter_name=config.validation_source.schema_adapter,
+        adapter_kwargs=config.validation_source.adapter_kwargs,
+    )
+
+    assert adapted[0]["conversation"][-1]["content"][0]["text"] == "validation"
+
+
+def test_custom_validation_split_of_training_source_inherits_adapter_columns():
+    config = DirectHFSFTDatasetConfig(
+        seq_length=16,
+        source=HFDatasetSourceConfig(
+            path_or_dataset="org/dataset",
+            schema_adapter="default_audio",
+            adapter_kwargs={"audio_column": "recording", "text_column": "transcript"},
+        ),
+        validation_source=HFDatasetSourceConfig(
+            path_or_dataset="org/dataset",
+            split="validation",
+            schema_adapter="default_audio",
+        ),
+        do_test=False,
+    )
+
+    config.validate()
+
+    assert config.validation_source.adapter_kwargs == {
+        "audio_column": "recording",
+        "text_column": "transcript",
+    }


### PR DESCRIPTION
## Summary

Explicit Direct-HF validation or test sources can point to a different custom dataset from the training source. When the training source configures adapter-specific column names, validation currently copies those names even if its own dataset uses the adapter defaults. Valid validation rows then fail during adaptation (for example, `default_audio` raises `KeyError: 'train_text'`) or can be interpreted with the wrong source semantics.

## Root cause

`DirectHFSFTDatasetConfig.validate()` inherits adapter arguments for another split of the training source. Source identity was checked only with `dataset_name`. Every custom `path_or_dataset` source has `dataset_name=None`, so unrelated custom training and validation paths compared equal and the explicit split was mutated before loading.

## Fix

For custom sources, inherit adapter arguments only when `path_or_dataset` also matches. Named-source behavior is unchanged. A focused regression covers the different-path failure, and a negative control preserves inheritance for a different split of the same custom source.

## Validation

Commands below omit private CPU-environment prefixes.

- Before the fix:
  `uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data/builders tests/unit_tests/data/builders/test_direct_hf_split_source_adapter.py`
  — **1 failed, 1 passed**; expected `KeyError: 'train_text'`.
- After the fix, same command — **2 passed**.
- Adjacent adapter coverage:
  `uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data/sources tests/unit_tests/data/sources/test_hf_adapters.py`
  — **21 passed**.
- `git diff --check` — **passed**.
- `UV_NO_SYNC=1 uv run pre-commit run --all-files` — **passed**.

## Scope

This changes only private adapter-argument inheritance for distinct custom sources. It does not change public APIs, adapter selection, named dataset presets, dependencies, or CI configuration.
