### PR TITLE
[model] fix: preserve singleton expert scale dimensions

### DIFF
--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -815,7 +815,7 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
             else:
                 weights_dict[param_name] = gathered_weights[i].unsqueeze(0)
         for param_name in weights_dict:
-            weights_dict[param_name] = weights_dict[param_name].squeeze()
+            weights_dict[param_name] = weights_dict[param_name].squeeze(0)
         return weights_dict
 
     def gather_from_ep_ranks_scale(

--- a/tests/unit_tests/models/test_param_mapping.py
+++ b/tests/unit_tests/models/test_param_mapping.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -107,6 +108,44 @@ class MockModule(torch.nn.Module):
         if has_bias:
             self.bias = torch.nn.Parameter(torch.randn(weight_shape[0], device=device))
         self.config = config
+
+
+def test_ep_gather_preserves_expert_scale_singleton_dimensions(mock_distributed_env):
+    """EP gathering must remove only its own staging dimension."""
+    mock_mpu, mock_dist = mock_distributed_env()
+    mapping = FusedExpertMapping(
+        "decoder.layers.0.mlp.experts.linear_fc2.weight0",
+        "model.layers.0.mlp.experts.down_proj",
+    )
+
+    class _MockGroup:
+        def size(self):
+            return 2
+
+        def rank(self):
+            return 0
+
+    mapping.ep_group = _MockGroup()
+    mock_mpu.get_expert_model_parallel_group.return_value = mapping.ep_group
+
+    def fake_all_gather(output, tensor, group):
+        assert group is mapping.ep_group
+        output[0].copy_(tensor)
+        output[1].copy_(tensor + 10)
+
+    mock_dist.all_gather.side_effect = fake_all_gather
+    local_scale = torch.tensor([[1.0], [2.0]])
+
+    result = mapping.gather_from_ep_ranks(
+        local_scale,
+        SimpleNamespace(config=SimpleNamespace(num_moe_experts=4)),
+        "model.layers.0.mlp.experts.down_proj",
+    )
+
+    gathered_scale = result["model.layers.0.mlp.experts.down_proj"]
+    assert gathered_scale.shape == (2, 2, 1)
+    torch.testing.assert_close(gathered_scale[0], local_scale)
+    torch.testing.assert_close(gathered_scale[1], local_scale + 10)
 
 
 class TestDirectMapping:


### PR DESCRIPTION
## Problem

Blockwise-FP8 Hugging Face export with expert parallelism can silently drop a valid singleton block-grid dimension from expert scale tensors. For example, a supported MoE down projection with per-expert scale shape `[2, 1]` and EP=2 is staged as `[2, 2, 1]`, but the current gather path returns `[2, 2]`. Grouped export consequently emits `[4, 2]` instead of the required `[4, 2, 1]` layout.

The public trigger is an `AutoBridge` FP8 export of a fused MoE model using blockwise scales and EP greater than one. The malformed scale shape can make the exported checkpoint incompatible with the Hugging Face quantized expert layout or give it incorrect quantization metadata.

Related context: #4804 tracks native quantized export workflows, but does not fix this shape-loss root cause.

## Root cause and fix

`gather_from_ep_ranks()` uses an extra leading dimension to stage tensors collected from each EP rank. Calling unqualified `squeeze()` removes both that staging dimension and any legitimate singleton dimensions already present in the source tensor.

Use `squeeze(0)` so only the EP staging axis is removed. No API or supported-format scope changes are included.

## Validation

Fail-before/pass-after deterministic CPU reproducer against the actual `gather_from_ep_ranks()` implementation:

```text
uv run --no-project python /tmp/reproduce_ep_gather_shape.py
before: exit 1 — AssertionError: expected (2, 2, 1), got (2, 2)
after:  exit 0
```

Focused regression and adjacent expert-mapping tests:

```text
uv run --no-project python -m pytest \
  tests/unit_tests/models/test_param_mapping.py::test_ep_gather_preserves_expert_scale_singleton_dimensions \
  tests/unit_tests/models/test_param_mapping.py::TestFusedExpertMapping \
  tests/unit_tests/models/test_param_mapping.py::TestFusedGatedExpertMapping -q
7 passed, 42 warnings in 1.03s
```

Additional checks:

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This changes only removal of the gather-owned staging axis and adds one focused CPU regression test. It does not change conversion APIs, quantization formats, model registrations, or Megatron-Core.
