### PR TITLE
[training] fix: Honor in-process restart limit

### DIFF
--- a/src/megatron/bridge/training/inprocess_restart.py
+++ b/src/megatron/bridge/training/inprocess_restart.py
@@ -93,7 +93,10 @@ def inprocess_restart(train_fn: Callable, config: InProcessRestartConfig, global
         finalize.append(inprocess.finalize.ThreadedFinalize(timeout=timedelta(seconds=10), fn=torch.cuda.empty_cache))
 
     initialize = inprocess.Compose(
-        inprocess.initialize.RetryController(min_world_size=active_world_size),
+        inprocess.initialize.RetryController(
+            max_iterations=config.max_iterations,
+            min_world_size=active_world_size,
+        ),
         inprocess.nested_restarter.NestedRestarterHandlingCompleted(),
     )
 

--- a/tests/unit_tests/training/test_inprocess_restart.py
+++ b/tests/unit_tests/training/test_inprocess_restart.py
@@ -16,6 +16,8 @@ import os
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from megatron.bridge.training.config import InProcessRestartConfig
 from megatron.bridge.training.inprocess_restart import inprocess_restart, maybe_wrap_for_inprocess_restart
 from megatron.bridge.training.state import GlobalState
@@ -23,6 +25,36 @@ from megatron.bridge.training.state import GlobalState
 
 class TestInProcessRestart:
     """Test cases for the inprocess_restart function."""
+
+    def test_inprocess_restart_honors_max_iterations(self):
+        """Test that a finite retry limit aborts before the next attempt."""
+        from nvidia_resiliency_ext.inprocess.exception import RestartAbort
+        from nvidia_resiliency_ext.inprocess.state import State
+
+        config = InProcessRestartConfig(
+            enabled=True,
+            max_iterations=2,
+            active_world_size=1,
+            granularity="rank",
+            empty_cuda_cache=False,
+        )
+        mock_global_state = MagicMock(spec=GlobalState)
+
+        with (
+            patch.dict(os.environ, {"MASTER_PORT": "29500"}),
+            patch("megatron.bridge.training.inprocess_restart.warnings.warn"),
+            patch("nvidia_resiliency_ext.inprocess.Wrapper") as mock_wrapper,
+        ):
+            mock_wrapper.return_value.return_value = MagicMock()
+            inprocess_restart(MagicMock(), config, mock_global_state)
+
+        retry_controller = mock_wrapper.call_args.kwargs["initialize"].instances[0]
+        allowed_state = State(rank=0, world_size=1, active_rank=0, active_world_size=1, iteration=1).freeze()
+        exhausted_state = State(rank=0, world_size=1, active_rank=0, active_world_size=1, iteration=2).freeze()
+
+        assert retry_controller(allowed_state) is allowed_state
+        with pytest.raises(RestartAbort):
+            retry_controller(exhausted_state)
 
     def test_inprocess_restart_resolves_default_active_world_size(self):
         """Test the documented WORLD_SIZE fallback for active ranks."""
@@ -53,6 +85,7 @@ class TestInProcessRestart:
         mock_train_fn = MagicMock()
         mock_config = MagicMock(spec=InProcessRestartConfig)
         mock_config.active_world_size = 2
+        mock_config.max_iterations = None
         mock_config.granularity = "rank"
         mock_config.empty_cuda_cache = True
         mock_config.max_rank_faults = None
@@ -108,7 +141,7 @@ class TestInProcessRestart:
             mock_finalize.assert_called()
 
             # Verify initialize components
-            mock_retry.assert_called_once_with(min_world_size=2)
+            mock_retry.assert_called_once_with(max_iterations=None, min_world_size=2)
             mock_nested_completed.assert_called_once()
 
             # Verify abort components


### PR DESCRIPTION
## Problem

Setting a finite InProcessRestartConfig.max_iterations has no effect. Bridge constructs the NVRx RetryController without that value, so the controller retains its None default and recoverable failures can retry beyond the configured limit.

Supported trigger: enable in-process restart, set a finite max_iterations, and encounter enough recoverable failures to reach that iteration. The expected NVRx RestartAbort is never raised, which defeats the configured safety bound and can keep rebuilding and reloading training state.

## Root cause and fix

The training wrapper forwards active_world_size to RetryController.min_world_size, but drops the adjacent max_iterations configuration. This change forwards that existing value at the controller ownership boundary. It adds no API, dependency, fallback, or broader restart behavior.

## Validation

Fail-before on unmodified production code:

    uv run --no-sync python -m pytest tests/unit_tests/training/test_inprocess_restart.py::TestInProcessRestart::test_inprocess_restart_honors_max_iterations -q --tb=short

Result: 1 failed because RestartAbort was not raised at iteration 2 for max_iterations=2.

Pass-after with this fix:

    uv run --no-sync python -m pytest tests/unit_tests/training/test_inprocess_restart.py::TestInProcessRestart::test_inprocess_restart_honors_max_iterations -q --tb=short

Result: 1 passed.

Adjacent validation:

    uv run --no-sync python -m pytest tests/unit_tests/training/test_inprocess_restart.py -q --tb=short

Result: 20 passed.

    uv run --no-sync pre-commit run --all-files

Result: passed.

    git diff --check

Result: passed.

## Scope

This validates the CPU controller contract only. It does not claim full-suite, GPU, distributed, convergence, model-quality, or performance validation.