### PR TITLE
[ckpt] fix: Keep torch-dist optimizer fresh when state is omitted

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2890,6 +2890,9 @@ def _load_checkpoint_from_path(
         else:
             gen_sd_optim = None
             gen_sd_opt_param_scheduler = None
+            if not release and not cfg.checkpoint.finetune and cfg.checkpoint.load_optim:
+                ignore_optimizer_state = True
+                print_rank_0("Optimizer state was not saved in the torch-dist checkpoint; using a fresh optimizer")
 
         # Determine if rerun state will be loaded
         if tp_pp_match and not release and not cfg.checkpoint.finetune and "rerun_state_machine" in state_dict:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -1628,6 +1628,77 @@ class TestLoadCheckpoint:
         assert result == (0, 0)
         assert optimizer.materialized_step == 0
 
+    def test_torch_dist_omitted_optimizer_keeps_load_state_fresh(self, load_checkpoint_fixtures):
+        """A torch-dist checkpoint without optimizer state must leave load state fresh."""
+        cfg = load_checkpoint_fixtures["mock_cfg"]
+        cfg.checkpoint.ckpt_format = "torch_dist"
+        cfg.checkpoint.load_rng = False
+        cfg.peft = None
+
+        state = load_checkpoint_fixtures["mock_state"]
+        state.train_state.step = 0
+        state.train_state.floating_point_operations_so_far = 0
+
+        optimizer = load_checkpoint_fixtures["mock_optimizer"]
+        optimizer.is_stub_optimizer = False
+        scheduler = load_checkpoint_fixtures["mock_scheduler"]
+        pg_collection = Mock()
+
+        checkpoint_without_optimizer = {"model": {}, "checkpoint_version": 3.0}
+        run_config = {
+            "model": {
+                "tensor_model_parallel_size": 1,
+                "pipeline_model_parallel_size": 1,
+            },
+            "checkpoint": {
+                "save_optim": False,
+                "save_rng": False,
+                "fully_parallel_save": False,
+            },
+        }
+
+        with (
+            patch("megatron.bridge.training.checkpointing.is_hf_checkpoint_dir", return_value=False),
+            patch("megatron.bridge.training.checkpointing.is_checkpoint_iteration_directory", return_value=True),
+            patch("megatron.bridge.training.checkpointing.file_exists", return_value=True),
+            patch("megatron.bridge.training.checkpointing.read_run_config", return_value=run_config),
+            patch("megatron.bridge.training.checkpointing.read_train_state", return_value=state.train_state),
+            patch("megatron.bridge.training.checkpointing.update_num_microbatches"),
+            patch("megatron.bridge.training.checkpointing._get_model_glu_interleave_sizes", return_value=(None, None)),
+            patch("megatron.bridge.training.checkpointing._load_model_state_dict"),
+            patch("megatron.bridge.training.checkpointing.dist_checkpointing.load_content_metadata", return_value={}),
+            patch("megatron.bridge.training.checkpointing.generate_state_dict", return_value={"model": {}}),
+            patch("megatron.bridge.training.checkpointing.torch.distributed.is_initialized", return_value=False),
+            patch("megatron.bridge.training.checkpointing.torch.cuda.empty_cache"),
+            patch("megatron.bridge.training.checkpointing.wandb_utils.on_load_checkpoint_success"),
+            patch("megatron.bridge.training.checkpointing.mlflow_utils.on_load_checkpoint_success"),
+            patch("megatron.bridge.training.checkpointing.comet_utils.on_load_checkpoint_success"),
+            patch(
+                "megatron.bridge.training.checkpointing._load_base_checkpoint",
+                side_effect=[
+                    ({}, "/checkpoints/iter_0000003", False, CheckpointType.GLOBAL),
+                    (
+                        checkpoint_without_optimizer,
+                        "/checkpoints/iter_0000003",
+                        False,
+                        CheckpointType.GLOBAL,
+                    ),
+                ],
+            ),
+        ):
+            result = _load_checkpoint_from_path(
+                "/checkpoints/iter_0000003",
+                state,
+                load_checkpoint_fixtures["mock_model"],
+                optimizer,
+                scheduler,
+                pg_collection=pg_collection,
+            )
+
+        assert result == (0, 0)
+        optimizer.load_state_dict.assert_not_called()
+        scheduler.load_state_dict.assert_not_called()
+
     @patch("torch.distributed.is_initialized")
     @patch("megatron.bridge.training.checkpointing._build_auto_bridge_for_save")
     def test_load_hf_pretrained_checkpoint_initializes_from_hf_source(


### PR DESCRIPTION
## Summary

A supported global `torch_dist` checkpoint saved with `checkpoint.save_optim=False` could not resume with the default `checkpoint.load_optim=True`. The saved run configuration correctly suppressed optimizer and scheduler load scaffolding, but common finalization still attempted `state_dict["optimizer"]` and raised `KeyError` before training resumed.

This is the immediate format sibling of the omitted-optimizer behavior fixed for FSDP in #5680.

## Root cause and fix

The `torch_dist` branch already reads the saved `save_optim` value and passes no optimizer or scheduler producer when those sections were intentionally omitted. Unlike the FSDP branch, it did not mark the common finalization step to keep load state fresh.

The fix sets the existing `ignore_optimizer_state` flag only for a normal training resume where the current config requests optimizer loading but the saved run configuration proves that optimizer state was not saved. Checkpoints that contain optimizer state and explicit `load_optim=False`, finetune, release, and legacy paths retain their existing behavior.

## Validation

The unchanged regression test on audited base `2536afa140a1837e60a4397511bb12fdc995b6b1` failed for the claimed reason:

```text
uv run python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint::test_torch_dist_omitted_optimizer_keeps_load_state_fresh -q --tb=short
# 1 failed: KeyError: 'optimizer'
```

After the fix:

```text
uv run python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint::test_torch_dist_omitted_optimizer_keeps_load_state_fresh -q --tb=short
# 1 passed

uv run python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadCheckpoint -q --tb=short
# 8 passed

uv run python -m pytest tests/unit_tests/training/test_checkpointing.py -k 'omitted_optimizer or includes_optimizer_scaffold_when_loading' -q --tb=short
# 3 passed, 180 deselected

git diff --check
# passed

uv run pre-commit run --all-files
# all hooks passed
```

## Scope

This changes only global `torch_dist` resume when the saved run configuration explicitly records `save_optim=False`. It does not change checkpoint formats, public APIs, strictness, FSDP behavior, legacy checkpoint fallback, distributed ownership, or checkpoint save semantics. No GPU, convergence, model-quality, performance, or full-suite validation is claimed.
