### PR TITLE
fix(data): propagate cyclic epochs to workers

### DIFF
--- a/src/megatron/bridge/data/samplers.py
+++ b/src/megatron/bridge/data/samplers.py
@@ -2,6 +2,7 @@
 
 """Dataloaders."""
 
+import multiprocessing
 import random
 from typing import Any, Callable, Iterator, Optional
 
@@ -409,7 +410,7 @@ class RandomSeedDataset(Dataset):
     def __init__(self, dataset: Dataset, seed: int) -> None:
         """Initialize RandomSeedDataset."""
         self.base_seed = seed
-        self.curr_seed = seed
+        self.curr_seed = multiprocessing.Value("q", seed, lock=False)
         self.dataset = dataset
 
     def __len__(self) -> int:
@@ -418,11 +419,11 @@ class RandomSeedDataset(Dataset):
 
     def set_epoch(self, epoch: int) -> None:
         """Set the current epoch number to adjust the random seed."""
-        self.curr_seed = self.base_seed + epoch
+        self.curr_seed.value = self.base_seed + epoch
 
     def __getitem__(self, idx: int) -> Any:
         """Get an item from the dataset, setting the random seed first."""
-        seed = idx + self.curr_seed
+        seed = idx + self.curr_seed.value
         torch.manual_seed(seed)
         random.seed(seed)
         np.random.seed(seed)

--- a/tests/unit_tests/data/test_samplers.py
+++ b/tests/unit_tests/data/test_samplers.py
@@ -1,11 +1,25 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 import pytest
+import torch
+from torch.utils.data import Dataset
 
-from megatron.bridge.data.samplers import MegatronPretrainingSampler
+from megatron.bridge.data.samplers import (
+    MegatronPretrainingSampler,
+    RandomSeedDataset,
+    build_pretraining_data_loader,
+)
 
 
 pytestmark = pytest.mark.unit
+
+
+class _RandomValueDataset(Dataset):
+    def __len__(self) -> int:
+        return 8
+
+    def __getitem__(self, idx: int) -> tuple[int, int]:
+        return idx, torch.randint(0, 1_000_000, (1,)).item()
 
 
 def test_single_sampler_rejects_unsafe_partial_distributed_batch() -> None:
@@ -69,3 +83,28 @@ def test_single_sampler_drops_partial_distributed_batch() -> None:
     )
 
     assert list(sampler) == [[2, 3]]
+
+
+@pytest.mark.parametrize(("num_workers", "persistent_workers"), [(0, False), (1, False), (1, True)])
+def test_cyclic_sampler_resume_seeds_worker_dataset_for_current_epoch(
+    num_workers: int, persistent_workers: bool
+) -> None:
+    """A resumed cyclic loader must seed stochastic samples with its resumed epoch."""
+    base_seed = 100
+    dataset = RandomSeedDataset(_RandomValueDataset(), seed=base_seed)
+    dataloader = build_pretraining_data_loader(
+        dataset=dataset,
+        consumed_samples=len(dataset),
+        dataloader_type="cyclic",
+        micro_batch_size=1,
+        num_workers=num_workers,
+        data_sharding=False,
+        persistent_workers=persistent_workers,
+    )
+
+    sample_idx, actual_value = next(iter(dataloader))
+    sample_idx = sample_idx.item()
+    generator = torch.Generator().manual_seed(base_seed + 1 + sample_idx)
+    expected_value = torch.randint(0, 1_000_000, (1,), generator=generator).item()
+
+    assert actual_value.item() == expected_value


### PR DESCRIPTION
## Summary

When a custom `DatasetProvider` returns `RandomSeedDataset` and uses the supported cyclic loader with workers, resumed or later epochs update the dataset seed only in the parent process. Worker copies therefore use stale epoch seeds: persistent workers repeat epoch-0 stochastic preprocessing indefinitely, while nonpersistent workers duplicate the first epoch and remain one epoch behind.

Store the wrapper's current seed in shared process memory so the cyclic sampler's existing epoch update is visible before workers retrieve the next indices.

## Supported trigger and impact

- a custom provider returns `RandomSeedDataset`;
- `dataloader_type="cyclic"`;
- `num_workers > 0`; and
- training resumes in, or advances to, an epoch after epoch 0.

For stochastic `__getitem__` preprocessing, workers seed Python, NumPy, and Torch as if they were still in an earlier epoch. Persistent workers reuse the exact per-index augmentation from epoch 0, and a resumed run diverges from the documented epoch-derived data stream while loading successfully.

## Root cause and minimal fix

`MegatronPretrainingRandomSampler.__iter__()` derives the epoch and calls `RandomSeedDataset.set_epoch()`. PyTorch starts DataLoader workers before it first advances that sampler generator, so ordinary parent-process attribute updates are not propagated to worker dataset copies.

`RandomSeedDataset` now keeps only its mutable current-seed integer in a lock-free `multiprocessing.Value`. The existing sampler update and per-item seed calculation otherwise remain unchanged. No loader, sampler-order, provider, or configuration contract changes.

## Regression evidence

An exact-source CPU reproducer resumed an eight-sample cyclic loader at epoch 1 and compared synchronous loading with one worker.

Before:

```text
index=5 synchronous=785518 worker=660224 expected_epoch1=785518
AssertionError: worker dataset did not use resumed epoch 1
```

After, unchanged reproducer:

```text
index=5 synchronous=785518 worker=785518 expected_epoch1=785518
```

The checked-in regression covers synchronous, nonpersistent-worker, and persistent-worker resume modes.

## Validation

```text
BRIDGE_SOURCE_ROOT="$PWD/src" PYTHONPATH="$HARNESS_ROOT" \
  uv run --project "$BRIDGE_PROJECT" --no-sync python -m pytest \
  -p bootstrap_sampler_test --confcutdir=tests/unit_tests/data -p no:cacheprovider \
  tests/unit_tests/data/test_samplers.py -q
# 8 passed

git diff --check
# passed

uv run --project "$BRIDGE_PROJECT" --no-sync pre-commit run --all-files
# all configured hooks passed
```

The small package-init harness only avoids unrelated optional CUDA imports on the CPU host; the test imports and executes the exact checkout's sampler module.

## Scope

This changes one internal epoch-seed storage value and adds one focused CPU regression. Built-in providers that do not use `RandomSeedDataset` are unchanged. No dependencies, public signatures, configurations, workflows, lockfiles, or Megatron-Core sources change. No GPU, distributed-process-group, convergence, model-quality, performance, or full-suite validation is claimed.
