### PR TITLE
[misc] fix: Exclude Qwen image placeholders from sampling

### DIFF
--- a/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
+++ b/src/megatron/bridge/inference/vlm/vlm_inference_controller.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import OrderedDict
+from typing import Any, OrderedDict
 
 import torch
 from megatron.core.inference.inference_request import InferenceRequest
+from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     TextGenerationController,
 )
@@ -97,6 +98,7 @@ class QwenVLTextGenerationController(VLMTextGenerationController):
         super().__init__(inference_wrapped_model, tokenizer, image_processor)
         vision_start_token_id = tokenizer.convert_tokens_to_ids("<|vision_start|>")
         image_token_id = tokenizer.convert_tokens_to_ids("<|image_pad|>")
+        self._image_token_id = image_token_id
 
         class QwenVLTokenizer(TokenizerWrapper):
             # pylint: disable=C0115,C0116
@@ -112,6 +114,29 @@ class QwenVLTextGenerationController(VLMTextGenerationController):
 
         self.tokenizer = QwenVLTokenizer(tokenizer)
         self.processor = processor
+
+    def sample_from_logits(
+        self,
+        last_token_logits: torch.Tensor,
+        sampling_params: SamplingParams | None = None,
+        vocab_size: int | None = None,
+        generation_started: torch.Tensor | None = None,
+        top_n_logprobs_dict: dict[int, list[dict[str, float]]] | None = None,
+        logits: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """Sample while excluding the structural image placeholder token."""
+        sampling_logits = last_token_logits.clone()
+        sampling_logits[..., self._image_token_id] = -torch.inf
+        return super().sample_from_logits(
+            sampling_logits,
+            sampling_params=sampling_params,
+            vocab_size=vocab_size,
+            generation_started=generation_started,
+            top_n_logprobs_dict=top_n_logprobs_dict,
+            logits=logits,
+            **kwargs,
+        )
 
     def tokenize_prompt(self, prompt: str, image):
         """Tokenize with the HF processor (image + text; same idea as hf_to_megatron_generate_vlm)."""

--- a/tests/unit_tests/inference/vlm/test_vlm_inference_controller.py
+++ b/tests/unit_tests/inference/vlm/test_vlm_inference_controller.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from megatron.core.inference.text_generation_controllers.text_generation_controller import TextGenerationController
 
 from megatron.bridge.inference.vlm.vlm_inference_controller import (
     QwenVLTextGenerationController,
@@ -154,6 +155,36 @@ class TestQwenVLTextGenerationController:
 
         with pytest.raises(ValueError, match="processor is required"):
             controller.tokenize_prompt("test", "image")
+
+    def test_sampling_excludes_image_placeholder(self, mock_tokenizer, mock_image_processor):
+        """Keep generated tokens from invalidating the request-owned visual payload."""
+        vision_start_token_id = 200001
+        image_token_id = 200004
+        ordinary_token_id = 7
+        mock_tokenizer.convert_tokens_to_ids.side_effect = {
+            "<|vision_start|>": vision_start_token_id,
+            "<|image_pad|>": image_token_id,
+        }.__getitem__
+
+        with patch.object(VLMTextGenerationController, "__init__", return_value=None):
+            controller = QwenVLTextGenerationController(
+                MagicMock(),
+                mock_tokenizer,
+                mock_image_processor,
+                MagicMock(),
+            )
+
+        logits = torch.full((1, image_token_id + 1), -100.0)
+        logits[0, ordinary_token_id] = 9.0
+        logits[0, image_token_id] = 10.0
+
+        def sample_argmax(_controller, last_token_logits, *_args, **_kwargs):
+            return torch.argmax(last_token_logits, dim=-1)
+
+        with patch.object(TextGenerationController, "sample_from_logits", sample_argmax):
+            sampled = controller.sample_from_logits(logits)
+
+        assert sampled.item() == ordinary_token_id
 
     def test_tokenizer_detokenize_with_special_token_151652(self, controller, mock_tokenizer):
         """Test that token 151652 is followed by 151655 during detokenization."""


### PR DESCRIPTION
# What does this PR do ?

Prevent Qwen2.5-VL and Qwen3-VL generation from sampling the structural `<|image_pad|>` placeholder.

On the supported legacy image-generation path, each decode step sends the accumulated token prefix while
replaying the request's fixed visual payload. If sampling emits `<|image_pad|>` before the last decode step,
the next forward sees more image placeholders than image embeddings: Qwen2.5-VL raises an image
feature/token-count error and Qwen3-VL reaches a mask/embedding shape mismatch.

# Changelog

- Mask the configured Qwen image-placeholder logit at the Qwen controller's sampling boundary.
- Clone the sampling logits so caller-owned logits remain unchanged.
- Add a deterministic regression test that makes the image placeholder the highest logit and verifies an
  ordinary token is sampled instead.

# Validation

Fail before the production change:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/inference/vlm/test_vlm_inference_controller.py::TestQwenVLTextGenerationController::test_sampling_excludes_image_placeholder -q --tb=short
```

Result: `1 failed`; the configured image placeholder (`200004`) was sampled instead of token `7`.

Pass after the production change:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/inference/vlm/test_vlm_inference_controller.py::TestQwenVLTextGenerationController::test_sampling_excludes_image_placeholder -q --tb=short
```

Result: `1 passed`.

Adjacent validation:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/inference/vlm/test_vlm_inference_controller.py tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py tests/unit_tests/inference/vlm/test_vlm_engine.py tests/unit_tests/inference/vlm/test_base.py -q --tb=short
uv run --no-sync pre-commit run --all-files
git diff --check
```

Results: `45 passed`; all pre-commit hooks passed; `git diff --check` passed.

# Scope

This change is limited to Qwen image-placeholder sampling. It does not change public APIs, MCore, video-token
handling, other VLM controllers, or generation architecture.

# GitHub Actions CI

CI will be triggered with `/ok to test` for the submitted commit.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added the focused regression test.
- [x] No documentation update is necessary for this runtime correctness fix.
- [x] This does not change optional-component import behavior.

# Additional Information

No related issue was found.
