### PR TITLE
[data] fix: Mask GPT SFT packing alignment gaps

### DIFF
--- a/src/megatron/bridge/data/datasets/gpt_sft.py
+++ b/src/megatron/bridge/data/datasets/gpt_sft.py
@@ -664,6 +664,7 @@ class GPTSFTDataset(Dataset):
             sequence_length=self.max_seq_length,
             pad_token_id=self.tokenizer.eos_id,
             pad_to_multiple_of=self.in_batch_packing_pad_to_multiple_of,
+            emit_padding_mask=self.in_batch_packing_pad_to_multiple_of > 1,
         )
         processed_batch["metadata"] = [item["metadata"] for item in batch]
         processed_batch["token_count"] = [int(item.get("token_count", len(item["input_ids"]))) for item in batch]

--- a/tests/unit_tests/data/datasets/test_gpt_sft.py
+++ b/tests/unit_tests/data/datasets/test_gpt_sft.py
@@ -328,6 +328,7 @@ class TestDataGPTSFTDataset:
         assert result["loss_mask"].tolist() == [[0, 1, 1, 1, 1, 1, 1, 0]]
         assert result["position_ids"].tolist() == [[0, 1, 2, 3, 0, 1, 2, 3]]
         assert result["attention_mask"] is None
+        assert result["padding_mask"].tolist() == [[False, False, False, False, False, False, False, True]]
         assert result["cu_seqlens_q"].tolist() == [0, 4, 7]
         assert result["cu_seqlens_kv"].tolist() == [0, 4, 7]
         assert result["cu_seqlens_q_padded"].tolist() == [0, 4, 8]


### PR DESCRIPTION
## Problem

GPT-SFT in-batch packing is a supported path with `dataloader_type="single"` or `"cyclic"` and `micro_batch_size > 1`. When context or sequence parallelism requires per-sequence alignment, the collator inserts physical padding positions but does not mark them for the MoE router.

LM labels and loss masks already exclude those positions, but pinned Megatron-Core still includes them in router z-loss normalization, auxiliary routing statistics/denominators, and adaptive expert-bias counts. This silently changes MoE training semantics, especially for short heterogeneous rows under larger CP/SP alignment multiples.

This boundary was introduced by #5493. The existing packed-padding contract and GPT-step forwarding path were established for sibling producers in #5470.

## Root cause and fix

`ConfigContainer.validate()` derives the CP/SP collation multiple and propagates it to `GPTSFTDataset`. `_collate_in_batch()` passes that multiple to the shared THD helper, but unlike the DirectHF sibling it did not opt into `padding_mask` emission.

The fix requests a stable boolean mask whenever the alignment multiple exceeds one. The existing GPT step then moves, partitions, and forwards it through the already-supported path. The regression extends the exact THD batch test to assert the synthetic alignment position.

## Regression evidence

Focused CPU regression using the exact checkout sources and an isolated package-init harness:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/data/datasets \
  tests/unit_tests/data/datasets/test_gpt_sft.py::TestDataGPTSFTDataset::test_in_batch_packing_emits_exact_thd_batch -q
```

- Before: `1 failed` with `KeyError: 'padding_mask'`.
- After, unchanged: `1 passed`.

Adjacent and static validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/data/datasets \
  tests/unit_tests/data/datasets/test_gpt_sft.py -q
# 31 passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# all configured hooks passed
```

## Scope

This changes one GPT-SFT producer argument and one CPU assertion. Ordinary LM cross-entropy was already masked and is unchanged. Pinned MCore still physically dispatches the alignment positions through its primary top-k map; this fix corrects the affected MoE regularization/statistics rather than claiming dispatch elimination. Quantile-balancing routing and unsupported router-scoped TE graph cases are outside this supported path.

No dependencies, CI workflows, public APIs, conversion code, or Megatron-Core sources change. No full-suite, GPU, convergence, model-quality, or performance validation is claimed.
