### PR TITLE
[model] fix: Reject unaligned FP8 QKV scale export

### DIFF
--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -54,6 +54,7 @@ from transformers.modeling_utils import PreTrainedModel
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.param_mapping import (
     MegatronParamMapping,
+    QKVMapping,
 )
 from megatron.bridge.models.conversion.peft_bridge import (
     AdapterWeight,
@@ -2117,6 +2118,21 @@ class MegatronModelBridge(
             pp_group,
             fp8_scale_inv_attr,
         )
+
+        for global_name, fp8_flag in global_fp8_flags.items():
+            block_size = self._fp8_scale_block_size(fp8_flag)
+            if block_size is None:
+                continue
+            mapping = mapping_registry.megatron_to_hf_lookup(self._get_lora_unwrapped_name(global_name))
+            if not isinstance(mapping, QKVMapping):
+                continue
+            head_size = model_config.kv_channels or (model_config.hidden_size // model_config.num_attention_heads)
+            if head_size % block_size != 0:
+                raise ValueError(
+                    f"Cannot export blockwise FP8 QKV scales: QKV head size {head_size} "
+                    f"is not divisible by FP8 block size {block_size}. Scale blocks that cross "
+                    "QKV head boundaries cannot be split into separate HF projections."
+                )
 
         # 2) Expand the global name list with `*.scale_inv` entries.
         #    This defines the final deterministic task ordering.

--- a/tests/unit_tests/models/test_fp8_param_export.py
+++ b/tests/unit_tests/models/test_fp8_param_export.py
@@ -30,7 +30,7 @@ from megatron.bridge.models.conversion.model_bridge import (
     WeightConversionTask,
     _HFNameSuffixMapping,
 )
-from megatron.bridge.models.conversion.param_mapping import split_qkv_weights
+from megatron.bridge.models.conversion.param_mapping import QKVMapping, split_qkv_weights
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 
 
@@ -160,6 +160,31 @@ class TestHFNameSuffixMapping:
 
 
 class TestFp8ParamExport:
+    def test_build_export_fp8_tasks_rejects_unaligned_qkv_scale_blocks(self, monkeypatch):
+        bridge = DummyBridge()
+        global_name = "decoder.layers.0.self_attention.linear_qkv.weight"
+        mapping = QKVMapping(global_name, "hf.q.weight", "hf.k.weight", "hf.v.weight")
+        _patch_export_task_context(
+            monkeypatch,
+            bridge,
+            global_name,
+            registry_factory=lambda: MegatronMappingRegistry(mapping),
+            detect_fp8=lambda *_a, **_k: {global_name: 128},
+        )
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                num_attention_heads=64,
+                num_query_groups=8,
+                hidden_size=2880,
+                kv_channels=64,
+                share_embeddings_and_output_weights=False,
+            ),
+            named_parameters=lambda: [],
+        )
+
+        with pytest.raises(ValueError, match="QKV head size 64.*FP8 block size 128"):
+            bridge.build_export_fp8_tasks(SimpleNamespace(state=SimpleNamespace(source=SimpleNamespace())), [model])
+
     @pytest.mark.parametrize(
         "export_weight_dtype, expect_unquantized",
         [("fp8", True), ("bf16", False)],


### PR DESCRIPTION
## What changed

Reject native blockwise-FP8 QKV export before task streaming when the FP8 row
block size does not divide the attention head size.

## User impact

GPT-OSS 20B uses 64-row QKV heads with 128-row FP8 blocks. Bridge previously
accepted this public export configuration, then failed while splitting the
trimmed QKV scale tensor, after export processing had begun.

The fused scale blocks cross the separate Q/K/V projection boundaries, so they
cannot be losslessly split into valid Hugging Face scale tensors. Task
construction now reports that unsupported geometry before any weights are
streamed.

## Root cause and fix

`build_export_fp8_tasks` gathered the block size but used it only for vocabulary
scale truncation. QKV scale tasks were routed through the ordinary `QKVMapping`,
whose splitter assumes scale rows align with QKV head boundaries.

The fix reuses the gathered block size and resolved mapping to validate that
alignment on every pipeline rank. Other mappings and aligned QKV geometries are
unchanged.

## Validation

Fail before:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/test_fp8_param_export.py::TestFp8ParamExport::test_build_export_fp8_tasks_rejects_unaligned_qkv_scale_blocks -q
FAILED: DID NOT RAISE ValueError
```

Pass after and adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/test_fp8_param_export.py -q
25 passed
```

Additional checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This does not add requantization or expand native FP8 export support to
block/head layouts that cannot be represented losslessly.
