### PR TITLE
[training] fix: Shut down NVRx before in-process restart

### DIFF
--- a/src/megatron/bridge/training/state.py
+++ b/src/megatron/bridge/training/state.py
@@ -29,7 +29,10 @@ from torch.distributed.checkpoint.stateful import Stateful
 from torch.utils.tensorboard.writer import SummaryWriter
 
 from megatron.bridge.training.config import ConfigContainer
-from megatron.bridge.training.nvrx_straggler import NVRxStragglerDetectionManager
+from megatron.bridge.training.nvrx_straggler import (
+    NVRxStragglerDetectionManager,
+    safe_shutdown_nvrx_straggler_manager,
+)
 from megatron.bridge.training.tokenizers.tokenizer import build_tokenizer
 from megatron.bridge.training.utils.log_utils import safe_serialize
 from megatron.bridge.training.utils.sig_utils import DistributedSignalHandler
@@ -502,6 +505,7 @@ class GlobalState:
             self._signal_handler.release()
         self._signal_handler = None
         self._straggler_timer = None
+        safe_shutdown_nvrx_straggler_manager(self._nvrx_straggler_manager)
         self._nvrx_straggler_manager = None
         self._nvrx_straggler_created = False
 

--- a/tests/unit_tests/training/test_state.py
+++ b/tests/unit_tests/training/test_state.py
@@ -1007,7 +1007,8 @@ class TestGlobalState:
         mock_signal_handler = MagicMock()
         state._signal_handler = mock_signal_handler
         state._straggler_timer = MagicMock()
-        state._nvrx_straggler_manager = MagicMock()
+        mock_nvrx_straggler_manager = MagicMock()
+        state._nvrx_straggler_manager = mock_nvrx_straggler_manager
         state._nvrx_straggler_created = True
 
         # Call reset_for_restart
@@ -1025,6 +1026,7 @@ class TestGlobalState:
         mock_signal_handler.release.assert_called_once()
         assert state._signal_handler is None
         assert state._straggler_timer is None
+        mock_nvrx_straggler_manager.shutdown.assert_called_once()
         assert state._nvrx_straggler_manager is None
         assert state._nvrx_straggler_created is False
 


### PR DESCRIPTION
## What changed

Shut down an initialized NVRx straggler manager before `GlobalState` clears it during in-process restart cleanup.

## Bug and impact

When NVRx straggler detection and in-process restart are both enabled, a recoverable training failure reaches `GlobalState.reset_for_restart()`. The old code discarded the manager without calling `shutdown()`.

NVRx keeps detector initialization as process-global state. On the retry, a new manager attempts to initialize the detector again, the initialization assertion is caught, and training continues with straggler reporting and `stop_if_detected` disabled.

The fix reuses the existing safe shutdown helper before clearing the private manager reference. It does not change either feature's configuration or public API.

## Regression evidence

The new assertion is unchanged between the base and fixed revisions.

Fail before:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_state.py::TestGlobalState::test_reset_for_restart -q --tb=short
1 failed: Expected 'shutdown' to have been called once. Called 0 times.
```

Pass after:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_state.py::TestGlobalState::test_reset_for_restart -q --tb=short
1 passed
```

Adjacent restart coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_inprocess_restart.py -q --tb=short -k 'not abort_checkpoint'
15 passed, 4 deselected
```

Static validation:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
all hooks passed
```

## Scope

This only changes NVRx manager cleanup on the existing in-process-restart reset boundary. It does not alter general failure cleanup, detector behavior, retry policy, distributed setup, or async checkpoint handling.
