### PR TITLE
[model, quant] fix: Preserve quantized expert scale dimensions

### DIFF
--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -824,7 +824,10 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
         megatron_module: Optional[MegatronModule],
         hf_param_name: Optional[str],
     ) -> Dict[str, torch.Tensor]:
-        """The difference from gather_from_ep_ranks is that we add an extra unsqueeze before we return a tensor.
+        """Gather expert scale tensors using the same staging path as expert weights.
+
+        Only the leading dimension added while grouping gathered tensors is removed,
+        so singleton dimensions belonging to the scale's block grid are preserved.
 
         Args:
             megatron_weights (Optional[torch.Tensor]): The local expert weight tensor

--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -877,7 +877,7 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
             else:
                 weights_dict[param_name] = gathered_weights[i].unsqueeze(0)
         for param_name in weights_dict:
-            weights_dict[param_name] = weights_dict[param_name].squeeze().unsqueeze(dim=-1)
+            weights_dict[param_name] = weights_dict[param_name].squeeze(0)
         return weights_dict
 
     def maybe_dequantize(self, tensor: torch.Tensor) -> torch.Tensor:

--- a/tests/unit_tests/models/test_param_mapping.py
+++ b/tests/unit_tests/models/test_param_mapping.py
@@ -148,6 +148,44 @@ def test_ep_gather_preserves_expert_scale_singleton_dimensions(mock_distributed_
     torch.testing.assert_close(gathered_scale[1], local_scale + 10)
 
 
+def test_ep_scale_gather_preserves_singleton_block_grid_dimensions(mock_distributed_env):
+    """Scale gathering must remove only its own staging dimension."""
+    mock_mpu, mock_dist = mock_distributed_env()
+    mapping = FusedExpertMapping(
+        "decoder.layers.0.mlp.experts.linear_fc2.weight0",
+        "model.layers.0.mlp.experts.down_proj",
+    )
+
+    class _MockGroup:
+        def size(self):
+            return 2
+
+        def rank(self):
+            return 0
+
+    mapping.ep_group = _MockGroup()
+    mock_mpu.get_expert_model_parallel_group.return_value = mapping.ep_group
+
+    def fake_all_gather(output, tensor, group):
+        assert group is mapping.ep_group
+        output[0].copy_(tensor)
+        output[1].copy_(tensor + 10)
+
+    mock_dist.all_gather.side_effect = fake_all_gather
+    local_scale = torch.tensor([[[1.0], [2.0]]])
+
+    result = mapping.gather_from_ep_ranks_scale(
+        local_scale,
+        SimpleNamespace(config=SimpleNamespace(num_moe_experts=4)),
+        "model.layers.0.mlp.experts.down_proj",
+    )
+
+    gathered_scale = result["model.layers.0.mlp.experts.down_proj"]
+    assert gathered_scale.shape == (2, 1, 2, 1)
+    torch.testing.assert_close(gathered_scale[0], local_scale)
+    torch.testing.assert_close(gathered_scale[1], local_scale + 10)
+
+
 class TestDirectMapping:
     def test_hf_to_megatron(self, mock_distributed_env, transformer_config):
         mock_distributed_env()


### PR DESCRIPTION
## Problem

`AutoBridge.export_hf_weights_quant()` can silently drop a valid singleton block-grid dimension from MoE expert scale tensors. The trigger is a selected expert weight whose block quantizer returns a scale shaped `[block_rows, block_cols, 1]` with either block-grid axis equal to one, which is valid when an expert shard dimension equals the caller-selected block size.

For grouped EP=2 export, two local scales shaped `[1, 2, 1]` are staged as `[2, 1, 2, 1]`, but the current helper emits `[2, 2, 1]`. Grouped accumulation then preserves that malformed geometry in the Hugging Face `*_scale_inv` tensor. Per-expert and EP=1 paths can lose the same quantizer-owned axis.

This affects the quantize-before-gather workflow introduced by #2737. The adjacent fix in #5731 established that ordinary EP gathering must remove only its own staging axis, but the quantization-specific scale helper retained the unqualified squeeze.

## Root cause and fix

`gather_from_ep_ranks_scale()` stages tensors with a leading EP-owned dimension, then calls unqualified `squeeze()` and re-adds only a trailing dimension. That removes every singleton axis, including valid block-grid axes owned by the quantizer.

Use `squeeze(0)` so only a size-one staging axis is removed. For grouped EP greater than one, the leading EP axis remains available to `_accumulate_grouped_export()` as designed.

## Regression evidence

The focused test executes the real helper with a deterministic two-rank gather and a `[1, 2, 1]` local scale.

Fail before:

```text
uv run --active --no-sync --no-project python -m pytest \
  tests/unit_tests/models/test_param_mapping.py::test_ep_scale_gather_preserves_singleton_block_grid_dimensions -q
1 failed — expected (2, 1, 2, 1), got (2, 2, 1)
```

Pass after, unchanged test:

```text
uv run --active --no-sync --no-project python -m pytest \
  tests/unit_tests/models/test_param_mapping.py::test_ep_scale_gather_preserves_singleton_block_grid_dimensions -q
1 passed
```

Adjacent validation:

```text
uv run --active --no-sync --no-project python -m pytest \
  tests/unit_tests/models/test_param_mapping.py::test_ep_gather_preserves_expert_scale_singleton_dimensions \
  tests/unit_tests/models/test_param_mapping.py::TestFusedExpertMapping \
  tests/unit_tests/models/test_param_mapping.py::TestFusedGatedExpertMapping -q
7 passed

uv run --active --no-sync --no-project python -m pytest \
  tests/unit_tests/quantization/test_quant_bridge.py::test_quantized_stream_accumulates_grouped_experts -q
1 passed

git diff --check
uv run --no-sync pre-commit run --all-files
```

Both repository checks passed. The focused CPU environment used the repository's pinned MCore revision and disabled only unrelated optional CUDA/Triton imports.

## Scope

This changes one internal tensor-axis operation and adds one focused CPU regression test. It does not change conversion APIs, quantization formats, model registrations, dependencies, workflows, the lockfile, or Megatron-Core.
