### PR TITLE
[data] fix: reject unsupported Nemotron Omni loss modes

### DIFF
--- a/src/megatron/bridge/data/builders/direct_hf_sft.py
+++ b/src/megatron/bridge/data/builders/direct_hf_sft.py
@@ -317,6 +317,10 @@ def build_direct_hf_sft_split(
                 resolve_model_collate(collate_key),
                 loss_mode=config.preprocessing.loss_mode,
             )
+        elif config.preprocessing.loss_mode != "assistant":
+            raise ValueError(
+                f"Processor type '{type(processor).__name__}' currently supports only assistant chat loss."
+            )
         else:
             selected_collate = None
     else:

--- a/tests/unit_tests/data/builders/test_direct_hf_sft.py
+++ b/tests/unit_tests/data/builders/test_direct_hf_sft.py
@@ -160,6 +160,22 @@ def test_builder_keeps_text_shaped_nemotron_omni_data_on_model_collator(monkeypa
     assert captured["collate_impl"] is None
 
 
+def test_builder_rejects_full_loss_for_nemotron_omni(monkeypatch):
+    row = {"conversation": [{"role": "user", "content": "question"}]}
+    processor_type = type("NemotronH_Nano_Omni_Reasoning_V3Processor", (_Tokenizer,), {})
+    monkeypatch.setattr(builder_module, "load_direct_hf_sft_examples", lambda source, preprocessing: [row])
+    config = DirectHFSFTDatasetConfig(
+        seq_length=16,
+        source=HFDatasetSourceConfig(path_or_dataset="org/chat"),
+        preprocessing=ChatSFTPreprocessingConfig(loss_mode="full"),
+        do_validation=False,
+        do_test=False,
+    )
+
+    with pytest.raises(ValueError, match="only assistant chat loss"):
+        build_direct_hf_sft_split(config, config.source, 1, processor_type())
+
+
 @pytest.mark.parametrize("loss_mode", ["last_turn", "full"])
 def test_builder_forwards_chat_loss_mode_to_model_collator(monkeypatch, loss_mode):
     row = {"conversation": [{"role": "user", "content": "question"}]}


### PR DESCRIPTION
## What changed

Reject non-`assistant` chat loss modes when the Direct-HF builder selects a model collator that cannot receive the requested mode, and add a focused Nemotron Omni regression test.

## Supported trigger and impact

The public Nemotron Omni Direct-HF recipe accepts `data.preprocessing.loss_mode=full` (or `last_turn`). The override reaches `build_direct_hf_sft_split`, but the Nemotron model collator has no `loss_mode` parameter and always constructs assistant-only labels and loss masks. Training therefore proceeds with a different objective than the requested one without warning.

The builder owns both the requested preprocessing mode and the collator-selection decision. This patch makes that unsupported combination fail immediately, matching the existing generic multimodal behavior, while leaving the supported `assistant` path unchanged.

## Regression evidence

Against base `5c4092faedd26a688a28ad218c6df1ebf6b3aad7`, a deterministic builder reproducer failed with:

```
AssertionError: Nemotron Omni accepted full loss but its collator can only emit assistant loss
```

The unchanged reproducer exits successfully after the fix.

Focused regression test:

```
uv run --no-sync python -m pytest tests/unit_tests/data/builders/test_direct_hf_sft.py::test_builder_rejects_full_loss_for_nemotron_omni -q
# 1 passed
```

Adjacent builder tests:

```
uv run --no-sync python -m pytest tests/unit_tests/data/builders/test_direct_hf_sft.py -q
# 39 passed
```

Repository checks:

```
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This is limited to Direct-HF model collators that do not explicitly accept `loss_mode`. It does not add new Nemotron Omni masking modes, change DeepSeek loss-mode forwarding, alter Energon data handling, or modify public APIs.
