### PR TITLE
[ckpt] fix: Publish selectors after checkpoint metadata

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1480,16 +1480,8 @@ def save_checkpoint(
                 if MultiStorageClientFeature.is_enabled():
                     msc = MultiStorageClientFeature.import_package()
                     msc.torch.save(train_state_dict, train_state_local_filename)
-                    msc.torch.save(train_state_dict, train_state_global_filename)
-                    # Write Megatron-LM tracker file for compatibility
-                    with msc.open(tracker_filename, "w") as f:
-                        f.write(str(step))
                 else:
                     torch.save(train_state_dict, train_state_local_filename)
-                    shutil.copy(train_state_local_filename, train_state_global_filename)
-                    # Write Megatron-LM tracker file for compatibility
-                    with open(tracker_filename, "w") as f:
-                        f.write(str(step))
 
                 cfg.to_yaml(config_filename)
 
@@ -1498,6 +1490,18 @@ def save_checkpoint(
                     tokenizer_instance = getattr(cfg.dataset, "tokenizer", None) if cfg.dataset else None
                     if tokenizer_instance is not None:
                         save_tokenizer_assets(tokenizer_instance, cfg.tokenizer, checkpoint_name)
+
+                if MultiStorageClientFeature.is_enabled():
+                    msc = MultiStorageClientFeature.import_package()
+                    msc.torch.save(train_state_dict, train_state_global_filename)
+                    # Write Megatron-LM tracker file for compatibility
+                    with msc.open(tracker_filename, "w") as f:
+                        f.write(str(step))
+                else:
+                    shutil.copy(train_state_local_filename, train_state_global_filename)
+                    # Write Megatron-LM tracker file for compatibility
+                    with open(tracker_filename, "w") as f:
+                        f.write(str(step))
 
                 tp_rank = (tensor_rank if tensor_rank is not None else pg_collection.tp.rank()) + 1
                 tp_world_size = pg_collection.tp.size()

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -618,6 +618,63 @@ def save_checkpoint_fixtures():
 class TestSaveCheckpoint:
     """Test checkpoint saving functionality."""
 
+    def test_metadata_failure_does_not_publish_incomplete_checkpoint(self, tmp_path, save_checkpoint_fixtures):
+        """A failed metadata write must leave automatic resume on the previous checkpoint."""
+        state = save_checkpoint_fixtures["mock_state"]
+        state.cfg.checkpoint.save = str(tmp_path)
+        state.cfg.checkpoint.most_recent_k = -1
+        state.cfg.to_yaml.side_effect = OSError("metadata write failed")
+
+        previous_state = TrainState(step=500)
+        latest_train_state = tmp_path / "latest_train_state.pt"
+        torch.save(previous_state.state_dict(), latest_train_state)
+        legacy_tracker = tmp_path / "latest_checkpointed_iteration.txt"
+        legacy_tracker.write_text("500")
+
+        pg_collection = Mock()
+        pg_collection.expt_dp.rank.return_value = 0
+        pg_collection.tp.rank.return_value = 0
+        pg_collection.tp.size.return_value = 1
+        pg_collection.pp.rank.return_value = 0
+        pg_collection.pp.size.return_value = 1
+
+        with (
+            patch("megatron.bridge.training.checkpointing.dist_checkpointing.save", return_value=None),
+            patch("megatron.bridge.training.checkpointing.TorchDistSaveShardedStrategy", return_value=Mock()),
+            patch("megatron.bridge.training.checkpointing.get_rng_state", return_value=Mock()),
+            patch("megatron.bridge.training.checkpointing.get_rerun_state_machine") as mock_rerun,
+            patch("megatron.bridge.training.checkpointing._get_model_glu_interleave_sizes", return_value=(None, None)),
+            patch(
+                "megatron.bridge.training.checkpointing.generate_state_dict",
+                return_value={"model": {"weight": Mock()}},
+            ),
+            patch(
+                "megatron.bridge.training.checkpointing.unwrap_model",
+                return_value=save_checkpoint_fixtures["mock_model"],
+            ),
+            patch("megatron.bridge.training.checkpointing.save_sharded_modelopt_state"),
+            patch("megatron.bridge.training.checkpointing.maybe_save_dataloader_state"),
+            patch("megatron.bridge.training.checkpointing.fault_tolerance"),
+            patch("megatron.bridge.training.checkpointing.is_empty_async_queue", return_value=True),
+            patch("megatron.bridge.training.checkpointing.get_rank_safe", return_value=0),
+            patch("megatron.bridge.training.checkpointing.is_last_rank", return_value=False),
+            patch("torch.distributed.is_initialized", return_value=False),
+        ):
+            mock_rerun.return_value.state_dict.return_value = {}
+            with pytest.raises(OSError, match="metadata write failed"):
+                save_checkpoint(
+                    state,
+                    save_checkpoint_fixtures["mock_model"],
+                    save_checkpoint_fixtures["mock_optimizer"],
+                    save_checkpoint_fixtures["mock_scheduler"],
+                    1000000,
+                    checkpointing_context={},
+                    pg_collection=pg_collection,
+                )
+
+        assert torch.load(latest_train_state, weights_only=True)["step"].item() == 500
+        assert legacy_tracker.read_text() == "500"
+
     @pytest.mark.parametrize("save_rng", [True, False])
     @patch("megatron.bridge.training.checkpointing.wandb_utils")
     @patch("megatron.bridge.training.checkpointing.is_last_rank")


### PR DESCRIPTION
## What changed

Checkpoint finalization now writes `run_config.yaml` and tokenizer metadata before publishing the root resume selectors (`latest_train_state.pt` and `latest_checkpointed_iteration.txt`).

## User impact

If required checkpoint metadata serialization or storage fails during synchronous or asynchronous finalization, the current code can advertise the new checkpoint even though it is incomplete. Automatic resume then selects that checkpoint; for a native distributed checkpoint without `run_config.yaml`, loading falls back to the legacy path and fails because the checkpoint has no legacy `args` entry. The prior complete checkpoint remains on disk but is no longer selected automatically.

The fix keeps selectors on the previous complete checkpoint until all required metadata for the new checkpoint has been written.

## Root cause and fix

The rank-zero finalizer published both resume selectors before calling `cfg.to_yaml`. Moving selector publication after required metadata creation preserves the publication invariant for both local filesystems and the multi-storage client path without changing payload writing, retention, or public APIs.

## Validation

Fail before, pass after:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_metadata_failure_does_not_publish_incomplete_checkpoint -q --tb=short
```

- Before: 1 failed because `latest_train_state.pt` advanced from step 500 to step 1000 after metadata failure.
- After: 1 passed.

Adjacent checkpoint coverage:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_metadata_failure_does_not_publish_incomplete_checkpoint tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_save_checkpoint_global tests/unit_tests/training/test_checkpointing.py::TestAsyncCheckpointRetention::test_async_retention_keeps_tracker_checkpoint_until_finalize tests/unit_tests/training/test_checkpointing.py::TestCheckpointLoggers::test_async_checkpoint_loggers_use_scheduled_step -q --tb=short
```

- 5 passed.

Also passed:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

## Scope

This change does not alter checkpoint payloads, retention policy, public APIs, dependencies, CI configuration, or upstream Megatron-Core code. No full-suite, convergence, model-quality, or performance validation was run.
