### PR TITLE
[data] fix: Treat empty media sequences as text-only

### DIFF
--- a/src/megatron/bridge/data/sft_processing.py
+++ b/src/megatron/bridge/data/sft_processing.py
@@ -142,18 +142,21 @@ class TokenizedPromptCompletion:
 _CONVERSATION_KEYS = ("messages", "conversation", "conversations")
 _CANONICAL_PROMPT_KEY = "prompt"
 _CANONICAL_COMPLETION_KEY = "completion"
+_PLURAL_MEDIA_KEYS = (
+    "images",
+    "image_paths",
+    "videos",
+    "video_paths",
+    "audio_paths",
+)
 _MEDIA_KEYS = (
     "image",
-    "images",
     "image_path",
-    "image_paths",
     "video",
-    "videos",
     "video_path",
-    "video_paths",
     "audio",
     "audio_path",
-    "audio_paths",
+    *_PLURAL_MEDIA_KEYS,
 )
 
 
@@ -275,7 +278,10 @@ def is_text_only_prompt_completion_example(
     preprocessing: PromptCompletionSFTPreprocessingConfig,
 ) -> bool:
     """Return whether a row is a text-only prompt-completion example."""
-    if any(example.get(key) is not None for key in _MEDIA_KEYS):
+    for key in _MEDIA_KEYS:
+        value = example.get(key)
+        if value is None or (key in _PLURAL_MEDIA_KEYS and isinstance(value, list) and not value):
+            continue
         return False
     try:
         normalize_sft_example(example, preprocessing)

--- a/tests/unit_tests/data/builders/test_direct_hf_sft.py
+++ b/tests/unit_tests/data/builders/test_direct_hf_sft.py
@@ -3,6 +3,7 @@
 import importlib
 
 import pytest
+from datasets import Dataset
 from megatron.training.config.instantiate_utils import instantiate
 
 from megatron.bridge.data.base import DatasetBuildContext
@@ -574,6 +575,29 @@ def test_builder_uses_prompt_completion_without_chat_template(monkeypatch):
     batch = train.collate_fn([train[0]])
     assert batch["tokens"].tolist()[0][-2:] == [ord("4"), tokenizer.eos_token_id]
     assert batch["loss_mask"].sum().item() == 2
+
+
+def test_builder_treats_empty_optional_media_as_text_only(monkeypatch):
+    row = Dataset.from_list([{"prompt": "Q", "completion": "A", "images": []}])[0]
+    monkeypatch.setattr(builder_module, "load_and_adapt_hf_dataset", lambda source: [row])
+    config = DirectHFSFTDatasetConfig(
+        seq_length=16,
+        source=HFDatasetSourceConfig(path_or_dataset="org/paired"),
+        preprocessing=PromptCompletionSFTPreprocessingConfig(),
+        pad_to_multiple_of=1,
+        do_validation=False,
+        do_test=False,
+    )
+
+    train, _, _ = DirectHFSFTDatasetBuilder(config).build(DatasetBuildContext(1, 0, 0, tokenizer=_Tokenizer()))
+
+    assert train is not None
+    assert train[0]["images"] == []
+    with pytest.raises(ValueError, match="supports text-only examples"):
+        select_direct_hf_sft_collate(
+            [{"prompt": "Q", "completion": "A", "images": [object()]}],
+            config.preprocessing,
+        )
 
 
 def test_direct_hf_sft_config_resolves_canonical_builder(monkeypatch):


### PR DESCRIPTION
## Problem

The supported Direct-HF prompt/completion path rejects otherwise valid text rows when a Hugging Face dataset retains an optional plural media column with no items, for example `images=[]`. This aborts split construction with `Prompt-completion preprocessing supports text-only examples.` before training can start.

## Root cause

`is_text_only_prompt_completion_example()` treated every media-key value other than `None` as a real payload. Hugging Face/Arrow represents empty optional sequences as lists, so zero media items were classified as multimodal.

## Fix

Treat only empty lists on plural media fields as absent. Singular media values, empty dictionaries or strings, and every non-empty media collection retain the existing rejection behavior.

The regression test round-trips the row through `Dataset.from_list`, exercises the full Direct-HF builder path, verifies metadata preservation, and keeps a non-empty media payload as a negative control.

## Validation

Fail-before on unmodified `main`:

```text
uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/builders/test_direct_hf_sft.py::test_builder_treats_empty_optional_media_as_text_only
# 1 failed with the expected text-only selector ValueError
```

Pass-after:

```text
uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/builders/test_direct_hf_sft.py::test_builder_treats_empty_optional_media_as_text_only
# 1 passed

uv run --no-sync python -m pytest -q --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_sft_processing.py tests/unit_tests/data/builders/test_direct_hf_sft.py
# 59 passed

uv run --no-sync pre-commit run --all-files
# all applicable hooks passed

git diff --check
# passed
```

## Scope

This is limited to Direct-HF prompt/completion text-only classification for empty plural media lists. It does not add multimodal prompt/completion support, change public APIs, dependencies, CI workflows, MCore, tokenization, or training semantics. No full-suite, model-quality, convergence, performance, GPU, or distributed validation is claimed.
