### PR TITLE
[data] fix: Reject truncated prompt-completion rows without supervision

### DIFF
--- a/src/megatron/bridge/data/sft_processing.py
+++ b/src/megatron/bridge/data/sft_processing.py
@@ -475,6 +475,8 @@ def tokenize_prompt_completion_example(
         loss_mask = torch.ones(input_ids.numel(), dtype=torch.bool)
     if skipped_tokens is not None and skipped_tokens.numel() > 0:
         loss_mask &= ~torch.isin(input_ids, skipped_tokens.to(device=input_ids.device, dtype=torch.long))
+    if preprocessing.loss_mode == "completion" and completion_value and not loss_mask[1:].any():
+        raise ValueError("Prompt-completion preprocessing must retain a supervised token for a non-empty completion.")
     return TokenizedPromptCompletion(
         input_ids=input_ids,
         loss_mask=loss_mask,

--- a/tests/unit_tests/data/test_sft_processing.py
+++ b/tests/unit_tests/data/test_sft_processing.py
@@ -301,6 +301,24 @@ def test_prompt_completion_full_loss_and_truncation_preserve_special_tokens():
     assert tokenized.loss_mask.tolist() == [True] * 5
 
 
+def test_prompt_completion_rejects_truncation_without_supervision():
+    tokenizer = _Tokenizer()
+    preprocessing = PromptCompletionSFTPreprocessingConfig(
+        add_bos=True,
+        add_sep=True,
+        add_eos=False,
+    )
+
+    with pytest.raises(ValueError, match="supervised token"):
+        tokenize_prompt_completion_example(
+            {"prompt": "P", "completion": "A"},
+            tokenizer,
+            preprocessing,
+            max_length=2,
+            sep_token_id=103,
+        )
+
+
 @pytest.mark.parametrize(
     ("truncation_method", "expected_completion"),
     [("right", "bc"), ("left", "defg")],


### PR DESCRIPTION
## What changed

Prompt/completion preprocessing now rejects a non-empty completion when truncation and requested special tokens leave no supervised next-token target.

## User impact

A supported completion-only configuration such as `add_bos=True`, `add_sep=True`, `add_eos=False`, and `seq_length=2` reserves the entire sequence for BOS and SEP. The shared tokenizer previously accepted the ordinary non-empty row after truncating both text segments away. Direct-HF then emitted only ignored labels, while GPT SFT emitted an all-zero loss mask, so training silently counted the sample while receiving no language-model signal.

## Root cause and fix

`tokenize_prompt_completion_example()` checked that the final sequence had at least two tokens, but did not check the post-shift supervision invariant. The fix adds a local guard after skipped-token masking: completion-only rows with a non-empty completion must retain at least one supervised token after the next-token shift. Full-loss behavior, intentionally empty completions, and sampler-generated padding rows are unchanged.

## Validation

The unchanged regression test failed on `origin/main` at `4a3f2c2ed162cafd027e941712d2022d5309ddbe`:

```text
uv run python -m pytest \
  tests/unit_tests/data/test_sft_processing.py::test_prompt_completion_rejects_truncation_without_supervision \
  -q --tb=short

FAILED: DID NOT RAISE ValueError
```

After the fix:

```text
uv run python -m pytest \
  tests/unit_tests/data/test_sft_processing.py \
  tests/unit_tests/data/collators/test_sft.py \
  -q --tb=short

35 passed
```

Additional checks:

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This does not change public APIs, full-loss semantics, chat preprocessing, packing policy, or supported model/backend scope.
