### PR TITLE
[model] fix: Skip singleton EP scale gather

### DIFF
--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -843,6 +843,9 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
             Dict[str, torch.Tensor]: Mapping from HF parameter names (one per EP rank)
             to the corresponding expert tensors gathered from each EP rank.
         """
+        if self.ep_size == 1:
+            return {str(hf_param_name): megatron_weights}
+
         if megatron_module is None:
             num_experts_per_rank = self.broadcast_obj_from_pp_rank(None, "num_experts_per_rank")
         else:

--- a/tests/unit_tests/quantization/test_quant_bridge.py
+++ b/tests/unit_tests/quantization/test_quant_bridge.py
@@ -418,3 +418,32 @@ class TestGatedMLPMappingQuant:
         assert torch.equal(result["up.weight"], q_up)
         assert torch.equal(result["gate.weight_scale_inv"], scale_gate)
         assert torch.equal(result["up.weight_scale_inv"], scale_up)
+
+    def test_megatron_to_hf_quant_skips_missing_singleton_ep_group(self, mock_distributed_env):
+        """Logical EP=1 must not fall through to the default WORLD group."""
+        _, mock_dist = mock_distributed_env()
+        mapping = GatedMLPMapping(
+            megatron_param="decoder.layers.0.mlp.experts.local_experts.0.linear_fc1.weight",
+            gate="model.layers.0.mlp.experts.0.gate_proj.weight",
+            up="model.layers.0.mlp.experts.0.up_proj.weight",
+        )
+        mapping.pp_group = None
+        mapping.ep_group = None
+        mapping._tp_group = None
+        mapping._etp_group = None
+        merged_weight = torch.randn(16, 4)
+        megatron_module = MockModule(types.SimpleNamespace(num_moe_experts=1), weight_shape=(16, 4))
+
+        result = mapping.megatron_to_hf_quant(
+            merged_weight,
+            megatron_module,
+            quantization_checker=dummy_quantization_checker,
+            quant_fn=scaled_fp8_blockwise,
+            quant_block_size=(2, 2),
+        )
+
+        assert result["model.layers.0.mlp.experts.0.gate_proj.weight"].shape == (8, 4)
+        assert result["model.layers.0.mlp.experts.0.up_proj.weight"].shape == (8, 4)
+        assert result["model.layers.0.mlp.experts.0.gate_proj.weight_scale_inv"].shape == (4, 2, 1)
+        assert result["model.layers.0.mlp.experts.0.up_proj.weight_scale_inv"].shape == (4, 2, 1)
+        mock_dist.all_gather.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fix quantized MoE checkpoint export when a supported partial
`ProcessGroupCollection` represents logical expert parallelism size 1 with
`ep=None` while the default WORLD group contains multiple ranks.

The expert scale helper sized its output list from logical EP (one tensor) but
passed `group=None` to `torch.distributed.all_gather`, which selects WORLD and
expects one output tensor per WORLD rank. Export therefore aborted before
producing the Hugging Face checkpoint.

The scale helper now uses the same EP=1 fast path as its sibling expert-weight
helper. This is intentionally limited to singleton EP and does not change the
existing EP>1 collective path or conversion APIs.

## Testing

- Fail-before: a deterministic two-rank Gloo reproducer running the full
  `GatedMLPMapping.megatron_to_hf_quant` path failed on both ranks with
  `ProcessGroupGloo::allgather: invalid output tensor list ... expected length 2, got 1`.
- Pass-after: the unchanged reproducer passed on both ranks.
- Adjacent control: the same run exercised an explicit EP=2 group and verified
  both gathered expert-scale names and values.
- Added focused regression:
  `uv run python -m pytest tests/unit_tests/quantization/test_quant_bridge.py::TestGatedMLPMappingQuant::test_megatron_to_hf_quant_skips_missing_singleton_ep_group -q`
- `git diff --check` passed.
- `uv run pre-commit run --all-files` passed.

The repository unit-test module could not be collected in the local CPU-only
environment because unrelated optional GPU packages are imported eagerly; the
real two-process collective reproducer supplied the fail-before/pass-after
runtime evidence. No full-suite, GPU, convergence, performance, or model-quality
validation was run.
