### PR TITLE
fix(data): honor explicit prompt column names

### DIFF
--- a/src/megatron/bridge/data/sft_processing.py
+++ b/src/megatron/bridge/data/sft_processing.py
@@ -190,7 +190,10 @@ def normalize_sft_example(
     validate_sft_preprocessing_config(preprocessing)
     row = dict(example)
     canonical_pair = _canonical_prompt_completion_values(row)
-    has_conversation = any(row.get(key) is not None for key in _CONVERSATION_KEYS)
+    conversation_keys = set(_CONVERSATION_KEYS)
+    if isinstance(preprocessing, PromptCompletionSFTPreprocessingConfig):
+        conversation_keys -= {preprocessing.prompt_column, preprocessing.completion_column}
+    has_conversation = any(row.get(key) is not None for key in conversation_keys)
 
     if canonical_pair is not None and has_conversation:
         raise ValueError("SFT rows must select exactly one schema: structured chat or prompt-completion.")

--- a/tests/unit_tests/data/test_sft_processing.py
+++ b/tests/unit_tests/data/test_sft_processing.py
@@ -219,6 +219,17 @@ def test_prompt_completion_rejects_structured_conversation():
         )
 
 
+def test_prompt_completion_honors_explicit_chat_named_text_column():
+    preprocessing = PromptCompletionSFTPreprocessingConfig(
+        prompt_column="messages",
+        completion_column="answer",
+    )
+    row = {"messages": "question", "answer": "answer"}
+    adapted = adapt_hf_dataset([row], adapter_name=None)[0]
+
+    assert normalize_sft_example(adapted, preprocessing) == row
+
+
 def test_prompt_completion_tokenizes_separately_and_masks_prompt():
     tokenizer = _Tokenizer()
     preprocessing = PromptCompletionSFTPreprocessingConfig(


### PR DESCRIPTION
## Summary

Direct Hugging Face SFT lets callers explicitly select raw prompt and completion columns. A valid paired-text source that selects `messages` as an ordinary string prompt column currently fails during normalization, even though the configuration validates and the row does not contain a structured conversation.

## Root cause

`normalize_sft_example()` inferred chat schema from conventional key names before consuming the selected prompt/completion columns. Therefore any non-`None` `messages`, `conversation`, or `conversations` value was treated as structured chat, including a string field explicitly selected as prompt text.

## Fix

Exclude explicitly selected prompt/completion columns from conventional chat-key inference. Other populated chat keys still trigger the existing ambiguity/rejection paths, and genuine structured conversations remain rejected by prompt/completion preprocessing.

## Validation

- Before the fix:
  `uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_sft_processing.py -k 'explicit_chat_named_text_column or rejects_structured_conversation'`
  — **1 failed, 1 passed** with the expected structured-conversation `ValueError`.
- After the fix, the same command — **2 passed**.
- Full focused module:
  `uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_sft_processing.py`
  — **21 passed**.
- Adjacent native adapter coverage:
  `uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data/sources tests/unit_tests/data/sources/test_hf_adapters.py`
  — **21 passed**.
- `git diff --check` — **passed**.
- `UV_NO_SYNC=1 uv run pre-commit run --all-files` — **passed**.

## Scope

This changes only schema classification when a conventional chat key is explicitly selected as a paired-text column. It does not change public APIs, chat preprocessing, native adapter output, multimodal handling, dependencies, or CI configuration. No GPU or distributed validation is needed for this CPU-only normalization contract.
