### PR TITLE
[docs] fix: Repair RL integration config bootstrap

### DIFF
--- a/docs/bridge-rl-integration.md
+++ b/docs/bridge-rl-integration.md
@@ -76,6 +76,7 @@ Translate your RL framework config into Megatron Bridge's `ConfigContainer` for 
 
 ```python
 import torch
+from megatron.bridge import AutoBridge
 from megatron.bridge.training.config import (
     ConfigContainer,
     TrainingConfig,
@@ -83,17 +84,38 @@ from megatron.bridge.training.config import (
     SchedulerConfig,
     DistributedDataParallelConfig,
     CheckpointConfig,
+    LoggerConfig,
     TokenizerConfig,
 )
 from nemo_rl.models.policy import PolicyConfig  # or your own policy cfg type
 
 # Example: map your RL config to Megatron config
 def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> ConfigContainer:
-    model_cfg = rl_cfg["megatron_cfg"].copy()
+    bridge = AutoBridge.from_hf_pretrained(rl_cfg["model_name"])
+    model_cfg = bridge.to_megatron_provider(load_weights=False)
+
+    # Keep framework-owned optimizer/scheduler/DDP mappings out of the model
+    # provider. Apply only provider fields, with Bridge validating each name.
+    provider_fields = (
+        "tensor_model_parallel_size",
+        "pipeline_model_parallel_size",
+        "context_parallel_size",
+        "expert_model_parallel_size",
+        "expert_tensor_parallel_size",
+        "sequence_parallel",
+        "recompute_granularity",
+        "recompute_method",
+        "recompute_num_layers",
+    )
+    model_overrides = {name: rl_cfg["megatron_cfg"][name] for name in provider_fields if name in rl_cfg["megatron_cfg"]}
+
     # Precision
-    dtype = rl_cfg["precision"]
-    model_cfg["bf16"] = dtype == "bfloat16"
-    model_cfg["fp16"] = dtype == "float16"
+    dtype = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }[rl_cfg["precision"]]
+    model_cfg.apply_overrides_and_finalize(dtype=dtype, overrides=model_overrides)
 
     checkpoint = CheckpointConfig(
         save_interval=100,
@@ -130,10 +152,10 @@ def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> Con
         tokenizer_model=rl_cfg["model_name"],
     )
 
-    return ConfigContainer(
+    cfg = ConfigContainer(
         model=model_cfg,
         checkpoint=checkpoint,
-        logger=None,
+        logger=LoggerConfig(),
         train=train,
         optimizer=opt,
         ddp=ddp,
@@ -141,6 +163,8 @@ def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> Con
         dataset=None,
         tokenizer=tokenizer,
     )
+    cfg.validate()
+    return cfg
 ```
 
 Initialize Megatron-Core using a helper similar to `setup_megatron_model` from NeMo-RL:

--- a/docs/fern/versions/0.4.2/pages/bridge-rl-integration.mdx
+++ b/docs/fern/versions/0.4.2/pages/bridge-rl-integration.mdx
@@ -72,6 +72,7 @@ Translate your RL framework config into Megatron Bridge's `ConfigContainer` for 
 
 ```python
 import torch
+from megatron.bridge import AutoBridge
 from megatron.bridge.training.config import (
     ConfigContainer,
     TrainingConfig,
@@ -79,17 +80,38 @@ from megatron.bridge.training.config import (
     SchedulerConfig,
     DistributedDataParallelConfig,
     CheckpointConfig,
+    LoggerConfig,
     TokenizerConfig,
 )
 from nemo_rl.models.policy import PolicyConfig  # or your own policy cfg type
 
 # Example: map your RL config to Megatron config
 def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> ConfigContainer:
-    model_cfg = rl_cfg["megatron_cfg"].copy()
+    bridge = AutoBridge.from_hf_pretrained(rl_cfg["model_name"])
+    model_cfg = bridge.to_megatron_provider(load_weights=False)
+
+    # Keep framework-owned optimizer/scheduler/DDP mappings out of the model
+    # provider. Apply only provider fields, with Bridge validating each name.
+    provider_fields = (
+        "tensor_model_parallel_size",
+        "pipeline_model_parallel_size",
+        "context_parallel_size",
+        "expert_model_parallel_size",
+        "expert_tensor_parallel_size",
+        "sequence_parallel",
+        "recompute_granularity",
+        "recompute_method",
+        "recompute_num_layers",
+    )
+    model_overrides = {name: rl_cfg["megatron_cfg"][name] for name in provider_fields if name in rl_cfg["megatron_cfg"]}
+
     # Precision
-    dtype = rl_cfg["precision"]
-    model_cfg["bf16"] = dtype == "bfloat16"
-    model_cfg["fp16"] = dtype == "float16"
+    dtype = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }[rl_cfg["precision"]]
+    model_cfg.apply_overrides_and_finalize(dtype=dtype, overrides=model_overrides)
 
     checkpoint = CheckpointConfig(
         save_interval=100,
@@ -126,10 +148,10 @@ def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> Con
         tokenizer_model=rl_cfg["model_name"],
     )
 
-    return ConfigContainer(
+    cfg = ConfigContainer(
         model=model_cfg,
         checkpoint=checkpoint,
-        logger=None,
+        logger=LoggerConfig(),
         train=train,
         optimizer=opt,
         ddp=ddp,
@@ -137,6 +159,8 @@ def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> Con
         dataset=None,
         tokenizer=tokenizer,
     )
+    cfg.validate()
+    return cfg
 ```
 
 Initialize Megatron-Core using a helper similar to `setup_megatron_model` from NeMo-RL:

--- a/docs/fern/versions/nightly/pages/bridge-rl-integration.mdx
+++ b/docs/fern/versions/nightly/pages/bridge-rl-integration.mdx
@@ -72,6 +72,7 @@ Translate your RL framework config into Megatron Bridge's `ConfigContainer` for 
 
 ```python
 import torch
+from megatron.bridge import AutoBridge
 from megatron.bridge.training.config import (
     ConfigContainer,
     TrainingConfig,
@@ -79,17 +80,38 @@ from megatron.bridge.training.config import (
     SchedulerConfig,
     DistributedDataParallelConfig,
     CheckpointConfig,
+    LoggerConfig,
     TokenizerConfig,
 )
 from nemo_rl.models.policy import PolicyConfig  # or your own policy cfg type
 
 # Example: map your RL config to Megatron config
 def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> ConfigContainer:
-    model_cfg = rl_cfg["megatron_cfg"].copy()
+    bridge = AutoBridge.from_hf_pretrained(rl_cfg["model_name"])
+    model_cfg = bridge.to_megatron_provider(load_weights=False)
+
+    # Keep framework-owned optimizer/scheduler/DDP mappings out of the model
+    # provider. Apply only provider fields, with Bridge validating each name.
+    provider_fields = (
+        "tensor_model_parallel_size",
+        "pipeline_model_parallel_size",
+        "context_parallel_size",
+        "expert_model_parallel_size",
+        "expert_tensor_parallel_size",
+        "sequence_parallel",
+        "recompute_granularity",
+        "recompute_method",
+        "recompute_num_layers",
+    )
+    model_overrides = {name: rl_cfg["megatron_cfg"][name] for name in provider_fields if name in rl_cfg["megatron_cfg"]}
+
     # Precision
-    dtype = rl_cfg["precision"]
-    model_cfg["bf16"] = dtype == "bfloat16"
-    model_cfg["fp16"] = dtype == "float16"
+    dtype = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }[rl_cfg["precision"]]
+    model_cfg.apply_overrides_and_finalize(dtype=dtype, overrides=model_overrides)
 
     checkpoint = CheckpointConfig(
         save_interval=100,
@@ -126,10 +148,10 @@ def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> Con
         tokenizer_model=rl_cfg["model_name"],
     )
 
-    return ConfigContainer(
+    cfg = ConfigContainer(
         model=model_cfg,
         checkpoint=checkpoint,
-        logger=None,
+        logger=LoggerConfig(),
         train=train,
         optimizer=opt,
         ddp=ddp,
@@ -137,6 +159,8 @@ def build_megatron_config(rl_cfg: PolicyConfig, pretrained_ckpt_dir: str) -> Con
         dataset=None,
         tokenizer=tokenizer,
     )
+    cfg.validate()
+    return cfg
 ```
 
 Initialize Megatron-Core using a helper similar to `setup_megatron_model` from NeMo-RL:

--- a/tests/unit_tests/doc_consistency/test_readme_consistency.py
+++ b/tests/unit_tests/doc_consistency/test_readme_consistency.py
@@ -259,6 +259,135 @@ def test_rl_integration_get_model_calls_supply_required_keyword_only_arguments()
     assert not missing, f"RL integration get_model calls omit required keyword-only arguments: {missing}"
 
 
+def test_rl_integration_builds_a_finalized_config_with_runtime_objects():
+    """RL integration builders must return an initialization-ready config."""
+
+    class Config:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class LoggerConfig(Config):
+        def finalize(self):
+            self.finalized = True
+
+    class Provider(Config):
+        def apply_overrides_and_finalize(self, dtype, overrides):
+            self.params_dtype = dtype
+            self.fp16 = dtype == "float16"
+            self.bf16 = dtype == "bfloat16"
+            for name, value in overrides.items():
+                if not hasattr(self, name):
+                    raise AttributeError(name)
+                setattr(self, name, value)
+            self.pipeline_dtype = dtype if self.pipeline_model_parallel_size > 1 else None
+            self.finalized = True
+            return self
+
+    class AutoBridge:
+        calls = []
+
+        @classmethod
+        def from_hf_pretrained(cls, model_name):
+            cls.calls.append(model_name)
+
+            class Bridge:
+                def to_megatron_provider(self, *, load_weights):
+                    assert load_weights is False
+                    return Provider(
+                        tensor_model_parallel_size=1,
+                        pipeline_model_parallel_size=1,
+                        context_parallel_size=1,
+                        expert_model_parallel_size=1,
+                        expert_tensor_parallel_size=1,
+                        sequence_parallel=False,
+                        recompute_granularity=None,
+                        recompute_method=None,
+                        recompute_num_layers=None,
+                    )
+
+            return Bridge()
+
+    class ConfigContainer(Config):
+        def validate(self):
+            assert isinstance(self.model, Provider)
+            assert self.model.finalized
+            assert isinstance(self.logger, LoggerConfig)
+            self.logger.finalize()
+            model_parallel_size = (
+                self.model.tensor_model_parallel_size
+                * self.model.pipeline_model_parallel_size
+                * self.model.context_parallel_size
+            )
+            assert 4 % model_parallel_size == 0
+            self.data_parallel_size = 4 // model_parallel_size
+            self.validated = True
+
+    rl_cfg = {
+        "model_name": "example/model",
+        "precision": "bfloat16",
+        "train_ckpt_dir": "/tmp/checkpoints",
+        "train_micro_batch_size": 1,
+        "train_global_batch_size": 4,
+        "megatron_cfg": {
+            "tensor_model_parallel_size": 2,
+            "pipeline_model_parallel_size": 2,
+            "context_parallel_size": 1,
+            "expert_model_parallel_size": 1,
+            "expert_tensor_parallel_size": 1,
+            "sequence_parallel": True,
+            "recompute_granularity": "selective",
+            "recompute_method": "uniform",
+            "recompute_num_layers": 1,
+            "train_iters": 10,
+            "distributed_data_parallel_config": {
+                "grad_reduce_in_fp32": True,
+                "overlap_grad_reduce": False,
+                "overlap_param_gather": False,
+                "average_in_collective": False,
+                "data_parallel_sharding_strategy": "no_shard",
+            },
+            "optimizer": {"lr": 1.0e-4, "use_distributed_optimizer": False},
+            "scheduler": {},
+        },
+    }
+
+    for path in RL_INTEGRATION_DOCS:
+        text = _read(path)
+        code = next(
+            match.group("code")
+            for match in re.finditer(r"```python\n(?P<code>.*?)```", text, re.DOTALL)
+            if "def build_megatron_config" in match.group("code")
+        )
+        tree = ast.parse(code, filename=str(path))
+        builder = next(
+            node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "build_megatron_config"
+        )
+        namespace = {
+            "AutoBridge": AutoBridge,
+            "CheckpointConfig": Config,
+            "ConfigContainer": ConfigContainer,
+            "DistributedDataParallelConfig": Config,
+            "LoggerConfig": LoggerConfig,
+            "OptimizerConfig": Config,
+            "PolicyConfig": dict,
+            "SchedulerConfig": Config,
+            "TokenizerConfig": Config,
+            "TrainingConfig": Config,
+            "torch": type("Torch", (), {"float32": "float32", "bfloat16": "bfloat16", "float16": "float16"}),
+        }
+        exec(compile(ast.Module(body=[builder], type_ignores=[]), str(path), "exec"), namespace)
+        config = namespace["build_megatron_config"](rl_cfg, "/tmp/pretrained")
+
+        assert AutoBridge.calls and AutoBridge.calls[-1] == rl_cfg["model_name"]
+        assert config.validated
+        assert config.data_parallel_size == 1
+        assert config.logger.finalized
+        assert config.model.params_dtype == "bfloat16"
+        assert config.model.pipeline_dtype == "bfloat16"
+        assert config.model.sequence_parallel is True
+        assert config.model.recompute_granularity == "selective"
+
+
 def test_model_examples_use_current_run_recipe_arguments():
     """Model examples that call run_recipe.py must not advertise removed arguments."""
     offenders: dict[str, list[str]] = {}


### PR DESCRIPTION
## What changed

The documented RL bootstrap now creates a real Megatron model provider through `AutoBridge`, applies validated provider overrides and precision finalization, supplies a `LoggerConfig`, and validates the assembled `ConfigContainer` before `initialize_megatron()` consumes it. The same correction is applied to the source guide and both published Fern copies.

## Bug and impact

Following the supported RL integration guide produced `ConfigContainer(model=<dict>, logger=None, ...)` and called `initialize_megatron()` without validation. The first initialization access to derived topology such as `data_parallel_size` therefore failed before distributed or model setup; simply adding validation still failed because a dictionary is not a model provider and the logger is required during finalization.

The regression test executes the documented builder in a small contract harness. It verifies provider construction, validated overrides, dtype finalization, logger finalization, and the derived data-parallel topology.

## Validation

Fail before, on unchanged `2e77041c194d106beb7462e226d7ca06b33ea63f`:

```text
extracted documented-builder contract test
FAILED: the builder never called AutoBridge and returned the raw mapping path
```

Pass after:

```text
uv run --no-project --with pytest python -m pytest -p no:cacheprovider --confcutdir=tests/unit_tests/doc_consistency tests/unit_tests/doc_consistency/test_readme_consistency.py::test_rl_integration_builds_a_finalized_config_with_runtime_objects -q
1 passed

uv run --no-project --with pytest python -m pytest -p no:cacheprovider --confcutdir=tests/unit_tests/doc_consistency tests/unit_tests/doc_consistency/test_readme_consistency.py -q
21 passed

uv run --no-project --with pre-commit==3.6.2 pre-commit run --all-files
all applicable hooks passed

git diff --check
passed
```

The project-managed pre-commit invocation could not resolve the existing `nvidia-resiliency-ext==0.6.0` pin on this workstation's glibc, so the same repository hooks were run in an isolated `uv` environment.

## Scope

This changes documentation and its executable consistency test only. It does not change runtime APIs, add model/backend support, or claim GPU, convergence, performance, or full-suite validation.
