### PR TITLE
[recipe] fix: allow MoE recipe construction without CUDA

### DIFF
--- a/src/megatron/bridge/training/flex_dispatcher_backend.py
+++ b/src/megatron/bridge/training/flex_dispatcher_backend.py
@@ -49,6 +49,12 @@ def apply_flex_dispatcher_backend(
             )
         return
 
+    if not torch.cuda.is_available() and moe_flex_dispatcher_backend in ("deepep", "hybridep"):
+        model_config.moe_token_dispatcher_type = "flex"
+        model_config.moe_flex_dispatcher_backend = moe_flex_dispatcher_backend
+        model_config.moe_shared_expert_overlap = False
+        return
+
     device_properties = torch.cuda.get_device_properties(0)
     if moe_flex_dispatcher_backend == "deepep":
         if not (
@@ -74,7 +80,6 @@ def apply_flex_dispatcher_backend(
         if get_rank_safe() == 0:
             logger.warning("Not a valid flex dispatcher backend. Skipping flex dispatcher backend configuration.")
         return
-
     model_config.moe_token_dispatcher_type = "flex"
     model_config.moe_flex_dispatcher_backend = moe_flex_dispatcher_backend
     model_config.moe_shared_expert_overlap = False

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -83,6 +83,18 @@ class _FakeBridge:
         return _FakeBridge()
 
 
+class _FakeMoeBridge(_FakeBridge):
+    @staticmethod
+    def from_hf_pretrained(hf_path: str, **kwargs):
+        _FakeBridge.from_hf_pretrained(hf_path, **kwargs)
+        return _FakeMoeBridge()
+
+    def to_megatron_provider(self, load_weights: bool = False):
+        cfg = super().to_megatron_provider(load_weights=load_weights)
+        cfg.num_moe_experts = 128
+        return cfg
+
+
 class _FakeTextConfig:
     architectures = None
 
@@ -375,6 +387,27 @@ _QWEN3_MOE_SFT_FUNCS = [
     ]
     if callable(getattr(_qwen_module, name, None))
 ]
+
+
+def test_qwen3_moe_peft_recipe_builds_without_cuda(monkeypatch: pytest.MonkeyPatch):
+    """Offline packing must be able to construct a public recipe without CUDA."""
+    from megatron.bridge.recipes.qwen import qwen3_30b_a3b_peft_config
+
+    mod = importlib.import_module("megatron.bridge.recipes.qwen.h100.qwen3_moe")
+    monkeypatch.setattr(mod, "AutoBridge", _FakeMoeBridge)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    def fail_hardware_probe(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("recipe construction probed CUDA device properties")
+
+    monkeypatch.setattr(torch.cuda, "get_device_properties", fail_hardware_probe)
+
+    cfg = qwen3_30b_a3b_peft_config()
+
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "deepep"
+
 
 _QWEN3_MOE_PEFT_FUNCS = [
     getattr(_qwen_module, name)

--- a/tests/unit_tests/training/test_deepep.py
+++ b/tests/unit_tests/training/test_deepep.py
@@ -25,6 +25,11 @@ from megatron.bridge.training.flex_dispatcher_backend import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _mock_cuda_available(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+
+
 class TestApplyDeepEP:
     """Test the apply_flex_dispatcher_backend function for DeepEP."""
 
@@ -89,6 +94,16 @@ class TestApplyDeepEP:
         assert config.moe_token_dispatcher_type == "flex"
         assert config.moe_flex_dispatcher_backend == "deepep"
         assert config.moe_shared_expert_overlap is False
+
+    @patch("torch.cuda.get_device_properties", side_effect=RuntimeError("CUDA initialization failed"))
+    def test_apply_flex_dispatcher_backend_preserves_cuda_probe_errors(self, mock_get_device_properties):
+        config = MagicMock(spec=TransformerConfig)
+        config.num_moe_experts = 8
+
+        with pytest.raises(RuntimeError, match="CUDA initialization failed"):
+            apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend="deepep")
+
+        mock_get_device_properties.assert_called_once_with(0)
 
     @patch("megatron.bridge.training.flex_dispatcher_backend.logger")
     def test_apply_flex_dispatcher_backend_warns_for_non_moe_model_none_experts(self, mock_logger):


### PR DESCRIPTION
## What does this PR do?

Public Qwen3-MoE SFT and PEFT recipes enable a flex dispatcher while they are being constructed. The official offline-packing workflow constructs these recipes before a GPU training job, but `apply_flex_dispatcher_backend()` unconditionally queried CUDA device 0. On a CPU preprocessing host this raised during recipe construction, before packing could start.

The changed path is:

`prepare_gpt_sft_packed_data.py` -> public Qwen3-MoE recipe factory -> `apply_flex_dispatcher_backend()` -> `torch.cuda.get_device_properties(0)`

The helper now records the requested supported flex backend without probing device properties when CUDA is unavailable. GPU processes keep the existing architecture check, and CUDA probe errors still propagate when CUDA is reported available. Runtime validation is unchanged.

Scope is limited to CPU-side construction of supported DeepEP and HybridEP recipe configs. It does not make those backends executable without GPUs and does not change training-time hardware validation.

## Regression evidence

The focused regression constructs the public `qwen3_30b_a3b_peft_config` with a real MoE-shaped provider and asserts that CUDA device properties are not queried when CUDA is unavailable.

Applied as a test-only change to `2e77041c194d106beb7462e226d7ca06b33ea63f`:

```
uv run python -m pytest tests/unit_tests/recipes/test_qwen_recipes.py::test_qwen3_moe_peft_recipe_builds_without_cuda -q
```

Result: failed at `torch.cuda.get_device_properties(0)` with `recipe construction probed CUDA device properties`.

With this fix, the unchanged command passes: `1 passed`.

## Validation

```
uv run python -m pytest tests/unit_tests/training/test_deepep.py -q
# 18 passed

uv run python -m pytest tests/unit_tests/recipes/test_qwen_recipes.py -k 'qwen3_moe or qwen3_30b_a3b' -q
# 21 passed, 68 deselected

git diff --check
# passed

uv run pre-commit run --all-files
# passed
```