### PR TITLE
[ckpt] feat: Add versioned weight update manifests

### DIFF
--- a/docs/bridge-rl-integration.md
+++ b/docs/bridge-rl-integration.md
@@ -372,6 +372,52 @@ Mappings that require transpose, permutation, interleaving, or grouped-export tr
 
 This contract is not BF16-only. For MXFP8 refit, a transport may materialize canonical logical views from quantized training storage and requantize persistent MXFP8 inference destinations in place. Direct transfer of packed MXFP8 data and scales is a different optimization and is valid only when the source and destination storage layouts, quantization backends, and topology are explicitly compatible.
 
+**Version and verify the exported tensor inventory:** Record metadata during the existing one-shot
+`export_hf_weights()` stream, then send a transport-neutral manifest as the stream trailer. The recorder retains only
+names, shapes, and dtypes, so it does not buffer tensor payloads or repeat the export. On the consumer, record metadata
+while staging each tensor and validate the trailer before making `target_version` visible to rollout workers.
+
+```python
+from megatron.bridge.models.conversion import WeightUpdateManifest, WeightUpdateRecorder
+
+# Producer: tensor frames and their metadata are produced in the same pass.
+sent_inventory = WeightUpdateRecorder()
+for name, tensor in sent_inventory.track(bridge.export_hf_weights([model], show_progress=False)):
+    send_tensor(name, tensor)
+
+manifest = sent_inventory.build_manifest(
+    model_id="meta-llama/Llama-3.2-1B",
+    model_config_id="hf-config-revision-or-digest",
+    update_mode="full",
+    base_version="step-99",
+    target_version="step-100",
+)
+send_manifest(manifest.to_json())  # trailer after the final tensor frame
+
+# Consumer: stage frames and retain only their metadata until the trailer arrives.
+received_inventory = WeightUpdateRecorder()
+for name, tensor in receive_tensors():
+    stage_tensor(name, tensor)
+    received_inventory.record(name, tensor)
+
+received_manifest = WeightUpdateManifest.from_json(receive_manifest())
+received_manifest.validate(
+    received_inventory,
+    expected_model_id="meta-llama/Llama-3.2-1B",
+    expected_model_config_id="hf-config-revision-or-digest",
+    expected_update_mode="full",
+    current_version="step-99",
+    expected_target_version="step-100",
+)
+activate_staged_weights(received_manifest.target_version)
+```
+
+Validation catches transport omissions, duplicates, reordering, and shape/dtype mismatches relative to the producer's
+recorded inventory, and rejects stale or wrong model/config/update context. It does not independently prove that the
+producer exported every model tensor. The metadata digest detects accidental manifest corruption; it is neither a
+tensor-content checksum nor an authentication mechanism. Content hashing, acknowledgement, retry, and atomic runtime
+activation remain consumer/transport responsibilities.
+
 ```python
 import os
 import torch

--- a/docs/fern/versions/nightly/pages/bridge-rl-integration.mdx
+++ b/docs/fern/versions/nightly/pages/bridge-rl-integration.mdx
@@ -364,6 +364,52 @@ Mappings that require transpose, permutation, interleaving, or grouped-export tr
 
 This contract is not BF16-only. For MXFP8 refit, a transport may materialize canonical logical views from quantized training storage and requantize persistent MXFP8 inference destinations in place. Direct transfer of packed MXFP8 data and scales is a different optimization and is valid only when the source and destination storage layouts, quantization backends, and topology are explicitly compatible.
 
+**Version and verify the exported tensor inventory:** Record metadata during the existing one-shot
+`export_hf_weights()` stream, then send a transport-neutral manifest as the stream trailer. The recorder retains only
+names, shapes, and dtypes, so it does not buffer tensor payloads or repeat the export. On the consumer, record metadata
+while staging each tensor and validate the trailer before making `target_version` visible to rollout workers.
+
+```python
+from megatron.bridge.models.conversion import WeightUpdateManifest, WeightUpdateRecorder
+
+# Producer: tensor frames and their metadata are produced in the same pass.
+sent_inventory = WeightUpdateRecorder()
+for name, tensor in sent_inventory.track(bridge.export_hf_weights([model], show_progress=False)):
+    send_tensor(name, tensor)
+
+manifest = sent_inventory.build_manifest(
+    model_id="meta-llama/Llama-3.2-1B",
+    model_config_id="hf-config-revision-or-digest",
+    update_mode="full",
+    base_version="step-99",
+    target_version="step-100",
+)
+send_manifest(manifest.to_json())  # trailer after the final tensor frame
+
+# Consumer: stage frames and retain only their metadata until the trailer arrives.
+received_inventory = WeightUpdateRecorder()
+for name, tensor in receive_tensors():
+    stage_tensor(name, tensor)
+    received_inventory.record(name, tensor)
+
+received_manifest = WeightUpdateManifest.from_json(receive_manifest())
+received_manifest.validate(
+    received_inventory,
+    expected_model_id="meta-llama/Llama-3.2-1B",
+    expected_model_config_id="hf-config-revision-or-digest",
+    expected_update_mode="full",
+    current_version="step-99",
+    expected_target_version="step-100",
+)
+activate_staged_weights(received_manifest.target_version)
+```
+
+Validation catches transport omissions, duplicates, reordering, and shape/dtype mismatches relative to the producer's
+recorded inventory, and rejects stale or wrong model/config/update context. It does not independently prove that the
+producer exported every model tensor. The metadata digest detects accidental manifest corruption; it is neither a
+tensor-content checksum nor an authentication mechanism. Content hashing, acknowledgement, retry, and atomic runtime
+activation remain consumer/transport responsibilities.
+
 ```python
 import os
 import torch

--- a/src/megatron/bridge/models/conversion/__init__.py
+++ b/src/megatron/bridge/models/conversion/__init__.py
@@ -28,6 +28,12 @@ from megatron.bridge.models.conversion.param_mapping import (
     RowParallelMapping,
 )
 from megatron.bridge.models.conversion.utils import weights_verification_table
+from megatron.bridge.models.conversion.weight_update_manifest import (
+    WeightUpdateManifest,
+    WeightUpdateMode,
+    WeightUpdateRecorder,
+    WeightUpdateTensor,
+)
 
 
 __all__ = [
@@ -44,4 +50,8 @@ __all__ = [
     "RowParallelMapping",
     "AutoMapping",
     "weights_verification_table",
+    "WeightUpdateManifest",
+    "WeightUpdateMode",
+    "WeightUpdateRecorder",
+    "WeightUpdateTensor",
 ]

--- a/src/megatron/bridge/models/conversion/weight_update_manifest.py
+++ b/src/megatron/bridge/models/conversion/weight_update_manifest.py
@@ -1,0 +1,337 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural manifests for streamed Hugging Face weight updates."""
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, Literal, cast
+
+import torch
+
+
+WeightUpdateMode = Literal["full", "delta", "adapter", "sparse"]
+_WEIGHT_UPDATE_MODES = ("full", "delta", "adapter", "sparse")
+_MANIFEST_FIELDS = frozenset(
+    {
+        "schema_version",
+        "model_id",
+        "model_config_id",
+        "update_mode",
+        "base_version",
+        "target_version",
+        "tensors",
+        "metadata_digest",
+    }
+)
+_TENSOR_FIELDS = frozenset({"name", "shape", "dtype"})
+
+
+@dataclass(frozen=True)
+class WeightUpdateTensor:
+    """Structural metadata for one ordered tensor in a weight update."""
+
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("tensor names must not be empty")
+        if any(type(dimension) is not int or dimension < 0 for dimension in self.shape):
+            raise ValueError(f"tensor {self.name} has an invalid shape: {self.shape}")
+        if not self.dtype:
+            raise ValueError(f"tensor {self.name} has an empty dtype")
+
+
+class WeightUpdateRecorder:
+    """Record ordered tensor metadata without retaining tensor payloads.
+
+    Use :meth:`track` around a one-shot export stream on the producer and
+    :meth:`record` as tensor frames arrive on the consumer. The recorder keeps
+    names, shapes, and dtypes only.
+    """
+
+    def __init__(self) -> None:
+        self._tensors: list[WeightUpdateTensor] = []
+        self._names: set[str] = set()
+
+    @property
+    def tensors(self) -> tuple[WeightUpdateTensor, ...]:
+        """Return the recorded ordered tensor metadata."""
+        return tuple(self._tensors)
+
+    def record(self, name: str, tensor: torch.Tensor) -> None:
+        """Record metadata for one tensor without retaining its payload."""
+        metadata = _tensor_metadata(name, tensor)
+        if metadata.name in self._names:
+            raise ValueError(f"duplicate tensor name: {metadata.name}")
+        self._names.add(metadata.name)
+        self._tensors.append(metadata)
+
+    def track(self, weights: Iterable[tuple[str, torch.Tensor]]) -> Iterator[tuple[str, torch.Tensor]]:
+        """Yield a weight stream unchanged while recording its metadata."""
+        for name, tensor in weights:
+            self.record(name, tensor)
+            yield name, tensor
+
+    def build_manifest(
+        self,
+        *,
+        model_id: str,
+        model_config_id: str,
+        update_mode: WeightUpdateMode,
+        base_version: str | None,
+        target_version: str,
+    ) -> "WeightUpdateManifest":
+        """Build a manifest trailer for the recorded stream."""
+        return WeightUpdateManifest(
+            model_id=model_id,
+            model_config_id=model_config_id,
+            update_mode=update_mode,
+            base_version=base_version,
+            target_version=target_version,
+            tensors=self.tensors,
+        )
+
+
+@dataclass(frozen=True)
+class WeightUpdateManifest:
+    """Versioned structural contract for one complete HF-coordinate update.
+
+    The manifest contains no tensor payloads. Send it as a trailer after the
+    recorded tensor stream, then validate it against the consumer's recorder
+    and expected context before activating staged weights.
+
+    ``metadata_digest`` detects accidental corruption of manifest metadata. It
+    is neither a tensor-content checksum nor an authentication mechanism.
+    """
+
+    model_id: str
+    model_config_id: str
+    update_mode: WeightUpdateMode
+    base_version: str | None
+    target_version: str
+    tensors: tuple[WeightUpdateTensor, ...]
+    schema_version: int = field(default=1, init=False)
+    metadata_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.model_id:
+            raise ValueError("model_id must not be empty")
+        if not self.model_config_id:
+            raise ValueError("model_config_id must not be empty")
+        if self.update_mode not in _WEIGHT_UPDATE_MODES:
+            raise ValueError(f"unsupported update_mode: {self.update_mode}")
+        if not self.target_version:
+            raise ValueError("target_version must not be empty")
+        if self.update_mode != "full" and not self.base_version:
+            raise ValueError(f"base_version is required for {self.update_mode} updates")
+        if self.base_version == self.target_version:
+            raise ValueError("base_version and target_version must differ")
+        if not self.tensors:
+            raise ValueError("a weight update must contain at least one tensor")
+
+        names: set[str] = set()
+        for tensor in self.tensors:
+            if tensor.name in names:
+                raise ValueError(f"duplicate tensor name: {tensor.name}")
+            names.add(tensor.name)
+
+        object.__setattr__(self, "metadata_digest", self._compute_metadata_digest())
+
+    @classmethod
+    def from_weights(
+        cls,
+        weights: Iterable[tuple[str, torch.Tensor]],
+        *,
+        model_id: str,
+        model_config_id: str,
+        update_mode: WeightUpdateMode,
+        base_version: str | None,
+        target_version: str,
+    ) -> "WeightUpdateManifest":
+        """Build a manifest by consuming an ordered weight iterable.
+
+        Use :class:`WeightUpdateRecorder` instead when tensor payloads must be
+        sent in the same one-shot pass.
+        """
+        recorder = WeightUpdateRecorder()
+        for name, tensor in weights:
+            recorder.record(name, tensor)
+        return recorder.build_manifest(
+            model_id=model_id,
+            model_config_id=model_config_id,
+            update_mode=update_mode,
+            base_version=base_version,
+            target_version=target_version,
+        )
+
+    def validate(
+        self,
+        inventory: WeightUpdateRecorder,
+        *,
+        expected_model_id: str,
+        expected_model_config_id: str,
+        expected_update_mode: WeightUpdateMode,
+        current_version: str | None,
+        expected_target_version: str,
+    ) -> None:
+        """Validate consumer context and the complete recorded inventory.
+
+        Args:
+            inventory: Metadata recorded while the consumer staged tensors.
+            expected_model_id: Model identity expected by the consumer.
+            expected_model_config_id: Model-config identity expected by the consumer.
+            expected_update_mode: Update mode allowed by the consumer operation.
+            current_version: Consumer version before this update is activated.
+            expected_target_version: Target version requested by the consumer operation.
+
+        Raises:
+            ValueError: If context or tensor metadata does not match exactly.
+        """
+        expected_context = {
+            "model_id": expected_model_id,
+            "model_config_id": expected_model_config_id,
+            "update_mode": expected_update_mode,
+            "base_version": current_version,
+            "target_version": expected_target_version,
+        }
+        actual_context = {
+            "model_id": self.model_id,
+            "model_config_id": self.model_config_id,
+            "update_mode": self.update_mode,
+            "base_version": self.base_version,
+            "target_version": self.target_version,
+        }
+        if actual_context != expected_context:
+            raise ValueError(f"weight-update context mismatch: expected {expected_context}, received {actual_context}")
+
+        actual_tensors = inventory.tensors
+        if len(actual_tensors) != len(self.tensors):
+            raise ValueError(f"expected {len(self.tensors)} tensors, received {len(actual_tensors)}")
+        for index, (expected_tensor, actual_tensor) in enumerate(zip(self.tensors, actual_tensors)):
+            if actual_tensor != expected_tensor:
+                raise ValueError(
+                    f"tensor {index} metadata mismatch: expected {expected_tensor}, received {actual_tensor}"
+                )
+
+    def to_json(self) -> str:
+        """Serialize this manifest as canonical JSON."""
+        payload = self._metadata_payload()
+        payload["metadata_digest"] = self.metadata_digest
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, payload: str | bytes) -> "WeightUpdateManifest":
+        """Deserialize and strictly validate a manifest from JSON."""
+        try:
+            decoded = json.loads(payload, object_pairs_hook=_object_without_duplicate_keys)
+            if not isinstance(decoded, dict):
+                raise TypeError("manifest must be a JSON object")
+            _require_exact_fields(decoded, _MANIFEST_FIELDS, "manifest")
+
+            schema_version = decoded["schema_version"]
+            if type(schema_version) is not int or schema_version != 1:
+                raise ValueError(f"unsupported schema_version: {schema_version}")
+
+            tensors_payload = decoded["tensors"]
+            if not isinstance(tensors_payload, list):
+                raise TypeError("tensors must be a list")
+            tensors = tuple(_tensor_from_json(tensor) for tensor in tensors_payload)
+
+            update_mode = decoded["update_mode"]
+            if not isinstance(update_mode, str):
+                raise TypeError("update_mode must be a string")
+            base_version = decoded["base_version"]
+            if base_version is not None and not isinstance(base_version, str):
+                raise TypeError("base_version must be a string or null")
+
+            manifest = cls(
+                model_id=_required_json_string(decoded, "model_id"),
+                model_config_id=_required_json_string(decoded, "model_config_id"),
+                update_mode=cast(WeightUpdateMode, update_mode),
+                base_version=base_version,
+                target_version=_required_json_string(decoded, "target_version"),
+                tensors=tensors,
+            )
+            digest = _required_json_string(decoded, "metadata_digest")
+        except (KeyError, TypeError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError(f"invalid weight-update manifest: {error}") from error
+
+        if digest != manifest.metadata_digest:
+            raise ValueError("weight-update manifest metadata digest mismatch")
+        return manifest
+
+    def _metadata_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "model_id": self.model_id,
+            "model_config_id": self.model_config_id,
+            "update_mode": self.update_mode,
+            "base_version": self.base_version,
+            "target_version": self.target_version,
+            "tensors": [
+                {"name": tensor.name, "shape": list(tensor.shape), "dtype": tensor.dtype} for tensor in self.tensors
+            ],
+        }
+
+    def _compute_metadata_digest(self) -> str:
+        canonical = json.dumps(self._metadata_payload(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+
+def _tensor_metadata(name: str, tensor: torch.Tensor) -> WeightUpdateTensor:
+    return WeightUpdateTensor(
+        name=name,
+        shape=tuple(tensor.shape),
+        dtype=str(tensor.dtype).removeprefix("torch."),
+    )
+
+
+def _object_without_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON field: {key}")
+        result[key] = value
+    return result
+
+
+def _require_exact_fields(payload: dict[str, object], expected: frozenset[str], context: str) -> None:
+    actual = set(payload)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        raise ValueError(f"invalid {context} fields: missing={missing}, unknown={unknown}")
+
+
+def _required_json_string(payload: dict[str, object], key: str) -> str:
+    value = payload[key]
+    if not isinstance(value, str):
+        raise TypeError(f"{key} must be a string")
+    return value
+
+
+def _tensor_from_json(payload: object) -> WeightUpdateTensor:
+    if not isinstance(payload, dict):
+        raise TypeError("tensor metadata must be an object")
+    _require_exact_fields(payload, _TENSOR_FIELDS, "tensor metadata")
+    name = _required_json_string(payload, "name")
+    dtype = _required_json_string(payload, "dtype")
+    shape_payload = payload["shape"]
+    if not isinstance(shape_payload, list) or not all(type(dimension) is int for dimension in shape_payload):
+        raise TypeError(f"tensor {name} shape must be a list of integers")
+    return WeightUpdateTensor(name=name, shape=tuple(shape_payload), dtype=dtype)

--- a/tests/unit_tests/models/test_weight_update_manifest.py
+++ b/tests/unit_tests/models/test_weight_update_manifest.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+import torch
+
+from megatron.bridge.models.conversion import (
+    WeightUpdateManifest,
+    WeightUpdateMode,
+    WeightUpdateRecorder,
+    WeightUpdateTensor,
+)
+
+
+def _weights() -> list[tuple[str, torch.Tensor]]:
+    return [
+        ("model.layers.0.mlp.experts.0.weight", torch.empty(4, 8, dtype=torch.bfloat16)),
+        ("model.layers.0.mlp.experts.1.weight", torch.empty(4, 8, dtype=torch.bfloat16)),
+    ]
+
+
+def _record(weights: list[tuple[str, torch.Tensor]]) -> WeightUpdateRecorder:
+    recorder = WeightUpdateRecorder()
+    for name, tensor in weights:
+        recorder.record(name, tensor)
+    return recorder
+
+
+def _manifest(*, update_mode: WeightUpdateMode = "full") -> WeightUpdateManifest:
+    recorder = _record(_weights())
+    return recorder.build_manifest(
+        model_id="org/model",
+        model_config_id="config-sha256:abc123",
+        update_mode=update_mode,
+        base_version="41",
+        target_version="42",
+    )
+
+
+def _validate(manifest: WeightUpdateManifest, recorder: WeightUpdateRecorder) -> None:
+    manifest.validate(
+        recorder,
+        expected_model_id="org/model",
+        expected_model_config_id="config-sha256:abc123",
+        expected_update_mode=manifest.update_mode,
+        current_version="41",
+        expected_target_version="42",
+    )
+
+
+def test_recorder_tracks_one_shot_stream_without_retaining_payloads() -> None:
+    weights = _weights()
+    recorder = WeightUpdateRecorder()
+
+    streamed = list(recorder.track(iter(weights)))
+
+    assert [id(tensor) for _, tensor in streamed] == [id(tensor) for _, tensor in weights]
+    assert recorder.tensors == (
+        WeightUpdateTensor("model.layers.0.mlp.experts.0.weight", (4, 8), "bfloat16"),
+        WeightUpdateTensor("model.layers.0.mlp.experts.1.weight", (4, 8), "bfloat16"),
+    )
+    assert not any(isinstance(value, torch.Tensor) for value in recorder.__dict__.values())
+
+
+def test_manifest_round_trip_and_validate_complete_update() -> None:
+    manifest = _manifest()
+
+    assert manifest.schema_version == 1
+    assert manifest.base_version == "41"
+    assert manifest.target_version == "42"
+    assert len(manifest.metadata_digest) == 64
+    assert WeightUpdateManifest.from_json(manifest.to_json()) == manifest
+    _validate(manifest, _record(_weights()))
+
+
+def test_manifest_rejects_missing_or_reordered_tensor() -> None:
+    manifest = _manifest(update_mode="delta")
+
+    with pytest.raises(ValueError, match="expected 2 tensors, received 1"):
+        _validate(manifest, _record(_weights()[:1]))
+    with pytest.raises(ValueError, match="tensor 0 metadata mismatch"):
+        _validate(manifest, _record(list(reversed(_weights()))))
+
+
+@pytest.mark.parametrize(
+    ("context_override", "value"),
+    [
+        ("expected_model_id", "other/model"),
+        ("expected_model_config_id", "config-sha256:different"),
+        ("expected_update_mode", "delta"),
+        ("current_version", "40"),
+        ("expected_target_version", "43"),
+    ],
+)
+def test_manifest_rejects_consumer_context_mismatch(context_override: str, value: str) -> None:
+    manifest = _manifest()
+    context = {
+        "expected_model_id": "org/model",
+        "expected_model_config_id": "config-sha256:abc123",
+        "expected_update_mode": "full",
+        "current_version": "41",
+        "expected_target_version": "42",
+    }
+    context[context_override] = value
+
+    with pytest.raises(ValueError, match="weight-update context mismatch"):
+        manifest.validate(
+            _record(_weights()),
+            expected_model_id=context["expected_model_id"],
+            expected_model_config_id=context["expected_model_config_id"],
+            expected_update_mode=cast(WeightUpdateMode, context["expected_update_mode"]),
+            current_version=context["current_version"],
+            expected_target_version=context["expected_target_version"],
+        )
+
+
+def test_manifest_rejects_tampered_metadata() -> None:
+    tampered_json = _manifest().to_json().replace('"target_version":"42"', '"target_version":"43"')
+
+    with pytest.raises(ValueError, match="metadata digest mismatch"):
+        WeightUpdateManifest.from_json(tampered_json)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda payload: payload.replace('"schema_version":1', '"schema_version":true'), "schema_version"),
+        (lambda payload: payload.replace('"shape":[4,8]', '"shape":[true,8]', 1), "list of integers"),
+        (lambda payload: payload.replace('{"base_version"', '{"unknown":1,"base_version"'), "unknown"),
+        (
+            lambda payload: payload.replace('"base_version":"41"', '"base_version":"41","base_version":"41"', 1),
+            "duplicate JSON field",
+        ),
+    ],
+)
+def test_manifest_parser_rejects_noncanonical_structure(mutate: Callable[[str], str], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        WeightUpdateManifest.from_json(mutate(_manifest().to_json()))
+
+
+def test_manifest_parser_normalizes_invalid_utf8_to_value_error() -> None:
+    with pytest.raises(ValueError, match="invalid weight-update manifest"):
+        WeightUpdateManifest.from_json(b"\xff")
+
+
+def test_manifest_rejects_duplicate_tensor_names() -> None:
+    duplicate = [("duplicate", torch.empty(2)), ("duplicate", torch.empty(2))]
+
+    with pytest.raises(ValueError, match="duplicate tensor name"):
+        WeightUpdateManifest.from_weights(
+            duplicate,
+            model_id="org/model",
+            model_config_id="config-sha256:abc123",
+            update_mode="full",
+            base_version=None,
+            target_version="42",
+        )
+
+
+def test_manifest_requires_base_version_for_incremental_updates() -> None:
+    with pytest.raises(ValueError, match="base_version is required"):
+        WeightUpdateManifest.from_weights(
+            _weights(),
+            model_id="org/model",
+            model_config_id="config-sha256:abc123",
+            update_mode="sparse",
+            base_version=None,
+            target_version="42",
+        )


### PR DESCRIPTION
# What does this PR do?

Adds a transport-neutral contract for versioning and verifying the existing one-shot Hugging Face-coordinate weight stream returned by `AutoBridge.export_hf_weights()`.

`WeightUpdateRecorder` observes names, shapes, and dtypes while tensors flow through without retaining payloads. The producer sends a `WeightUpdateManifest` as the stream trailer. Before activating staged weights, the consumer validates the exact recorded inventory plus expected model, config, update mode, base version, and target version.

This is a bounded first slice under [#4515](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/4515) and [#5371](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/5371). It does not change a protected `AutoBridge` signature.

## Supported trigger and impact

The [RL integration guide](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/60b91488afc05e8dc70b999b5f89382b1dfcbe58/docs/bridge-rl-integration.md) documents streaming `export_hf_weights()` and ordered conversion tasks across TP/PP/MoE/CP. It currently leaves identity, completeness, ordering, and version visibility to downstream transport code.

Primary landscape evidence demonstrates the same root contract across independent runtimes:

- [verl#7324](https://github.com/verl-project/verl/pull/7324) fixed a sharded FSDP+EP update that emitted only part of the expert inventory.
- [TorchTitan#4236](https://github.com/pytorch/torchtitan/pull/4236) added reusable HF/vLLM state-dict adaptation for distributed weight movement.
- [miles#2589](https://github.com/radixark/miles/pull/2589) made serving-side version transitions explicit because they affect in-flight samples.
- [vLLM#52497](https://github.com/vllm-project/vllm/pull/52497) made IPC payloads rank-local for MoE ownership, and [vLLM#53751](https://github.com/vllm-project/vllm/pull/53751) added checkpoint-coordinate sparse NCCL updates.
- [TRL#7017](https://github.com/huggingface/trl/pull/7017) added versioned adapter synchronization and checkpointed rollout version state.

Without a producer-authoritative trailer, a transport can finish while the consumer has a stale, incomplete, reordered, or wrong-context inventory.

## Root cause and minimal scope

The existing stream carries `(name, tensor)` frames but no terminal structural identity. This PR:

- adds immutable, versioned `WeightUpdateManifest` and `WeightUpdateTensor` types;
- adds `WeightUpdateRecorder`, which observes a one-shot stream without retaining tensor payloads;
- validates exact tensor count/order/name/shape/dtype and consumer model/config/mode/base/target context;
- strictly rejects duplicate or unknown JSON fields, invalid scalar types, invalid UTF-8, and digest mismatches; and
- documents how the manifest trailer composes with ordinary export.

## Fail-before and pass-after evidence

Fail-before on the recorded unmodified base `dd150c1d73ed9a25ad3ee87149cb98a0a2ca3614`:

```text
uv run --no-project python -m pytest --confcutdir=tests/unit_tests/models tests/unit_tests/models/test_weight_update_manifest.py::test_manifest_round_trip_and_validate_complete_update -q
1 failed: the conversion package does not expose a versioned weight-update manifest
```

After rebasing onto current `main` at `60b91488afc05e8dc70b999b5f89382b1dfcbe58`, the identical focused command passed:

```text
1 passed
```

Adjacent validation:

```text
uv run --no-project python -m pytest --confcutdir=tests/unit_tests tests/unit_tests/models/test_weight_update_manifest.py tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_export_hf_weights tests/unit_tests/doc_consistency/test_readme_consistency.py::test_rl_integration_get_model_calls_supply_required_keyword_only_arguments tests/unit_tests/doc_consistency/test_readme_consistency.py::test_rl_integration_builds_a_finalized_config_with_runtime_objects -q
19 passed

uv run --no-project mypy --strict src/megatron/bridge/models/conversion/weight_update_manifest.py
Success: no issues found in 1 source file

git diff --check origin/main...HEAD
passed

uv run --no-sync pre-commit run --all-files
passed
```

A fresh reviewer subagent was requested but the reviewer service was unavailable. A separate read-only fallback pass rechecked duplicates, the supported path, Bridge ownership, diff scope, red/green evidence, tests, DCO, and public sanitization; no blocker remained.

## Scope and non-goals

- The recorder and manifest do not retain tensor payloads.
- Completeness is checked relative to the producer's recorded inventory; this does not independently prove that the producer exported every model tensor.
- The digest detects accidental metadata corruption. It is not tensor-content hashing or authentication.
- No NCCL, RDT, IPC, ZMQ, HTTP, storage, acknowledgement, retry, runtime activation, or full-resync framework is added.
- No conversion mapping, checkpoint, quantization, adapter lifecycle, dependency, CI workflow, or protected conversion signature is changed.
- Local refit planning, sparse/delta production, content integrity, distributed ownership, and transport-specific atomicity remain separate contracts.

## Submission gates

- [x] Focused fail-before/pass-after regression recorded.
- [x] Focused unit and adjacent tests pass on current base.
- [x] Strict mypy, `git diff --check`, and all-files pre-commit pass.
- [x] DCO sign-off present.
- [x] Existing Draft PR updated; no duplicate PR opened.

Current commit: `a3279a9a255a6c1ab19c7c1ce911a34623bc94f0`.
