### PR TITLE
perf(data): streamline offline packed SFT preparation

### DIFF
--- a/docs/training/packed-sequences.md
+++ b/docs/training/packed-sequences.md
@@ -49,6 +49,17 @@ row; it does not materialize an offline dataset or load the full source into
 RAM. Use a microbatch-yielding `single` or `cyclic` dataloader; GPT-SFT
 in-batch packing does not support the global-batch `batch` dataloader.
 
+### Bounded-memory Parquet preparation
+
+For large offline Parquet preparations, set
+`cfg.dataset.offline_packing_specs.stream_packed_parquet = True` or pass
+`--stream-packed-parquet`. This fills one pack at a time and flushes Parquet
+row groups at a bounded token count, avoiding corpus-sized Python token lists.
+The logical rows, sequence boundaries, loss masks, and packing metadata are
+unchanged, although the physical Parquet bytes and row-group layout differ.
+Streaming is supported only for Parquet output; the legacy NumPy format still
+uses materialized output.
+
 ## When to Use It
 
 Packed sequences are a good fit when all of the following are true:

--- a/scripts/training/prepare_gpt_sft_packed_data.py
+++ b/scripts/training/prepare_gpt_sft_packed_data.py
@@ -67,6 +67,12 @@ def main() -> None:
         default=1,
         help="Tokenizer worker processes. Values less than or equal to 1 run serially (default: 1).",
     )
+    parser.add_argument(
+        "--stream-packed-parquet",
+        action="store_true",
+        default=None,
+        help="Fill and write Parquet row groups incrementally to bound token-list conversion memory.",
+    )
     args = parser.parse_args()
 
     import megatron.bridge.recipes as all_recipes
@@ -107,10 +113,13 @@ def main() -> None:
         sys.exit(f"Error: recipe '{args.recipe}' has no offline packing specs.")
 
     offline_packing_specs.num_tokenizer_workers = args.num_tokenizer_workers
+    if args.stream_packed_parquet is not None:
+        offline_packing_specs.stream_packed_parquet = args.stream_packed_parquet
 
     logger.info("Recipe:   %s", args.recipe)
     logger.info("Seq len:  %s", offline_packing_specs.packed_sequence_size)
     logger.info("Workers:  %s", offline_packing_specs.num_tokenizer_workers)
+    logger.info("Streaming Parquet: %s", offline_packing_specs.stream_packed_parquet)
 
     logger.info("Building tokenizer...")
     tokenizer = build_tokenizer(cfg.tokenizer)
@@ -144,6 +153,7 @@ def main() -> None:
             dataset_kwargs=builder.dataset_kwargs,
             pad_seq_to_mult=offline_packing_specs.pad_seq_to_mult,
             num_tokenizer_workers=offline_packing_specs.num_tokenizer_workers,
+            stream_packed_parquet=offline_packing_specs.stream_packed_parquet,
             dataset_builder=build_gpt_sft_split,
         )
 
@@ -159,6 +169,7 @@ def main() -> None:
                 dataset_kwargs=builder.dataset_kwargs,
                 pad_seq_to_mult=offline_packing_specs.pad_seq_to_mult,
                 num_tokenizer_workers=offline_packing_specs.num_tokenizer_workers,
+                stream_packed_parquet=offline_packing_specs.stream_packed_parquet,
                 dataset_builder=build_gpt_sft_split,
             )
         elif args.val_input_path or args.packed_val_data_path:

--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -610,6 +610,9 @@ class GPTSFTDatasetBuilder:
         self._num_tokenizer_workers = (
             -1 if config.offline_packing_specs is None else config.offline_packing_specs.num_tokenizer_workers
         )
+        self._stream_packed_parquet = (
+            False if config.offline_packing_specs is None else config.offline_packing_specs.stream_packed_parquet
+        )
         self._rewrite_packed_data = config.hf_dataset is not None and config.hf_rewrite
         self._packing_fingerprint = _packing_fingerprint(config, config.dataset_kwargs)
 
@@ -707,6 +710,7 @@ class GPTSFTDatasetBuilder:
             dataset_kwargs=self.dataset_kwargs,
             pad_seq_to_mult=self._pad_seq_to_mult,
             num_tokenizer_workers=self._num_tokenizer_workers,
+            stream_packed_parquet=self._stream_packed_parquet,
             dataset_builder=build_gpt_sft_split,
         )
 

--- a/src/megatron/bridge/data/conversation_processing.py
+++ b/src/megatron/bridge/data/conversation_processing.py
@@ -1563,13 +1563,27 @@ def _value_contains_token_sequence(
     return None if any(result is None for result in results) else False
 
 
+def _conversation_contains_token_sequences(
+    example_or_conversation: Mapping[str, Any] | Sequence[Mapping[str, Any]],
+    tokenizer: Any,
+    token_sequences: Sequence[Sequence[int]],
+) -> bool | None:
+    """Return whether rendered conversation payloads contain any requested token sequence."""
+    payloads: list[Any] = [
+        {key: value for key, value in turn.items() if key != "role"}
+        for turn in _conversation_from_example(example_or_conversation)
+    ]
+    payloads.append(chat_template_kwargs_from_example(example_or_conversation))
+    return _value_contains_token_sequence(payloads, tokenizer, token_sequences)
+
+
 def _conversation_contains_boundary_tokens(
     example_or_conversation: Mapping[str, Any] | Sequence[Mapping[str, Any]],
     tokenizer: Any,
     boundary_config: AssistantMaskBoundaryConfig,
 ) -> bool | None:
     """Return whether rendered conversation payloads contain structural token sequences."""
-    token_sequences = [
+    token_sequences: list[Sequence[int]] = [
         *(_token_map_from_boundary_config(boundary_config.role_start_tokens).values()),
         *(_token_map_from_boundary_config(boundary_config.role_end_tokens).values()),
         *(
@@ -1579,12 +1593,29 @@ def _conversation_contains_boundary_tokens(
             if (token_ids := _as_token_id_list(raw_token_ids))
         ),
     ]
-    payloads: list[Any] = [
-        {key: value for key, value in turn.items() if key != "role"}
-        for turn in _conversation_from_example(example_or_conversation)
+    return _conversation_contains_token_sequences(example_or_conversation, tokenizer, token_sequences)
+
+
+def _conversation_contains_loss_boundary_tokens(
+    example_or_conversation: Mapping[str, Any] | Sequence[Mapping[str, Any]],
+    tokenizer: Any,
+    boundary_config: AssistantMaskBoundaryConfig,
+) -> bool | None:
+    """Return whether payloads contain a loss-role start or any role-end boundary."""
+    role_start_tokens = _token_map_from_boundary_config(boundary_config.role_start_tokens)
+    role_end_tokens = _token_map_from_boundary_config(boundary_config.role_end_tokens)
+    loss_roles = set(boundary_config.loss_roles)
+    token_sequences: list[Sequence[int]] = [
+        *(token_ids for role, token_ids in role_start_tokens.items() if role in loss_roles),
+        *(role_end_tokens.values()),
+        *(
+            token_ids
+            for raw_variants in boundary_config.role_end_token_variants.values()
+            for raw_token_ids in raw_variants
+            if (token_ids := _as_token_id_list(raw_token_ids))
+        ),
     ]
-    payloads.append(chat_template_kwargs_from_example(example_or_conversation))
-    return _value_contains_token_sequence(payloads, tokenizer, token_sequences)
+    return _conversation_contains_token_sequences(example_or_conversation, tokenizer, token_sequences)
 
 
 def _trim_leading_token_ids(
@@ -1641,6 +1672,7 @@ def _assistant_mask_from_boundary_config(
     *,
     include_content: bool = True,
     conversation_roles: Sequence[str] | None = None,
+    ignore_nonloss_role_starts: bool = False,
 ) -> torch.Tensor | None:
     role_start_tokens = _token_map_from_boundary_config(boundary_config.role_start_tokens)
     role_end_tokens = _token_map_from_boundary_config(boundary_config.role_end_tokens)
@@ -1699,9 +1731,21 @@ def _assistant_mask_from_boundary_config(
     found_loss_segment = False
     for marker_idx, (start_pos, role, marker_len) in enumerate(deduped_markers):
         content_start = start_pos + marker_len
-        next_marker_start = deduped_markers[marker_idx + 1][0] if marker_idx + 1 < len(deduped_markers) else len(ids)
         if role not in loss_roles:
             continue
+        if ignore_nonloss_role_starts:
+            next_marker_start = next(
+                (
+                    later_start
+                    for later_start, later_role, _ in deduped_markers[marker_idx + 1 :]
+                    if later_role in loss_roles
+                ),
+                len(ids),
+            )
+        else:
+            next_marker_start = (
+                deduped_markers[marker_idx + 1][0] if marker_idx + 1 < len(deduped_markers) else len(ids)
+            )
 
         candidate_end_spans = []
         for priority, role_end_pattern in enumerate([role_end_tokens[role], *role_end_token_variants.get(role, [])]):
@@ -1714,7 +1758,11 @@ def _assistant_mask_from_boundary_config(
                 search_start = end_start + 1
         if not candidate_end_spans:
             continue
-        if conversation_roles is not None and len({end_start for end_start, _, _ in candidate_end_spans}) != 1:
+        if (
+            conversation_roles is not None
+            and not ignore_nonloss_role_starts
+            and len({end_start for end_start, _, _ in candidate_end_spans}) != 1
+        ):
             return None
         end_start, _, after_end = min(candidate_end_spans)
         role_end_span = (end_start, after_end)
@@ -1761,18 +1809,50 @@ def build_assistant_loss_mask(
 
     mask = _assistant_mask_from_hf_chat_template(example_or_conversation, ids, processor, tokenizer)
     if boundary_config is not None:
-        boundary_scan_is_safe = not boundary_config.rendered_turn_end_roles and (
-            not conversation
-            or _conversation_contains_boundary_tokens(example_or_conversation, tokenizer, boundary_config) is False
+        boundary_tokens_in_payload = (
+            _conversation_contains_boundary_tokens(example_or_conversation, tokenizer, boundary_config)
+            if conversation
+            else False
         )
-        if mask is None or float(mask.sum().item()) == 0.0:
-            boundary_mask = _assistant_mask_from_conversation_turns(
-                example_or_conversation,
-                ids,
-                tokenizer,
-                tokenizer,
-                boundary_config,
+        boundary_scan_is_safe = not boundary_config.rendered_turn_end_roles and (boundary_tokens_in_payload is False)
+        direct_boundary_scan_is_safe = boundary_scan_is_safe
+        ignore_nonloss_role_starts = False
+        if (
+            not direct_boundary_scan_is_safe
+            and not boundary_config.rendered_turn_end_roles
+            and conversation_roles is not None
+            and boundary_tokens_in_payload is True
+        ):
+            # Non-loss role markers cannot change assistant span ownership once the payload scan
+            # proves there are no end markers or loss-role starts. Those ambiguous loss boundaries
+            # continue through the conversation-prefix fallback below.
+            direct_boundary_scan_is_safe = (
+                _conversation_contains_loss_boundary_tokens(example_or_conversation, tokenizer, boundary_config)
+                is False
             )
+            ignore_nonloss_role_starts = direct_boundary_scan_is_safe
+        if mask is None or float(mask.sum().item()) == 0.0:
+            # Payload analysis makes the token scan exact for clean conversations and payloads
+            # containing only non-loss role markers. Prefer it over rendering every conversation
+            # prefix, which is quadratic for long tool-use trajectories.
+            boundary_mask = (
+                _assistant_mask_from_boundary_config(
+                    ids,
+                    boundary_config,
+                    conversation_roles=conversation_roles,
+                    ignore_nonloss_role_starts=ignore_nonloss_role_starts,
+                )
+                if direct_boundary_scan_is_safe
+                else None
+            )
+            if boundary_mask is None:
+                boundary_mask = _assistant_mask_from_conversation_turns(
+                    example_or_conversation,
+                    ids,
+                    tokenizer,
+                    tokenizer,
+                    boundary_config,
+                )
             if boundary_mask is None and processor is not tokenizer:
                 boundary_mask = _assistant_mask_from_conversation_turns(
                     example_or_conversation,
@@ -1781,25 +1861,31 @@ def build_assistant_loss_mask(
                     tokenizer,
                     boundary_config,
                 )
-            if boundary_mask is None and boundary_scan_is_safe:
-                boundary_mask = _assistant_mask_from_boundary_config(
-                    ids,
-                    boundary_config,
-                    conversation_roles=conversation_roles,
-                )
             if boundary_mask is None and not boundary_scan_is_safe and mask is not None:
                 mask = None
             if mask is None or (boundary_mask is not None and float(boundary_mask.sum().item()) > 0.0):
                 mask = boundary_mask
         else:
-            boundary_token_mask = _assistant_mask_from_conversation_turns(
-                example_or_conversation,
-                ids,
-                tokenizer,
-                tokenizer,
-                boundary_config,
-                include_content=False,
+            boundary_token_mask = (
+                _assistant_mask_from_boundary_config(
+                    ids,
+                    boundary_config,
+                    include_content=False,
+                    conversation_roles=conversation_roles,
+                    ignore_nonloss_role_starts=ignore_nonloss_role_starts,
+                )
+                if direct_boundary_scan_is_safe
+                else None
             )
+            if boundary_token_mask is None:
+                boundary_token_mask = _assistant_mask_from_conversation_turns(
+                    example_or_conversation,
+                    ids,
+                    tokenizer,
+                    tokenizer,
+                    boundary_config,
+                    include_content=False,
+                )
             if boundary_token_mask is None and processor is not tokenizer:
                 boundary_token_mask = _assistant_mask_from_conversation_turns(
                     example_or_conversation,
@@ -1808,13 +1894,6 @@ def build_assistant_loss_mask(
                     tokenizer,
                     boundary_config,
                     include_content=False,
-                )
-            if boundary_token_mask is None and boundary_scan_is_safe:
-                boundary_token_mask = _assistant_mask_from_boundary_config(
-                    ids,
-                    boundary_config,
-                    include_content=False,
-                    conversation_roles=conversation_roles,
                 )
             if boundary_token_mask is not None:
                 mask = torch.maximum(mask, boundary_token_mask)

--- a/src/megatron/bridge/data/packing/algorithms.py
+++ b/src/megatron/bridge/data/packing/algorithms.py
@@ -16,7 +16,7 @@
 
 import collections
 import logging
-from typing import Dict, List, Sequence, Tuple, TypeVar
+from typing import Any, Dict, Iterator, List, Sequence, Tuple, TypeVar
 
 import numpy as np
 from tqdm import tqdm
@@ -303,6 +303,88 @@ def create_packing_strategy(
     return assignments, packing_metadata
 
 
+def _to_python_list(values: Any) -> list:
+    """Convert one tensor/array/list to an independent Python list."""
+    if hasattr(values, "tolist"):
+        return values.tolist()
+    return np.asarray(values).tolist()
+
+
+def iter_packing_strategy(
+    assignments: List[List[int]],
+    sequences: Dict[int, List[Dict]],
+    pack_size: int,
+    pad_id: int,
+) -> Iterator[Dict]:
+    """Yield filled packs without materializing corpus-sized Python token lists.
+
+    This preserves :func:`fill_packing_strategy` ordering: samples in every
+    length bucket are permuted once, and assignments consume that permutation
+    from the end. Only the samples used by the current pack are converted to
+    Python lists.
+
+    Args:
+          assignments: A list of bins containing sequence lengths.
+          sequences: Tokenized samples grouped by runtime sequence length.
+          pack_size: Maximum sequence length used to build ``assignments``.
+          pad_id: Tokenizer padding token. Retained for parity with
+              :func:`fill_packing_strategy`.
+
+    Yields:
+          Packed rows with ``input_ids``, shifted ``loss_mask``, and
+          ``seq_start_id`` fields.
+    """
+    del pad_id
+    ifile_handles: dict[int, tuple[list[int], bool]] = {}
+    for seq_len in tqdm(range(pack_size + 1)):
+        per_seq_data = sequences[seq_len]
+        if not per_seq_data:
+            continue
+
+        permutation = np.random.permutation(len(per_seq_data)).tolist()
+        try:
+            for item in per_seq_data:
+                item["loss_mask"]
+            use_loss_mask = True
+        except KeyError:
+            try:
+                for item in per_seq_data:
+                    item["answer_start_idx"]
+                use_loss_mask = False
+            except KeyError as err:
+                err_msg = "Key errors loss_mask and answer_start_idx missing in example - "
+                err_msg += f"{err} {per_seq_data[0]}"
+                logging.error(err_msg)
+                raise ValueError(err_msg) from err
+        ifile_handles[seq_len] = (permutation, use_loss_mask)
+
+    for assignment in tqdm(assignments):
+        packed_input_ids: list = []
+        packed_loss_mask: list = []
+        seq_start_id = [0]
+        for seq_length in assignment:
+            permutation, use_loss_mask = ifile_handles[seq_length]
+            item = sequences[seq_length][permutation.pop()]
+            item_input_ids = _to_python_list(item["input_ids"])
+            if use_loss_mask:
+                item_loss_mask = _to_python_list(item["loss_mask"])[1:] + [False]
+            else:
+                answer_start_idx = item["answer_start_idx"]
+                item_loss_mask = [idx >= (answer_start_idx - 1) for idx in range(len(item_input_ids))]
+            packed_input_ids.extend(item_input_ids)
+            packed_loss_mask.extend(item_loss_mask)
+            seq_start_id.append(len(packed_input_ids))
+        yield {
+            "input_ids": packed_input_ids,
+            "loss_mask": packed_loss_mask,
+            "seq_start_id": seq_start_id[:-1],
+        }
+
+    assert all(not handle[0] for handle in ifile_handles.values()), (
+        "Error: There are items left over from the assignment"
+    )
+
+
 def fill_packing_strategy(
     assignments: List[List[int]],
     sequences: Dict[int, List[Dict]],
@@ -326,56 +408,7 @@ def fill_packing_strategy(
           output_data: A list of dictionaries, where each dictionary represents a packed sequence with its input IDs,
                         loss mask (if available), and starting indices.
     """
-    ifile_handles = dict()
-    for seq_len in tqdm(range(pack_size + 1)):
-        per_seq_data = sequences[seq_len]
-        if len(per_seq_data) > 0:
-            perm = np.random.permutation(len(per_seq_data))
-            input_ids = np.array([x["input_ids"] for x in per_seq_data])[perm].tolist()
-            try:
-                loss_mask = np.array([x["loss_mask"] for x in per_seq_data])[perm].tolist()
-                # roll loss mask by 1 to align with labels. We want to train on the output after the last context token
-                loss_mask = [x[1:] + [False] for x in loss_mask]
-            except KeyError:
-                try:
-                    loss_mask = np.array(
-                        [
-                            [
-                                # (x['answer_start_idx'] - 1) because we want to train on the output
-                                # after the last context token
-                                idx >= (x["answer_start_idx"] - 1)
-                                for idx in range(len(x["input_ids"]))
-                            ]
-                            for x in per_seq_data
-                        ]
-                    )[perm].tolist()
-                except KeyError as err:
-                    err_msg = "Key errors loss_mask and answer_start_idx missing in example - "
-                    err_msg += f"{err} {per_seq_data[0]}"
-                    logging.error(err_msg)
-                    raise ValueError(err_msg)
-            ifile_handles[seq_len] = (input_ids, loss_mask)
-    input_ids, loss_mask, seq_start_id = {}, {}, {}
-    for oindex, assignment in tqdm(enumerate(assignments), total=len(assignments)):
-        _input_ids, _loss_mask, _seq_start_id = [], [], [0]
-        for seq_length in assignment:
-            _input_ids.extend(ifile_handles[seq_length][0].pop())
-            _loss_mask.extend(ifile_handles[seq_length][1].pop())
-            _seq_start_id.append(len(_input_ids))
-        input_ids[oindex] = _input_ids
-        loss_mask[oindex] = _loss_mask
-        seq_start_id[oindex] = _seq_start_id[:-1]
-    output_data = []
-    for i in range(len(input_ids)):
-        item_dict = {
-            "input_ids": input_ids[i],
-            "loss_mask": loss_mask[i],
-            "seq_start_id": seq_start_id[i],
-        }
-        output_data.append(item_dict)
-    assert all(not seq[0] for seq in ifile_handles.values()), "Error: There are items left over from the assignment"
-    assert all(not seq[1] for seq in ifile_handles.values()), "Error: There are items left over from the assignment"
-    return output_data
+    return list(iter_packing_strategy(assignments, sequences, pack_size, pad_id))
 
 
 def get_seqlen_list(elem: Dict) -> Tuple[List[int], int]:

--- a/src/megatron/bridge/data/packing/config.py
+++ b/src/megatron/bridge/data/packing/config.py
@@ -37,6 +37,8 @@ class PackedSequenceSpecs:
     pad_cu_seqlens: bool = False
     """Pad cumulative sequence boundaries for full-iteration, whole-layer, or attention-scoped CUDA graphs."""
     pad_seq_to_mult: int | None = 1
+    stream_packed_parquet: bool = False
+    """Fill and write Parquet row groups incrementally to bound token-list conversion memory."""
 
     def __post_init__(self) -> None:
         """Validate alignment settings and any explicitly supplied artifacts."""

--- a/src/megatron/bridge/data/packing/offline.py
+++ b/src/megatron/bridge/data/packing/offline.py
@@ -21,23 +21,78 @@ from collections.abc import Callable
 from multiprocessing import Pool
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import numpy as np
 import torch
 from megatron.core.msc_utils import MultiStorageClientFeature
 from tqdm import tqdm
 
-from megatron.bridge.data.packing.algorithms import create_hist, create_packing_strategy, fill_packing_strategy
+from megatron.bridge.data.packing.algorithms import (
+    create_hist,
+    create_packing_strategy,
+    fill_packing_strategy,
+    iter_packing_strategy,
+)
 from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer
 
 
 logger = logging.getLogger(__name__)
 
 _shared_dataset = None
+_PACKING_ITEM_KEYS = ("input_ids", "loss_mask", "answer_start_idx")
+
+
+def _storage_path(path: str | Path) -> Any:
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        return msc.Path(str(path))
+    return Path(path)
+
+
+def _temporary_sibling(path: str | Path) -> Any:
+    destination = _storage_path(path)
+    suffix = destination.suffix
+    stem = destination.name[: -len(suffix)] if suffix else destination.name
+    return destination.with_name(f".{stem}.{uuid4().hex}.tmp{suffix}")
+
+
+def _publish_staged_path(staged_path: Any, destination_path: str | Path) -> None:
+    destination = _storage_path(destination_path)
+    if MultiStorageClientFeature.is_enabled():
+        staged_path.rename(destination)
+    else:
+        staged_path.replace(destination)
+
+
+def _remove_staged_path(staged_path: Any | None) -> None:
+    if staged_path is not None:
+        staged_path.unlink(missing_ok=True)
+
+
+def _select_packing_item_fields(item):
+    if not isinstance(item, dict):
+        return item
+    selected = {}
+    for key in _PACKING_ITEM_KEYS:
+        if key not in item:
+            continue
+        value = item[key]
+        if key in {"input_ids", "loss_mask"}:
+            if torch.is_tensor(value):
+                value = value.detach().cpu().numpy()
+            elif not isinstance(value, np.ndarray):
+                value = np.asarray(value)
+        selected[key] = value
+    return selected
 
 
 def _get_shared_dataset_item(i):
-    return _shared_dataset[i]
+    try:
+        return _select_packing_item_fields(_shared_dataset[i])
+    except Exception as error:
+        error.add_note(f"Failed to prepare packed-SFT dataset index {i}.")
+        raise
 
 
 def _init_shared_dataset_worker(dataset):
@@ -47,7 +102,7 @@ def _init_shared_dataset_worker(dataset):
 
 def _materialize_dataset_items(dataset, num_workers):
     if num_workers <= 1:
-        return np.array([dataset[i] for i in tqdm(range(len(dataset)))])
+        return np.array([_select_packing_item_fields(dataset[i]) for i in tqdm(range(len(dataset)))])
 
     # File-backed tensor sharing avoids one descriptor per returned tensor; the pool still needs descriptors.
     previous_sharing_strategy = torch.multiprocessing.get_sharing_strategy()
@@ -79,10 +134,10 @@ def _pre_pad_data_point(data: dict, max_seq_length: int, max_stored_length_to_pa
     """Pad a single data point so its runtime segment length is divisible by the requested multiple.
 
     Pads ``input_ids``/``context_ids`` with ``pad_id`` and ``loss_mask`` with ``0`` (no loss on
-    pad positions). The chat preprocessing path (``_chat_preprocess``) returns ``torch`` tensors
-    rather than plain lists, so values are normalized to lists before concatenating; this avoids a
-    ``TypeError`` from ``tensor + list`` and keeps ``loss_mask`` the same length as ``input_ids`` so
-    that grouped samples do not produce a ragged array in ``fill_packing_strategy``.
+    pad positions). The chat preprocessing path (``_chat_preprocess``) returns ``torch`` tensors;
+    those and NumPy arrays retain their compact representation so corpus-scale preparation does not
+    expand every token into a Python object. Plain-list inputs remain lists. ``loss_mask`` stays the
+    same length as ``input_ids`` so grouped samples cannot produce ragged packing inputs.
 
     Args:
         data: A single tokenized example. Mutated in place.
@@ -99,19 +154,28 @@ def _pre_pad_data_point(data: dict, max_seq_length: int, max_stored_length_to_pa
         if key not in data:
             continue
         val = data[key]
-        # _chat_preprocess returns torch tensors / numpy arrays; normalize to a plain list.
-        val = val.tolist() if hasattr(val, "tolist") else list(val)
         sequence_length = len(val)
-        if sequence_length <= max_stored_length_to_pad:
-            val = val + [pad_value] * (max_stored_length_to_pad - sequence_length)
-        else:
+        if sequence_length > max_stored_length_to_pad:
             if sequence_length > max_seq_length + 1:
                 logger.info(
                     "Sequence length %d exceeds max_seq_length %d; truncating for packing.",
                     sequence_length,
                     max_seq_length,
                 )
-            val = val[:max_stored_length_to_pad]
+            if torch.is_tensor(val):
+                val = val[:max_stored_length_to_pad].clone()
+            elif isinstance(val, np.ndarray):
+                val = val[:max_stored_length_to_pad].copy()
+            else:
+                val = list(val[:max_stored_length_to_pad])
+        elif sequence_length < max_stored_length_to_pad:
+            padding_length = max_stored_length_to_pad - sequence_length
+            if torch.is_tensor(val):
+                val = torch.cat((val, val.new_full((padding_length,), pad_value)))
+            elif isinstance(val, np.ndarray):
+                val = np.concatenate((val, np.full(padding_length, pad_value, dtype=val.dtype)))
+            else:
+                val = list(val) + [pad_value] * padding_length
         data[key] = val
     return
 
@@ -149,7 +213,6 @@ def tokenize_dataset(
     """
     if not dataset_kwargs:
         dataset_kwargs = {}
-
     # Handle tool_schemas - convert to JSON string if needed
     ts = dataset_kwargs.get("tool_schemas")
     if ts and not isinstance(ts, str):
@@ -227,6 +290,7 @@ def prepare_gpt_sft_packed_data(
     dataset_kwargs: dict | None = None,
     pad_seq_to_mult: int | None = 1,
     num_tokenizer_workers: int = -1,
+    stream_packed_parquet: bool = False,
     *,
     dataset_builder: Callable[..., Any],
 ):
@@ -249,11 +313,17 @@ def prepare_gpt_sft_packed_data(
             preparation (e.g., set to 2 * context_parallel_size for THD CP).
         num_tokenizer_workers: Number of worker processes used to materialize tokenized samples.
             Values less than or equal to 1 run serially.
+        stream_packed_parquet: Fill and write Parquet row groups incrementally instead of retaining
+            corpus-sized Python token lists. This option is not supported for legacy NumPy output.
         dataset_builder: Builder-owned callable that constructs one unpacked GPT SFT split.
 
     Returns:
         None: Saves the packed sequence data to the specified output path.
     """
+    output_path_str = str(output_path)
+    is_parquet_output = output_path_str.lower().endswith((".parquet", ".pq"))
+    if stream_packed_parquet and not is_parquet_output:
+        raise ValueError("stream_packed_parquet requires a Parquet output path.")
     logger.info(f"Preparing packed sequence from {input_path}")
     dataset = tokenize_dataset(
         input_path,
@@ -269,43 +339,117 @@ def prepare_gpt_sft_packed_data(
 
     random_state = np.random.get_state()
     np.random.seed(seed)
+    staged_output_path = None
     try:
         assignments, packing_metadata = create_packing_strategy(histogram, packed_sequence_size, packing_algorithm)
-        output_data = fill_packing_strategy(assignments, sequences, packed_sequence_size, tokenizer.eos_id)
+
+        if stream_packed_parquet:
+            from megatron.bridge.data.packing.parquet import write_packed_parquet_streaming
+
+            staged_output_path = _temporary_sibling(output_path)
+            output_rows = iter_packing_strategy(assignments, sequences, packed_sequence_size, tokenizer.eos_id)
+            try:
+                write_packed_parquet_streaming(
+                    output_rows,
+                    staged_output_path,
+                    _publish_on_completion=False,
+                )
+            except Exception:
+                _remove_staged_path(staged_output_path)
+                raise
+        else:
+            output_data = fill_packing_strategy(assignments, sequences, packed_sequence_size, tokenizer.eos_id)
     finally:
         np.random.set_state(random_state)
 
-    # save output data
-    output_path_str = str(output_path)
-    if output_path_str.lower().endswith((".parquet", ".pq")):
-        from megatron.bridge.data.packing.parquet import write_packed_parquet
-
-        write_packed_parquet(output_data, output_path)
-    else:
-        # Legacy .npy format
-        if MultiStorageClientFeature.is_enabled():
-            msc = MultiStorageClientFeature.import_package()
-            msc.numpy.save(output_path, output_data)
-        else:
-            np.save(output_path, output_data)
-
-    # save packing metadata, packing_metadata is appended to the packing file if it exists
-    if output_metadata_path is not None:
+    if not stream_packed_parquet:
+        # Keep every materialized output hidden until its metadata is ready,
+        # matching the streaming path's retry-safe publication contract.
+        staged_output_path = _temporary_sibling(output_path)
         try:
-            with output_metadata_path.open(mode="r") as f:
-                packing_metadata_file = json.load(f)
-                # 'packing_metadata_file' is expected to be a list of dicts: List[Dict[str, int]]
-                # Each dict corresponds to a packed dataset. Typically there will be two dicts,
-                # one each for the packed val and train datasets.
-                # Each dict records two values: 'max_samples_per_bin', the max
-                # number of samples per packed sequence, and 'dataset_max_seqlen', the max
-                # sequence length per sample in the packed dataset.
-                assert isinstance(packing_metadata_file, list), "invalid packing_metadata_file!"
-        except FileNotFoundError:
-            packing_metadata_file = []
+            if is_parquet_output:
+                from megatron.bridge.data.packing.parquet import write_packed_parquet
 
-        packing_metadata_file.append(packing_metadata)
-        with output_metadata_path.open(mode="w") as f:
-            json.dump(packing_metadata_file, f)
+                write_packed_parquet(output_data, staged_output_path)
+            else:
+                # Legacy .npy format. The staged sibling retains the .npy
+                # suffix so NumPy does not silently append a second suffix.
+                if MultiStorageClientFeature.is_enabled():
+                    msc = MultiStorageClientFeature.import_package()
+                    msc.numpy.save(staged_output_path, output_data)
+                else:
+                    np.save(staged_output_path, output_data)
+        except Exception:
+            _remove_staged_path(staged_output_path)
+            raise
+
+    # Save packing metadata. Streaming output stays at a temporary sibling
+    # until metadata is complete, so a failed preparation cannot leave a
+    # discoverable packed dataset that the builder would accept on retry.
+    staged_metadata_path = None
+    metadata_backup_path = None
+    metadata_path = None
+    metadata_published = False
+    try:
+        if output_metadata_path is not None:
+            metadata_path = _storage_path(output_metadata_path)
+            staged_metadata_path = _temporary_sibling(output_metadata_path)
+            metadata_existed = True
+            try:
+                with metadata_path.open(mode="r") as f:
+                    packing_metadata_file = json.load(f)
+                    # 'packing_metadata_file' is expected to be a list of dicts: List[Dict[str, int]]
+                    # Each dict corresponds to a packed dataset. Typically there will be two dicts,
+                    # one each for the packed val and train datasets.
+                    # Each dict records two values: 'max_samples_per_bin', the max
+                    # number of samples per packed sequence, and 'dataset_max_seqlen', the max
+                    # sequence length per sample in the packed dataset.
+                    assert isinstance(packing_metadata_file, list), "invalid packing_metadata_file!"
+            except FileNotFoundError:
+                metadata_existed = False
+                packing_metadata_file = []
+
+            packing_metadata_file.append(packing_metadata)
+            with staged_metadata_path.open(mode="w") as f:
+                json.dump(packing_metadata_file, f)
+
+            # Keep the previous metadata recoverable until the packed dataset
+            # is published. The dataset path is the builder's completion gate,
+            # so metadata must be rolled back if that final publication fails.
+            if metadata_existed:
+                metadata_backup_path = _temporary_sibling(output_metadata_path)
+                _publish_staged_path(metadata_path, metadata_backup_path)
+            try:
+                _publish_staged_path(staged_metadata_path, output_metadata_path)
+            except Exception:
+                if metadata_backup_path is not None:
+                    _publish_staged_path(metadata_backup_path, output_metadata_path)
+                    metadata_backup_path = None
+                raise
+            staged_metadata_path = None
+            metadata_published = True
+
+        if staged_output_path is not None:
+            try:
+                _publish_staged_path(staged_output_path, output_path)
+            except Exception:
+                if metadata_published:
+                    if metadata_backup_path is not None:
+                        _publish_staged_path(metadata_backup_path, output_metadata_path)
+                        metadata_backup_path = None
+                    else:
+                        metadata_path.unlink(missing_ok=True)
+                raise
+            staged_output_path = None
+    except Exception:
+        _remove_staged_path(staged_metadata_path)
+        _remove_staged_path(staged_output_path)
+        raise
+
+    if metadata_backup_path is not None:
+        try:
+            _remove_staged_path(metadata_backup_path)
+        except Exception as error:
+            logger.warning("Unable to remove packed metadata backup %s: %s", metadata_backup_path, error)
 
     logger.info(f"Packed sequence is prepared and saved to {output_path}")

--- a/src/megatron/bridge/data/packing/parquet.py
+++ b/src/megatron/bridge/data/packing/parquet.py
@@ -30,8 +30,11 @@ from __future__ import annotations
 
 import bisect
 import logging
+from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import numpy as np
 from megatron.core.msc_utils import MultiStorageClientFeature
@@ -97,6 +100,113 @@ def write_packed_parquet(
             f.write(buf.getvalue().to_pybytes())
     else:
         pq.write_table(table, str(output_path), row_group_size=row_group_size)
+
+
+def write_packed_parquet_streaming(
+    rows: Iterable[dict],
+    output_path: str | Path,
+    row_group_size: int = 500,
+    max_row_group_tokens: int = 4 * 1024 * 1024,
+    *,
+    _publish_on_completion: bool = True,
+) -> None:
+    """Incrementally write packed rows with bounded Python-list memory.
+
+    A 128K packed dataset can otherwise place about 64 million tokens in one
+    500-row conversion batch. This writer retains the existing row-count cap
+    while also flushing once the current batch reaches a token budget.
+
+    Args:
+        rows: Iterable of packed row dictionaries.
+        output_path: Path to write the Parquet file.
+        row_group_size: Maximum rows per Parquet row group.
+        max_row_group_tokens: Approximate maximum input tokens converted to
+            Arrow in one row group. A single longer row is still written.
+        _publish_on_completion: Write to a temporary sibling and publish only
+            after all rows finish. Local publication uses an atomic replace;
+            MSC remote publication uses its staged rename. Offline preparation
+            disables this only when it owns a wider output-plus-metadata
+            transaction.
+
+    Raises:
+        ValueError: If either row-group limit is not positive.
+    """
+    if row_group_size <= 0:
+        raise ValueError("row_group_size must be positive.")
+    if max_row_group_tokens <= 0:
+        raise ValueError("max_row_group_tokens must be positive.")
+
+    pa, pq = _lazy_import_pyarrow()
+    schema = pa.schema(
+        [
+            pa.field("input_ids", pa.list_(pa.int64())),
+            pa.field("loss_mask", pa.list_(pa.int8())),
+            pa.field("seq_start_id", pa.list_(pa.int64())),
+        ]
+    )
+
+    def make_table(batch: list[dict]) -> Any:
+        return pa.table(
+            {
+                "input_ids": [row["input_ids"] for row in batch],
+                "loss_mask": pa.array(
+                    [[int(value) for value in row["loss_mask"]] for row in batch],
+                    type=pa.list_(pa.int8()),
+                ),
+                "seq_start_id": [row["seq_start_id"] for row in batch],
+            },
+            schema=schema,
+        )
+
+    msc_enabled = MultiStorageClientFeature.is_enabled()
+    msc = MultiStorageClientFeature.import_package() if msc_enabled else None
+    destination_path = msc.Path(str(output_path)) if msc is not None else Path(output_path)
+    write_path = destination_path
+    if _publish_on_completion:
+        write_path = destination_path.with_name(f".{destination_path.name}.{uuid4().hex}.tmp")
+
+    def write_rows(writer: Any) -> None:
+        batch: list[dict] = []
+        batch_tokens = 0
+        for row in rows:
+            row_tokens = len(row["input_ids"])
+            if batch and (len(batch) >= row_group_size or batch_tokens + row_tokens > max_row_group_tokens):
+                writer.write_table(make_table(batch))
+                batch = []
+                batch_tokens = 0
+            batch.append(row)
+            batch_tokens += row_tokens
+        if batch:
+            writer.write_table(make_table(batch))
+
+    completed = False
+    local_stage_path = None
+    try:
+        if msc is not None:
+            # MSC 0.51 object-write handles use BytesIO. Write to a local file
+            # instead, then use upload_file's filename route so remote output
+            # remains bounded by disk rather than corpus-sized process memory.
+            suffix = Path(str(output_path)).suffix or ".parquet"
+            with NamedTemporaryFile(prefix="bridge-packed-", suffix=suffix, delete=False) as local_stage:
+                local_stage_path = Path(local_stage.name)
+            with pq.ParquetWriter(str(local_stage_path), schema) as writer:
+                write_rows(writer)
+            msc.upload_file(str(write_path), str(local_stage_path))
+        else:
+            with pq.ParquetWriter(str(write_path), schema) as writer:
+                write_rows(writer)
+
+        if _publish_on_completion:
+            if msc is not None:
+                write_path.rename(destination_path)
+            else:
+                write_path.replace(destination_path)
+        completed = True
+    finally:
+        if local_stage_path is not None:
+            local_stage_path.unlink(missing_ok=True)
+        if not completed:
+            write_path.unlink(missing_ok=True)
 
 
 class GPTSFTPackedParquetDataset(GPTSFTPackedDataset):

--- a/tests/unit_tests/data/builders/test_gpt_sft_config.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_config.py
@@ -51,6 +51,7 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
         packed_sequence_size=128,
         max_single_sequence_length=120,
         pad_seq_to_mult=8,
+        stream_packed_parquet=True,
     )
     config = GPTSFTDatasetConfig(
         seq_length=128,
@@ -72,6 +73,7 @@ def test_config_round_trip_is_declarative_and_serializable(tmp_path):
     assert restored.hf_dataset.dataset_name == "squad"
     assert restored.offline_packing_specs.packed_sequence_size == 128
     assert restored.offline_packing_specs.max_single_sequence_length == 120
+    assert restored.offline_packing_specs.stream_packed_parquet is True
     assert isinstance(restored.preprocessing, PromptCompletionSFTPreprocessingConfig)
     assert "tokenizer" not in serialized
 
@@ -714,6 +716,8 @@ def test_hf_rewrite_regenerates_existing_builder_managed_packed_data(monkeypatch
         packed_sequence_size=128,
         max_single_sequence_length=120,
         tokenizer_model_name="test-tokenizer",
+        num_tokenizer_workers=8,
+        stream_packed_parquet=True,
     )
     config = GPTSFTDatasetConfig(
         seq_length=128,
@@ -741,6 +745,8 @@ def test_hf_rewrite_regenerates_existing_builder_managed_packed_data(monkeypatch
 
     assert [call["input_path"].name for call in pack_calls] == ["training.jsonl", "validation.jsonl"]
     assert all(call["max_seq_length"] == 120 for call in pack_calls)
+    assert all(call["num_tokenizer_workers"] == 8 for call in pack_calls)
+    assert all(call["stream_packed_parquet"] is True for call in pack_calls)
     assert json.loads(builder.pack_metadata.read_text()) == []
 
 

--- a/tests/unit_tests/data/packing/test_algorithms.py
+++ b/tests/unit_tests/data/packing/test_algorithms.py
@@ -23,6 +23,7 @@ from megatron.bridge.data.packing.algorithms import (
     create_hist,
     first_fit,
     first_fit_decreasing,
+    iter_packing_strategy,
 )
 
 
@@ -98,6 +99,44 @@ def test_create_hist_skips_oversize_sequences(caplog):
     assert sequences[3] == [in_range]
     assert 4 not in sequences
     assert "Skipped 1 sequences longer than the maximum packed sequence length 3" in caplog.text
+
+
+def test_iter_packing_strategy_converts_only_the_current_pack():
+    """Streaming fill must not expand every tokenized sample up front."""
+    converted = []
+
+    class DeferredList:
+        def __init__(self, values, label):
+            self.values = values
+            self.label = label
+
+        def tolist(self):
+            converted.append(self.label)
+            return list(self.values)
+
+    sequences = {
+        0: [],
+        1: [
+            {
+                "input_ids": DeferredList([10, 11], "ids-0"),
+                "loss_mask": DeferredList([True, True], "mask-0"),
+            },
+            {
+                "input_ids": DeferredList([20, 21], "ids-1"),
+                "loss_mask": DeferredList([False, True], "mask-1"),
+            },
+        ],
+        2: [],
+    }
+
+    np.random.seed(0)
+    rows = iter_packing_strategy([[1], [1]], sequences, pack_size=2, pad_id=0)
+    first_row = next(rows)
+
+    assert first_row["input_ids"] in ([10, 11], [20, 21])
+    assert len(converted) == 2
+    assert len(list(rows)) == 1
+    assert sorted(converted) == ["ids-0", "ids-1", "mask-0", "mask-1"]
 
 
 class TestSegmentTreeMatchesLinearScan:

--- a/tests/unit_tests/data/packing/test_offline.py
+++ b/tests/unit_tests/data/packing/test_offline.py
@@ -19,7 +19,9 @@ import numpy as np
 import pytest
 import torch
 
+import megatron.bridge.data.packing.offline as offline_module
 from megatron.bridge.data.packing.offline import (
+    _get_shared_dataset_item,
     _init_shared_dataset_worker,
     _materialize_dataset_items,
     _pre_pad_data_point,
@@ -31,7 +33,20 @@ from megatron.bridge.data.packing.offline import (
 PAD_ID = 0
 
 
-def test_configured_seed_controls_offline_packing(monkeypatch):
+def test_worker_error_identifies_dataset_index():
+    class FailingDataset:
+        def __getitem__(self, index):
+            raise ValueError(f"invalid row {index}")
+
+    _init_shared_dataset_worker(FailingDataset())
+
+    with pytest.raises(ValueError, match="invalid row 17") as error:
+        _get_shared_dataset_item(17)
+
+    assert error.value.__notes__ == ["Failed to prepare packed-SFT dataset index 17."]
+
+
+def test_configured_seed_controls_offline_packing(monkeypatch, tmp_path):
     """Identical input and configured seed must produce identical packed rows."""
 
     class TinyDataset:
@@ -57,10 +72,15 @@ def test_configured_seed_controls_offline_packing(monkeypatch):
     def prepare_with_ambient_seed(ambient_seed):
         packed_outputs = []
         np.random.seed(ambient_seed)
-        monkeypatch.setattr(np, "save", lambda _, rows: packed_outputs.append(rows))
+
+        def save_staged(path, rows):
+            packed_outputs.append(rows)
+            Path(path).write_bytes(b"staged numpy")
+
+        monkeypatch.setattr(np, "save", save_staged)
         prepare_gpt_sft_packed_data(
             input_path=Path("unused.jsonl"),
-            output_path=Path("unused.npy"),
+            output_path=tmp_path / "unused.npy",
             output_metadata_path=None,
             packed_sequence_size=10,
             tokenizer=SimpleNamespace(eos_id=PAD_ID),
@@ -75,8 +95,172 @@ def test_configured_seed_controls_offline_packing(monkeypatch):
     assert prepare_with_ambient_seed(0) == prepare_with_ambient_seed(4)
 
 
+def test_streaming_packing_rejects_legacy_numpy_output():
+    """The bounded writer is specific to Parquet output."""
+    with pytest.raises(ValueError, match="requires a Parquet output path"):
+        prepare_gpt_sft_packed_data(
+            input_path=Path("unused.jsonl"),
+            output_path=Path("unused.npy"),
+            output_metadata_path=None,
+            packed_sequence_size=8,
+            tokenizer=SimpleNamespace(eos_id=PAD_ID),
+            max_seq_length=8,
+            stream_packed_parquet=True,
+            dataset_builder=lambda *args, **kwargs: pytest.fail("validation must precede dataset construction"),
+        )
+
+
+def test_streaming_output_is_not_published_when_metadata_write_fails(tmp_path, monkeypatch):
+    output_path = tmp_path / "packed.idx.parquet"
+    metadata_path = tmp_path / "missing" / "packed.metadata.json"
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.tokenize_dataset", lambda *args, **kwargs: [])
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.create_hist", lambda *args: ([], {}))
+    monkeypatch.setattr(
+        "megatron.bridge.data.packing.offline.create_packing_strategy",
+        lambda *args: ([], {"packing_efficiency": 100.0}),
+    )
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.iter_packing_strategy", lambda *args: iter(()))
+
+    def write_staged_output(rows, path, *, _publish_on_completion):
+        assert list(rows) == []
+        assert _publish_on_completion is False
+        Path(path).write_bytes(b"staged parquet")
+
+    monkeypatch.setattr(
+        "megatron.bridge.data.packing.parquet.write_packed_parquet_streaming",
+        write_staged_output,
+    )
+
+    with pytest.raises(FileNotFoundError):
+        prepare_gpt_sft_packed_data(
+            input_path=Path("unused.jsonl"),
+            output_path=output_path,
+            output_metadata_path=metadata_path,
+            packed_sequence_size=8,
+            tokenizer=SimpleNamespace(eos_id=PAD_ID),
+            max_seq_length=8,
+            stream_packed_parquet=True,
+            dataset_builder=lambda *args, **kwargs: pytest.fail("tokenization is stubbed"),
+        )
+
+    assert not output_path.exists()
+    assert sorted(item.name for item in tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("output_suffix", [".idx.parquet", ".npy"])
+def test_materialized_output_is_not_published_when_metadata_write_fails(
+    tmp_path,
+    monkeypatch,
+    output_suffix,
+):
+    output_path = tmp_path / f"packed{output_suffix}"
+    metadata_path = tmp_path / "missing" / "packed.metadata.json"
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.tokenize_dataset", lambda *args, **kwargs: [])
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.create_hist", lambda *args: ([], {}))
+    monkeypatch.setattr(
+        "megatron.bridge.data.packing.offline.create_packing_strategy",
+        lambda *args: ([], {"packing_efficiency": 100.0}),
+    )
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.fill_packing_strategy", lambda *args: [])
+
+    if output_suffix == ".idx.parquet":
+        monkeypatch.setattr(
+            "megatron.bridge.data.packing.parquet.write_packed_parquet",
+            lambda rows, path: Path(path).write_bytes(b"staged parquet"),
+        )
+    else:
+        monkeypatch.setattr(
+            "megatron.bridge.data.packing.offline.np.save",
+            lambda path, rows: Path(path).write_bytes(b"staged numpy"),
+        )
+
+    with pytest.raises(FileNotFoundError):
+        prepare_gpt_sft_packed_data(
+            input_path=Path("unused.jsonl"),
+            output_path=output_path,
+            output_metadata_path=metadata_path,
+            packed_sequence_size=8,
+            tokenizer=SimpleNamespace(eos_id=PAD_ID),
+            max_seq_length=8,
+            dataset_builder=lambda *args, **kwargs: pytest.fail("tokenization is stubbed"),
+        )
+
+    assert not output_path.exists()
+    assert sorted(item.name for item in tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("stream_packed_parquet", [False, True])
+@pytest.mark.parametrize("existing_metadata", [False, True])
+def test_metadata_is_rolled_back_when_output_publication_fails(
+    tmp_path,
+    monkeypatch,
+    stream_packed_parquet,
+    existing_metadata,
+):
+    output_path = tmp_path / "packed.idx.parquet"
+    metadata_path = tmp_path / "packed.metadata.json"
+    original_metadata = b'[{"existing": true}]'
+    if existing_metadata:
+        metadata_path.write_bytes(original_metadata)
+
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.tokenize_dataset", lambda *args, **kwargs: [])
+    monkeypatch.setattr("megatron.bridge.data.packing.offline.create_hist", lambda *args: ([], {}))
+    monkeypatch.setattr(
+        "megatron.bridge.data.packing.offline.create_packing_strategy",
+        lambda *args: ([], {"packing_efficiency": 100.0}),
+    )
+
+    if stream_packed_parquet:
+        monkeypatch.setattr("megatron.bridge.data.packing.offline.iter_packing_strategy", lambda *args: iter(()))
+
+        def write_staged_output(rows, path, *, _publish_on_completion):
+            assert list(rows) == []
+            assert _publish_on_completion is False
+            Path(path).write_bytes(b"staged parquet")
+
+        monkeypatch.setattr(
+            "megatron.bridge.data.packing.parquet.write_packed_parquet_streaming",
+            write_staged_output,
+        )
+    else:
+        monkeypatch.setattr("megatron.bridge.data.packing.offline.fill_packing_strategy", lambda *args: [])
+        monkeypatch.setattr(
+            "megatron.bridge.data.packing.parquet.write_packed_parquet",
+            lambda rows, path: Path(path).write_bytes(b"staged parquet"),
+        )
+
+    publish_staged_path = offline_module._publish_staged_path
+
+    def fail_output_publication(staged_path, destination_path):
+        if Path(destination_path) == output_path:
+            raise OSError("synthetic output publication failure")
+        publish_staged_path(staged_path, destination_path)
+
+    monkeypatch.setattr(offline_module, "_publish_staged_path", fail_output_publication)
+
+    with pytest.raises(OSError, match="synthetic output publication failure"):
+        prepare_gpt_sft_packed_data(
+            input_path=Path("unused.jsonl"),
+            output_path=output_path,
+            output_metadata_path=metadata_path,
+            packed_sequence_size=8,
+            tokenizer=SimpleNamespace(eos_id=PAD_ID),
+            max_seq_length=8,
+            stream_packed_parquet=stream_packed_parquet,
+            dataset_builder=lambda *args, **kwargs: pytest.fail("tokenization is stubbed"),
+        )
+
+    assert not output_path.exists()
+    if existing_metadata:
+        assert metadata_path.read_bytes() == original_metadata
+        assert sorted(item.name for item in tmp_path.iterdir()) == [metadata_path.name]
+    else:
+        assert not metadata_path.exists()
+        assert sorted(item.name for item in tmp_path.iterdir()) == []
+
+
 def test_pre_pad_data_point_chat_tensors_do_not_raise():
-    """Chat path returns torch tensors; padding must not raise TypeError (see issue #2610)."""
+    """Chat tensors should retain compact storage while being padded (see issue #2610)."""
     data = {
         "input_ids": torch.LongTensor([5, 6, 7]),
         "loss_mask": torch.BoolTensor([False, True, True]),
@@ -85,14 +269,38 @@ def test_pre_pad_data_point_chat_tensors_do_not_raise():
     # stored max_stored_length_to_pad=9 -> input_ids padded to length 9
     _pre_pad_data_point(data, max_seq_length=16, max_stored_length_to_pad=9, pad_id=PAD_ID)
 
-    assert isinstance(data["input_ids"], list)
-    assert isinstance(data["loss_mask"], list)
+    assert isinstance(data["input_ids"], torch.Tensor)
+    assert isinstance(data["loss_mask"], torch.Tensor)
     # loss_mask must end up the same length as input_ids, otherwise fill_packing_strategy's
     # np.array([...loss_mask...]) raises an inhomogeneous-shape error when samples are grouped.
     assert len(data["loss_mask"]) == len(data["input_ids"])
     # padded loss_mask positions carry 0 (no loss on pad tokens)
-    assert data["loss_mask"][3:] == [0] * (len(data["loss_mask"]) - 3)
-    assert data["input_ids"][3:] == [PAD_ID] * (len(data["input_ids"]) - 3)
+    assert data["loss_mask"][3:].tolist() == [False] * (len(data["loss_mask"]) - 3)
+    assert data["input_ids"][3:].tolist() == [PAD_ID] * (len(data["input_ids"]) - 3)
+
+
+def test_pre_pad_data_point_numpy_arrays_retain_compact_storage():
+    data = {
+        "input_ids": np.asarray([5, 6, 7], dtype=np.int64),
+        "loss_mask": np.asarray([False, True, True], dtype=np.bool_),
+    }
+
+    _pre_pad_data_point(data, max_seq_length=16, max_stored_length_to_pad=9, pad_id=PAD_ID)
+
+    assert isinstance(data["input_ids"], np.ndarray)
+    assert isinstance(data["loss_mask"], np.ndarray)
+    assert data["input_ids"].tolist() == [5, 6, 7] + [PAD_ID] * 6
+    assert data["loss_mask"].tolist() == [False, True, True] + [False] * 6
+
+
+def test_pre_pad_data_point_truncated_tensor_releases_original_storage():
+    data = {"input_ids": torch.arange(20), "loss_mask": torch.ones(20, dtype=torch.bool)}
+
+    _pre_pad_data_point(data, max_seq_length=16, max_stored_length_to_pad=9, pad_id=PAD_ID)
+
+    assert data["input_ids"].tolist() == list(range(9))
+    assert data["input_ids"].untyped_storage().nbytes() == 9 * data["input_ids"].element_size()
+    assert data["loss_mask"].untyped_storage().nbytes() == 9 * data["loss_mask"].element_size()
 
 
 def test_pre_pad_data_point_equalizes_loss_mask_lengths():
@@ -263,6 +471,52 @@ def test_materialize_dataset_items_uses_serial_path_for_non_positive_workers(mon
 
     assert _materialize_dataset_items(TinyDataset(), -1).tolist() == [10, 11, 12]
     assert _materialize_dataset_items(TinyDataset(), 0).tolist() == [10, 11, 12]
+
+
+def test_materialize_dataset_items_discards_fields_unused_by_packing():
+    """The packing boundary keeps only compact fields consumed by packing."""
+
+    class TinyDataset:
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, index):
+            assert index == 0
+            return {
+                "input_ids": [10, 11, 12],
+                "loss_mask": [False, True, True],
+                "context_ids": [10],
+                "answer_ids": [11, 12],
+                "metadata": {"tools": [{"large": "unused"}]},
+            }
+
+    item = _materialize_dataset_items(TinyDataset(), 1)[0]
+    assert set(item) == {"input_ids", "loss_mask"}
+    assert isinstance(item["input_ids"], np.ndarray)
+    assert isinstance(item["loss_mask"], np.ndarray)
+    assert item["input_ids"].tolist() == [10, 11, 12]
+    assert item["loss_mask"].tolist() == [False, True, True]
+
+
+def test_materialize_dataset_items_converts_chat_tensors_before_worker_return():
+    """Compact NumPy values avoid retaining one shared-memory tensor file per field and sample."""
+
+    class TinyDataset:
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, index):
+            assert index == 0
+            return {
+                "input_ids": torch.tensor([10, 11, 12]),
+                "loss_mask": torch.tensor([False, True, True]),
+            }
+
+    item = _materialize_dataset_items(TinyDataset(), 1)[0]
+    assert isinstance(item["input_ids"], np.ndarray)
+    assert isinstance(item["loss_mask"], np.ndarray)
+    assert item["input_ids"].dtype == np.int64
+    assert item["loss_mask"].dtype == np.bool_
 
 
 @pytest.mark.parametrize("pool_fails", [False, True])

--- a/tests/unit_tests/data/packing/test_parquet.py
+++ b/tests/unit_tests/data/packing/test_parquet.py
@@ -21,7 +21,9 @@ and the validate_row helper.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,7 +33,11 @@ import pytest
 pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
 
-from megatron.bridge.data.packing.parquet import GPTSFTPackedParquetDataset, write_packed_parquet
+from megatron.bridge.data.packing.parquet import (
+    GPTSFTPackedParquetDataset,
+    write_packed_parquet,
+    write_packed_parquet_streaming,
+)
 from megatron.bridge.data.packing.paths import (
     _resolve_parquet_paths,
     is_packed_parquet_file,
@@ -95,6 +101,77 @@ def test_write_packed_parquet_normalizes_mixed_loss_mask_types(tmp_path):
     table = pq.read_table(path)
     assert table.schema.field("loss_mask").type == pa.list_(pa.int8())
     assert table.column("loss_mask").to_pylist() == [[1, 0, 1, 0]]
+
+
+@pytest.mark.unit
+def test_write_packed_parquet_streaming_bounds_row_groups(tmp_path):
+    rows = [_make_packed_row(n_tokens=4, n_seqs=1) for _ in range(5)]
+    path = tmp_path / "streaming.idx.parquet"
+    baseline_path = tmp_path / "baseline.idx.parquet"
+
+    write_packed_parquet(rows, baseline_path)
+    write_packed_parquet_streaming(rows, path, row_group_size=5, max_row_group_tokens=8)
+
+    parquet_file = pq.ParquetFile(path)
+    table = parquet_file.read()
+    assert parquet_file.metadata.num_row_groups == 3
+    assert [parquet_file.metadata.row_group(i).num_rows for i in range(3)] == [2, 2, 1]
+    assert table.schema.field("input_ids").type == pa.list_(pa.int64())
+    assert table.schema.field("loss_mask").type == pa.list_(pa.int8())
+    assert table.column("input_ids").to_pylist() == [row["input_ids"] for row in rows]
+    assert table.column("loss_mask").to_pylist() == [row["loss_mask"] for row in rows]
+    assert table.column("seq_start_id").to_pylist() == [row["seq_start_id"] for row in rows]
+    assert table.equals(pq.read_table(baseline_path))
+
+
+@pytest.mark.unit
+def test_write_packed_parquet_streaming_failure_does_not_publish_partial_file(tmp_path):
+    path = tmp_path / "failed-streaming.idx.parquet"
+
+    def failing_rows():
+        yield _make_packed_row(n_tokens=4, n_seqs=1)
+        yield _make_packed_row(n_tokens=4, n_seqs=1)
+        yield _make_packed_row(n_tokens=4, n_seqs=1)
+        raise RuntimeError("synthetic row failure")
+
+    with pytest.raises(RuntimeError, match="synthetic row failure"):
+        write_packed_parquet_streaming(failing_rows(), path, row_group_size=2)
+
+    assert not path.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.unit
+def test_write_packed_parquet_streaming_uses_bounded_msc_sink(tmp_path, monkeypatch):
+    path = tmp_path / "msc-streaming.idx.parquet"
+    uploaded_local_paths = []
+
+    def upload_file(remote_path, local_path):
+        uploaded_local_paths.append(Path(local_path))
+        shutil.copyfile(local_path, remote_path)
+
+    fake_msc = SimpleNamespace(
+        Path=Path,
+        open=lambda *args, **kwargs: pytest.fail("streaming must not use an MSC BytesIO write handle"),
+        upload_file=upload_file,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.data.packing.parquet.MultiStorageClientFeature.is_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.data.packing.parquet.MultiStorageClientFeature.import_package",
+        lambda: fake_msc,
+    )
+    monkeypatch.setattr(pa, "BufferOutputStream", lambda: pytest.fail("streaming must not buffer whole output"))
+
+    rows = [_make_packed_row(n_tokens=4, n_seqs=1) for _ in range(3)]
+    write_packed_parquet_streaming(rows, path, row_group_size=2)
+
+    assert pq.read_table(path).column("input_ids").to_pylist() == [row["input_ids"] for row in rows]
+    assert sorted(item.name for item in tmp_path.iterdir()) == [path.name]
+    assert len(uploaded_local_paths) == 1
+    assert not uploaded_local_paths[0].exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/data/test_conversation_processing.py
+++ b/tests/unit_tests/data/test_conversation_processing.py
@@ -17,6 +17,7 @@ import json
 import pytest
 import torch
 
+import megatron.bridge.data.conversation_processing as conversation_processing
 from megatron.bridge.data.collators.sft import text_chat_collate_fn
 from megatron.bridge.data.conversation_processing import (
     _MAX_SCANNED_REPR_CHARS,
@@ -261,6 +262,7 @@ class _LiteralChatMLBoundaryTokenizer(_ChatMLBoundaryTokenizer):
         "literal assistant start": [20, 102, 30],
         "quoted assistant turn": [20, 102, 30, 103, 31],
         "answer with quoted end": [40, 103, 41],
+        "answer with quoted user start": [40, 100, 41],
         "structured with quoted end": [40, 103, 41],
     }
 
@@ -701,6 +703,44 @@ def test_chatml_boundary_mask_does_not_treat_literal_control_markers_as_structur
         True,
         True,
     ]
+
+
+def test_chatml_boundary_uses_direct_scan_for_marker_clean_conversation(monkeypatch):
+    def fail_on_prefix_render(*args, **kwargs):
+        raise AssertionError("marker-clean conversations should not render every prefix")
+
+    monkeypatch.setattr(conversation_processing, "_assistant_mask_from_conversation_turns", fail_on_prefix_render)
+
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": ""},
+            ]
+        },
+        _LiteralChatMLBoundaryTokenizer(),
+    )
+
+    assert tokenized.assistant_mask.tolist() == [False, False, False, False, False, True, True]
+
+
+def test_chatml_boundary_direct_scan_ignores_nonloss_marker_when_loss_boundaries_are_clean(monkeypatch):
+    def fail_on_prefix_render(*args, **kwargs):
+        raise AssertionError("a uniquely extraneous non-loss marker should not require prefix renders")
+
+    monkeypatch.setattr(conversation_processing, "_assistant_mask_from_conversation_turns", fail_on_prefix_render)
+
+    tokenized = tokenize_chat_example(
+        {
+            "messages": [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer with quoted user start"},
+            ]
+        },
+        _LiteralChatMLBoundaryTokenizer(),
+    )
+
+    assert tokenized.assistant_mask.tolist() == [False, False, False, False, False, True, True, True, True, True]
 
 
 def test_chatml_boundary_mask_remains_role_safe_through_right_truncation():

--- a/tests/unit_tests/scripts/test_prepare_gpt_sft_packed_data.py
+++ b/tests/unit_tests/scripts/test_prepare_gpt_sft_packed_data.py
@@ -35,6 +35,7 @@ class _PackedSequenceSpecs:
     packed_sequence_size: int = 2048
     pad_seq_to_mult: int = 8
     num_tokenizer_workers: int = -1
+    stream_packed_parquet: bool = False
 
 
 @dataclass
@@ -91,6 +92,8 @@ def _install_pack_sft_stubs(monkeypatch: pytest.MonkeyPatch, recipe_fn) -> Mock:
     builders = types.ModuleType("megatron.bridge.data.builders")
     builders.GPTSFTDatasetBuilder = _GPTSFTDatasetBuilder
     builders.GPTSFTDatasetConfig = _DatasetConfig
+    gpt_sft_builder = types.ModuleType("megatron.bridge.data.builders.gpt_sft")
+    gpt_sft_builder.build_gpt_sft_split = Mock()
     packing = types.ModuleType("megatron.bridge.data.packing")
     training = types.ModuleType("megatron.bridge.training")
     tokenizers = types.ModuleType("megatron.bridge.training.tokenizers")
@@ -108,6 +111,7 @@ def _install_pack_sft_stubs(monkeypatch: pytest.MonkeyPatch, recipe_fn) -> Mock:
     monkeypatch.setitem(sys.modules, "megatron.bridge", bridge)
     monkeypatch.setitem(sys.modules, "megatron.bridge.data", data)
     monkeypatch.setitem(sys.modules, "megatron.bridge.data.builders", builders)
+    monkeypatch.setitem(sys.modules, "megatron.bridge.data.builders.gpt_sft", gpt_sft_builder)
     monkeypatch.setitem(sys.modules, "megatron.bridge.data.packing", packing)
     monkeypatch.setitem(sys.modules, "megatron.bridge.training", training)
     monkeypatch.setitem(sys.modules, "megatron.bridge.training.tokenizers", tokenizers)
@@ -118,6 +122,7 @@ def _install_pack_sft_stubs(monkeypatch: pytest.MonkeyPatch, recipe_fn) -> Mock:
     monkeypatch.setattr(bridge, "recipes", recipes, raising=False)
     monkeypatch.setattr(bridge, "data", data, raising=False)
     monkeypatch.setattr(data, "builders", builders, raising=False)
+    monkeypatch.setattr(builders, "gpt_sft", gpt_sft_builder, raising=False)
     monkeypatch.setattr(data, "packing", packing, raising=False)
     monkeypatch.setattr(packing, "offline", offline, raising=False)
     monkeypatch.setattr(bridge, "training", training, raising=False)
@@ -187,6 +192,7 @@ def test_prepare_gpt_sft_packed_data_forwards_supported_overrides_and_explicit_p
             "4096",
             "--hf-path",
             "nvidia/unit",
+            "--stream-packed-parquet",
             *worker_args,
             "--train-input-path",
             str(train_input),
@@ -208,13 +214,14 @@ def test_prepare_gpt_sft_packed_data_forwards_supported_overrides_and_explicit_p
     assert kwargs["packed_sequence_size"] == 2048
     assert kwargs["max_seq_length"] == 4096
     assert kwargs["num_tokenizer_workers"] == expected_workers
+    assert kwargs["stream_packed_parquet"] is True
     assert kwargs["dataset_kwargs"] == {
         "chat": "template",
         "use_hf_tokenizer_chat_template": True,
     }
 
 
-def test_prepare_gpt_sft_packed_data_forwards_worker_count_to_default_builder(monkeypatch):
+def test_prepare_gpt_sft_packed_data_forwards_streaming_and_worker_count_to_default_builder(monkeypatch):
     module = _load_module()
 
     def unit_recipe():
@@ -224,7 +231,14 @@ def test_prepare_gpt_sft_packed_data_forwards_worker_count_to_default_builder(mo
     monkeypatch.setattr(
         sys,
         "argv",
-        ["prepare_gpt_sft_packed_data.py", "--recipe", "unit_recipe", "--num-tokenizer-workers", "8"],
+        [
+            "prepare_gpt_sft_packed_data.py",
+            "--recipe",
+            "unit_recipe",
+            "--num-tokenizer-workers",
+            "8",
+            "--stream-packed-parquet",
+        ],
     )
 
     module.main()
@@ -232,4 +246,23 @@ def test_prepare_gpt_sft_packed_data_forwards_worker_count_to_default_builder(mo
     assert len(_GPTSFTDatasetBuilder.instances) == 1
     builder = _GPTSFTDatasetBuilder.instances[0]
     assert builder.kwargs["config"].offline_packing_specs.num_tokenizer_workers == 8
+    assert builder.kwargs["config"].offline_packing_specs.stream_packed_parquet is True
+    assert builder.prepare_data_called
+
+
+def test_prepare_gpt_sft_packed_data_preserves_recipe_streaming_without_cli_flag(monkeypatch):
+    module = _load_module()
+
+    def unit_recipe():
+        specs = _PackedSequenceSpecs(stream_packed_parquet=True)
+        return _RecipeConfig(dataset=_DatasetConfig(offline_packing_specs=specs))
+
+    _install_pack_sft_stubs(monkeypatch, unit_recipe)
+    monkeypatch.setattr(sys, "argv", ["prepare_gpt_sft_packed_data.py", "--recipe", "unit_recipe"])
+
+    module.main()
+
+    assert len(_GPTSFTDatasetBuilder.instances) == 1
+    builder = _GPTSFTDatasetBuilder.instances[0]
+    assert builder.kwargs["config"].offline_packing_specs.stream_packed_parquet is True
     assert builder.prepare_data_called


### PR DESCRIPTION
## Overview

Make offline GPT SFT packing faster and bounded-memory without changing the tokenizer backend or adding a dependency.

Key changes:

- retain only the compact token, loss-mask, and answer-boundary fields needed by packing
- use a role-safe assistant-mask boundary fast path, with ambiguous inputs falling back or failing closed
- preserve the established seeded packing assignments while filling one pack at a time
- optionally stream bounded Parquet row groups instead of retaining corpus-sized Python token lists
- preserve recipe-configured streaming when the CLI flag is omitted
- stage every output mode until metadata succeeds, and roll metadata back if final data publication fails
- avoid Multi-Storage Client's in-memory object writer by staging remote Parquet output in a local temporary file and uploading by filename
- add focused tests and user-facing instructions for `stream_packed_parquet`

The tokenizer backend and default materialized-output setting remain unchanged. GigaToken is intentionally excluded and will be proposed separately.

## CoderForge 128K results

A controlled three-way benchmark used the same immutable first 512 CoderForge `SWE_Rebench` trajectories, Qwen3-0.6B tokenizer snapshot, 128K pack settings, one 32-CPU/128-GiB DFW node, node-local input/output, three warmups, and three measured fresh processes per worker count. It measured the prior combined source with GigaToken and tokenization profiling explicitly disabled for the neutral condition. All variants produced 195 packs, 24,083,264 stored tokens, identical metadata, and the same logical packed-data SHA-256.

Best-tuned endpoint decomposition:

| implementation | backend | best workers | median end-to-end | elapsed reduction vs prior row | throughput speedup vs prior row |
|---|---|---:|---:|---:|---:|
| pre-PR | Hugging Face | 32 | 73.352 s | — | — |
| this PR | Hugging Face | 32 | 61.539 s | 16.1% | 1.192x |
| this PR + separate follow-up | GigaToken | 16 | 55.536 s | 9.8% | 1.108x |

This PR saves 11.813 seconds of the total 17.816-second reduction, or 66.3% of the saved time. GigaToken contributes the remaining 6.003 seconds, or 33.7%. From pre-PR to the combined experiment, elapsed time falls 24.3% and throughput improves 1.321x.

At the matched w32 setting, GigaToken takes 55.598 seconds, so the incremental saving is 5.941 seconds and the neutral/GigaToken shares are 66.5%/33.5%. The conclusion is unchanged.

Worker-count medians for the dependency-free comparison:

| workers | pre-PR Hugging Face | this PR Hugging Face |
|---:|---:|---:|
| 8 | 123.745 s | 101.041 s |
| 16 | 78.820 s | 64.295 s |
| 32 | 73.352 s | 61.539 s |

The streaming result uses six bounded Parquet row groups instead of the pre-PR materialized file's single row group, so physical bytes differ; logical rows, token IDs, masks, sequence boundaries, metadata, row count, and stored-token count match exactly.

An additional confirmation ran the pre-review stripped PR commit `e64439ffb` at w32: its three fresh-process measurements were 61.209, 61.578, and 61.825 seconds (61.578-second median), within 0.1% of the controlled neutral median. Its outputs were byte-identical to the controlled streaming result. The subsequent review fixes affect only omitted-flag behavior and publication-failure rollback, not this successful explicit-streaming benchmark path.

## Validation

- exact current signed commit: `b72ef463ccb03a76d8b5e908ff77810c51a2aeba`
- 259 selected unit tests passed on exact pre-review commit `e64439ffb`
- 32 exact-current focused tests passed after the review fixes (26 offline-packing and 6 CLI cases)
- `pre-commit run --all-files` passed on the exact current source
- `git diff --check` passed
- the exact base-to-source full-index binary diff SHA-256 was `1e44bf85a36862b7aa734ea923a0f39f3080db6fee50a4ebbeb6b0c327baaf16`
- exact-commit three-repetition performance confirmation completed successfully
- no `scripts/performance/` file or benchmark driver is included
