### PR TITLE
docs(model-card): verify Qwen3 30B-A3B GB300 performance

### DIFF
--- a/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
+++ b/examples/model_verification_cards/qwen3-30b-a3b/card.yaml
@@ -4,9 +4,10 @@
 title: qwen3_30b_a3b
 summary: >
   Performance scope: pretrain_performance.H100 and pretrain_performance.GB200
-  use tuned canonical performance recipes; timing and throughput metrics from
-  functional training items remain sanity checks rather than optimized
-  performance results.
+  and pretrain_performance.GB300 use tuned canonical performance recipes;
+  timing and throughput metrics from functional
+  training items remain sanity checks rather than optimized performance
+  results.
   Weak-scaling scope: pretrain_weak_scaling.GB300 records measured scaling
   from 8 through 256 GPUs with constant token slots per GPU per step.
   Qwen3-30B-A3B support verification covers conversion, inference, and training.
@@ -28,6 +29,7 @@ verification_index:
   performance:
     H100: verified
     GB200: verified
+    GB300: verified
   weak_scaling:
     GB300: verified
 model:
@@ -558,6 +560,30 @@ items:
         load balancing, HybridEP, MXFP8, and full-iteration CUDA graphs. Over
         steps 41-50, the run averages at most 7 seconds per step and at least
         900 model TFLOP/s/GPU.
+
+    GB300:
+      status: verified
+      precision: fp8_mx
+      bridge_commit: 0480586879f2513958fd8634fc529693ae13e536  # pragma: allowlist secret
+      command: >
+        ./scripts/training/train.sh --wait --nodes 2 --gpus-per-node 4
+        --recipe qwen3_30b_a3b_pretrain_8gpu_gb300_fp8mx_config
+        --mode pretrain --max_steps 50 --seq_length 4096
+        logger.save_config_filepath=work/model-verification/qwen3-30b-a3b/gb300-performance/ConfigContainer.yaml
+      last_verified: 2026-08-18
+      metrics:
+        initial_loss: 12.34753
+        final_loss: 8.125566
+        last_10_steps_step_time_ms_avg: 5854.910
+        last_10_steps_model_tflops_per_gpu_avg: 1030.070
+        last_10_steps_tokens_per_second_per_gpu_avg: 44773.361
+      expected_result: >
+        On exactly 8 GB300s, the canonical MXFP8 mock-data recipe completes
+        exactly 50 optimizer steps at TP1/PP1/CP1/EP8/ETP1, GBS/MBS 512/8,
+        and sequence length 4096. All 50 keyed rows have finite loss with zero
+        skipped or NaN iterations. Loss moves from 12.34753 to 8.125566; the
+        final ten steps average 5854.910 ms, 1030.070 TFLOP/s/GPU, and
+        44773.361 tokens/s/GPU. The resolved configuration persists.
 
   pretrain_weak_scaling:
     GB300:

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -84,6 +84,7 @@ TRAINING_THROUGHPUT_INPUTS = {
     ("qwen3-30b-a3b", "checkpoint_resume", "GB200"): (4096, 512, 8),
     ("qwen3-30b-a3b", "pretrain_performance", "H100"): (4096, 1024, 16),
     ("qwen3-30b-a3b", "pretrain_performance", "GB200"): (4096, 512, 8),
+    ("qwen3-30b-a3b", "pretrain_performance", "GB300"): (4096, 512, 8),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 8): (4096, 512, 8),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 32): (4096, 2048, 32),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 128): (4096, 8192, 128),


### PR DESCRIPTION
## Summary

- add verified GB300 MXFP8 performance evidence to the Qwen3 30B-A3B model card
- record 50-step loss, step-time, TFLOP/s/GPU, and token-slot throughput metrics
- register the audited throughput inputs in the validator test

## Evidence

- Tracking: https://linear.app/nvidia/issue/MB-1361
- Successful CI job: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/403061894
- Megatron Bridge commit: `0480586879f2513958fd8634fc529693ae13e536`
- Final-10: 5854.910 ms, 1030.070 TFLOP/s/GPU, 44773.361 tokens/s/GPU

The artifact contains exactly 50 optimizer-step rows, finite loss from 12.34753 to 8.125566, zero skipped/NaN iterations, and the resolved ConfigContainer.

## Validation

- model-card validator
- 38 targeted validator tests
- `pre-commit run --all-files`
- `git diff --check`