### PR TITLE
fix(recipe): skip optimizer-step param gather for full CUDA graphs

### DIFF
--- a/docs/training/cuda-graphs.md
+++ b/docs/training/cuda-graphs.md
@@ -95,6 +95,8 @@ The most important interactions are:
 - `delay_wgrad_compute`: adds extra constraints when captured scopes include attention or MoE router
 - `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`: requires `NCCL_GRAPH_REGISTER=0` in the relevant path
 - CPU offloading: incompatible
+- `overlap_param_gather_with_optimizer_step`: incompatible with full-iteration capture because the parameter gather
+  is dispatched from the preceding optimizer step, outside the captured iteration
 
 These interactions are stable enough to treat as design constraints, not just
 debugging tips.

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -681,7 +681,15 @@ def set_post_overrides(
     )
     logger.info(f"DP: {dp}; TP: {tp}; PP: {pp}; CP: {cp}; VP: {vp}")
     # NOTE: overlap_param_gather_with_optimizer_step causes NaN grad norm for fp8_mx. Disabling it until the issue is resolved.
-    if dp > 1 and pp > 1 and vp > 1 and compute_dtype not in ("fp8_mx", "nvfp4"):
+    # Full-iteration CUDA graphs also cannot capture the dependency on the param gather
+    # dispatched from the preceding optimizer step.
+    if (
+        dp > 1
+        and pp > 1
+        and vp > 1
+        and compute_dtype not in ("fp8_mx", "nvfp4")
+        and not is_full_iteration_cuda_graph(recipe.model)
+    ):
         # Do not enable overlap_param_gather_with_optimizer_step for muon optimizer.
         if recipe.optimizer.optimizer != "dist_muon":
             recipe.optimizer.overlap_param_gather_with_optimizer_step = True

--- a/tests/unit_tests/recipes/test_override_precedence.py
+++ b/tests/unit_tests/recipes/test_override_precedence.py
@@ -468,6 +468,79 @@ class TestCudaGraphOverrides:
         assert recipe.rng.te_rng_tracker is True
 
 
+class TestParamGatherOverlap:
+    @pytest.mark.parametrize(
+        ("cuda_graph_impl", "expected_optimizer_step_overlap"),
+        [
+            pytest.param("none", True, id="graphs-disabled"),
+            pytest.param("full_iteration", False, id="full-iteration"),
+        ],
+    )
+    def test_post_overrides_guard_optimizer_step_overlap_for_full_iteration_graphs(
+        self,
+        monkeypatch,
+        cuda_graph_impl,
+        expected_optimizer_step_overlap,
+    ):
+        """Full-iteration graphs keep regular param gather overlap but not optimizer-step dispatch."""
+        from utils import overrides as override_utils
+
+        from megatron.bridge.training.comm_overlap import CommOverlapConfig
+
+        base_config = SimpleNamespace(
+            num_gpus=64,
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=4,
+            context_parallel_size=2,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            gtp_weight_remat_size=1,
+            expert_gtp_weight_remat_size=1,
+            global_batch_size=256,
+        )
+        monkeypatch.setattr(override_utils, "get_workload_base_config", lambda *_args, **_kwargs: base_config)
+        recipe = SimpleNamespace(
+            optimizer=SimpleNamespace(
+                optimizer="adam",
+                use_precision_aware_optimizer=False,
+                overlap_param_gather=True,
+                overlap_param_gather_with_optimizer_step=False,
+            ),
+            model=SimpleNamespace(
+                tensor_model_parallel_size=2,
+                pipeline_model_parallel_size=4,
+                context_parallel_size=2,
+                virtual_pipeline_model_parallel_size=5,
+                expert_model_parallel_size=1,
+                expert_tensor_parallel_size=None,
+                cuda_graph_impl=cuda_graph_impl,
+                cuda_graph_modules=[],
+                cuda_graph_scope=None,
+            ),
+            train=SimpleNamespace(global_batch_size=256),
+            comm_overlap=CommOverlapConfig(
+                tp_comm_overlap=False,
+                overlap_param_gather=True,
+                overlap_param_gather_with_optimizer_step=False,
+            ),
+        )
+
+        recipe = override_utils.set_post_overrides(
+            recipe,
+            model_family_name="llama",
+            model_recipe_name="llama3_70b",
+            gpu="b200",
+            num_gpus=64,
+            compute_dtype="bf16",
+            task="pretrain",
+        )
+
+        assert recipe.optimizer.overlap_param_gather_with_optimizer_step is expected_optimizer_step_overlap
+        assert recipe.comm_overlap.overlap_param_gather_with_optimizer_step is expected_optimizer_step_overlap
+        assert recipe.optimizer.overlap_param_gather is True
+        assert recipe.comm_overlap.overlap_param_gather is True
+
+
 # ---------------------------------------------------------------------------
 # Consistency check: full override chain produces expected final state
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do ?

Prevent the performance override path from enabling `overlap_param_gather_with_optimizer_step` when full-iteration CUDA graph capture is active.

The optimizer-step overlap dispatches the parameter gather from the preceding optimizer step, outside the captured iteration. Waiting for that gather during the captured forward pass creates a dependency on uncaptured work and causes CUDA graph capture to fail.

Regular `overlap_param_gather` remains enabled.

# Changelog

- Guard the `overlap_param_gather_with_optimizer_step` performance override with `is_full_iteration_cuda_graph()`.
- Preserve the existing behavior when CUDA graphs are disabled.
- Add regression coverage for both graph-disabled and full-iteration configurations.
- Document the incompatibility between optimizer-step parameter-gather overlap and full-iteration capture.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

Local validation:

- `pre-commit run --all-files` — passed.
- Python syntax compilation for the changed Python files — passed.
- Targeted guard execution smoke test — passed.
- The focused pytest test was not run locally because Torch is unavailable on the host; the regression test is included for GitHub CI.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No.
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to #1688
- End-to-end before/after validation: https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/1688#issuecomment-5407220366

## End-to-end validation

The change was validated with the Llama 3 70B performance pretraining recipe using:

- BF16
- 64 B200 GPUs
- TP=2, PP=4, CP=2, VP=5
- sequence length 8192
- micro batch size 1
- `use_megatron_fsdp=False` / `no_shard`
- full-iteration CUDA graph capture

Before this change, the performance overrides enabled `overlap_param_gather_with_optimizer_step=True`. Training completed three iterations, then CUDA graph capture failed with `cudaErrorStreamCaptureIsolation` on all 64 ranks.

With the new guard:

- `overlap_param_gather_with_optimizer_step=False`
- regular `overlap_param_gather=True`
- full-iteration capture completed on all 64 ranks
- training completed 30/30 iterations
- zero capture-isolation errors, skipped iterations, or NaN iterations
- iteration-3 loss and gradient norm matched the unpatched run

The public before/after report is recorded in
https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/1688#issuecomment-5407220366.