### PR TITLE
fix(misc): normalize zero-temperature sampling

### DIFF
--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -386,7 +386,10 @@ def build_sampling_params(
     stop_words: list[str] | None,
 ) -> SamplingParams:
     """Build MCore ``SamplingParams`` from CLI-derived values."""
-    if top_k is None:
+    if temperature == 0.0:
+        top_k = 1
+        top_p = 0.0
+    elif top_k is None:
         top_k = 0 if top_p > 0.0 else 1
     if top_k > 0 and top_p > 0.0:
         raise ValueError("--top_k and --top_p cannot both be positive.")

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -23,11 +23,13 @@ from enum import Enum
 from pathlib import Path
 
 import pytest
-from megatron.core.inference.sampling.torch_sampling import TorchSampling
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MODULE_PATH = _REPO_ROOT / "src" / "megatron" / "bridge" / "inference" / "text_generation.py"
+_TORCH_SAMPLING_PATH = (
+    _REPO_ROOT / "3rdparty" / "Megatron-LM" / "megatron" / "core" / "inference" / "sampling" / "torch_sampling.py"
+)
 
 
 class _AttnBackend(Enum):
@@ -64,6 +66,26 @@ def _module(name: str, **attrs: object) -> types.ModuleType:
     for attr_name, value in attrs.items():
         setattr(module, attr_name, value)
     return module
+
+
+def _load_torch_sampling() -> type:
+    base_module_name = "megatron.core.inference.sampling.base"
+    original_base_module = sys.modules.get(base_module_name)
+    sys.modules[base_module_name] = _module(base_module_name, Sampling=object)
+    try:
+        spec = importlib.util.spec_from_file_location("torch_sampling_under_test", _TORCH_SAMPLING_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.TorchSampling
+    finally:
+        if original_base_module is None:
+            sys.modules.pop(base_module_name, None)
+        else:
+            sys.modules[base_module_name] = original_base_module
+
+
+TorchSampling = _load_torch_sampling()
 
 
 def _install_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -392,6 +414,23 @@ def test_top_p_sampling_is_compatible_with_default_cli_values(text_generation):
 
     assert params.kwargs["top_k"] == 0
     assert sampled.shape == (1,)
+
+
+def test_zero_temperature_top_p_sampling_is_greedy(text_generation):
+    params = _parse_sampling_params(text_generation, ["--temperature", "0", "--top_p", "0.9"])
+    logits = text_generation.torch.tensor([[1.0, 2.0, 3.0]])
+
+    sampled = TorchSampling.sample_from_logits(
+        logits,
+        params.kwargs["temperature"],
+        params.kwargs["top_k"],
+        params.kwargs["top_p"],
+        generator=text_generation.torch.Generator().manual_seed(0),
+    )
+
+    assert params.kwargs["top_k"] == 1
+    assert params.kwargs["top_p"] == 0.0
+    assert sampled.item() == 2
 
 
 def test_default_sampling_remains_greedy(text_generation):


### PR DESCRIPTION
## Summary

The maintained standalone sync and async text-generation CLIs accept `--temperature 0 --top_p 0.9`. Their shared sampling builder previously resolved that to active nucleus sampling with a zero temperature. The pinned MCore torch sampler then divided finite logits by zero and aborted generation with a non-finite probability error after model and distributed initialization.

Normalize exact zero-temperature requests to greedy decoding (`top_k=1`, `top_p=0`). This matches the pinned MCore OpenAI completion frontends and preserves every nonzero-temperature path.

## Root cause and fix

`add_sampling_args` accepts zero temperature, and `build_sampling_params` selected `top_k=0` whenever positive top-p was supplied. Both offline entrypoints forwarded that tuple unchanged to MCore. The minimal fix handles exact temperature zero at the shared Bridge ownership boundary before the existing omitted-top-k and incompatibility logic.

The regression parses the supported Bridge CLI, exercises the production builder, and calls the exact pinned CPU-pure `torch_sampling.py` implementation. Only the sampler's abstract base import is stubbed so this focused unit test does not initialize unrelated CUDA/MCore package dependencies.

## Regression evidence

Before the production fix, the new test failed with:

```text
temperature = 0.0, top_k = 0, top_p = 0.9
RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
```

After the unchanged production fix:

```text
tests/unit_tests/scripts/test_text_generation.py::test_zero_temperature_top_p_sampling_is_greedy
1 passed
```

## Validation

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation.py -q
# 21 passed

uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation_entrypoint.py \
  tests/unit_tests/scripts/test_async_text_generation_entrypoint.py -q
# 7 passed

uv run --no-sync pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

## Scope

No dependencies, lockfiles, workflows, public signatures, MCore source, server request handling, model code, or nonzero-temperature sampling behavior changed. No GPU, distributed, convergence, performance, or full-suite validation is claimed.
