### PR TITLE
[ckpt] fix: Validate custom manager save signature

### DIFF
--- a/docs/fern/versions/nightly/pages/training/checkpointing.mdx
+++ b/docs/fern/versions/nightly/pages/training/checkpointing.mdx
@@ -346,6 +346,7 @@ from megatron.bridge.training.checkpointing import (
     load_checkpoint,
     init_checkpointing_context,
 )
+from megatron.bridge.training.callbacks import CallbackManager
 from megatron.bridge.training.config import CheckpointConfig
 from megatron.bridge.training.state import GlobalState
 
@@ -357,7 +358,7 @@ class MyCheckpointManager:
         # Initialize internal context for caching strategies
         self._context = init_checkpointing_context(checkpoint_config)
 
-    def save(self, ctx: CheckpointSaveContext) -> None:
+    def save(self, ctx: CheckpointSaveContext, callback_manager: CallbackManager | None) -> None:
         """Save a checkpoint with custom logic."""
         # Option 1: Completely custom implementation
         # my_custom_save(ctx.state, ctx.model, ...)
@@ -372,6 +373,7 @@ class MyCheckpointManager:
             checkpointing_context=self._context,
             non_persistent_ckpt=ctx.non_persistent_ckpt,
             train_data_iterator=ctx.train_data_iterator,
+            callback_manager=callback_manager,
         )
         # Add custom post-processing (e.g., upload to cloud)
         upload_to_s3(ctx.state.cfg.checkpoint.save)

--- a/docs/training/checkpointing.md
+++ b/docs/training/checkpointing.md
@@ -407,6 +407,7 @@ from megatron.bridge.training.checkpointing import (
     load_checkpoint,
     init_checkpointing_context,
 )
+from megatron.bridge.training.callbacks import CallbackManager
 from megatron.bridge.training.config import CheckpointConfig
 from megatron.bridge.training.state import GlobalState
 
@@ -419,7 +420,7 @@ class MyCheckpointManager:
         # Initialize internal context for caching strategies
         self._context = init_checkpointing_context(checkpoint_config)
 
-    def save(self, ctx: CheckpointSaveContext) -> None:
+    def save(self, ctx: CheckpointSaveContext, callback_manager: CallbackManager | None) -> None:
         """Save a checkpoint with custom logic."""
         # Option 1: Completely custom implementation
         # my_custom_save(ctx.state, ctx.model, ...)
@@ -434,6 +435,7 @@ class MyCheckpointManager:
             checkpointing_context=self._context,
             non_persistent_ckpt=ctx.non_persistent_ckpt,
             train_data_iterator=ctx.train_data_iterator,
+            callback_manager=callback_manager,
         )
         # Add custom post-processing (e.g., upload to cloud)
         upload_to_s3(ctx.state.cfg.checkpoint.save)

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import gc
+import inspect
 import os
 import random
 import shutil
@@ -822,6 +823,14 @@ def create_checkpoint_manager(checkpoint_config: CheckpointConfig) -> Checkpoint
                 f"Custom checkpoint manager '{checkpoint_config.custom_manager_class}' "
                 f"does not implement the CheckpointManager protocol."
             )
+
+        try:
+            inspect.signature(manager.save).bind(None, None)
+        except (TypeError, ValueError) as err:
+            raise TypeError(
+                f"Custom checkpoint manager '{checkpoint_config.custom_manager_class}' save method "
+                "must accept (ctx, callback_manager)."
+            ) from err
 
         return manager
 

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -4555,7 +4555,7 @@ class TestCheckpointManager:
                 self.checkpoint_config = checkpoint_config
                 self.initialized = True
 
-            def save(self, _ctx):
+            def save(self, _ctx, _callback_manager):
                 pass
 
             def load(self, _ctx):
@@ -4576,6 +4576,30 @@ class TestCheckpointManager:
             assert isinstance(manager, CustomTestManager)
             assert manager.checkpoint_config is config
             assert manager.initialized is True
+
+    def test_create_checkpoint_manager_rejects_incompatible_save_signature(self):
+        """Test custom managers must accept the callback manager used by training saves."""
+
+        class CustomTestManager:
+            def __init__(self, _checkpoint_config):
+                pass
+
+            def save(self, _ctx):
+                pass
+
+            def load(self, _ctx):
+                return (0, 0)
+
+            def finalize_async_saves(self, _state, blocking=False, terminate=False):
+                pass
+
+        with patch("importlib.import_module") as mock_import:
+            mock_module = Mock(CustomTestManager=CustomTestManager)
+            mock_import.return_value = mock_module
+            config = CheckpointConfig(custom_manager_class="megatron.bridge.test.CustomTestManager")
+
+            with pytest.raises(TypeError, match="save"):
+                create_checkpoint_manager(config)
 
     def test_default_checkpoint_manager_init(self):
         """Test DefaultCheckpointManager initialization."""


### PR DESCRIPTION
## What changed

Custom checkpoint managers are now rejected during factory construction when their bound `save` method cannot accept the `(ctx, callback_manager)` arguments used by training. The public custom-manager examples and their nightly documentation mirror now accept and forward `callback_manager`.

## Supported trigger and impact

A manager implemented from the published example defined `save(self, ctx)`. Python's runtime-checkable protocol accepted that class because it checks member presence rather than callable signatures. Standard and MegatronMIMO training then called `save(ctx, callback_manager)` at the first interval, terminal, signal, duration, non-persistent, or exit checkpoint and raised an arity `TypeError`.

This could let training run until its first save before aborting without producing the intended checkpoint.

The regression was introduced when the checkpoint callback argument was added in #2905 after the custom-manager interface was introduced in #1955.

## Root cause and minimal fix

`create_checkpoint_manager()` advertised a `TypeError` for protocol-incompatible managers, but `isinstance(..., CheckpointManager)` could not validate method signatures. The factory now bind-checks the configured manager's bound `save` method against exactly the two positional arguments supplied by the shared training consumer. This keeps the failure at setup time and does not change the public protocol or training call sites.

## Validation

Fail-before on unmodified `main`:

```text
uv run --frozen --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestCheckpointManager::test_create_checkpoint_manager_rejects_incompatible_save_signature -q --tb=short

1 failed: Failed: DID NOT RAISE <class 'TypeError'>
```

Pass-after:

```text
uv run --frozen --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestCheckpointManager::test_create_checkpoint_manager_rejects_incompatible_save_signature -q --tb=short

1 passed
```

Focused and adjacent:

```text
uv run --frozen --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestCheckpointManager tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestSetupMegatronMIMOCheckpointLoading::test_load_dispatches_through_custom_checkpoint_manager -q --tb=short

18 passed
```

- `git diff --check`: passed
- `uv run --no-sync pre-commit run --all-files`: passed

## Scope

This only validates the save-call arity exercised by standard and MegatronMIMO training. It does not add a new checkpoint format, change load discovery, alter custom backend limitations, or claim GPU/convergence validation.
