### PR TITLE
fix(training): skip flex dispatcher device probe when no backend is requested

### DIFF
--- a/src/megatron/bridge/training/flex_dispatcher_backend.py
+++ b/src/megatron/bridge/training/flex_dispatcher_backend.py
@@ -49,7 +49,12 @@ def apply_flex_dispatcher_backend(
             )
         return
 
-    if not torch.cuda.is_available() and moe_flex_dispatcher_backend in ("deepep", "hybridep"):
+    if moe_flex_dispatcher_backend not in ("deepep", "hybridep"):
+        if get_rank_safe() == 0:
+            logger.warning("Not a valid flex dispatcher backend. Skipping flex dispatcher backend configuration.")
+        return
+
+    if not torch.cuda.is_available():
         model_config.moe_token_dispatcher_type = "flex"
         model_config.moe_flex_dispatcher_backend = moe_flex_dispatcher_backend
         model_config.moe_shared_expert_overlap = False
@@ -76,10 +81,7 @@ def apply_flex_dispatcher_backend(
                 )
             _fallback_to_alltoall(model_config)
             return
-    else:
-        if get_rank_safe() == 0:
-            logger.warning("Not a valid flex dispatcher backend. Skipping flex dispatcher backend configuration.")
-        return
+
     model_config.moe_token_dispatcher_type = "flex"
     model_config.moe_flex_dispatcher_backend = moe_flex_dispatcher_backend
     model_config.moe_shared_expert_overlap = False

--- a/tests/unit_tests/training/test_deepep.py
+++ b/tests/unit_tests/training/test_deepep.py
@@ -442,3 +442,77 @@ class TestValidateHybridEP:
 
         # Verify get_device_properties was called
         mock_get_device_properties.assert_called_once_with(0)
+
+
+class TestApplyFlexDispatcherBackendWithoutCuda:
+    """Test apply_flex_dispatcher_backend on a host with no CUDA device."""
+
+    @pytest.mark.parametrize("backend", [None, "not-a-backend"])
+    @patch("torch.cuda.get_device_properties", side_effect=RuntimeError("No CUDA GPUs are available"))
+    @patch("megatron.bridge.training.flex_dispatcher_backend.logger")
+    def test_unrecognized_backend_skips_device_probe(
+        self,
+        mock_logger,
+        mock_get_device_properties,
+        backend,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test that an MoE config requesting no usable backend is left alone without probing a device."""
+        monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+        config = SimpleNamespace(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend=None,
+            moe_shared_expert_overlap=True,
+        )
+
+        apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend=backend)
+
+        mock_get_device_properties.assert_not_called()
+        assert config.moe_token_dispatcher_type == "alltoall"
+        assert config.moe_flex_dispatcher_backend is None
+        assert config.moe_shared_expert_overlap is True
+        mock_logger.warning.assert_called_once()
+        assert "Not a valid flex dispatcher backend" in mock_logger.warning.call_args[0][0]
+
+    @pytest.mark.parametrize("backend", ["deepep", "hybridep"])
+    @patch("torch.cuda.get_device_properties", side_effect=RuntimeError("No CUDA GPUs are available"))
+    def test_supported_backend_still_selects_flex_without_cuda(
+        self,
+        mock_get_device_properties,
+        backend,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test that a supported backend still configures the flex dispatcher when CUDA is unavailable."""
+        monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+        config = SimpleNamespace(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend=None,
+            moe_shared_expert_overlap=True,
+        )
+
+        apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend=backend)
+
+        mock_get_device_properties.assert_not_called()
+        assert config.moe_token_dispatcher_type == "flex"
+        assert config.moe_flex_dispatcher_backend == backend
+        assert config.moe_shared_expert_overlap is False
+
+    @patch("torch.cuda.get_device_properties")
+    @patch("megatron.bridge.training.flex_dispatcher_backend.logger")
+    def test_unrecognized_backend_skips_device_probe_on_gpu_host(self, mock_logger, mock_get_device_properties):
+        """Test that the unrecognized-backend path also avoids the device probe when CUDA is available."""
+        config = SimpleNamespace(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend=None,
+            moe_shared_expert_overlap=True,
+        )
+
+        apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend=None)
+
+        mock_get_device_properties.assert_not_called()
+        assert config.moe_token_dispatcher_type == "alltoall"
+        assert config.moe_flex_dispatcher_backend is None
+        assert "Not a valid flex dispatcher backend" in mock_logger.warning.call_args[0][0]


### PR DESCRIPTION
# What does this PR do ?

Fixes seven public MoE recipe factories (six Qwen3-VL, StepFun step37) crashing with `RuntimeError: No CUDA GPUs are available` when constructed on a CPU-only host, by skipping the flex-dispatcher device probe on the branch that never reads it.

# Changelog

- `src/megatron/bridge/training/flex_dispatcher_backend.py`: return early for an unrecognized backend above the device probe; drop the now-unreachable `else`.
- `tests/unit_tests/training/test_deepep.py`: 5 tests covering the no-backend path and the CUDA-unavailable branches.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- **Root cause:** `flex_dispatcher_backend.py:58` probed `torch.cuda.get_device_properties(0)` above the backend dispatch; the `else` at :79-82 warns and returns without reading it. The :52 guard from #5732 is conjunctive on `backend in ("deepep","hybridep")`, so `None` fell through.
- **Blast radius:** six Qwen3-VL factories + StepFun step37 pass `moe_flex_dispatcher_backend=None`; blocks the offline-packing workflow on CPU hosts.
- **Regression?** No — broken since `c62795c6` (HybridEP support, 2025-11-20). Found while testing #5732; #5732 narrowed it, did not cause it.
- **Verification:** red-green in `nvcr.io/nvidian/nemo:nightly` at `5c4092fae` — RED 3 failed, GREEN 5 passed, full file 24 passed. E2e: `CUDA_VISIBLE_DEVICES="" ... qwen3_vl_30b_a3b_sft_config()` raised pre-fix, returns `alltoall`/`None` post-fix.
- **Preserved:** GPU arch checks, #5732's no-CUDA flex path, and `validate_flex_dispatcher_backend` are unchanged.
