### PR TITLE
[misc] fix: Surface failed sync inference requests

### DIFF
--- a/scripts/inference/text_generation.py
+++ b/scripts/inference/text_generation.py
@@ -161,6 +161,10 @@ def _generate_with_dynamic_engine(
     ) as llm:
         if llm.is_primary_rank:
             outputs = llm.generate(prompts, sampling_params)
+            failed_outputs = [output for output in outputs if output.failed()]
+            if failed_outputs:
+                details = ", ".join(f"request {output.request_id}={output.status.name}" for output in failed_outputs)
+                raise RuntimeError(f"Inference failed: {details}")
             _print_results(prompts, outputs)
 
 

--- a/tests/unit_tests/scripts/test_text_generation_entrypoint.py
+++ b/tests/unit_tests/scripts/test_text_generation_entrypoint.py
@@ -179,3 +179,57 @@ def test_print_results_includes_returned_log_probabilities(
     assert "Generated log probs: [-0.3]" in rendered
     assert "Prompt top-n logprobs: [{'prompt-token': -0.1}]" in rendered
     assert "Generated top-n logprobs: [{'generated-token': -0.3}]" in rendered
+
+
+@pytest.mark.unit
+def test_dynamic_generation_rejects_failed_inference_requests(
+    text_generation_entrypoint: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailedLLM:
+        is_primary_rank = True
+
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> _FailedLLM:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def generate(self, _prompts: list[str], _sampling_params: object) -> list[types.SimpleNamespace]:
+            return [
+                types.SimpleNamespace(
+                    request_id=7,
+                    status=types.SimpleNamespace(name="FAILED"),
+                    generated_text="",
+                    failed=lambda: True,
+                )
+            ]
+
+    monkeypatch.setattr(text_generation_entrypoint, "MegatronLLM", _FailedLLM)
+    args = types.SimpleNamespace(
+        max_new_tokens=1,
+        max_seq_length=32,
+        max_batch_size=None,
+        tp=1,
+        block_size_tokens=8,
+        kv_cache_buffer_size_gb=1.0,
+        max_tokens=1,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+        use_coordinator=False,
+        coordinator_host=None,
+        coordinator_port=None,
+    )
+    tokenizer = types.SimpleNamespace(tokenize=lambda _prompt: [1, 2])
+
+    with pytest.raises(RuntimeError, match="request 7.*FAILED"):
+        text_generation_entrypoint._generate_with_dynamic_engine(
+            args,
+            model=object(),
+            tokenizer=tokenizer,
+            prompts=["Hello world"],
+            sampling_params=object(),
+        )


### PR DESCRIPTION
## Problem

The supported synchronous dynamic text-generation CLI can receive a completed failed request from MCore without an exception. For example, with chunked prefill disabled, a normal two-token prompt and `--max_tokens 1` make MCore return a request with `Status.FAILED` and `TokenOverflowError`.

The sync Bridge entrypoint previously rendered that request as an empty generation and exited successfully. Shell, Slurm, and launcher automation therefore reported success even though inference produced no result. MCore also emits a warning, but that does not change the process exit status.

## Root cause and fix

The runtime path is CLI prompt/token budget → `MegatronLLM.generate()` → returned `DynamicInferenceRequest` values → `_print_results()`. The async Bridge entrypoint already checks MCore's public `failed()` contract, but the synchronous dynamic path passed every returned value directly to the renderer.

The fix adds the same narrow check at the sync consumer boundary. If any returned request failed, the CLI raises with its request ID and status before printing results. Successful output and distributed cleanup are unchanged.

## Validation

Fail-before focused regression:

```text
PYTHONPATH="$PWD/src" uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation_entrypoint.py::test_dynamic_generation_rejects_failed_inference_requests -q
```

- Before: exit 1 with `Failed: DID NOT RAISE <class 'RuntimeError'>`.
- After: exit 0; 1 passed.

Focused and adjacent sync/async entrypoint tests:

```text
PYTHONPATH="$PWD/src" uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation_entrypoint.py \
  tests/unit_tests/scripts/test_async_text_generation_entrypoint.py -q
```

- Result: 7 passed.

```text
uv run --no-sync pre-commit run --all-files
git diff --check
```

- Result: all hooks passed; diff check passed.

## Scope

This change only surfaces completed failed requests from the standalone synchronous dynamic text-generation CLI. It does not change MCore request semantics, async generation, the OpenAI server, legacy static generation, token budgeting, model loading, public APIs, dependencies, CI workflows, or upstream Megatron-LM. No GPU functional test, full suite, convergence, model-quality, or performance validation is claimed.

No existing issue or open pull request was found for this sync root cause. The established async sibling behavior was added in #5548.
