### PR TITLE
fix(recipe): resync Moonlight pipeline layout

### DIFF
--- a/src/megatron/bridge/recipes/moonlight/h100/moonlight_16b.py
+++ b/src/megatron/bridge/recipes/moonlight/h100/moonlight_16b.py
@@ -33,9 +33,11 @@ _MOONLIGHT_16B_FINETUNING_UNPADDED_VOCAB_SIZE = 163842
 
 def _moonlight_16b_model_provider() -> MLAModelProvider:
     """Build the Moonlight architecture from its Hugging Face configuration."""
-    return AutoBridge.from_hf_pretrained(
+    model = AutoBridge.from_hf_pretrained(
         _MOONLIGHT_16B_MODEL_ID, revision=_MOONLIGHT_16B_MODEL_REVISION
     ).to_megatron_provider(load_weights=False)
+    model._pipeline_model_parallel_layout_builder = _get_moonlight_pipeline_layout
+    return model
 
 
 def _moonlight_16b_finetuning_model_provider(
@@ -130,7 +132,7 @@ def _apply_moonlight_16b_finetuning_convergence_contract(cfg: ConfigContainer) -
     cfg.ddp.use_distributed_optimizer = True
 
 
-def _get_moonlight_pipeline_layout(pp_size: int, vp_size: int):
+def _get_moonlight_pipeline_layout(pp_size: int, vp_size: int | None):
     """Get pipeline layout for Moonlight-16B based on PP and VP size."""
     map_pp_vp_to_layout = {
         (1, 1): None,
@@ -140,6 +142,7 @@ def _get_moonlight_pipeline_layout(pp_size: int, vp_size: int):
         (2, 2): [["embedding"] + ["decoder"] * 7] + [["decoder"] * 7] * 2 + [["decoder"] * 6 + ["loss"]],
         (4, 2): [["embedding"] + ["decoder"] * 4] + [["decoder"] * 4] * 6 + [["decoder"] * 3 + ["loss"]],
     }
+    vp_size = 1 if vp_size is None else vp_size
     if (pp_size, vp_size) not in map_pp_vp_to_layout:
         raise ValueError(
             f"Invalid PP and VP size: {pp_size} and {vp_size} to infer PP layout "

--- a/tests/unit_tests/recipes/test_moonlight_recipes.py
+++ b/tests/unit_tests/recipes/test_moonlight_recipes.py
@@ -21,12 +21,14 @@
 #
 
 import importlib
+from dataclasses import dataclass
 from typing import Callable
 
 import pytest
 import torch
 
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
+from tests.unit_tests.training.test_run_recipe_qwen3_omni import _load_recipe_runner_module
 
 
 _moonlight_module = importlib.import_module("megatron.bridge.recipes.moonlight")
@@ -76,8 +78,13 @@ def _apply_test_overrides(cfg, name: str):
     return cfg
 
 
+@dataclass(init=False)
 class _FakeMoonlightModelProvider:
     """Fake Moonlight model provider for testing without model I/O."""
+
+    pipeline_model_parallel_size: int = 1
+    virtual_pipeline_model_parallel_size: int | None = None
+    pipeline_model_parallel_layout: object | None = None
 
     def __init__(self, *args, **kwargs):
         # Store all the kwargs that would be passed to the real provider
@@ -110,6 +117,15 @@ class _FakeMoonlightModelProvider:
         self.moe_token_dispatcher_type = "alltoall"
         self.moe_enable_deepep = False
         self.moe_shared_expert_overlap = True
+        self.overlap_moe_expert_parallel_comm = False
+        self.delay_wgrad_compute = False
+        self.gradient_accumulation_fusion = False
+        self.mtp_num_layers = None
+        self.bf16 = False
+        self.fp16 = False
+        self.tp_comm_overlap = False
+        self.use_te_rng_tracker = False
+        self.use_cpu_initialization = False
 
         # Set parallelism defaults if not provided
         if not hasattr(self, "tensor_model_parallel_size"):
@@ -482,6 +498,35 @@ def test_moonlight_16b_legacy_sft_contract_remains_available(monkeypatch: pytest
     assert cfg.model.sequence_parallel is True
     assert cfg.model.vocab_size == 163844
     assert cfg.dataset.offline_packing_specs.pad_seq_to_mult == 4
+
+
+def test_moonlight_pipeline_layout_tracks_supported_runner_override(monkeypatch: pytest.MonkeyPatch):
+    """Recipe-owned layouts must follow supported public pipeline overrides."""
+    from megatron.bridge.recipes.moonlight import moonlight_16b_sft_config
+    from megatron.bridge.recipes.moonlight.h100.moonlight_16b import _get_moonlight_pipeline_layout
+    from megatron.bridge.training import comm_overlap
+    from megatron.bridge.training import config as training_config
+    from megatron.bridge.training.config import runtime_config_update
+    from megatron.bridge.training.utils.omegaconf_utils import process_config_with_overrides
+
+    patch_recipe_module_global(monkeypatch, moonlight_16b_sft_config, "AutoBridge", _FakeBridge)
+    cfg = moonlight_16b_sft_config()
+    recipe_runner, _ = _load_recipe_runner_module()
+    cli_overrides = [
+        "model.pipeline_model_parallel_size=2",
+        "model.virtual_pipeline_model_parallel_size=1",
+    ]
+
+    cfg = process_config_with_overrides(cfg, cli_overrides=cli_overrides)
+    recipe_runner.sync_model_pipeline_layout(cfg, cli_overrides=cli_overrides)
+    monkeypatch.setattr(comm_overlap, "is_te_min_version", lambda _: True)
+    monkeypatch.setattr(training_config, "validate_flex_dispatcher_backend", lambda _: None)
+    monkeypatch.setattr(cfg.optimizer, "finalize", lambda: None)
+    monkeypatch.setenv("WORLD_SIZE", "16")
+    runtime_config_update(cfg)
+
+    assert cfg.data_parallel_size == 8
+    assert cfg.model.pipeline_model_parallel_layout == _get_moonlight_pipeline_layout(2, 1)
 
 
 def test_moonlight_16b_peft_convergence_contract(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Problem

The public recipe runner accepts pipeline-topology overrides and rebuilds recipe-owned layouts before training. Moonlight-16B already defines supported PP/VP layouts, but its provider did not register that builder with the shared runner.

For the supported `moonlight_16b_sft_config` override `model.pipeline_model_parallel_size=2 model.virtual_pipeline_model_parallel_size=1` on 16 ranks, the override and Bridge runtime validation succeed (TP=1, PP=2, CP=1, EP=8, DP=8), but the layout remained `None`. Megatron-Core then tries to split Moonlight's 27 decoder layers evenly across two pipeline stages and fails instead of using the recipe's documented 14/13 split.

## Root cause and fix

`sync_model_pipeline_layout()` can only rebuild a layout when the model provider exposes `_pipeline_model_parallel_layout_builder`. Moonlight's provider omitted that registration even though `_get_moonlight_pipeline_layout()` already owns all supported layouts.

Register the existing builder when constructing the provider and normalize MCore's `None` representation for no virtual pipeline parallelism to VP=1. This matches the established recipe-owned layout contract and adds no topology or API surface.

## Validation

The focused regression applies the real Hydra overrides, invokes the shared runner synchronizer, and completes Bridge runtime configuration validation before checking the resolved layout.

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/test_moonlight_recipes.py -k pipeline_layout_tracks_supported_runner_override -q
base: 1 failed, 15 deselected (layout was None)
fix:  1 passed, 15 deselected

uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/test_moonlight_recipes.py -k "not peft_convergence_contract" -q
15 passed, 1 deselected

uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/test_deepseek_recipes.py tests/unit_tests/recipes/test_glm_45v_recipes.py tests/unit_tests/recipes/kimi_vl/test_kimi_k25_vl.py -k pipeline_layout -q
25 passed, 73 deselected

git diff --check
passed

uv run --no-sync pre-commit run --all-files
all hooks passed
```

## Scope

This change only resynchronizes Moonlight's existing layouts after supported PP/VP overrides. It does not add new layouts, change recipe defaults or public APIs, modify Megatron-Core, or claim model-quality, convergence, performance, GPU, distributed, or full-suite validation.
