### PR TITLE
[model] fix: accumulate grouped quantized exports

### DIFF
--- a/src/megatron/bridge/models/conversion/quant_bridge.py
+++ b/src/megatron/bridge/models/conversion/quant_bridge.py
@@ -65,6 +65,7 @@ class MegatronQuantizationBridge:
         embeddings_are_tied = self._share_embeddings_and_output_weights(model_config)
 
         hf_state_dict: Mapping[str, torch.Tensor] = hf_pretrained.state if hasattr(hf_pretrained, "state") else {}
+        grouped_buffers: dict[str, dict[int, torch.Tensor]] = {}
 
         for task in self._with_progress_tracking(
             megatron_to_hf_tasks, "Converting to HuggingFace (Quantized)", show_progress
@@ -72,6 +73,16 @@ class MegatronQuantizationBridge:
             converted_weights_dict = task.mapping.megatron_to_hf_quant(
                 task.param_weight, task.megatron_module, quantization_checker, quant_fn, quant_block_size
             )
+            if getattr(task.mapping, "is_grouped_export", False):
+                converted_weights_dict = self._accumulate_grouped_export(
+                    task,
+                    converted_weights_dict,
+                    model_config,
+                    grouped_buffers,
+                    hf_state_dict,
+                )
+                if converted_weights_dict is None:
+                    continue
             converted_weights_dict = self.maybe_modify_converted_hf_weight(
                 task,
                 converted_weights_dict,

--- a/tests/unit_tests/quantization/test_quant_bridge.py
+++ b/tests/unit_tests/quantization/test_quant_bridge.py
@@ -21,6 +21,7 @@ import torch
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 from megatron.bridge.models.conversion import quant_bridge as quant_bridge_module
+from megatron.bridge.models.conversion.model_bridge import MegatronModelBridge, WeightConversionTask
 from megatron.bridge.models.conversion.param_mapping import (
     AutoMapping,
     ColumnParallelMapping,
@@ -201,6 +202,53 @@ def test_quantized_stream_uses_model_config_for_tied_embeddings(monkeypatch):
 
     assert list(exported) == []
     assert seen_configs == [model_config]
+
+
+def test_quantized_stream_accumulates_grouped_experts(monkeypatch):
+    class GroupedQuantMapping:
+        is_grouped_export = True
+        ep_size = 1
+
+        def megatron_to_hf_quant(self, weight, *_args):
+            return {
+                "model.layers.0.mlp.experts.down_proj": weight,
+                "model.layers.0.mlp.experts.down_proj_scale_inv": weight + 10,
+            }
+
+    model = types.SimpleNamespace(config=types.SimpleNamespace(num_moe_experts=2))
+    bridge = MegatronModelBridge()
+    monkeypatch.setattr(bridge, "_share_embeddings_and_output_weights", lambda _config: False)
+    monkeypatch.setattr(bridge, "_with_progress_tracking", lambda tasks, *_args: tasks)
+    monkeypatch.setattr(quant_bridge_module, "unwrap_model", lambda _models: [model])
+
+    tasks = [
+        WeightConversionTask(
+            param_name=f"decoder.layers.0.mlp.experts.linear_fc2.weight{expert}",
+            global_param_name=f"decoder.layers.0.mlp.experts.linear_fc2.weight{expert}",
+            mapping=GroupedQuantMapping(),
+            megatron_module=types.SimpleNamespace(),
+            param_weight=torch.tensor([[float(expert + 1)]]),
+        )
+        for expert in range(2)
+    ]
+
+    exported = list(
+        bridge.stream_weights_megatron_to_hf_quant(
+            model,
+            types.SimpleNamespace(),
+            quantization_checker=lambda _name: True,
+            quant_fn=lambda weight, _block_size: (weight, weight + 10),
+            conversion_tasks=tasks,
+            show_progress=False,
+        )
+    )
+
+    assert [weight.param_name for weight in exported] == [
+        "model.layers.0.mlp.experts.down_proj",
+        "model.layers.0.mlp.experts.down_proj_scale_inv",
+    ]
+    torch.testing.assert_close(exported[0].weight, torch.tensor([[[1.0]], [[2.0]]]))
+    torch.testing.assert_close(exported[1].weight, torch.tensor([[[11.0]], [[12.0]]]))
 
 
 class TestColumnParallelMappingQuant:


### PR DESCRIPTION
## Summary

Quantized Megatron-to-Hugging Face export emitted one entry per expert for grouped expert mappings. Because all expert tasks map to the same packed Hugging Face key, consumers saw duplicate names and could retain only one expert instead of the complete expert tensor.

The regression is reachable through `AutoBridge.export_hf_weights_quant()` for model bridges using grouped expert mappings, including packed Qwen expert projections. It originated in the quantize-before-resharding path added by #2737.

## Root cause and fix

The ordinary export stream already accumulates grouped expert tasks before yielding them, but the quantized stream yielded each task immediately. Reuse the existing grouped-export accumulator for quantized weight and scale tensors, while leaving non-grouped mappings unchanged.

## Validation

The regression test failed unchanged against the unmodified base:

```text
uv run --no-sync python -m pytest tests/unit_tests/quantization/test_quant_bridge.py::test_quantized_stream_accumulates_grouped_experts -q
```

Result: `1 failed`; the stream contained two extra duplicate weight/scale keys.

The same command passed after the fix: `1 passed`.

Adjacent focused validation:

```text
uv run --no-sync python -m pytest \
  tests/unit_tests/quantization/test_quant_bridge.py::test_quantized_stream_uses_model_config_for_tied_embeddings \
  tests/unit_tests/quantization/test_quant_bridge.py::test_quantized_stream_accumulates_grouped_experts \
  tests/unit_tests/quantization/test_quant_bridge.py::TestColumnParallelMappingQuant \
  tests/unit_tests/quantization/test_quant_bridge.py::TestRowParallelMappingQuant \
  tests/unit_tests/quantization/test_quant_bridge.py::TestReplicatedMappingQuant \
  tests/unit_tests/quantization/test_quant_bridge.py::TestAutoMappingQuant \
  tests/unit_tests/models/test_model_bridge.py::test_stream_weights_megatron_to_hf_transforms_grouped_tensor_once_after_accumulation \
  tests/unit_tests/models/test_model_bridge.py::test_grouped_export_uses_mapping_local_ep_size -q
```

Result: `11 passed`.

```text
git diff --check
uv run --frozen --no-sync pre-commit run --all-files
```

Result: passed.

## Scope

This changes only mappings that explicitly set `is_grouped_export`. It does not change dense or per-expert export, quantization math, model configuration, or public APIs.
