### PR TITLE
fix(recipe): pin expert tensor parallelism on Qwen3.5-VL MoE pretrain recipes

### DIFF
--- a/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
@@ -227,6 +227,7 @@ def qwen35_vl_35b_a3b_pretrain_8gpu_h100_bf16_mock_config() -> ConfigContainer:
     cfg.model.freeze_vision_projection = False
     cfg.model.seq_length = 4096
     cfg.model.expert_model_parallel_size = 4
+    cfg.model.expert_tensor_parallel_size = 1
 
     cfg.optimizer, cfg.scheduler = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=500,
@@ -346,6 +347,7 @@ def qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_mock_config() -> ConfigContain
     cfg.model.freeze_vision_projection = False
     cfg.model.seq_length = 4096
     cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
 
     cfg.optimizer, cfg.scheduler = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=500,
@@ -397,6 +399,7 @@ def qwen35_vl_397b_a17b_pretrain_512gpu_h100_bf16_mock_config() -> ConfigContain
     cfg.model.freeze_vision_projection = False
     cfg.model.seq_length = 4096
     cfg.model.expert_model_parallel_size = 16
+    cfg.model.expert_tensor_parallel_size = 1
 
     cfg.optimizer, cfg.scheduler = distributed_fused_adam_with_cosine_annealing(
         lr_warmup_iters=500,

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -1113,6 +1113,62 @@ def test_qwen35_vl_35b_a3b_pretrain_mock_defaults(monkeypatch: pytest.MonkeyPatc
     assert cfg.train.micro_batch_size == 2
 
 
+class _FakeModelCfgWithoutExpertTensorParallel(_FakeModelCfg):
+    """Fake model configuration that leaves expert tensor parallelism unset."""
+
+    def __init__(self):
+        super().__init__()
+        # Megatron-Core resolves an unset value to the dense tensor parallel size.
+        self.expert_tensor_parallel_size = None
+
+
+class _FakeAutoBridgeWithoutExpertTensorParallel:
+    """Fake AutoBridge whose provider leaves expert tensor parallelism unset."""
+
+    @staticmethod
+    def from_hf_pretrained(hf_path: str):
+        return _FakeAutoBridgeWithoutExpertTensorParallel()
+
+    def to_megatron_provider(self, load_weights: bool = False):
+        return _FakeModelCfgWithoutExpertTensorParallel()
+
+
+@pytest.mark.parametrize(
+    ("recipe_func", "world_size"),
+    [
+        (_qwen35_vl_h100_module.qwen35_vl_35b_a3b_pretrain_8gpu_h100_bf16_mock_config, 8),
+        (_qwen35_vl_h100_module.qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_mock_config, 128),
+        (_qwen35_vl_h100_module.qwen35_vl_397b_a17b_pretrain_512gpu_h100_bf16_mock_config, 512),
+    ],
+)
+def test_qwen35_vl_moe_pretrain_mock_grids_divide_their_named_world_size(
+    recipe_func: Callable,
+    world_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """MoE pretrain mock recipes own dense and expert grids that divide the world size they name."""
+    patch_recipe_module_global(
+        monkeypatch,
+        _qwen35_vl_h100_module,
+        "AutoBridge",
+        _FakeAutoBridgeWithoutExpertTensorParallel,
+    )
+
+    cfg = recipe_func()
+
+    assert cfg.model.expert_tensor_parallel_size == 1
+    dense_grid = (
+        cfg.model.tensor_model_parallel_size * cfg.model.context_parallel_size * cfg.model.pipeline_model_parallel_size
+    )
+    expert_grid = (
+        cfg.model.expert_tensor_parallel_size
+        * cfg.model.expert_model_parallel_size
+        * cfg.model.pipeline_model_parallel_size
+    )
+    assert world_size % dense_grid == 0, f"dense grid {dense_grid} does not divide {world_size}"
+    assert world_size % expert_grid == 0, f"expert grid {expert_grid} does not divide {world_size}"
+
+
 def test_qwen35_vl_122b_a10b_pretrain_mock_defaults(monkeypatch: pytest.MonkeyPatch):
     """Test that 122B-A10B pretrain mock has correct large MoE parallelism."""
     patch_recipe_module_global(monkeypatch, _qwen35_vl_module, "AutoBridge", _FakeAutoBridge)


### PR DESCRIPTION
# What does this PR do ?

Fixes three Qwen3.5-VL MoE pretrain recipes raising `RuntimeError` at `initialize_model_parallel`, by pinning the expert tensor parallel size they left unset.

# Changelog

- `src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py`: set `expert_tensor_parallel_size = 1` on the 35B-A3B/8gpu, 122B-A10B/128gpu and 397B-A17B/512gpu pretrain mock recipes.
- `tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py`: 1 parametrized test (3 cases) asserting the dense and expert grids divide each recipe's named world size, built through a provider fake that leaves ETP unset.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- **Root cause:** ETP unset, so Megatron-Core resolves it to the dense TP (`model_parallel_config.py:506`, `parallel_state.py:871`) and the expert grid needs 4x the ranks each recipe name advertises.
- **Blast radius:** `tutorials/data/datacomp/train_qwen36_example.sh` and both `qwen3.6-35b-a3b` card leaves launch the 35B-A3B recipe on 8 GPUs with no overrides; all fail at init.
- **Regression?** No, latent since `4d7ce790` (#4622). Masked in unit tests because the shared `_FakeModelCfg` pre-sets ETP=1.
- **Verification:** 8xH100, `nvcr.io/nvidian/nemo:nightly`. `initialize_model_parallel` at the recipe topology: ETP unset gives `world_size (8) is not divisible by expert_tensor_model_pipeline_parallel size (32)`; ETP=1 gives OK (dp=1 etp=1 ep=4). Unit red-green 3 failed to 3 passed; `pytest tests/unit_tests/recipes/qwen_vl/` 225 passed.
- **Not included:** the card leaves' GBS 512 vs recipe GBS 32 mismatch is a separate card-side defect.
- Related to # (issue)
