### PR TITLE
[model] fix: Preserve distributed context during export

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1541,7 +1541,8 @@ class AutoBridge(Generic[MegatronModelT]):
             raise ImportError("megatron.bridge.training is not available.")
 
         # Export ckpt performs on CPU
-        with temporary_distributed_context(backend="gloo"):
+        model_context = nullcontext() if dist.is_initialized() else temporary_distributed_context(backend="gloo")
+        with model_context:
             # Load the Megatron model
             megatron_model = self.load_megatron_model(megatron_path, wrap_with_ddp=False)
 

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -2035,6 +2035,42 @@ class TestAutoBridge:
                     strict=False,
                 )
 
+    @pytest.mark.skipif(
+        not torch.distributed.is_available() or not torch.distributed.is_gloo_available(),
+        reason="Gloo is required to exercise caller-owned distributed state",
+    )
+    def test_export_ckpt_preserves_existing_distributed_context(self, tmp_path):
+        """Export reuses distributed state owned by its caller."""
+        bridge = AutoBridge.__new__(AutoBridge)
+        mock_megatron_model = [Mock()]
+
+        assert not torch.distributed.is_initialized()
+        torch.distributed.init_process_group(
+            backend="gloo",
+            init_method=f"file://{tmp_path / 'distributed_init'}",
+            rank=0,
+            world_size=1,
+        )
+        try:
+            with (
+                patch.object(bridge, "load_megatron_model", return_value=mock_megatron_model) as mock_load,
+                patch.object(bridge, "save_hf_pretrained") as mock_save,
+            ):
+                bridge.export_ckpt("./megatron_checkpoint", "./hf_export")
+
+            assert torch.distributed.is_initialized()
+            mock_load.assert_called_once_with("./megatron_checkpoint", wrap_with_ddp=False)
+            mock_save.assert_called_once_with(
+                mock_megatron_model,
+                "./hf_export",
+                show_progress=True,
+                source_path=None,
+                strict=False,
+            )
+        finally:
+            if torch.distributed.is_initialized():
+                torch.distributed.destroy_process_group()
+
     def test_export_ckpt_with_kwargs(self):
         """Test export_ckpt with custom kwargs."""
         # Setup mocks


### PR DESCRIPTION
## Summary

- preserve a caller-owned distributed context in `AutoBridge.export_ckpt`
- retain the existing temporary Gloo lifecycle for standalone export
- add a real world-size-one Gloo regression test

## Supported trigger and impact

`AutoBridge.export_ckpt` is a documented one-call export API. If a supported in-process caller already owns the default process group, export unconditionally tries to create another default group and fails before checkpoint loading or Hugging Face saving with:

```text
ValueError: trying to initialize the default process group twice!
```

The focused validated case is world-size-one Gloo, which the downstream CPU checkpoint load path supports. This PR does not claim new multi-rank export topology support.

## Root cause and fix

`export_ckpt` always entered `temporary_distributed_context`, even though adjacent `import_ckpt` and `load_megatron_model` paths reuse caller-owned distributed state. The fix selects `nullcontext()` when distributed is already initialized and otherwise keeps the existing temporary Gloo context.

## Regression evidence

A deterministic private reproducer AST-loaded the exact production definitions and used real PyTorch Gloo while mocking only checkpoint load/save and MCore initialization beyond the failing boundary:

```text
uv run --no-sync python repro_export_ckpt_dist.py .
```

- Before: exit 1 with the duplicate-default-group `ValueError` before load/save.
- After: exit 0; existing caller state remained initialized and load/save were reached.
- Negative control: the same run exercised standalone export and confirmed its temporary group was cleaned up.

The committed unit test encodes the caller-owned-state contract with a real world-size-one Gloo group. Local collection of the full test module was blocked before test execution by unrelated CPU optional-package imports that require CUDA; the exact-source reproducer above was used for local runtime evidence.

## Validation

Passed:

```text
uv run --no-sync python -m py_compile src/megatron/bridge/models/conversion/auto_bridge.py tests/unit_tests/models/test_auto_bridge.py
uv run --no-sync ruff check src/megatron/bridge/models/conversion/auto_bridge.py tests/unit_tests/models/test_auto_bridge.py
uv run --no-sync ruff format --check src/megatron/bridge/models/conversion/auto_bridge.py tests/unit_tests/models/test_auto_bridge.py
git diff --check
uv run --no-sync pre-commit run --all-files
```

No dependency, public signature, CI workflow, checkpoint-format, or multi-rank behavior changes are included.
