### PR TITLE
[misc] fix: Enable OpenAI streaming for HF tokenizers

### DIFF
--- a/src/megatron/bridge/inference/_tokenizer.py
+++ b/src/megatron/bridge/inference/_tokenizer.py
@@ -46,6 +46,11 @@ class HFTokenizerAdapter:
     ) -> None:
         self._tokenizer = tokenizer
         self._force_skip_special_tokens = force_skip_special_tokens
+        # MCore's incremental detokenizer treats ``_tokenizer`` as its Hugging Face wrapper.
+        if not hasattr(tokenizer, "tokenizer"):
+            tokenizer.tokenizer = tokenizer
+        if not hasattr(tokenizer, "include_special_tokens"):
+            tokenizer.include_special_tokens = force_skip_special_tokens is False
         if set_pad_token and tokenizer.pad_token is None and tokenizer.eos_token is not None:
             tokenizer.pad_token = tokenizer.eos_token
         self.eod = tokenizer.eos_token_id

--- a/tests/unit_tests/inference/test_tokenizer.py
+++ b/tests/unit_tests/inference/test_tokenizer.py
@@ -16,6 +16,12 @@
 
 from __future__ import annotations
 
+from megatron.core.inference.text_generation_server.dynamic_text_gen_server.incremental_detokenizer import (
+    HuggingFaceFastIncrementalDetokenizer,
+)
+from tokenizers import Tokenizer, models
+from transformers import PreTrainedTokenizerFast
+
 from megatron.bridge.inference._tokenizer import HFTokenizerAdapter
 
 
@@ -119,3 +125,14 @@ def test_openai_server_preserves_hf_chat_template_contract():
             },
         )
     ]
+
+
+def test_openai_streaming_accepts_hf_fast_tokenizer_adapter():
+    backend = Tokenizer(models.WordLevel(vocab={"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]", eos_token="[UNK]")
+    adapter = HFTokenizerAdapter(tokenizer)
+
+    detokenizer = HuggingFaceFastIncrementalDetokenizer(adapter, [])
+
+    assert detokenizer.text == ""
+    assert detokenizer.update([tokenizer.eos_token_id]) == ""


### PR DESCRIPTION
## Problem

The maintained Bridge OpenAI-compatible server rejects supported `stream=true` requests even when it loaded a real Hugging Face fast tokenizer.

`build_tokenizer()` stores the raw Hugging Face tokenizer at `HFTokenizerAdapter._tokenizer`. The pinned MCore streaming endpoints then treat that value as MCore's Hugging Face wrapper and look for `_tokenizer.tokenizer`. Standard fast tokenizers expose `backend_tokenizer` / internal `_tokenizer`, not `.tokenizer`, so both chat and text completion streaming return HTTP 400 before submitting generation:

```text
ValueError: Streaming is currently supported only for Hugging Face fast tokenizers.
```

Non-streaming generation is unaffected. This is adjacent to the OpenAI adapter contract completed in #5091.

## Fix

When the wrapped tokenizer does not already provide MCore's wrapper fields, expose:

- `tokenizer` pointing to the real Hugging Face fast tokenizer;
- `include_special_tokens` derived from the adapter's detokenization policy.

The second field keeps incremental streaming aligned with Bridge's normal special-token behavior; without it, construction succeeds but the EOS marker is emitted in the stream.

## Regression evidence

An exact-source CPU reproducer passed a real `PreTrainedTokenizerFast` through the audited Bridge adapter into the pinned MCore incremental detokenizer.

- Before: exit 1 at the false fast-tokenizer rejection shown above.
- After, unchanged: exit 0; EOS produces no streamed text.

The added unit regression exercises that same cross-package contract with a real fast tokenizer.

Focused and adjacent CPU validation (isolated package-init harness; exact checkout source paths):

```text
uv run --no-project --python 3.12 \
  --with pytest --with pytest-mock --with tokenizers --with transformers --with torch --with pillow \
  python -m pytest --confcutdir=tests/unit_tests/inference \
  tests/unit_tests/inference/test_tokenizer.py \
  tests/unit_tests/inference/vlm/test_vlm_inference_controller.py -q

21 passed
```

Static validation:

```text
git diff --check
# passed

uv run --no-project --python 3.12 --with pre-commit==3.6.0 pre-commit run --all-files
# all configured hooks passed
```

The project-managed pre-commit invocation was blocked before hook execution because the pinned resiliency wheel requires a newer glibc platform; the isolated invocation above ran the repository's complete configured hook set.

## Scope

This changes only the private inference tokenizer adapter and one CPU unit test. It does not change model weights, generation algorithms, dependencies, CI, public conversion APIs, or MCore source. No full-suite, GPU/model-quality, convergence, or performance validation is claimed.
