### PR TITLE
docs: add Qwen3 235B performance verification

### DIFF
--- a/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
+++ b/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
@@ -1,0 +1,235 @@
+# Agent-readable model verification card.
+# status: unverified | verified | unsupported | not_applicable
+
+title: qwen3_235b_a22b
+summary: >
+  Performance scope: pretrain_performance.GB200 is verified with the tuned
+  canonical 256-GPU MXFP8 recipe, while pretrain_performance.GB300 is being
+  verified with its matching recipe. Model-level and functional training
+  workflows remain unverified in this card.
+verification_index:
+  model_level:
+    unverified:
+      - hf_to_megatron_cpu
+      - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
+      - manual_forward_pass
+      - inference
+  training:
+    H100:
+      unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+  performance:
+    GB300: unverified
+    GB200: verified
+model:
+  hf_id: Qwen/Qwen3-235B-A22B
+  hf_revision: 8efa61729e24bd65b1d152b5ab5409052aa80e65  # pragma: allowlist secret
+  architecture: Qwen3MoeForCausalLM
+  min_transformers_version: "5.8.1"
+verification_environment:
+  base_container: nvcr.io/nvidia/nemo:26.08
+  bridge_commit: bc09410353986ac7255ffd31fb2b720fb9007107  # pragma: allowlist secret
+
+items:
+  hf_to_megatron_cpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  hf_to_megatron_gpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  megatron_to_hf_cpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  megatron_to_hf_gpu:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  manual_forward_pass:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  inference:
+    status: unverified
+    precision: bf16
+    command: null
+    last_verified: null
+    expected_result: >
+      This workflow remains unverified and requires a public run against the
+      pinned Hugging Face revision with all applicable verification gates.
+
+  pretrain:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  sft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  sft_export_inference:
+    H100:
+      status: unverified
+      precision: bf16
+      commands: null
+      last_verified: null
+      depends_on: sft
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  sft_long_context:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  peft:
+    H100:
+      status: unverified
+      precision: bf16
+      enabled_features: {}
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  checkpoint_resume:
+    H100:
+      status: unverified
+      precision: bf16
+      command: null
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      depends_on: pretrain
+      resume_comparison:
+        reference_item: pretrain
+        sentinel_steps: [51, 100]
+        loss_relative_tolerance: 1.0e-2
+        loss_absolute_tolerance: 1.0e-6
+        sentinels_match: null
+      expected_result: >
+        This workflow remains unverified and requires a bounded public run with
+        the model's pinned revision and all applicable verification gates.
+
+  pretrain_performance:
+    GB300:
+      status: unverified
+      precision: fp8_mx
+      command: >
+        ./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4
+        --recipe qwen3_235b_a22b_pretrain_256gpu_gb300_fp8mx_config
+        --mode pretrain --max_steps 50 --seq_length 4096
+        logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/gb300-performance/ConfigContainer.yaml
+      last_verified: null
+      metrics:
+        initial_loss: null
+        final_loss: null
+        last_10_steps_step_time_ms_avg: null
+        last_10_steps_model_tflops_per_gpu_avg: null
+        last_10_steps_tokens_per_second_per_gpu_avg: null
+      expected_result: >
+        The canonical 256-GPU GB300 MXFP8 recipe must complete exactly 50
+        optimizer steps with finite loss, no skipped or NaN iterations, all
+        five metrics, and a persisted resolved configuration.
+
+    GB200:
+      status: verified
+      precision: fp8_mx
+      bridge_commit: 0480586879f2513958fd8634fc529693ae13e536  # pragma: allowlist secret
+      command: >
+        ./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4
+        --recipe qwen3_235b_a22b_pretrain_256gpu_gb200_fp8mx_config
+        --mode pretrain --max_steps 50 --seq_length 4096
+        logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/gb200-performance/ConfigContainer.yaml
+      last_verified: 2026-08-19
+      metrics:
+        initial_loss: 12.75152
+        final_loss: 8.126326
+        last_10_steps_step_time_ms_avg: 17905.340
+        last_10_steps_model_tflops_per_gpu_avg: 1083.660
+        last_10_steps_tokens_per_second_per_gpu_avg: 7320.274
+      expected_result: >
+        On exactly 256 GB200s, the canonical MXFP8 mock-data recipe completes
+        exactly 50 optimizer steps at TP1/PP8/CP1/EP32/ETP1, VPP3, GBS/MBS
+        8192/1, and sequence length 4096. All 50 keyed rows have finite loss
+        with zero skipped or NaN iterations. Loss moves from 12.75152 to
+        8.126326; the final ten steps average 17905.340 ms, 1083.660
+        TFLOP/s/GPU, and 7320.274 tokens/s/GPU. The resolved configuration
+        persists.

--- a/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
+++ b/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
@@ -3,10 +3,9 @@
 
 title: qwen3_235b_a22b
 summary: >
-  Performance scope: pretrain_performance.GB200 is verified with the tuned
-  canonical 256-GPU MXFP8 recipe, while pretrain_performance.GB300 is being
-  verified with its matching recipe. Model-level and functional training
-  workflows remain unverified in this card.
+  Performance scope: pretrain_performance.GB200 and pretrain_performance.GB300
+  are verified with their tuned canonical 256-GPU MXFP8 recipes. Model-level
+  and functional training workflows remain unverified in this card.
 verification_index:
   model_level:
     unverified:
@@ -20,7 +19,7 @@ verification_index:
     H100:
       unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
   performance:
-    GB300: unverified
+    GB300: verified
     GB200: verified
 model:
   hf_id: Qwen/Qwen3-235B-A22B
@@ -190,24 +189,28 @@ items:
 
   pretrain_performance:
     GB300:
-      status: unverified
+      status: verified
       precision: fp8_mx
+      bridge_commit: fbb7570cf7eec94fd2e6064454d84f7fad07fbfa  # pragma: allowlist secret
       command: >
         ./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4
         --recipe qwen3_235b_a22b_pretrain_256gpu_gb300_fp8mx_config
         --mode pretrain --max_steps 50 --seq_length 4096
         logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/gb300-performance/ConfigContainer.yaml
-      last_verified: null
+      last_verified: 2026-08-17
       metrics:
-        initial_loss: null
-        final_loss: null
-        last_10_steps_step_time_ms_avg: null
-        last_10_steps_model_tflops_per_gpu_avg: null
-        last_10_steps_tokens_per_second_per_gpu_avg: null
+        initial_loss: 12.75473
+        final_loss: 8.126335
+        last_10_steps_step_time_ms_avg: 14920.840
+        last_10_steps_model_tflops_per_gpu_avg: 1300.440
+        last_10_steps_tokens_per_second_per_gpu_avg: 8784.492
       expected_result: >
-        The canonical 256-GPU GB300 MXFP8 recipe must complete exactly 50
-        optimizer steps with finite loss, no skipped or NaN iterations, all
-        five metrics, and a persisted resolved configuration.
+        On exactly 256 GB300s, the canonical MXFP8 mock-data recipe completes
+        exactly 50 optimizer steps at TP1/PP4/CP1/EP32/ETP1, GBS/MBS 8192/2,
+        and sequence length 4096. All 50 keyed rows have finite loss with zero
+        skipped or NaN iterations. Loss moves from 12.75473 to 8.126335; the
+        final ten steps average 14920.840 ms, 1300.440 TFLOP/s/GPU, and
+        8784.492 tokens/s/GPU. The resolved configuration persists.
 
     GB200:
       status: verified

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -88,6 +88,7 @@ TRAINING_THROUGHPUT_INPUTS = {
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 32): (4096, 2048, 32),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 128): (4096, 8192, 128),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 256): (4096, 16384, 256),
+    ("qwen3-235b-a22b", "pretrain_performance", "GB300"): (4096, 8192, 256),
     ("qwen3-235b-a22b", "pretrain_performance", "GB200"): (4096, 8192, 256),
     ("qwen3-8b", "pretrain", "H100"): (4096, 1024, 16),
     ("qwen3-8b", "sft", "H100"): (2048, 32, 4),

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -88,6 +88,7 @@ TRAINING_THROUGHPUT_INPUTS = {
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 32): (4096, 2048, 32),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 128): (4096, 8192, 128),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 256): (4096, 16384, 256),
+    ("qwen3-235b-a22b", "pretrain_performance", "GB200"): (4096, 8192, 256),
     ("qwen3-8b", "pretrain", "H100"): (4096, 1024, 16),
     ("qwen3-8b", "sft", "H100"): (2048, 32, 4),
     ("qwen3-8b", "sft_long_context", "H100"): (32768, 8, 8),


### PR DESCRIPTION
## What does this PR do?

Adds the Qwen3 235B-A22B model verification card and records verified pretraining-performance results from the canonical 256-GPU MXFP8 recipes.

- GB300: 14,920.840 ms/step, 1,300.440 model TFLOPS/GPU, 8,784.492 tokens/s/GPU; loss 12.75473 -> 8.126335
- GB200: 17,905.340 ms/step, 1,083.660 model TFLOPS/GPU, 7,320.274 tokens/s/GPU; loss 12.75152 -> 8.126326

Tracking: [MB-1361](https://linear.app/nvidia/issue/MB-1361/verify-missing-model-card-performance-numbers-for-2608-recipes)
Evidence: [GB300 job 400075099](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/400075099), [GB200 job 403061897](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/403061897)

## Testing

- Card schema validator
- 38 focused model-card validator tests
- `pre-commit run --all-files`
- `git diff --check`
