### PR TITLE
docs(model-card): verify K-EXAONE-2 GPU import

### DIFF
--- a/examples/model_verification_cards/k-exaone-2/card.yaml
+++ b/examples/model_verification_cards/k-exaone-2/card.yaml
@@ -6,26 +6,26 @@ summary: >
   Performance disclaimer: this model has not been performance-tuned; reported
   timing and throughput metrics are sanity checks, not optimized performance
   results. K-EXAONE 2.0 750B-A37B has public H100 recipes for pretraining,
-  full SFT, and PEFT in this Bridge revision. CPU conversion, clean-commit GPU
-  conversion reruns, training, export-after-SFT, long-context SFT, and
-  checkpoint resume remain unverified. Complete 750B GPU import and export artifacts have persisted,
-  the imported checkpoint reloaded successfully, and a full 59,396-tensor
-  audit is bitwise exact. A 2-GPU structural MoE/MTP proxy also completed three
+  full SFT, and PEFT in this Bridge revision. CPU conversion, GPU export,
+  training, export-after-SFT, long-context SFT, and checkpoint resume remain
+  unverified. A complete 750B GPU import from a clean commit persisted and
+  reloaded successfully, and a full 59,396-tensor audit is bitwise exact. A
+  2-GPU structural MoE/MTP proxy also completed three
   finite optimizer steps and saved checkpoints, but does not substitute for a
   full-model training item. A memory-bounded reference forward processed all
   78 Hugging Face decoder layers for a Korean prompt; Megatron matched its
   next token with 0.999993 cosine similarity. Complete-model deterministic
   inference generated and independently confirmed exactly 16 new tokens. The
-  implementation fixes are committed and clean-commit conversion reruns must
-  complete before their status promotion.
+  implementation fixes are committed; GPU export remains unverified pending
+  its own clean-commit rerun and exact audit.
 verification_index:
   model_level:
     verified:
+      - hf_to_megatron_gpu
       - manual_forward_pass
       - inference
     unverified:
       - hf_to_megatron_cpu
-      - hf_to_megatron_gpu
       - megatron_to_hf_cpu
       - megatron_to_hf_gpu
   training:
@@ -37,8 +37,8 @@ model:
   architecture: ExaoneMoeForCausalLM
   min_transformers_version: "5.9.0"
 verification_environment:
-  base_container: nvcr.io/nvidia/nemo:26.06
-  bridge_commit: 68d7e875d3bcfad5cd0e7e7d18770cc7e5630034  # pragma: allowlist secret
+  base_container: nvcr.io/nvidia/nemo:26.08
+  bridge_commit: 766f7106e6502f71f799706a1dd874644eadb9ef  # pragma: allowlist secret
 
 items:
   hf_to_megatron_cpu:
@@ -53,7 +53,7 @@ items:
       dtypes, and values.
 
   hf_to_megatron_gpu:
-    status: unverified
+    status: verified
     precision: bf16
     command: >
       ./scripts/conversion/convert.sh import --executor slurm --device gpu
@@ -63,14 +63,13 @@ items:
       --megatron-path work/model-verification/k-exaone-2/imported-megatron
       --torch-dtype bfloat16 --tp 1 --pp 3 --ep 16 --etp 1
       --distributed-timeout-minutes 180 --low-memory-save
-    last_verified: null
+    last_verified: 2026-08-24
     expected_result: >
       The pinned 59,396-tensor BF16 checkpoint imported and persisted
       iter_0000000 on 48 H100 GPUs, and that artifact subsequently reloaded
-      for a full GPU export. A distributed audit compared all 59,396 tensors
-      and 1,498,715,008,512 payload bytes with zero missing, unexpected,
-      shape, dtype, or value mismatches. This item remains unverified only
-      because its clean-commit import/reload rerun is still in progress.
+      for a full distributed GPU re-export audit. The audit compared all
+      59,396 tensors and 1,498,715,010,176 payload bytes with zero missing,
+      unexpected, duplicate, shape, dtype, or value mismatches.
 
   megatron_to_hf_cpu:
     status: unverified
@@ -109,6 +108,7 @@ items:
   manual_forward_pass:
     status: verified
     precision: bf16
+    bridge_commit: 68d7e875d3bcfad5cd0e7e7d18770cc7e5630034  # pragma: allowlist secret
     command: >
       uv run python -m torch.distributed.run --standalone --nproc_per_node=48
       examples/conversion/compare_hf_and_megatron/compare.py


### PR DESCRIPTION
## Summary

- promote the K-EXAONE-2 750B-A37B GPU import leaf to verified
- record the clean Bridge commit and `nvcr.io/nvidia/nemo:26.08` provenance
- preserve the existing manual-forward and deterministic-inference commit provenance
- correct the immutable source checkpoint payload total

## Verification

- imported the pinned BF16 Hugging Face revision on 48 H100 GPUs with TP1/PP3/EP16/ETP1
- persisted and independently reloaded the complete 48-shard `iter_0000000` checkpoint
- completed an exact distributed re-export audit of 59,396 tensors and 1,498,715,010,176 payload bytes with zero missing, unexpected, duplicate, shape, dtype, or value mismatches
- left GPU export and all other unverified leaves unchanged

## Tests

- model verification card validator
- 55 focused validator unit tests
- `pre-commit run --all-files`
