### PR TITLE
[model] fix: Support locally saved Qwen2-Audio checkpoints

### DIFF
--- a/src/megatron/bridge/models/qwen_audio/qwen2_audio_bridge.py
+++ b/src/megatron/bridge/models/qwen_audio/qwen2_audio_bridge.py
@@ -121,20 +121,28 @@ class Qwen2AudioBridge(MegatronModelBridge):
         Returns:
             MegatronMappingRegistry with all parameter mappings
         """
+        language_model_prefix = "language_model.model"
+        hf_state = getattr(getattr(self, "hf_pretrained", None), "state", None)
+        hf_source = getattr(hf_state, "source", None)
+        if hf_source is not None:
+            hf_keys = hf_source.get_all_keys()
+            if any(key.startswith("language_model.model.model.") for key in hf_keys):
+                language_model_prefix = "language_model.model.model"
+
         # Language model direct mappings
         # Maps: Megatron param name -> HuggingFace param name
         param_mappings = {
             # Embeddings and output layers
-            "language_model.embedding.word_embeddings.weight": "language_model.model.embed_tokens.weight",
+            "language_model.embedding.word_embeddings.weight": f"{language_model_prefix}.embed_tokens.weight",
             "language_model.output_layer.weight": "language_model.lm_head.weight",
-            "language_model.decoder.final_layernorm.weight": "language_model.model.norm.weight",
+            "language_model.decoder.final_layernorm.weight": f"{language_model_prefix}.norm.weight",
             # Layer normalization for attention and MLP
-            "language_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": "language_model.model.layers.*.input_layernorm.weight",
-            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": "language_model.model.layers.*.post_attention_layernorm.weight",
+            "language_model.decoder.layers.*.self_attention.linear_qkv.layer_norm_weight": f"{language_model_prefix}.layers.*.input_layernorm.weight",
+            "language_model.decoder.layers.*.mlp.linear_fc1.layer_norm_weight": f"{language_model_prefix}.layers.*.post_attention_layernorm.weight",
             # Attention output projection
-            "language_model.decoder.layers.*.self_attention.linear_proj.weight": "language_model.model.layers.*.self_attn.o_proj.weight",
+            "language_model.decoder.layers.*.self_attention.linear_proj.weight": f"{language_model_prefix}.layers.*.self_attn.o_proj.weight",
             # MLP output projection
-            "language_model.decoder.layers.*.mlp.linear_fc2.weight": "language_model.model.layers.*.mlp.down_proj.weight",
+            "language_model.decoder.layers.*.mlp.linear_fc2.weight": f"{language_model_prefix}.layers.*.mlp.down_proj.weight",
         }
 
         mapping_list = []
@@ -159,22 +167,22 @@ class Qwen2AudioBridge(MegatronModelBridge):
                 # QKV: Combine separate Q, K, V matrices into single QKV matrix
                 QKVMapping(
                     megatron_param="language_model.decoder.layers.*.self_attention.linear_qkv.weight",
-                    q="language_model.model.layers.*.self_attn.q_proj.weight",
-                    k="language_model.model.layers.*.self_attn.k_proj.weight",
-                    v="language_model.model.layers.*.self_attn.v_proj.weight",
+                    q=f"{language_model_prefix}.layers.*.self_attn.q_proj.weight",
+                    k=f"{language_model_prefix}.layers.*.self_attn.k_proj.weight",
+                    v=f"{language_model_prefix}.layers.*.self_attn.v_proj.weight",
                 ),
                 # QKV bias: Combine separate Q, K, V biases into single QKV bias (Qwen2 specific)
                 QKVMapping(
                     megatron_param="language_model.decoder.layers.*.self_attention.linear_qkv.bias",
-                    q="language_model.model.layers.*.self_attn.q_proj.bias",
-                    k="language_model.model.layers.*.self_attn.k_proj.bias",
-                    v="language_model.model.layers.*.self_attn.v_proj.bias",
+                    q=f"{language_model_prefix}.layers.*.self_attn.q_proj.bias",
+                    k=f"{language_model_prefix}.layers.*.self_attn.k_proj.bias",
+                    v=f"{language_model_prefix}.layers.*.self_attn.v_proj.bias",
                 ),
                 # Gated MLP: Combine gate and up projection matrices into single FC1 matrix
                 GatedMLPMapping(
                     megatron_param="language_model.decoder.layers.*.mlp.linear_fc1.weight",
-                    gate="language_model.model.layers.*.mlp.gate_proj.weight",
-                    up="language_model.model.layers.*.mlp.up_proj.weight",
+                    gate=f"{language_model_prefix}.layers.*.mlp.gate_proj.weight",
+                    up=f"{language_model_prefix}.layers.*.mlp.up_proj.weight",
                 ),
             ]
         )

--- a/tests/unit_tests/models/qwen_audio/test_qwen2_audio_bridge.py
+++ b/tests/unit_tests/models/qwen_audio/test_qwen2_audio_bridge.py
@@ -252,6 +252,76 @@ class TestQwen2AudioBridgeMappingRegistry:
         has_mlp = any("mlp" in name for name in mapping_names)
         assert has_mlp, "Should contain MLP mappings"
 
+    def test_mapping_registry_accepts_transformers_save_layout(self, qwen2_audio_bridge, tmp_path):
+        """A checkpoint saved by the pinned HF class must satisfy Bridge mappings."""
+        from safetensors import safe_open
+        from transformers import Qwen2AudioConfig, Qwen2AudioForConditionalGeneration
+
+        config = Qwen2AudioConfig(
+            audio_token_index=30,
+            audio_config={
+                "num_mel_bins": 8,
+                "d_model": 8,
+                "encoder_layers": 1,
+                "encoder_attention_heads": 1,
+                "encoder_ffn_dim": 16,
+                "max_source_positions": 8,
+            },
+            text_config={
+                "vocab_size": 32,
+                "max_position_embeddings": 32,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 1,
+                "num_key_value_heads": 1,
+                "tie_word_embeddings": False,
+            },
+        )
+        model = Qwen2AudioForConditionalGeneration(config)
+        model.save_pretrained(tmp_path, safe_serialization=True)
+        with safe_open(tmp_path / "model.safetensors", framework="pt") as checkpoint:
+            hf_keys = set(checkpoint.keys())
+
+        qwen2_audio_bridge.hf_config = config
+        qwen2_audio_bridge.hf_pretrained = SimpleNamespace(
+            state=SimpleNamespace(source=SimpleNamespace(get_all_keys=lambda: hf_keys))
+        )
+        registry = qwen2_audio_bridge.mapping_registry()
+        language_params = [
+            "language_model.embedding.word_embeddings.weight",
+            "language_model.output_layer.weight",
+            "language_model.decoder.final_layernorm.weight",
+            "language_model.decoder.layers.0.self_attention.linear_qkv.layer_norm_weight",
+            "language_model.decoder.layers.0.mlp.linear_fc1.layer_norm_weight",
+            "language_model.decoder.layers.0.self_attention.linear_proj.weight",
+            "language_model.decoder.layers.0.mlp.linear_fc2.weight",
+            "language_model.decoder.layers.0.self_attention.linear_qkv.weight",
+            "language_model.decoder.layers.0.self_attention.linear_qkv.bias",
+            "language_model.decoder.layers.0.mlp.linear_fc1.weight",
+        ]
+        mappings = qwen2_audio_bridge._validate_conversion_mappings(
+            registry,
+            language_params,
+            hf_keys,
+        )
+
+        mapped_hf_names = set()
+        for mapping in mappings.values():
+            if isinstance(mapping.hf_param, str):
+                mapped_hf_names.add(mapping.hf_param)
+            else:
+                mapped_hf_names.update(mapping.hf_param.values())
+        assert mapped_hf_names <= hf_keys
+
+    def test_mapping_registry_defaults_to_released_layout(self, qwen2_audio_bridge):
+        """Published Qwen2-Audio checkpoints retain the existing mapping layout."""
+        mapping = qwen2_audio_bridge.mapping_registry().megatron_to_hf_lookup(
+            "language_model.embedding.word_embeddings.weight"
+        )
+
+        assert mapping.hf_param == "language_model.model.embed_tokens.weight"
+
 
 class TestQwen2AudioBridgeEdgeCases:
     """Test edge cases and error conditions."""


### PR DESCRIPTION
## What changed

Support Qwen2-Audio checkpoints produced by `Qwen2AudioForConditionalGeneration.save_pretrained()` with the Transformers version pinned by Bridge, while preserving the existing mappings for published Qwen2-Audio checkpoints.

The bridge now selects the language-model prefix from the source checkpoint keys. A focused regression saves a tiny real Qwen2-Audio model, validates every language-model mapping against the resulting safetensors keys, and retains a negative control for the released checkpoint layout.

## Bug and impact

This is a boundary case exposed by the stricter mapping validation added in #5262. The pinned Transformers class saves language weights under `language_model.model.model.*`, but the Qwen2-Audio bridge always mapped `language_model.model.*`. The supported `AutoBridge.from_hf_pretrained(<local-directory>)` conversion path therefore failed before loading any weights for locally constructed, fine-tuned, or re-saved Qwen2-Audio checkpoints.

The fix is local to `Qwen2AudioBridge.mapping_registry()`: it detects the nested layout from the source keys and applies that prefix consistently to embeddings, norms, attention projections/QKV, and MLP mappings.

## Validation

The pytest targets below were run in a CPU environment with the repository-pinned Transformers 5.12.1; unavailable optional CUDA extensions were disabled without changing repository test code.

Fail before on unmodified `d352aceda8ed4136f1db787bcf449c1b210a2438`:

```text
uv run python -m pytest tests/unit_tests/models/qwen_audio/test_qwen2_audio_bridge.py::TestQwen2AudioBridgeMappingRegistry::test_mapping_registry_accepts_transformers_save_layout -q --tb=short
1 failed: ValueError: Hugging Face checkpoint is missing mapped parameter(s)
```

Pass after:

```text
uv run python -m pytest tests/unit_tests/models/qwen_audio/test_qwen2_audio_bridge.py::TestQwen2AudioBridgeMappingRegistry::test_mapping_registry_accepts_transformers_save_layout -q --tb=short
1 passed

uv run python -m pytest tests/unit_tests/models/qwen_audio/test_qwen2_audio_bridge.py -q --tb=short
22 passed

git diff --check
passed

uv run pre-commit run --all-files
passed
```

## Scope

- No public API, dependency, workflow, or Megatron-Core changes.
- Published single-prefix Qwen2-Audio checkpoint mappings remain the default and have a regression control.
- This does not broaden model support or alter the separate Nemotron-H conversion bridge.
