### PR TITLE
fix(security): harden checkpoint and Energon input loading

### DIFF
--- a/src/megatron/bridge/data/energon/base_energon_datamodule.py
+++ b/src/megatron/bridge/data/energon/base_energon_datamodule.py
@@ -12,18 +12,115 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import logging
 from typing import Any, Callable, Literal, Optional
 
 from megatron.core.process_groups_config import ProcessGroupCollection
-from megatron.energon import WorkerConfig, get_savable_loader, get_train_dataset
+from megatron.energon import Sample, WorkerConfig, get_savable_loader, get_train_dataset
+from megatron.energon import dataset_config as _energon_dataset_config
 from megatron.energon.epathlib import EPath
 from megatron.energon.flavors.webdataset.default_generic_webdataset import DefaultGenericWebdatasetFactory
+from megatron.energon.typed_converter import JsonParser
 
 
 logger = logging.getLogger(__name__)
 
-_energon_factory_init = DefaultGenericWebdatasetFactory.__init__
+_ORIGINAL_METHOD_ATTRIBUTE = "__megatron_bridge_original_method__"
+_TRUSTED_DATASET_FACTORY_MODULE_PREFIXES = (
+    "megatron.bridge.data.energon",
+    "megatron.energon",
+)
+_TRUSTED_DATASET_FACTORY_MODULE_ALIASES = frozenset(
+    {
+        "megatron.bridge.models.qwen_vl.data.energon",
+    }
+)
+_energon_factory_init = getattr(
+    DefaultGenericWebdatasetFactory.__init__,
+    _ORIGINAL_METHOD_ATTRIBUTE,
+    DefaultGenericWebdatasetFactory.__init__,
+)
+_energon_load_config = getattr(
+    _energon_dataset_config.load_config,
+    _ORIGINAL_METHOD_ATTRIBUTE,
+    _energon_dataset_config.load_config,
+)
+
+
+def _validate_energon_dataset_metadata(value: Any, *, root: bool = True) -> None:
+    """Reject executable object references in untrusted dataset factory metadata."""
+    if isinstance(value, list):
+        for item in value:
+            _validate_energon_dataset_metadata(item, root=False)
+        return
+    if not isinstance(value, dict):
+        return
+
+    module_name = value.get("__module__")
+    function_name = value.get("__function__")
+    class_name = value.get("__class__")
+    if function_name is not None:
+        raise ValueError(
+            "Energon dataset metadata cannot resolve serialized Python functions. "
+            "Use declarative configuration or pass a Python callable from trusted application code."
+        )
+    if class_name is not None:
+        trusted_class = (
+            isinstance(module_name, str)
+            and isinstance(class_name, str)
+            and (
+                module_name in _TRUSTED_DATASET_FACTORY_MODULE_ALIASES
+                or any(
+                    module_name == prefix or module_name.startswith(f"{prefix}.")
+                    for prefix in _TRUSTED_DATASET_FACTORY_MODULE_PREFIXES
+                )
+            )
+        )
+        if trusted_class:
+            module = importlib.import_module(module_name)
+            referenced_type = getattr(module, class_name, None)
+            required_base = DefaultGenericWebdatasetFactory if root else Sample
+            trusted_class = isinstance(referenced_type, type) and issubclass(referenced_type, required_base)
+        if not trusted_class:
+            raise ValueError(
+                "Energon dataset metadata cannot instantiate serialized Python classes. "
+                "Only packaged Energon dataset factory and sample classes are allowed."
+            )
+
+    for item in value.values():
+        _validate_energon_dataset_metadata(item, root=False)
+
+
+def _secure_energon_load_config(
+    path: EPath | dict[str, Any],
+    *,
+    default_type: type,
+    default_kwargs: dict[str, Any] | None = None,
+    parser: JsonParser = JsonParser(strict=True),
+) -> Any:
+    """Validate dataset metadata before Energon resolves serialized objects."""
+    is_dataset_factory = isinstance(default_type, type) and issubclass(default_type, DefaultGenericWebdatasetFactory)
+    if not is_dataset_factory:
+        return _energon_load_config(
+            path,
+            default_type=default_type,
+            default_kwargs=default_kwargs,
+            parser=parser,
+        )
+
+    if isinstance(path, dict):
+        data = path
+    else:
+        with path.open("rb") as config_file:
+            data = _energon_dataset_config.load_yaml(config_file)
+    _validate_energon_dataset_metadata(data)
+    return _energon_load_config(
+        data,
+        default_type=default_type,
+        default_kwargs=default_kwargs,
+        parser=parser,
+    )
 
 
 def _secure_energon_factory_init(
@@ -60,6 +157,9 @@ def _secure_energon_factory_init(
 
 # Energon constructs this factory internally after reading dataset.yaml, so
 # Bridge must install the guard before calling get_train_dataset().
+setattr(_secure_energon_load_config, _ORIGINAL_METHOD_ATTRIBUTE, _energon_load_config)
+_energon_dataset_config.load_config = _secure_energon_load_config
+setattr(_secure_energon_factory_init, _ORIGINAL_METHOD_ATTRIBUTE, _energon_factory_init)
 DefaultGenericWebdatasetFactory.__init__ = _secure_energon_factory_init
 
 

--- a/src/megatron/bridge/data/energon/base_energon_datamodule.py
+++ b/src/megatron/bridge/data/energon/base_energon_datamodule.py
@@ -13,13 +13,54 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.energon import WorkerConfig, get_savable_loader, get_train_dataset
+from megatron.energon.epathlib import EPath
+from megatron.energon.flavors.webdataset.default_generic_webdataset import DefaultGenericWebdatasetFactory
 
 
 logger = logging.getLogger(__name__)
+
+_energon_factory_init = DefaultGenericWebdatasetFactory.__init__
+
+
+def _secure_energon_factory_init(
+    self: DefaultGenericWebdatasetFactory,
+    path: EPath,
+    *,
+    subflavors: dict[str, Any] | None = None,
+    field_map: dict[str, str] | None = None,
+    sample_loader: str | Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    part_filter: str | list[str] | Callable[[str], bool] | None = None,
+    **kwargs: Any,
+) -> None:
+    """Reject dataset-local Python hooks before Energon resolves their files."""
+    executable_fields = [
+        name
+        for name, value in (("sample_loader", sample_loader), ("part_filter", part_filter))
+        if isinstance(value, str)
+    ]
+    if executable_fields:
+        raise ValueError(
+            "Energon dataset metadata cannot load Python files through "
+            f"{', '.join(executable_fields)}. Use a declarative field_map instead."
+        )
+    _energon_factory_init(
+        self,
+        path,
+        subflavors=subflavors,
+        field_map=field_map,
+        sample_loader=sample_loader,
+        part_filter=part_filter,
+        **kwargs,
+    )
+
+
+# Energon constructs this factory internally after reading dataset.yaml, so
+# Bridge must install the guard before calling get_train_dataset().
+DefaultGenericWebdatasetFactory.__init__ = _secure_energon_factory_init
 
 
 class EnergonMultiModalDataModule:

--- a/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py
+++ b/src/megatron/bridge/diffusion/data/common/diffusion_task_encoder_with_sp.py
@@ -24,6 +24,7 @@ from megatron.energon.task_encoder.cooking import Cooker, basic_sample_keys
 from megatron.bridge.data.energon.metadata import sample_metadata_kwargs
 from megatron.bridge.data.packing.algorithms import first_fit_decreasing
 from megatron.bridge.diffusion.data.common.diffusion_sample import DiffusionSample
+from megatron.bridge.diffusion.data.common.safe_decoder import SafeDiffusionSampleDecoder
 from megatron.bridge.diffusion.data.common.sequence_packing_utils import packing_length
 
 
@@ -51,6 +52,8 @@ def cook(sample: dict) -> dict:
 
 
 class DiffusionTaskEncoderWithSequencePacking(DefaultTaskEncoder, ABC):  # noqa: D101
+    decoder = SafeDiffusionSampleDecoder()
+
     cookers = [
         Cooker(cook),
     ]

--- a/src/megatron/bridge/diffusion/data/common/safe_decoder.py
+++ b/src/megatron/bridge/diffusion/data/common/safe_decoder.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Safe decoding for Bridge diffusion WebDataset fields."""
+
+import io
+import re
+from typing import Any
+
+import torch
+from megatron.energon.flavors.webdataset.sample_decoder import SampleDecoder
+from webdataset.autodecode import basichandlers
+
+from megatron.bridge.utils.safe_pickle import safe_torch_tensor_pickle_loads
+
+
+_PICKLE_EXTENSIONS = frozenset({"pickle", "pkl", "pyd"})
+
+
+def _safe_basic_handler(key: str, data: bytes) -> Any:
+    """Decode tensor fields safely and delegate non-executable formats."""
+    extension = re.sub(r".*[.]", "", key).lower()
+    if extension in _PICKLE_EXTENSIONS:
+        return safe_torch_tensor_pickle_loads(data)
+    if extension == "pth":
+        return torch.load(io.BytesIO(data), map_location="cpu", weights_only=True)
+    return basichandlers(key, data)
+
+
+class SafeDiffusionSampleDecoder(SampleDecoder):
+    """Energon decoder that never uses WebDataset's unrestricted pickle handlers."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        replaced = False
+        for index, handler in enumerate(self._decoder.handlers):
+            if handler is basichandlers:
+                self._decoder.handlers[index] = _safe_basic_handler
+                replaced = True
+        if not replaced:
+            raise RuntimeError("Energon SampleDecoder no longer exposes the expected WebDataset basic handler.")

--- a/src/megatron/bridge/utils/instantiate_utils.py
+++ b/src/megatron/bridge/utils/instantiate_utils.py
@@ -105,6 +105,15 @@ _DISALLOWED_TARGETS: set[str] = {
     },
 }
 
+# Resolve aliases before enforcing these entries. For example,
+# ``numpy.lib.npyio.load`` is the same callable as ``numpy.load`` and
+# ``torch.serialization.load`` is the same callable as ``torch.load``.
+_DISALLOWED_CANONICAL_TARGETS: set[str] = {
+    "numpy.load",
+    "torch.serialization.load",
+    "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+}
+
 _DISALLOWED_CALLABLE_FIELD_NAMES: set[str] = {
     "collate_impl",
     "hf_filter_lambda",
@@ -182,7 +191,17 @@ def _resolve_target(
     """Resolve target string, type, or callable after Bridge validation."""
     if isinstance(target, str):
         _validate_target_prefix(target=target, full_key=full_key)
-    return _mcore_resolve_target(target, full_key, check_callable)
+    resolved_target = _mcore_resolve_target(target, full_key, check_callable)
+    if isinstance(target, str):
+        module = getattr(resolved_target, "__module__", None)
+        qualname = getattr(resolved_target, "__qualname__", None)
+        canonical_target = f"{module}.{qualname}" if isinstance(module, str) and isinstance(qualname, str) else None
+        if canonical_target in _DISALLOWED_CANONICAL_TARGETS:
+            raise InstantiationException(
+                f"Instantiation of '{target}' is not allowed because it resolves to the unsafe target "
+                f"'{canonical_target}'." + (f"\nfull_key: {full_key}" if full_key else "")
+            )
+    return resolved_target
 
 
 _mcore_instantiate_utils._resolve_target = _resolve_target

--- a/src/megatron/bridge/utils/instantiate_utils.py
+++ b/src/megatron/bridge/utils/instantiate_utils.py
@@ -111,6 +111,7 @@ _DISALLOWED_TARGETS: set[str] = {
 _DISALLOWED_CANONICAL_TARGETS: set[str] = {
     "numpy.load",
     "torch.serialization.load",
+    "transformers.dynamic_module_utils.get_class_in_module",
     "transformers.dynamic_module_utils.get_class_from_dynamic_module",
 }
 
@@ -201,6 +202,8 @@ def _resolve_target(
                 f"Instantiation of '{target}' is not allowed because it resolves to the unsafe target "
                 f"'{canonical_target}'." + (f"\nfull_key: {full_key}" if full_key else "")
             )
+        if canonical_target is not None:
+            _validate_target_prefix(target=canonical_target, full_key=full_key)
     return resolved_target
 
 

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -262,12 +262,7 @@ class _TorchTensorRestrictedUnpickler(_RestrictedUnpickler):
             ("torch.storage", "_load_from_bytes"),
         }:
             return _safe_torch_load_from_bytes
-        if module in self._SAFE_MODULES and name in self._SAFE_MODULES[module]:
-            return pickle.Unpickler.find_class(self, module, name)
-        raise pickle.UnpicklingError(
-            f"Restricted unpickler refused to load '{module}.{name}'. "
-            "Only safe built-in types and plain torch tensors are allowed."
-        )
+        return super().find_class(module, name)
 
 
 class _NumpyRestrictedUnpickler(pickle.Unpickler):

--- a/src/megatron/bridge/utils/safe_pickle.py
+++ b/src/megatron/bridge/utils/safe_pickle.py
@@ -239,6 +239,37 @@ class _RestrictedUnpickler(pickle.Unpickler):
         )
 
 
+def _safe_torch_load_from_bytes(data: bytes) -> object:
+    """Reconstruct tensor storage bytes without enabling arbitrary pickle globals."""
+    import torch
+
+    return torch.load(io.BytesIO(data), map_location="cpu", weights_only=True)
+
+
+class _TorchTensorRestrictedUnpickler(_RestrictedUnpickler):
+    """Restricted unpickler for plain tensors and containers of tensors."""
+
+    _SAFE_MODULES = MappingProxyType(
+        {
+            **_RestrictedUnpickler._SAFE_MODULES,
+            "torch._utils": frozenset({"_rebuild_tensor", "_rebuild_tensor_v2"}),
+        }
+    )
+
+    def find_class(self, module: str, name: str) -> object:
+        if (module, name) in {
+            ("megatron.core.safe_globals", "safe_load_from_bytes"),
+            ("torch.storage", "_load_from_bytes"),
+        }:
+            return _safe_torch_load_from_bytes
+        if module in self._SAFE_MODULES and name in self._SAFE_MODULES[module]:
+            return pickle.Unpickler.find_class(self, module, name)
+        raise pickle.UnpicklingError(
+            f"Restricted unpickler refused to load '{module}.{name}'. "
+            "Only safe built-in types and plain torch tensors are allowed."
+        )
+
+
 class _NumpyRestrictedUnpickler(pickle.Unpickler):
     """Unpickler that allows safe builtins and the narrow set of numpy types needed for object array reconstruction.
 
@@ -426,6 +457,11 @@ def safe_pickle_load(fp) -> object:
 def safe_pickle_loads(data: bytes) -> object:
     """Deserialize pickle data using a restricted unpickler that only allows safe types."""
     return _RestrictedUnpickler(io.BytesIO(data)).load()
+
+
+def safe_torch_tensor_pickle_loads(data: bytes) -> object:
+    """Deserialize raw pickle data containing only safe containers and plain torch tensors."""
+    return _TorchTensorRestrictedUnpickler(io.BytesIO(data)).load()
 
 
 def safe_load_npy(data: bytes):

--- a/tests/unit_tests/data/energon/test_safe_dataset_config.py
+++ b/tests/unit_tests/data/energon/test_safe_dataset_config.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+from typing import Any, Callable
+
 import pytest
-from megatron.energon.dataset_config import load_config
+from megatron.energon import CaptioningSample, StandardWebdatasetFactory
+from megatron.energon import dataset_config as energon_dataset_config
 from megatron.energon.epathlib import EPath
 from megatron.energon.flavors.webdataset.default_generic_webdataset import DefaultGenericWebdatasetFactory
 
@@ -36,7 +40,7 @@ def test_dataset_yaml_rejects_python_hooks_before_import(field, tmp_path):
         default_kwargs["sample_loader"] = lambda sample: sample
 
     with pytest.raises(ValueError, match="cannot load Python files"):
-        load_config(
+        energon_dataset_config.load_config(
             EPath(config_path),
             default_type=DefaultGenericWebdatasetFactory,
             default_kwargs=default_kwargs,
@@ -65,3 +69,121 @@ def test_factory_guard_preserves_callable_hooks(monkeypatch, tmp_path):
 
     assert captured["sample_loader"] is sample_loader
     assert captured["part_filter"] is part_filter
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_dataset_yaml_rejects_serialized_functions_before_execution(nested, tmp_path):
+    marker = tmp_path / "serialized-function-executed"
+    module_path = tmp_path / "evil_config.py"
+    module_path.write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).touch()\ndef payload(sample=None):\n    return sample\n"
+    )
+    config = {"__module__": "evil_config", "__function__": "payload"}
+    default_kwargs = None
+    if nested:
+        config = {"sample_loader": config}
+        default_kwargs = {"path": EPath(tmp_path), "part_filter": ["json"]}
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.syspath_prepend(str(tmp_path))
+        with pytest.raises(ValueError, match="cannot resolve serialized Python functions"):
+            energon_dataset_config.load_config(
+                config,
+                default_type=DefaultGenericWebdatasetFactory,
+                default_kwargs=default_kwargs,
+            )
+
+    assert not marker.exists()
+
+
+def test_dataset_yaml_rejects_serialized_class_before_execution(tmp_path):
+    marker = tmp_path / "serialized-class-executed"
+    config = {
+        "unused": {
+            "__module__": "subprocess",
+            "__class__": "Popen",
+            "args": ["/usr/bin/touch", str(marker)],
+        }
+    }
+
+    with pytest.raises(ValueError, match="cannot instantiate serialized Python classes"):
+        energon_dataset_config.load_config(
+            config,
+            default_type=DefaultGenericWebdatasetFactory,
+            default_kwargs={"path": EPath(tmp_path), "field_map": {}},
+        )
+
+    assert not marker.exists()
+
+
+def test_dataset_yaml_allows_packaged_factory_and_sample_classes(monkeypatch, tmp_path):
+    captured = {}
+
+    def original_init(self, path, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(base_energon_datamodule, "_energon_factory_init", original_init)
+    config = {
+        "__module__": "megatron.energon",
+        "__class__": "StandardWebdatasetFactory",
+        "sample_type": {
+            "__module__": "megatron.energon",
+            "__class__": "CaptioningSample",
+        },
+        "field_map": {"image": "jpg", "caption": "txt"},
+    }
+
+    dataset = energon_dataset_config.load_config(
+        config,
+        default_type=DefaultGenericWebdatasetFactory,
+        default_kwargs={"path": EPath(tmp_path)},
+    )
+
+    assert isinstance(dataset, StandardWebdatasetFactory)
+    assert dataset.__sample_type__ is CaptioningSample
+    assert captured["field_map"] == config["field_map"]
+
+
+def test_dataset_yaml_allows_legacy_chatml_factory_alias(monkeypatch, tmp_path):
+    def original_init(self, path, **kwargs):
+        return None
+
+    monkeypatch.setattr(base_energon_datamodule, "_energon_factory_init", original_init)
+    dataset = energon_dataset_config.load_config(
+        {
+            "__module__": "megatron.bridge.models.qwen_vl.data.energon",
+            "__class__": "ChatMLWebdataset",
+        },
+        default_type=DefaultGenericWebdatasetFactory,
+        default_kwargs={"path": EPath(tmp_path)},
+    )
+
+    from megatron.bridge.data.energon.task_encoder_utils import ChatMLWebdataset
+
+    assert isinstance(dataset, ChatMLWebdataset)
+
+
+def _trusted_metadataset_joiner(*samples: Any) -> tuple[Any, ...]:
+    return samples
+
+
+def test_non_dataset_config_preserves_serialized_joiner_functions():
+    joiner = energon_dataset_config.load_config(
+        {
+            "__module__": __name__,
+            "__function__": "_trusted_metadataset_joiner",
+        },
+        default_type=Callable[..., tuple[Any, ...]],
+    )
+
+    assert joiner is _trusted_metadataset_joiner
+
+
+def test_energon_guards_are_reload_safe():
+    reloaded = importlib.reload(base_energon_datamodule)
+    original_attribute = reloaded._ORIGINAL_METHOD_ATTRIBUTE
+
+    assert getattr(reloaded._secure_energon_factory_init, original_attribute) is reloaded._energon_factory_init
+    assert reloaded._energon_factory_init is not reloaded._secure_energon_factory_init
+    assert getattr(reloaded._secure_energon_load_config, original_attribute) is reloaded._energon_load_config
+    assert reloaded._energon_load_config is not reloaded._secure_energon_load_config

--- a/tests/unit_tests/data/energon/test_safe_dataset_config.py
+++ b/tests/unit_tests/data/energon/test_safe_dataset_config.py
@@ -1,0 +1,55 @@
+import pytest
+from megatron.energon.dataset_config import load_config
+from megatron.energon.epathlib import EPath
+from megatron.energon.flavors.webdataset.default_generic_webdataset import DefaultGenericWebdatasetFactory
+
+from megatron.bridge.data.energon import base_energon_datamodule
+
+
+@pytest.mark.parametrize("field", ["sample_loader", "part_filter"])
+def test_dataset_yaml_rejects_python_hooks_before_import(field, tmp_path):
+    marker = tmp_path / "dataset-python-executed"
+    metadata_dir = tmp_path / ".nv-meta"
+    metadata_dir.mkdir()
+    module_path = metadata_dir / "evil.py"
+    module_path.write_text(f"from pathlib import Path\nPath({str(marker)!r}).touch()\n")
+    config_path = metadata_dir / "dataset.yaml"
+    config_path.write_text(
+        "sample_loader: evil.py\npart_filter:\n  - json\n"
+        if field == "sample_loader"
+        else "part_filter: evil.py\n"
+    )
+    default_kwargs = {"path": EPath(tmp_path)}
+    if field == "part_filter":
+        default_kwargs["sample_loader"] = lambda sample: sample
+
+    with pytest.raises(ValueError, match="cannot load Python files"):
+        load_config(
+            EPath(config_path),
+            default_type=DefaultGenericWebdatasetFactory,
+            default_kwargs=default_kwargs,
+        )
+
+    assert not marker.exists()
+
+
+def test_factory_guard_preserves_callable_hooks(monkeypatch, tmp_path):
+    captured = {}
+
+    def original_init(self, path, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(base_energon_datamodule, "_energon_factory_init", original_init)
+
+    def sample_loader(sample):
+        return sample
+
+    def part_filter(_part):
+        return True
+
+    base_energon_datamodule._secure_energon_factory_init(
+        object(), EPath(tmp_path), sample_loader=sample_loader, part_filter=part_filter
+    )
+
+    assert captured["sample_loader"] is sample_loader
+    assert captured["part_filter"] is part_filter

--- a/tests/unit_tests/data/energon/test_safe_dataset_config.py
+++ b/tests/unit_tests/data/energon/test_safe_dataset_config.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 from megatron.energon.dataset_config import load_config
 from megatron.energon.epathlib import EPath
@@ -15,9 +29,7 @@ def test_dataset_yaml_rejects_python_hooks_before_import(field, tmp_path):
     module_path.write_text(f"from pathlib import Path\nPath({str(marker)!r}).touch()\n")
     config_path = metadata_dir / "dataset.yaml"
     config_path.write_text(
-        "sample_loader: evil.py\npart_filter:\n  - json\n"
-        if field == "sample_loader"
-        else "part_filter: evil.py\n"
+        "sample_loader: evil.py\npart_filter:\n  - json\n" if field == "sample_loader" else "part_filter: evil.py\n"
     )
     default_kwargs = {"path": EPath(tmp_path)}
     if field == "part_filter":

--- a/tests/unit_tests/diffusion/data/common/test_safe_decoder.py
+++ b/tests/unit_tests/diffusion/data/common/test_safe_decoder.py
@@ -32,11 +32,12 @@ class _WriteMarkerPayload:
 
 
 @pytest.mark.parametrize("extension", ["pickle", "pkl", "pyd"])
-def test_safe_decoder_loads_plain_tensor_pickles(extension):
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_safe_decoder_loads_plain_tensor_pickles(extension, protocol):
     decoder = SafeDiffusionSampleDecoder()
     value = {"embedding": torch.arange(4, dtype=torch.float32), "shape": [1, 4]}
 
-    restored = decoder.decode(f"sample.{extension}", pickle.dumps(value))
+    restored = decoder.decode(f"sample.{extension}", pickle.dumps(value, protocol=protocol))
 
     assert restored["shape"] == value["shape"]
     assert torch.equal(restored["embedding"], value["embedding"])
@@ -54,20 +55,27 @@ def test_safe_decoder_loads_weights_only_pth():
     assert torch.equal(restored["embedding"], value["embedding"])
 
 
-@pytest.mark.parametrize("extension", ["pickle", "pth"])
-def test_safe_decoder_rejects_executable_payloads(extension, tmp_path):
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_safe_decoder_rejects_pickle_payloads_for_all_protocols(protocol, tmp_path):
     decoder = SafeDiffusionSampleDecoder()
-    marker = tmp_path / f"{extension}-executed"
+    marker = tmp_path / f"pickle-{protocol}-executed"
     payload = _WriteMarkerPayload(str(marker))
-    if extension == "pickle":
-        data = pickle.dumps(payload)
-    else:
-        buffer = io.BytesIO()
-        torch.save(payload, buffer)
-        data = buffer.getvalue()
 
     with pytest.raises(DecodingError) as error:
-        decoder.decode(f"sample.{extension}", data)
+        decoder.decode("sample.pickle", pickle.dumps(payload, protocol=protocol))
+
+    assert isinstance(error.value.__cause__, pickle.UnpicklingError)
+    assert not marker.exists()
+
+
+def test_safe_decoder_rejects_executable_pth_payload(tmp_path):
+    decoder = SafeDiffusionSampleDecoder()
+    marker = tmp_path / "pth-executed"
+    buffer = io.BytesIO()
+    torch.save(_WriteMarkerPayload(str(marker)), buffer)
+
+    with pytest.raises(DecodingError) as error:
+        decoder.decode("sample.pth", buffer.getvalue())
 
     assert isinstance(error.value.__cause__, pickle.UnpicklingError)
     assert not marker.exists()

--- a/tests/unit_tests/diffusion/data/common/test_safe_decoder.py
+++ b/tests/unit_tests/diffusion/data/common/test_safe_decoder.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import io
 import os
 import pickle

--- a/tests/unit_tests/diffusion/data/common/test_safe_decoder.py
+++ b/tests/unit_tests/diffusion/data/common/test_safe_decoder.py
@@ -1,0 +1,59 @@
+import io
+import os
+import pickle
+
+import pytest
+import torch
+from webdataset.autodecode import DecodingError
+
+from megatron.bridge.diffusion.data.common.safe_decoder import SafeDiffusionSampleDecoder
+
+
+class _WriteMarkerPayload:
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+    def __reduce__(self):
+        return os.system, (f"touch {self.marker}",)
+
+
+@pytest.mark.parametrize("extension", ["pickle", "pkl", "pyd"])
+def test_safe_decoder_loads_plain_tensor_pickles(extension):
+    decoder = SafeDiffusionSampleDecoder()
+    value = {"embedding": torch.arange(4, dtype=torch.float32), "shape": [1, 4]}
+
+    restored = decoder.decode(f"sample.{extension}", pickle.dumps(value))
+
+    assert restored["shape"] == value["shape"]
+    assert torch.equal(restored["embedding"], value["embedding"])
+
+
+def test_safe_decoder_loads_weights_only_pth():
+    decoder = SafeDiffusionSampleDecoder()
+    value = {"embedding": torch.arange(4, dtype=torch.float32), "shape": [1, 4]}
+    buffer = io.BytesIO()
+    torch.save(value, buffer)
+
+    restored = decoder.decode("sample.pth", buffer.getvalue())
+
+    assert restored["shape"] == value["shape"]
+    assert torch.equal(restored["embedding"], value["embedding"])
+
+
+@pytest.mark.parametrize("extension", ["pickle", "pth"])
+def test_safe_decoder_rejects_executable_payloads(extension, tmp_path):
+    decoder = SafeDiffusionSampleDecoder()
+    marker = tmp_path / f"{extension}-executed"
+    payload = _WriteMarkerPayload(str(marker))
+    if extension == "pickle":
+        data = pickle.dumps(payload)
+    else:
+        buffer = io.BytesIO()
+        torch.save(payload, buffer)
+        data = buffer.getvalue()
+
+    with pytest.raises(DecodingError) as error:
+        decoder.decode(f"sample.{extension}", data)
+
+    assert isinstance(error.value.__cause__, pickle.UnpicklingError)
+    assert not marker.exists()

--- a/tests/unit_tests/utils/test_instantiate_utils.py
+++ b/tests/unit_tests/utils/test_instantiate_utils.py
@@ -813,6 +813,29 @@ class TestTargetPrefixValidation:
     @pytest.mark.parametrize(
         "target",
         [
+            "numpy.lib.npyio.load",
+            "torch.serialization.load",
+            "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        ],
+    )
+    def test_instantiate_rejects_canonical_aliases_and_dynamic_code_helpers(self, target):
+        """Test that aliases and dynamic-code helpers cannot bypass exact target checks."""
+        with pytest.raises(InstantiationException, match="resolves to the unsafe target"):
+            instantiate({"_target_": target, "_call_": False})
+
+    def test_instantiate_rejects_unsafe_alias_hidden_in_unused_kwarg(self):
+        """Test that recursive instantiation rejects unsafe targets before filtering kwargs."""
+        config = {
+            "_target_": "tests.unit_tests.utils.test_instantiate_utils.TestClass",
+            "name": "safe",
+            "unused": {"_target_": "numpy.lib.npyio.load", "_call_": False},
+        }
+        with pytest.raises(InstantiationException, match="resolves to the unsafe target"):
+            instantiate(config)
+
+    @pytest.mark.parametrize(
+        "target",
+        [
             "megatron.bridge.utils.instantiate_utils.target_allowlist.add_prefix",
             "megatron.bridge.utils.instantiate_utils.target_allowlist.disable",
             "megatron.training.config.instantiate_utils.target_allowlist.add_prefix",

--- a/tests/unit_tests/utils/test_instantiate_utils.py
+++ b/tests/unit_tests/utils/test_instantiate_utils.py
@@ -815,6 +815,7 @@ class TestTargetPrefixValidation:
         [
             "numpy.lib.npyio.load",
             "torch.serialization.load",
+            "transformers.dynamic_module_utils.get_class_in_module",
             "transformers.dynamic_module_utils.get_class_from_dynamic_module",
         ],
     )
@@ -822,6 +823,35 @@ class TestTargetPrefixValidation:
         """Test that aliases and dynamic-code helpers cannot bypass exact target checks."""
         with pytest.raises(InstantiationException, match="resolves to the unsafe target"):
             instantiate({"_target_": target, "_call_": False})
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "torch.serialization.os.system",
+            "transformers.dynamic_module_utils.os.system",
+        ],
+    )
+    def test_instantiate_rejects_imported_module_traversal(self, target):
+        """Test that allowed modules cannot expose callables from disallowed modules."""
+        with pytest.raises(InstantiationException, match="is not in the allowlist"):
+            instantiate({"_target_": target, "_call_": False})
+
+    def test_instantiate_rejects_transformers_module_loader_before_execution(self, monkeypatch, tmp_path):
+        """Test that the Transformers module loader cannot execute attacker-controlled source."""
+        marker = tmp_path / "dynamic-module-executed"
+        module_path = tmp_path / "payload.py"
+        module_path.write_text(f"from pathlib import Path\nPath({str(marker)!r}).touch()\nclass Payload: pass\n")
+        monkeypatch.setattr("transformers.dynamic_module_utils.HF_MODULES_CACHE", str(tmp_path))
+        config = {
+            "_target_": "transformers.dynamic_module_utils.get_class_in_module",
+            "class_name": "Payload",
+            "module_path": module_path.name,
+        }
+
+        with pytest.raises(InstantiationException, match="resolves to the unsafe target"):
+            instantiate(config)
+
+        assert not marker.exists()
 
     def test_instantiate_rejects_unsafe_alias_hidden_in_unused_kwarg(self):
         """Test that recursive instantiation rejects unsafe targets before filtering kwargs."""

--- a/tests/unit_tests/utils/test_safe_pickle.py
+++ b/tests/unit_tests/utils/test_safe_pickle.py
@@ -29,7 +29,13 @@ import torch
 from megatron.energon.savable_loader import SavableDataLoaderState
 from megatron.energon.state import FlexState
 
-from megatron.bridge.utils.safe_pickle import energon_torch_load, safe_load_npy, safe_pickle_load, safe_pickle_loads
+from megatron.bridge.utils.safe_pickle import (
+    energon_torch_load,
+    safe_load_npy,
+    safe_pickle_load,
+    safe_pickle_loads,
+    safe_torch_tensor_pickle_loads,
+)
 
 
 class _BucketKey(Enum):
@@ -262,6 +268,34 @@ class TestSafePickleRejectsUnsafe:
             codecs.unregister(search)
 
         assert not hook_called
+
+
+class TestSafeTorchTensorPickle:
+    """Raw WebDataset tensor pickles allow data but reject executable globals."""
+
+    def test_plain_tensor_container_round_trip(self):
+        value = {
+            "embedding": torch.arange(6, dtype=torch.float32).reshape(2, 3),
+            "mask": torch.tensor([True, False]),
+        }
+
+        restored = safe_torch_tensor_pickle_loads(pickle.dumps(value))
+
+        assert restored.keys() == value.keys()
+        assert torch.equal(restored["embedding"], value["embedding"])
+        assert torch.equal(restored["mask"], value["mask"])
+
+    def test_rejects_reduce_payload_without_executing_it(self, tmp_path):
+        marker = tmp_path / "pickle-executed"
+
+        class Payload:
+            def __reduce__(self):
+                return os.system, (f"touch {marker}",)
+
+        with pytest.raises(pickle.UnpicklingError, match="Restricted unpickler refused"):
+            safe_torch_tensor_pickle_loads(pickle.dumps(Payload()))
+
+        assert not marker.exists()
 
 
 class TestAllowlistImmutability:


### PR DESCRIPTION
## Summary

- reject checkpoint targets that resolve through allowed modules to disallowed callables, including imported-module traversal and Transformers dynamic-module helpers
- decode diffusion WebDataset pickle and PTH tensor fields through restricted loaders, including legacy pickle protocols
- validate Energon dataset metadata before resolving serialized functions or classes, and reject dataset-local Python hook paths while preserving packaged dataset/sample types and trusted in-process callables

Related: NVBug 6643370, NVBug 6643379, NVBug 6643385

## Root cause

These reports share a security class, not one literal code root cause: three separate input boundaries treated untrusted serialized metadata as executable configuration. The fixes remain isolated at each boundary so they do not conflate checkpoint instantiation, shard field decoding, and Energon dataset configuration behavior.

## Per-bug coverage

- **6643370:** validates both the requested and resolved canonical target, blocking NumPy/PyTorch loader aliases, imported-module traversal, both Transformers dynamic-module helpers, and unsafe targets nested in otherwise unused configuration.
- **6643379:** covers raw tensor pickle protocols 0–5 and weights-only PTH round trips; malicious reducers fail loudly without side effects across every supported pickle protocol and for PTH; Flux and Wan compatibility remains covered.
- **6643385:** rejects string-valued Python hooks plus serialized function and arbitrary-class mappings before import or instantiation. Packaged Energon factory/sample types, the legacy ChatML factory alias, declarative field maps, metadataset joiners, and trusted callable hooks remain supported. Reload-idempotence is covered.

## Validation

- 234 focused tests passed across instantiation, restricted pickle loading, Energon configuration/builders, and diffusion decoding.
- Three independent adversarial review rounds completed; the final independent slice passed 266 focused tests with no remaining findings.
- `uv run pre-commit run --all-files` passed.

No dependencies, CI workflows, public conversion APIs, or Megatron-LM submodule files are changed.
