### PR TITLE
fix: support torch-memory-saver in container CI

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -132,6 +132,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/root/.cache/uv \
     if [ -n "$BASELINE_MCORE_REF" ]; then \
         export MAMBA_FORCE_BUILD=TRUE CAUSAL_CONV1D_FORCE_BUILD=TRUE && \
+        export TMS_CUDA_MAJOR="$("${CUDA_HOME:-/usr/local/cuda}"/bin/nvcc --version | sed -n 's/.*release \([0-9][0-9]*\).*/\1/p' | head -1)" && \
+        test -n "$TMS_CUDA_MAJOR" && \
         export FLASH_MLA_DISABLE_SM90=1 NVCC_THREADS=16 \
             CFLAGS="-I/usr/local/cuda/include/cccl${CFLAGS:+ $CFLAGS} -DNDEBUG" \
             CXXFLAGS="-I/usr/local/cuda/include/cccl${CXXFLAGS:+ $CXXFLAGS} -DNDEBUG" && \
@@ -146,6 +148,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/root/.cache/uv \
     export MAMBA_FORCE_BUILD=TRUE CAUSAL_CONV1D_FORCE_BUILD=TRUE && \
+    export TMS_CUDA_MAJOR="$("${CUDA_HOME:-/usr/local/cuda}"/bin/nvcc --version | sed -n 's/.*release \([0-9][0-9]*\).*/\1/p' | head -1)" && \
+    test -n "$TMS_CUDA_MAJOR" && \
     # flash-mla (Megatron-LM's no_pypi_wheels group) has no PyPI wheel and is built from source by
     # the uv sync below. Point the compilers at the CCCL/libcu++ headers (under cccl/ in this base
     # image, not the default CUDA include path) and scope the build to the target archs.

--- a/docker/common/import_check_skip.txt
+++ b/docker/common/import_check_skip.txt
@@ -25,6 +25,8 @@ torch_tensorrt
 quack  # imports nvidia-cutlass-dsl MLIR libs, which dlopen libcuda at import
 peft # transitively imports optional CUDA-backed modules that dlopen libcuda
 transformer_engine # dlopens libcuda at import
+torch_memory_saver_hook_mode_preload_cu13  # dlopens libcuda at import
+torch_memory_saver_hook_mode_torch_cu13  # dlopens libcuda at import
 
 # Requires the libfuse system library (multi-storage-client FUSE backend; optional):
 mfusepy


### PR DESCRIPTION
# What does this PR do ?

Support `torch-memory-saver` in the Megatron-Bridge image build and its post-build import verification.

Megatron-Core commit `ab5e2c9de62182b3544f1cd2884a4b146d64803c` added `torch-memory-saver` to its `dev` extra. The package builds CUDA-suffixed extensions and requires `TMS_CUDA_MAJOR`, but the Megatron-Bridge Dockerfile installs all MCore extras without setting it. This causes `build-Megatron-Bridge` to fail with:

```text
RuntimeError: TMS_CUDA_MAJOR env var must be set for CUDA builds
```

After the package builds, the post-build import sweep runs the image without NVIDIA driver injection. The two TMS CUDA hook extensions therefore cannot load `libcuda.so.1`; they need the same documented exemption as the other driver-dependent modules in `import_check_skip.txt`.

# Changelog

- Derive the CUDA major version from `nvcc` before both baseline and dispatched MCore dependency syncs.
- Fail the Docker layer immediately if the CUDA major cannot be determined.
- Exempt the two TMS CUDA hook extension modules from the driverless import sweep because they dlopen `libcuda.so.1` at import time.

# GitHub Actions CI

Local validation:

- `pre-commit run --all-files` (all configured hooks passed)
- `git diff --check`
- Targeted shell validation of CUDA-major extraction from `nvcc` release output
- Targeted validation that `import_check.py` loads both TMS module exemptions

A full image build was not run locally because the Docker daemon was unavailable. CI should exercise the affected container-build path.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (Docker-only environment setup; targeted extraction and repository hooks were validated.)
- [x] Did you add or update any necessary documentation? (No user-facing behavior or interface changes.)
- [x] Does the PR affect components that are optional to install? (`torch-memory-saver` is pulled through MCore's `dev` extra.)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? (No Python import behavior changes.)

# Additional Information

- [First failing pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/64090146)
- [Representative failing job](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/408258334)
- [Driverless import-check failure](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/411118645)
- [Preceding successful pipeline](https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/pipelines/63800455)
- Related MCore change: NVIDIA/Megatron-LM#6701
