### PR TITLE
fix(training): fail fast on malformed launcher rank

### DIFF
--- a/src/megatron/bridge/utils/common_utils.py
+++ b/src/megatron/bridge/utils/common_utils.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import torch
 import torch.distributed
 from megatron.core import DistributedDataParallel as DDP
-from megatron.core._rank_utils import safe_get_rank as _get_rank_safe
+from megatron.core._rank_utils import safe_get_rank as get_rank_safe  # noqa: F401
 from megatron.core._rank_utils import safe_get_world_size as get_world_size_safe  # noqa: F401
 from megatron.core.transformer.module import Float16Module
 from megatron.core.utils import get_batch_on_this_cp_rank
@@ -41,14 +41,6 @@ try:
     ALL_MODULE_WRAPPER_CLASSNAMES = (DDP, torch_FSDP, Float16Module)
 except ImportError:
     ALL_MODULE_WRAPPER_CLASSNAMES = (DDP, Float16Module)
-
-
-def get_rank_safe() -> int:
-    """Get the distributed rank, falling back to zero for malformed launcher state."""
-    try:
-        return _get_rank_safe()
-    except (TypeError, ValueError):
-        return 0
 
 
 def get_last_rank() -> int:

--- a/tests/unit_tests/utils/test_common_utils.py
+++ b/tests/unit_tests/utils/test_common_utils.py
@@ -73,12 +73,22 @@ class TestGetRankSafe:
         mock_is_initialized.assert_called_once()
 
     @patch("torch.distributed.is_initialized")
-    @patch.dict(os.environ, {"RANK": "invalid"})
+    @patch.dict(os.environ, {"RANK": "invalid"}, clear=True)
     def test_invalid_rank_env_var(self, mock_is_initialized):
-        """Test get_rank_safe falls back to 0 when RANK is malformed."""
+        """Test get_rank_safe propagates an actionable error when RANK is malformed."""
         mock_is_initialized.return_value = False
 
-        assert get_rank_safe() == 0
+        with pytest.raises(ValueError, match="invalid literal for int.*invalid"):
+            get_rank_safe()
+
+    @patch("torch.distributed.is_initialized")
+    @patch.dict(os.environ, {"SLURM_NTASKS": "8", "SLURM_PROCID": "invalid"}, clear=True)
+    def test_invalid_slurm_rank_env_var(self, mock_is_initialized):
+        """Test get_rank_safe propagates an actionable error when SLURM_PROCID is malformed."""
+        mock_is_initialized.return_value = False
+
+        with pytest.raises(ValueError, match="invalid literal for int.*invalid"):
+            get_rank_safe()
 
 
 class TestGetWorldSizeSafe:


### PR DESCRIPTION
## Summary

- directly re-export Megatron Core `safe_get_rank` instead of swallowing malformed launcher values
- require malformed `RANK` and `SLURM_PROCID` to propagate actionable `ValueError`s
- retain coverage for initialized distributed state, valid `RANK`/SLURM fallbacks, and the no-launcher rank-0 default

## Why

Merged PR #5710 added a Bridge compatibility wrapper to keep an older test returning rank 0 after the pinned Megatron Core implementation intentionally began raising on malformed rank values. Bridge uses this helper around initialization, checkpoint publication, and rank-gated logging, so silently treating malformed multi-rank launcher state as rank 0 can make multiple processes perform rank-0-only work. Propagating the conversion error fails fast before that unsafe state spreads.

## Testing

- `uv run python -m pytest tests/unit_tests/utils/test_common_utils.py` (44 passed)
- `uv run pre-commit run --all-files`

Follow-up to #5710.