### PR TITLE
[ckpt] fix: Publish checkpoints after tokenizer assets

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1893,6 +1893,8 @@ def save_tokenizer_assets(
     tokenizer: MegatronTokenizer,
     tokenizer_config: TokenizerConfig,
     checkpoint_path: str,
+    *,
+    raise_on_error: bool = False,
 ) -> None:
     """Save tokenizer files to the checkpoint directory.
 
@@ -1904,6 +1906,7 @@ def save_tokenizer_assets(
         tokenizer: The tokenizer instance to save.
         tokenizer_config: The tokenizer configuration (used for file-based tokenizers).
         checkpoint_path: The checkpoint directory path.
+        raise_on_error: Propagate tokenizer persistence errors to the caller.
     """
     if tokenizer is None:
         return
@@ -2022,6 +2025,8 @@ def save_tokenizer_assets(
             import traceback
 
             logger.error(traceback.format_exc())
+        if raise_on_error:
+            raise
 
 
 def _generate_model_state_dict(

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -605,6 +605,32 @@ def save_megatron_model(
         dist=None,
     )
 
+    # Complete tokenizer construction and persistence before save_checkpoint publishes
+    # the root selectors for this checkpoint.
+    if tokenizer_config is not None:
+        from megatron.bridge.training.checkpointing import (
+            get_checkpoint_name,
+            save_tokenizer_assets,
+        )
+
+        tokenizer_error: Exception | None = None
+        try:
+            tokenizer = build_tokenizer(tokenizer_config)
+            checkpoint_name = get_checkpoint_name(str(path), 0, release=False)
+            save_tokenizer_assets(tokenizer, tokenizer_config, checkpoint_name, raise_on_error=True)
+        except Exception as error:
+            tokenizer_error = error
+
+        if torch.distributed.is_initialized():
+            tokenizer_errors: list[str | None] = [None] * torch.distributed.get_world_size()
+            local_error = None if tokenizer_error is None else f"{type(tokenizer_error).__name__}: {tokenizer_error}"
+            torch.distributed.all_gather_object(tokenizer_errors, local_error)
+            failures = [error for error in tokenizer_errors if error is not None]
+            if failures:
+                raise RuntimeError(f"Failed to save tokenizer assets on one or more ranks: {failures}")
+        elif tokenizer_error is not None:
+            raise tokenizer_error
+
     if low_memory_save:
         # Low-memory save flow: process factories incrementally, freeing memory as we go
         import gc
@@ -775,22 +801,6 @@ def save_megatron_model(
             num_floating_point_operations_so_far=0,
             callback_manager=None,
         )
-
-    # Save tokenizer files separately if tokenizer config is provided
-    if tokenizer_config is not None:
-        from megatron.bridge.training.checkpointing import (
-            get_checkpoint_name,
-            save_tokenizer_assets,
-        )
-
-        # Build the tokenizer
-        tokenizer = build_tokenizer(tokenizer_config)
-
-        # Get the checkpoint name for step 0
-        checkpoint_name = get_checkpoint_name(str(path), 0, release=False)
-
-        # Save tokenizer files
-        save_tokenizer_assets(tokenizer, tokenizer_config, checkpoint_name)
 
 
 def dtype_from_str(dtype: str) -> torch.dtype:

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -1033,8 +1033,125 @@ class TestSaveMegatronModel:
         mock_build_tokenizer.assert_called_once()
         mock_get_checkpoint_name.assert_called_once()
         mock_save_tokenizer_assets.assert_called_once_with(
-            mock_tokenizer, tokenizer_config, "/fake/checkpoint/iter_0000000"
+            mock_tokenizer,
+            tokenizer_config,
+            "/fake/checkpoint/iter_0000000",
+            raise_on_error=True,
         )
+
+    @patch("megatron.bridge.training.model_load_save.save_checkpoint")
+    @patch("megatron.bridge.training.model_load_save.get_model_config")
+    @patch("megatron.bridge.training.model_load_save.GlobalState")
+    @patch("megatron.bridge.training.model_load_save.ConfigContainer")
+    @patch("megatron.bridge.training.model_load_save.OptimizerConfig")
+    @patch("megatron.bridge.training.model_load_save.LoggerConfig")
+    @patch("megatron.bridge.training.model_load_save.CheckpointConfig")
+    def test_tokenizer_failure_does_not_publish_incomplete_checkpoint(
+        self,
+        mock_ckpt_config,
+        mock_logger_config,
+        mock_opt_config,
+        mock_config_container,
+        mock_global_state,
+        mock_get_model_config,
+        mock_save_checkpoint,
+        tmp_path,
+    ):
+        """A failed tokenizer save must leave automatic resume on the previous checkpoint."""
+
+        class MockModelConfig(ModelProviderMixin, Mock):
+            def provide(self, pre_process=None, post_process=None, vp_stage=None):
+                return Mock()
+
+            def finalize(self) -> None:
+                pass
+
+        mock_get_model_config.return_value = MockModelConfig()
+        mock_global_state.return_value = Mock()
+        mock_config_container.return_value = Mock()
+
+        latest_train_state = tmp_path / "latest_train_state.pt"
+        latest_train_state.write_text("500")
+
+        def publish_selector(**kwargs):
+            latest_train_state.write_text("0")
+
+        mock_save_checkpoint.side_effect = publish_selector
+
+        tokenizer = Mock()
+        tokenizer.save_pretrained.side_effect = OSError("tokenizer write failed")
+        checkpoint_name = tmp_path / "iter_0000000"
+
+        with (
+            patch("megatron.bridge.training.model_load_save.build_tokenizer", return_value=tokenizer),
+            patch(
+                "megatron.bridge.training.checkpointing.get_checkpoint_name",
+                return_value=str(checkpoint_name),
+            ),
+            pytest.raises(OSError, match="tokenizer write failed"),
+        ):
+            save_megatron_model(
+                [Mock()],
+                tmp_path,
+                ckpt_format="torch_dist",
+                hf_tokenizer_path="org/model",
+                low_memory_save=False,
+            )
+
+        assert latest_train_state.read_text() == "500"
+
+    @patch("megatron.bridge.training.model_load_save.save_checkpoint")
+    @patch("megatron.bridge.training.model_load_save.get_model_config")
+    @patch("megatron.bridge.training.model_load_save.GlobalState")
+    @patch("megatron.bridge.training.model_load_save.ConfigContainer")
+    @patch("megatron.bridge.training.model_load_save.OptimizerConfig")
+    @patch("megatron.bridge.training.model_load_save.LoggerConfig")
+    @patch("megatron.bridge.training.model_load_save.CheckpointConfig")
+    def test_tokenizer_failure_stops_all_ranks_before_checkpoint_save(
+        self,
+        mock_ckpt_config,
+        mock_logger_config,
+        mock_opt_config,
+        mock_config_container,
+        mock_global_state,
+        mock_get_model_config,
+        mock_save_checkpoint,
+        tmp_path,
+    ):
+        """Every rank must observe a tokenizer failure before entering checkpoint save."""
+
+        class MockModelConfig(ModelProviderMixin, Mock):
+            def provide(self, pre_process=None, post_process=None, vp_stage=None):
+                return Mock()
+
+            def finalize(self) -> None:
+                pass
+
+        mock_get_model_config.return_value = MockModelConfig()
+        mock_global_state.return_value = Mock()
+        mock_config_container.return_value = Mock()
+
+        def gather_rank_zero_error(errors, local_error):
+            assert local_error is None
+            errors[:] = ["OSError: tokenizer write failed", None]
+
+        with (
+            patch("megatron.bridge.training.model_load_save.build_tokenizer", return_value=Mock()),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.get_rank", return_value=1),
+            patch("torch.distributed.get_world_size", return_value=2),
+            patch("torch.distributed.all_gather_object", side_effect=gather_rank_zero_error),
+            pytest.raises(RuntimeError, match="tokenizer write failed"),
+        ):
+            save_megatron_model(
+                [Mock()],
+                tmp_path,
+                ckpt_format="torch_dist",
+                hf_tokenizer_path="org/model",
+                low_memory_save=False,
+            )
+
+        mock_save_checkpoint.assert_not_called()
 
     @patch("megatron.bridge.training.model_load_save.save_checkpoint")
     @patch("megatron.bridge.training.model_load_save.get_model_config")


### PR DESCRIPTION
## Problem

`save_megatron_model(..., hf_tokenizer_path=...)` used to call `save_checkpoint()` before constructing and persisting tokenizer assets. `save_checkpoint()` publishes the root checkpoint selectors, while `save_tokenizer_assets()` logged and suppressed persistence errors. A supported export could therefore return after advertising a checkpoint whose explicitly requested tokenizer assets were never written.

This failure shape is also visible in #3990, where tokenizer construction fails after checkpoint save has already reported success.

## Root cause and fix

The export path crossed the publication boundary before completing its rank-0 tokenizer work. This change:

- completes tokenizer construction and persistence before `save_checkpoint()`;
- opts this export path into tokenizer persistence error propagation without changing existing training or MIMO callers;
- gathers tokenizer errors across initialized ranks before any rank enters checkpoint save, so a rank-0 write failure cannot strand peers in checkpoint collectives.

## Validation

Fail-before on the unmodified base:

```text
uv run python -m pytest tests/unit_tests/training/test_model_load_save.py::TestSaveMegatronModel::test_tokenizer_failure_does_not_publish_incomplete_checkpoint -vv
```

Result: failed because the expected `OSError` was suppressed after the mocked selector publication.

Pass-after with the unchanged regression:

```text
uv run python -m pytest tests/unit_tests/training/test_model_load_save.py::TestSaveMegatronModel::test_tokenizer_failure_does_not_publish_incomplete_checkpoint -vv
```

Result: `1 passed`.

Focused and adjacent unit tests:

```text
uv run python -m pytest tests/unit_tests/training/test_model_load_save.py::TestSaveMegatronModel tests/unit_tests/training/test_tokenizer_checkpointing.py -q
```

Result: `20 passed`.

A deterministic two-rank run additionally injected the tokenizer write failure on rank 0 and verified that both ranks stopped before checkpoint save and exited without hanging.

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This is limited to explicit tokenizer assets in `save_megatron_model`. It does not change normal training/MIMO error policy, bundled-tokenizer reload selection, dependencies, CI, public conversion signatures, or Megatron-Core.
