### PR TITLE
fix(data): apply the null-content contract to legacy chat turns

### DIFF
--- a/src/megatron/bridge/data/conversation_processing.py
+++ b/src/megatron/bridge/data/conversation_processing.py
@@ -578,8 +578,9 @@ def normalize_chat_conversation(
     """Normalize supported text-chat schemas to OpenAI-style messages.
 
     Rows may use ``messages``, singular ``conversation``, or legacy plural
-    ``conversations`` with ``from``/``value`` keys. Null OpenAI message content
-    is converted to an empty string before chat-template rendering.
+    ``conversations`` with ``from``/``value`` keys. Null message content is
+    converted to an empty string before chat-template rendering, in either
+    supported schema.
     """
     if isinstance(example_or_conversation, Mapping):
         source = example_or_conversation
@@ -611,7 +612,13 @@ def normalize_chat_conversation(
             continue
         if "from" in turn and "value" in turn:
             role = str(turn["from"]).lower()
-            normalized.append({"role": _LEGACY_CHAT_ROLE_ALIASES.get(role, role), "content": turn["value"]})
+            value = turn["value"]
+            normalized.append(
+                {
+                    "role": _LEGACY_CHAT_ROLE_ALIASES.get(role, role),
+                    "content": "" if value is None else value,
+                }
+            )
             continue
         raise ValueError("Chat turns must contain role/content or legacy from/value fields.")
 

--- a/tests/unit_tests/data/test_conversation_processing.py
+++ b/tests/unit_tests/data/test_conversation_processing.py
@@ -1439,6 +1439,37 @@ def test_shared_chat_preprocessing_normalizes_sharegpt_roles_before_templating()
     assert tokenized.assistant_mask.any()
 
 
+def test_normalize_chat_conversation_converts_null_legacy_value_to_empty_content():
+    row = {
+        "conversations": [
+            {"from": "human", "value": "question"},
+            {"from": "gpt", "value": None},
+        ]
+    }
+
+    assert normalize_chat_conversation(row) == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": ""},
+    ]
+
+
+def test_normalize_chat_conversation_matches_null_and_empty_spellings_across_schemas():
+    def sharegpt(value):
+        return {"conversations": [{"from": "human", "value": "question"}, {"from": "gpt", "value": value}]}
+
+    openai_null = {
+        "messages": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": None},
+        ]
+    }
+
+    normalized = normalize_chat_conversation(sharegpt(None))
+
+    assert normalized == normalize_chat_conversation(sharegpt(""))
+    assert normalized == normalize_chat_conversation(openai_null)
+
+
 def test_normalize_chat_conversation_normalizes_openai_tool_calls_without_mutating_input():
     row = {
         "messages": [


### PR DESCRIPTION
# What does this PR do ?

Fixes ShareGPT chat SFT rows with a null `value` training the model on the literal string `None`, by applying the documented null-content contract to the legacy `from`/`value` branch of `normalize_chat_conversation`.

# Changelog

- `src/megatron/bridge/data/conversation_processing.py`: legacy `from`/`value` branch converts a null `value` to `""`; docstring widened to both schemas.
- `tests/unit_tests/data/test_conversation_processing.py`: 2 tests over the patched branch and null/empty equivalence.

# Additional Information

- **Root cause:** `conversation_processing.py:606-611` applies `None` -> `""` then `continue`s, so the legacy branch at `:612-615` copied `value` into `content` unconverted. Jinja stringifies `None` instead of raising, so it reaches the training text silently.
- **Blast radius:** any chat SFT run over a ShareGPT-format corpus, every model. Not DeepSeek-specific.
- **Regression?** No — broken since null handling landed in `46c42552` (#5541); the legacy branch (`0845a7dd`, #5078) never had it.
- **Verification:** red-green in `nvcr.io/nvidian/nemo:nightly` on EOS at base `4a3f2c2e`. RED (job 5901189): 2 failed on `content=None` vs `''`. GREEN (job 5901199): 2 passed, file 110 passed. `tests/unit_tests/data/` 796 -> 798 passed, same 2 pre-existing unrelated failures.
- **Not included:** the `raise` at `:616` also rejects an assistant turn with `tool_calls` and no `content` key, making DeepSeek-V4 tool-call-only support unreachable from `build_direct_hf_sft_split`. Separate root cause, and the remedy is a maintainer call — reported separately, not fixed here.