### PR TITLE
fix(data): use Energon validation recipe for val split

### DIFF
--- a/src/megatron/bridge/data/energon/base_energon_datamodule.py
+++ b/src/megatron/bridge/data/energon/base_energon_datamodule.py
@@ -16,7 +16,7 @@ import logging
 from typing import Any, Literal, Optional
 
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.energon import WorkerConfig, get_savable_loader, get_train_dataset
+from megatron.energon import WorkerConfig, get_savable_loader, get_train_dataset, get_val_dataset
 
 
 logger = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ class EnergonMultiModalDataModule:
         and batching samples for validation. Defaults to None and will be the same as task_encoder.
         pg_collection (ProcessGroupCollection, optional): Process group collection for distributed training.
         If provided, used instead of the global parallel_state. Defaults to None.
-        **kwargs: Additional keyword arguments. Will be passed to get_train_dataset() of Energon
+        **kwargs: Additional keyword arguments passed to the selected Energon dataset builder.
         """
 
         super().__init__()
@@ -171,23 +171,28 @@ class EnergonMultiModalDataModule:
             raise ValueError("Invalid value for split. Allowed values are 'train' or 'val'.")
 
         if split == "train":
-            task_encoder = self.task_encoder
-        else:
-            task_encoder = self.validation_task_encoder
+            return get_train_dataset(
+                self.path,
+                batch_size=self.micro_batch_size,
+                task_encoder=self.task_encoder,
+                worker_config=worker_config,
+                packing_buffer_size=self.packing_buffer_size,
+                split_part="train",
+                shuffle_buffer_size=self.shuffle_buffer_size,
+                max_samples_per_sequence=self.max_samples_per_sequence,
+                **self.kwargs,
+            )
 
-        _dataset = get_train_dataset(
+        return get_val_dataset(
             self.path,
             batch_size=self.micro_batch_size,
-            task_encoder=task_encoder,
+            task_encoder=self.validation_task_encoder,
             worker_config=worker_config,
             packing_buffer_size=self.packing_buffer_size,
-            split_part=split,
-            shuffle_buffer_size=self.shuffle_buffer_size,
+            split_part="val",
             max_samples_per_sequence=self.max_samples_per_sequence,
             **self.kwargs,
         )
-
-        return _dataset
 
     def build(self):
         return self.train_dataloader(), self.val_dataloader()

--- a/src/megatron/bridge/data/energon/base_energon_datamodule.py
+++ b/src/megatron/bridge/data/energon/base_energon_datamodule.py
@@ -17,7 +17,7 @@ import logging
 from typing import Any, Callable, Literal, Optional
 
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.energon import Sample, WorkerConfig, get_savable_loader, get_train_dataset
+from megatron.energon import Sample, WorkerConfig, get_savable_loader, get_train_dataset, get_val_dataset
 from megatron.energon import dataset_config as _energon_dataset_config
 from megatron.energon.epathlib import EPath
 from megatron.energon.flavors.webdataset.default_generic_webdataset import DefaultGenericWebdatasetFactory
@@ -229,7 +229,7 @@ class EnergonMultiModalDataModule:
         and batching samples for validation. Defaults to None and will be the same as task_encoder.
         pg_collection (ProcessGroupCollection, optional): Process group collection for distributed training.
         If provided, used instead of the global parallel_state. Defaults to None.
-        **kwargs: Additional keyword arguments. Will be passed to get_train_dataset() of Energon
+        **kwargs: Additional keyword arguments passed to the selected Energon dataset builder.
         """
 
         super().__init__()
@@ -312,23 +312,28 @@ class EnergonMultiModalDataModule:
             raise ValueError("Invalid value for split. Allowed values are 'train' or 'val'.")
 
         if split == "train":
-            task_encoder = self.task_encoder
-        else:
-            task_encoder = self.validation_task_encoder
+            return get_train_dataset(
+                self.path,
+                batch_size=self.micro_batch_size,
+                task_encoder=self.task_encoder,
+                worker_config=worker_config,
+                packing_buffer_size=self.packing_buffer_size,
+                split_part="train",
+                shuffle_buffer_size=self.shuffle_buffer_size,
+                max_samples_per_sequence=self.max_samples_per_sequence,
+                **self.kwargs,
+            )
 
-        _dataset = get_train_dataset(
+        return get_val_dataset(
             self.path,
             batch_size=self.micro_batch_size,
-            task_encoder=task_encoder,
+            task_encoder=self.validation_task_encoder,
             worker_config=worker_config,
             packing_buffer_size=self.packing_buffer_size,
-            split_part=split,
-            shuffle_buffer_size=self.shuffle_buffer_size,
+            split_part="val",
             max_samples_per_sequence=self.max_samples_per_sequence,
             **self.kwargs,
         )
-
-        return _dataset
 
     def build(self):
         return self.train_dataloader(), self.val_dataloader()

--- a/tests/functional_tests/test_groups/data/energon/test_base_energon_datamodule.py
+++ b/tests/functional_tests/test_groups/data/energon/test_base_energon_datamodule.py
@@ -105,12 +105,14 @@ class TestEnergonMultiModalDataModuleFunctional:
         since we don't have a real Energon dataset available in this environment.
         """
         with (
-            patch("megatron.bridge.data.energon.base_energon_datamodule.get_train_dataset") as mock_get_dataset,
+            patch("megatron.bridge.data.energon.base_energon_datamodule.get_train_dataset") as mock_get_train_dataset,
+            patch("megatron.bridge.data.energon.base_energon_datamodule.get_val_dataset") as mock_get_val_dataset,
             patch("megatron.bridge.data.energon.base_energon_datamodule.get_savable_loader") as mock_get_loader,
         ):
             # Setup dataset mock
             mock_dataset = MagicMock()
-            mock_get_dataset.return_value = mock_dataset
+            mock_get_train_dataset.return_value = mock_dataset
+            mock_get_val_dataset.return_value = mock_dataset
 
             # Setup loader mock
             mock_loader_instance = MagicMock()
@@ -122,7 +124,8 @@ class TestEnergonMultiModalDataModuleFunctional:
             mock_get_loader.return_value = mock_loader_instance
 
             yield {
-                "get_train_dataset": mock_get_dataset,
+                "get_train_dataset": mock_get_train_dataset,
+                "get_val_dataset": mock_get_val_dataset,
                 "get_savable_loader": mock_get_loader,
                 "loader_instance": mock_loader_instance,
             }
@@ -183,13 +186,15 @@ class TestEnergonDataModuleCPHandling:
 
     @pytest.fixture
     def mock_energon(self):
-        """Mock energon dependencies (get_train_dataset, get_savable_loader)."""
+        """Mock Energon dataset builders and loader creation."""
         with (
-            patch(f"{self.MODULE_PATH}.get_train_dataset") as mock_get_dataset,
+            patch(f"{self.MODULE_PATH}.get_train_dataset") as mock_get_train_dataset,
+            patch(f"{self.MODULE_PATH}.get_val_dataset") as mock_get_val_dataset,
             patch(f"{self.MODULE_PATH}.get_savable_loader") as mock_get_loader,
         ):
             mock_dataset = MagicMock()
-            mock_get_dataset.return_value = mock_dataset
+            mock_get_train_dataset.return_value = mock_dataset
+            mock_get_val_dataset.return_value = mock_dataset
 
             mock_loader = MagicMock()
             mock_data = [{"id": i} for i in range(10)]
@@ -198,7 +203,8 @@ class TestEnergonDataModuleCPHandling:
             mock_get_loader.return_value = mock_loader
 
             yield {
-                "get_train_dataset": mock_get_dataset,
+                "get_train_dataset": mock_get_train_dataset,
+                "get_val_dataset": mock_get_val_dataset,
                 "get_savable_loader": mock_get_loader,
                 "loader": mock_loader,
             }
@@ -232,9 +238,9 @@ class TestEnergonDataModuleCPHandling:
             **kwargs,
         )
 
-    def _get_worker_config(self, mocks, call_index=0):
-        """Extract the worker_config passed to get_train_dataset."""
-        return mocks["get_train_dataset"].call_args_list[call_index][1]["worker_config"]
+    def _get_worker_config(self, mocks, dataset_builder="get_train_dataset", call_index=0):
+        """Extract the worker_config passed to an Energon dataset builder."""
+        return mocks[dataset_builder].call_args_list[call_index][1]["worker_config"]
 
     # ----------------------------------------------------------------
     # CP handling: train_dataloader
@@ -317,7 +323,7 @@ class TestEnergonDataModuleCPHandling:
         dm = self._make_datamodule(pg_collection=pg)
         dm.val_dataloader()
 
-        wc = self._get_worker_config(mock_energon)
+        wc = self._get_worker_config(mock_energon, "get_val_dataset")
         assert wc.rank == 2
         assert wc.world_size == 4
 
@@ -328,7 +334,7 @@ class TestEnergonDataModuleCPHandling:
         dm = self._make_datamodule(num_workers=4, num_val_workers=8, pg_collection=pg)
         dm.val_dataloader()
 
-        wc = self._get_worker_config(mock_energon)
+        wc = self._get_worker_config(mock_energon, "get_val_dataset")
         assert wc.num_workers == 8
 
     def test_val_dataloader_defaults_num_val_workers_to_num_workers(self, mock_energon):
@@ -338,7 +344,7 @@ class TestEnergonDataModuleCPHandling:
         dm = self._make_datamodule(num_workers=6, pg_collection=pg)
         dm.val_dataloader()
 
-        wc = self._get_worker_config(mock_energon)
+        wc = self._get_worker_config(mock_energon, "get_val_dataset")
         assert wc.num_workers == 6
 
     # ----------------------------------------------------------------
@@ -417,8 +423,24 @@ class TestEnergonDataModuleCPHandling:
         dm = self._make_datamodule(task_encoder=train_encoder, validation_task_encoder=val_encoder)
         dm.datasets_provider(MagicMock(), split="val")
 
-        _, kwargs = mock_energon["get_train_dataset"].call_args
+        _, kwargs = mock_energon["get_val_dataset"].call_args
         assert kwargs["task_encoder"] is val_encoder
+
+    def test_datasets_provider_uses_validation_recipe_for_val(self, mock_energon):
+        """Val split should use Energon's validation recipe, not the training recipe."""
+        worker_config = MagicMock()
+        dm = self._make_datamodule(max_samples_per_sequence=8)
+
+        dm.datasets_provider(worker_config, split="val")
+
+        mock_energon["get_train_dataset"].assert_not_called()
+        mock_energon["get_val_dataset"].assert_called_once()
+
+        _, kwargs = mock_energon["get_val_dataset"].call_args
+        assert kwargs["split_part"] == "val"
+        assert kwargs["worker_config"] is worker_config
+        assert kwargs["max_samples_per_sequence"] == 8
+        assert "shuffle_buffer_size" not in kwargs
 
     def test_datasets_provider_uses_train_task_encoder_for_train(self, mock_energon):
         """Train split should use the train task_encoder."""


### PR DESCRIPTION
# What does this PR do ?

Use Energon's validation dataset recipe for the validation split instead of constructing validation data through the training recipe.

# Changelog

- Route the training split through `get_train_dataset()` and the validation split through `get_val_dataset()`.
- Keep training-only shuffle configuration out of the validation path while preserving existing dataset-loading options.
- Add regression coverage for validation dataset recipe selection and update existing validation dataloader tests to use the validation builder.

# Validation

- A focused regression harness confirms that the pre-fix implementation selects `get_train_dataset()` for validation and the updated implementation selects `get_val_dataset()`.
- The same harness confirms that the training split continues to use `get_train_dataset()`.
- `git diff --check` passes.
- Python compilation checks pass for both changed files.

# GitHub Actions CI

This is an external contribution, so GitHub Actions CI will require approval from an NVIDIA developer.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed Contributor guidelines
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? No documentation changes are needed for this fix.
- [ ] Does the PR affect components that are optional to install? No.
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

Fixes #5626