### PR TITLE
[data] fix: Preserve final-only validation samples

### DIFF
--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -128,6 +128,8 @@ def get_train_valid_test_num_samples(cfg: ConfigContainer) -> tuple[int, int, in
 
     if cfg.validation.eval_interval:
         eval_iters = (cfg.train.train_iters // cfg.validation.eval_interval + 1) * cfg.validation.eval_iters
+    elif cfg.validation.eval_interval is None:
+        eval_iters = cfg.validation.eval_iters or 0
     else:
         eval_iters = 0
     test_iters = cfg.validation.eval_iters

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -445,6 +445,15 @@ class TestDataLoaders:
 class TestSampleBasedDataLoaders:
     """Tests for sample-based training data loader functionality."""
 
+    def test_get_train_valid_test_num_samples_final_only_validation(self):
+        cfg = create_simple_test_config()
+        cfg.validation.eval_interval = None
+
+        _, valid_samples, _ = get_train_valid_test_num_samples(cfg)
+
+        expected_valid_samples = cfg.validation.eval_iters * cfg.train.global_batch_size
+        assert valid_samples == expected_valid_samples
+
     def test_get_train_valid_test_num_samples_iteration_based(self):
         """Test sample calculation for iteration-based training."""
         cfg = create_simple_test_config()


### PR DESCRIPTION
## Summary

When normal training sets `validation.eval_interval=None`, Bridge documents that periodic validation is skipped but final validation still runs. Dataset sizing instead requested zero validation samples. Size-aware providers could therefore omit the validation dataset, clear `do_valid`, and silently skip the promised final pass; providers returning an empty dataset could fail during sampler setup.

This is a follow-up boundary case related to #2721 and #2732.

## Root cause and fix

`get_train_valid_test_num_samples()` treated every falsey interval as disabling validation data. It now distinguishes the documented `None` final-only mode from `0`: `None` budgets one `eval_iters` slice, while `0` retains its existing disabled behavior.

The patch is limited to the owning sizing branch and one regression test. It does not change periodic scheduling, eval-only `skip_train`, provider APIs, or dataset/sampler behavior.

## Validation

Fail before, with the regression test applied to unmodified `main` production code:

```bash
uv run --no-sync python -m pytest tests/functional_tests/test_groups/data/test_loaders.py::TestSampleBasedDataLoaders::test_get_train_valid_test_num_samples_final_only_validation -q --tb=short
```

Result: `1 failed`; `assert 0 == 320`.

Pass after, including adjacent iteration- and sample-based controls:

```bash
uv run --no-sync python -m pytest tests/functional_tests/test_groups/data/test_loaders.py::TestSampleBasedDataLoaders::test_get_train_valid_test_num_samples_final_only_validation tests/functional_tests/test_groups/data/test_loaders.py::TestSampleBasedDataLoaders::test_get_train_valid_test_num_samples_iteration_based tests/functional_tests/test_groups/data/test_loaders.py::TestSampleBasedDataLoaders::test_get_train_valid_test_num_samples_sample_based -q --tb=short
```

Result: `3 passed`.

Additional checks:

- `git diff --check` passed.
- `uv run pre-commit run --all-files` passed all hooks.

No full-suite, convergence, model-quality, or performance validation was run.
