### PR TITLE
docs(model-card): add Nemotron 3 Nano performance evidence

### DIFF
--- a/examples/model_verification_cards/nemotron-3-nano-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/nemotron-3-nano-30b-a3b/card.yaml
@@ -1,0 +1,212 @@
+# Agent-readable model verification card.
+# status: unverified | verified | unsupported | not_applicable
+
+title: nemotron_3_nano_30b_a3b
+summary: >
+  Performance scope: pretrain_performance.GB300 uses the tuned canonical
+  8-GPU MXFP8 recipe. Model-level and functional training workflows remain
+  unverified in this card.
+verification_index:
+  model_level:
+    unverified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+      - inference
+  training:
+    H100:
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+  performance:
+    GB300: verified
+model:
+  hf_id: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  hf_revision: 2d59de1cbd51c0adf384eb906b766d1aee0e0517  # pragma: allowlist secret
+  architecture: NemotronHForCausalLM
+  min_transformers_version: "5.8.1"
+verification_environment:
+  base_container: nvcr.io/nvidia/nemo:26.08
+  bridge_commit: bc09410353986ac7255ffd31fb2b720fb9007107  # pragma: allowlist secret
+
+items:
+  hf_to_megatron_cpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  hf_to_megatron_gpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  megatron_to_hf_cpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  megatron_to_hf_gpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  manual_forward_pass:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  inference:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  pretrain:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  sft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  sft_export_inference:
+    H100:
+      status: unverified
+      precision: bf16
+      commands: null
+      last_verified: null
+      depends_on: sft
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  sft_long_context:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  peft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  checkpoint_resume:
+    H100:
+      status: unverified
+      precision: bf16
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      depends_on: pretrain
+      resume_comparison:
+        reference_item: pretrain
+        sentinel_steps: [51, 100]
+        loss_relative_tolerance: 1.0e-2
+        loss_absolute_tolerance: 1.0e-6
+        sentinels_match: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  pretrain_performance:
+    GB300:
+      status: verified
+      precision: fp8_mx
+      bridge_commit: 0480586879f2513958fd8634fc529693ae13e536  # pragma: allowlist secret
+      command: >
+        ./scripts/training/train.sh --wait --nodes 2 --gpus-per-node 4
+        --recipe nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config
+        --mode pretrain --max_steps 50 --seq_length 8192
+        logger.save_config_filepath=work/model-verification/nemotron-3-nano-30b-a3b/gb300-performance/ConfigContainer.yaml
+      last_verified: 2026-08-18
+      metrics:
+        initial_loss: 12.18025
+        final_loss: 0.004964447
+        last_10_steps_step_time_ms_avg: 12455.140
+        last_10_steps_model_tflops_per_gpu_avg: 937.770
+        last_10_steps_tokens_per_second_per_gpu_avg: 42094.107
+      expected_result: >
+        On exactly 8 GB300s, the canonical MXFP8 mock-data recipe completes
+        exactly 50 optimizer steps at TP1/PP1/CP1/EP8/ETP1, GBS/MBS 512/4,
+        and sequence length 8192. All 50 keyed rows have finite loss with zero
+        skipped or NaN iterations. Loss moves from 12.18025 to 0.004964447;
+        the final ten steps average 12455.140 ms, 937.770 TFLOP/s/GPU, and
+        42094.107 tokens/s/GPU. The resolved configuration persists.

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -54,6 +54,7 @@ TRAINING_THROUGHPUT_INPUTS = {
     ("nemotron-3-nano-4b", "sft_long_context", "H100"): (32768, 8, 8),
     ("nemotron-3-nano-4b", "peft", "H100"): (2048, 32, 8),
     ("nemotron-3-nano-4b", "checkpoint_resume", "H100"): (4096, 1024, 8),
+    ("nemotron-3-nano-30b-a3b", "pretrain_performance", "GB300"): (8192, 512, 8),
     ("nemotron-3-nano-omni-30b-a3b-reasoning", "sft", "H100"): (4096, 64, 16),
     ("nemotron-3-nano-omni-30b-a3b-reasoning", "peft", "H100"): (4096, 64, 8),
     ("nemotron-3-super-120b-a12b", "pretrain", "H100"): (4096, 1280, 64),


### PR DESCRIPTION
## Summary

- add the Nemotron 3 Nano 30B-A3B verification card with verified GB300 MXFP8 performance evidence
- leave model-level and functional training workflows explicitly unverified
- register the audited throughput inputs in the validator test

## Evidence

- Tracking: https://linear.app/nvidia/issue/MB-1361
- Successful CI job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/403061875
- Megatron Bridge commit: `0480586879f2513958fd8634fc529693ae13e536`
- Final-10: 12455.140 ms, 937.770 TFLOP/s/GPU, 42094.107 tokens/s/GPU

The artifact contains exactly 50 optimizer-step rows, finite loss from 12.18025 to 0.004964447, zero skipped/NaN iterations, and the resolved ConfigContainer.

## Validation

- model-card validator
- 38 targeted validator tests
- `pre-commit run --all-files`
- `git diff --check`