### PR TITLE
[training] fix: restore alltoall when flex backend is cleared

### DIFF
--- a/src/megatron/bridge/training/flex_dispatcher_backend.py
+++ b/src/megatron/bridge/training/flex_dispatcher_backend.py
@@ -83,6 +83,10 @@ def apply_flex_dispatcher_backend(
 def validate_flex_dispatcher_backend(model_config: TransformerConfig) -> None:
     """Validate DeepEP or HybridEP is supported for the current GPU architecture."""
     if model_config.moe_token_dispatcher_type == "flex":
+        if model_config.moe_flex_dispatcher_backend is None:
+            _fallback_to_alltoall(model_config)
+            return
+
         device_properties = torch.cuda.get_device_properties(0)
         if model_config.moe_flex_dispatcher_backend == "deepep":
             if not (

--- a/tests/unit_tests/training/test_deepep.py
+++ b/tests/unit_tests/training/test_deepep.py
@@ -190,6 +190,27 @@ class TestApplyDeepEP:
 class TestFlexDispatcherFallback:
     """Test unsupported flex backends stay disabled after config finalization."""
 
+    @patch("torch.cuda.get_device_properties")
+    def test_none_backend_override_falls_back_to_alltoall(self, mock_get_device_properties):
+        """Test that clearing a configured flex backend restores the standard dispatcher."""
+        mock_properties = MagicMock()
+        mock_properties.major = 9
+        mock_properties.name = "NVIDIA H100"
+        mock_get_device_properties.return_value = mock_properties
+        config = SimpleNamespace(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend=None,
+            moe_shared_expert_overlap=True,
+        )
+
+        apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend="deepep")
+        config.moe_flex_dispatcher_backend = None
+        validate_flex_dispatcher_backend(config)
+
+        assert config.moe_token_dispatcher_type == "alltoall"
+        assert config.moe_flex_dispatcher_backend is None
+
     @pytest.mark.parametrize(
         ("backend", "major", "device_name"),
         [


### PR DESCRIPTION
## Summary

- restore the standard alltoall dispatcher when a finalized flex backend is cleared
- cover the post-factory override lifecycle with a focused regression test

## Supported trigger and impact

The shared recipe runner accepts trailing configuration overrides after the recipe factory returns. A flex-enabled MoE recipe such as Qwen3-Next therefore accepts model.moe_flex_dispatcher_backend=null after the factory has selected the flex dispatcher.

Previously that override cleared only the backend. Bridge validation accepted the resulting flex dispatcher with no backend, and pinned Megatron-Core then raised ValueError: Invalid backend: None while constructing the MoE layer. This prevents an otherwise documented alltoall configuration from starting training.

This is a recurrence of the invariant documented in #2861. Its earlier fix was scoped to the legacy performance launcher; the unified recipe finalization path remained exposed.

## Root cause and fix

ConfigContainer calls validate_flex_dispatcher_backend after post-factory overrides and model finalization. That validation checked hardware support for named DeepEP and HybridEP backends but did not reconcile flex with a cleared backend.

The fix uses the existing alltoall fallback at this final shared boundary before Megatron-Core model construction. It does not change backend hardware support or enable any new mode.

## Regression evidence

Fail before:

- uv run --no-sync python -m pytest tests/unit_tests/training/test_deepep.py::TestFlexDispatcherFallback::test_none_backend_override_falls_back_to_alltoall -q
- 1 failed: dispatcher remained flex instead of alltoall after the backend was cleared

Pass after:

- same focused command: 1 passed
- uv run --no-sync python -m pytest tests/unit_tests/training/test_deepep.py -q: 18 passed
- uv run --no-sync python -m pytest tests/unit_tests/recipes/test_qwen_recipes.py -k qwen3_next -q: 3 passed, 85 deselected
- uv run --no-sync pre-commit run --all-files: passed
- uv run --no-sync mypy --strict --ignore-missing-imports src/megatron/bridge/training/flex_dispatcher_backend.py: passed

## Scope

No Megatron-Core changes, public API changes, dependency changes, CI changes, or backend availability changes are included.