### PR TITLE
[recipe] fix: Correct Qwen2-Audio SFT minimum LR

### DIFF
--- a/src/megatron/bridge/recipes/qwen2_audio/h100/qwen2_audio.py
+++ b/src/megatron/bridge/recipes/qwen2_audio/h100/qwen2_audio.py
@@ -49,6 +49,7 @@ def qwen2_audio_7b_sft_1gpu_h100_bf16_config() -> ConfigContainer:
         pipeline_model_parallel_size=1,
         peft=None,
         finetune_lr=5e-6,
+        min_lr=5e-7,
     )
 
     # Keep the complete process environment visible on the recipe.

--- a/tests/unit_tests/recipes/test_qwen2_audio_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen2_audio_recipes.py
@@ -180,6 +180,7 @@ class TestQwen2AudioSftConfig:
         assert cfg.peft is None
         # Cosine annealing scheduler exposes max_lr / min_lr.
         assert cfg.optimizer.lr == pytest.approx(5e-6)
+        assert cfg.optimizer.min_lr <= cfg.optimizer.lr
 
     def test_sft_config_lora_uses_higher_lr(self):
         """The PEFT recipe uses lr=1e-4 for LoRA."""


### PR DESCRIPTION
## Problem

The supported no-argument `qwen2_audio_7b_sft_config()` recipe cannot start training with its defaults. It publishes `optimizer.lr=5e-6` but inherits `optimizer.min_lr=3e-5`.

Bridge forwards those values as the maximum and minimum learning rates when constructing the pinned Megatron-Core scheduler. Scheduler setup requires `max_lr >= min_lr`, so the default full-SFT path aborts before training starts.

The PEFT sibling is unaffected because it uses `lr=1e-4`, which is above the shared `3e-5` minimum. The example script is also unaffected because it explicitly overrides both values.

## Fix

Set the full-SFT factory's minimum learning rate to `5e-7`, matching the optimizer helper's 0.1× convention for its documented `5e-6` maximum. This keeps the change at the owning factory and preserves the shared common-builder and PEFT defaults.

The focused recipe test now asserts the scheduler ordering invariant in addition to the existing exact maximum-LR contract.

## Regression evidence

Focused test before the fix:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/recipes \
  tests/unit_tests/recipes/test_qwen2_audio_recipes.py::TestQwen2AudioSftConfig::test_sft_config_full_sft_uses_low_lr -q

1 failed
assert cfg.optimizer.min_lr <= cfg.optimizer.lr
E AssertionError: assert 3e-05 <= 5e-06
```

The unchanged focused test after the fix:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/recipes \
  tests/unit_tests/recipes/test_qwen2_audio_recipes.py::TestQwen2AudioSftConfig::test_sft_config_full_sft_uses_low_lr -q

1 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/recipes \
  tests/unit_tests/recipes/test_qwen2_audio_recipes.py -q

17 passed

git diff --check
uv run --no-sync pre-commit run --all-files
```

Both repository checks passed.

## Scope

This changes one full-SFT recipe argument and one focused assertion. It does not change public APIs, the shared optimizer helper, PEFT behavior, dependencies, workflows, the lockfile, or Megatron-Core. No GPU, convergence, model-quality, performance, or full-suite validation is claimed.
