### PR TITLE
fix(misc): preserve legacy generated text

### DIFF
--- a/scripts/inference/text_generation.py
+++ b/scripts/inference/text_generation.py
@@ -194,6 +194,10 @@ def _generate_with_legacy_static_engine(
         legacy=True,
     )
     outputs = engine.generate(prompts=prompts, sampling_params=sampling_params)
+    for output in outputs:
+        generated_tokens = getattr(output, "generated_tokens", None)
+        if generated_tokens is not None:
+            output.generated_text = tokenizer.detokenize(generated_tokens.tolist())
     _print_results(prompts, outputs)
 
 

--- a/tests/unit_tests/scripts/test_text_generation_entrypoint.py
+++ b/tests/unit_tests/scripts/test_text_generation_entrypoint.py
@@ -182,6 +182,44 @@ def test_print_results_includes_returned_log_probabilities(
 
 
 @pytest.mark.unit
+def test_legacy_generation_prints_text_from_generated_tokens(
+    text_generation_entrypoint: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy output must not derive the completion from the raw prompt's character length."""
+
+    class _GeneratedTokens:
+        def tolist(self) -> list[int]:
+            return [7]
+
+    class _LegacyEngine:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def generate(self, **_kwargs: object) -> list[types.SimpleNamespace]:
+            return [types.SimpleNamespace(generated_text="", generated_tokens=_GeneratedTokens())]
+
+    messages: list[str] = []
+    monkeypatch.setattr(text_generation_entrypoint, "StaticInferenceEngine", _LegacyEngine)
+    monkeypatch.setattr(text_generation_entrypoint, "print_rank_0", messages.append)
+    tokenizer = types.SimpleNamespace(
+        tokenize=lambda _prompt: [1, 2],
+        detokenize=lambda tokens: " answer" if tokens == [7] else "Question answer",
+    )
+    args = types.SimpleNamespace(max_new_tokens=1, max_seq_length=16, max_batch_size=None, seed=0)
+
+    text_generation_entrypoint._generate_with_legacy_static_engine(
+        args,
+        model=object(),
+        tokenizer=tokenizer,
+        prompts=["Question<|im_end|>"],
+        sampling_params=object(),
+    )
+
+    assert "[0] Generated:  answer" in messages
+
+
+@pytest.mark.unit
 def test_dynamic_generation_rejects_failed_inference_requests(
     text_generation_entrypoint: types.ModuleType,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

The supported `--use-legacy-generation` path could print an empty or truncated completion when the raw prompt was not character-preserving under tokenization and decoding (for example, a prompt containing tokenizer special-token text).

The legacy static engine correctly retains the generated-token tensor, but its materialized `generated_text` may be derived by slicing decoded prompt-plus-generation text using the raw prompt's character length. This change rematerializes the completion from `generated_tokens` at the Bridge entrypoint before printing it.

## User impact

A valid legacy text-generation request could complete successfully while Bridge displayed the wrong generated text. The token output itself was correct; only result materialization at this entrypoint was corrupted.

## Fix

Decode the already-separated generated-token tensor with the configured tokenizer for legacy outputs. The dynamic generation path and engine APIs are unchanged.

## Validation

Regression test, before the fix:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_text_generation_entrypoint.py::test_legacy_generation_prints_text_from_generated_tokens -q --tb=short
1 failed
```

The unchanged regression test, after the fix:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_text_generation_entrypoint.py::test_legacy_generation_prints_text_from_generated_tokens -q --tb=short
1 passed
```

Adjacent tests:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_text_generation_entrypoint.py -q --tb=short
6 passed
```

Additional checks:

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This is limited to legacy result materialization in `scripts/inference/text_generation.py`. It does not change generation semantics, public APIs, dependencies, CI configuration, or Megatron-Core.
