### PR TITLE
ci(docker): make the fw_base vLLM wheel build optional

### DIFF
--- a/docker/Dockerfile.fw_base
+++ b/docker/Dockerfile.fw_base
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 # Build layer variables
-# Supported mode: FW_DEP_BUILDER=base, FW_BASE_FINAL=fw_toolkit_builder
+# Supported mode: FW_DEP_BUILDER=base, FW_BASE_FINAL=fw_toolkit_builder,
+# VLLM_WHEEL_SRC=vllm_wheel_build|vllm_wheel_none
 # TRT-LLM stages are not present in this Dockerfile.
 ARG FW_DEP_BUILDER
 ARG FW_BASE_FINAL
+ARG VLLM_WHEEL_SRC=vllm_wheel_build
 
 ARG NEMO_FW_BASE_IMAGE
 FROM ${NEMO_FW_BASE_IMAGE} AS base
@@ -31,7 +33,7 @@ ENV NVIDIA_PRODUCT_NAME="NeMo Framework" \
 ##
 ##############################################################################
 
-FROM base AS vllm_wheel
+FROM base AS vllm_wheel_build
 
 ARG VLLM_VERSION=v0.14.1
 ARG MAX_JOBS=4
@@ -46,6 +48,13 @@ RUN mkdir -p /src/vllm && \
     python use_existing_torch.py && \
     pip install -r requirements/build/cuda.txt && \
     pip wheel --no-deps --no-build-isolation -v .
+
+# /src/vllm must exist for the install step's bind mount.
+FROM base AS vllm_wheel_none
+
+RUN mkdir -p /src/vllm
+
+FROM ${VLLM_WHEEL_SRC} AS vllm_wheel
 
 ##############################################################################
 ##
@@ -127,10 +136,14 @@ RUN --mount=type=bind,source=docker/common/install_nsys.sh,target=/opt/install_n
 # Copy Wheels
 RUN --mount=type=bind,from=vllm_wheel,source=/src/vllm/,target=/tmp/vllm/ \
     --mount=type=bind,source=docker/patches/vllm.patch,target=/opt/vllm.patch \
+    if ! compgen -G "/tmp/vllm/vllm*.whl" >/dev/null; then \
+    echo "No vLLM wheel produced; skipping vLLM install."; \
+    else \
     pip install /tmp/vllm/vllm*.whl && \
     pushd /usr/local/lib/python3.12/dist-packages/vllm && \
     patch -p1 < /opt/vllm.patch && \
-    popd
+    popd; \
+    fi
 
 ##############################################################################
 ##

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,6 +132,7 @@ docker build \
 | `FW_BASE_FINAL` | Output stage. `trtllm_install` (with TRT-LLM) or `fw_toolkit_builder` (without) |
 | `UV_VERSION` | uv version to install |
 | `VLLM_VERSION` | vLLM git tag to build |
+| `VLLM_WHEEL_SRC` | Stage supplying the vLLM wheel. `vllm_wheel_build` (default) builds it from source; `vllm_wheel_none` skips both the build and the install |
 | `TRT_LLM_COMMIT` | TensorRT-LLM git commit or tag |
 | `TRT_LLM_VERSION` | TensorRT-LLM version string embedded as an image environment variable |
 | `TRT_VER` | TensorRT version for the TRT-LLM install scripts |


### PR DESCRIPTION
# What does this PR do ?

Makes the from-source vLLM wheel build in `Dockerfile.fw_base` selectable, so a base image whose toolchain cannot compile vLLM can still produce an fw-base image.

# Changelog

- Add global `ARG VLLM_WHEEL_SRC` (default `vllm_wheel_build`) that selects the stage supplying the vLLM wheel, mirroring the existing `FW_DEP_BUILDER` / `FW_BASE_FINAL` stage selection.
- Rename the build stage to `vllm_wheel_build` and add `vllm_wheel_none`, which supplies no wheel; `vllm_wheel` is now an alias for the selected stage, so `--target vllm_wheel` and the install step's bind mount are unchanged.
- Skip the `pip install` + `vllm.patch` step when no wheel is present.

Default behavior is unchanged: a build that does not pass `VLLM_WHEEL_SRC` still compiles vLLM from source.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? — not applicable; this changes the build graph only, and both paths are exercised by the fw-base image builds in NeMo-CI.
- [x] Did you add or update any necessary documentation? — added `VLLM_WHEEL_SRC` to the `Dockerfile.fw_base` build-argument reference in `docker/README.md`.
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) — vLLM becomes optional in fw-base when `VLLM_WHEEL_SRC=vllm_wheel_none`.
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- Consumer: NeMo-CI passes `--build-arg VLLM_WHEEL_SRC` from `FW_BASE_BUILD_ARGS` and sets `vllm_wheel_none` for the Rubin build profile, whose preview CUDA toolkit cannot compile vLLM's FlashAttention-3 sm90a kernels.

