### PR TITLE
fix(deepseek): support V3 distributed conversion

### DIFF
--- a/examples/model_verification_cards/deepseek-v3/card.yaml
+++ b/examples/model_verification_cards/deepseek-v3/card.yaml
@@ -3,22 +3,24 @@
 
 title: deepseek_v3
 summary: >
-  The canonical pretrain_performance.H100 1024-GPU BF16,
-  pretrain_performance.GB200 256-GPU MXFP8, and pretrain_performance.GB300
-  256-GPU MXFP8 recipes are verified.
+  Distributed H100 GPU import, BF16 export, and deterministic inference are
+  verified against the pinned blockwise-FP8 checkpoint. The canonical
+  pretrain_performance.H100 1024-GPU BF16, pretrain_performance.GB200 256-GPU
+  MXFP8, and pretrain_performance.GB300 256-GPU MXFP8 recipes are also verified.
   Timing and throughput metrics from future functional training items remain
-  sanity checks rather than optimized performance results. Model-level
-  conversion, forward correlation, inference, functional training,
-  fine-tuning, and checkpoint-resume verification are deferred.
+  sanity checks rather than optimized performance results. CPU conversion,
+  forward correlation, functional training, fine-tuning, and checkpoint-resume
+  verification remain deferred.
 verification_index:
   model_level:
+    verified:
+      - hf_to_megatron_gpu
+      - megatron_to_hf_gpu
+      - inference
     unverified:
       - hf_to_megatron_cpu
-      - hf_to_megatron_gpu
       - megatron_to_hf_cpu
-      - megatron_to_hf_gpu
       - manual_forward_pass
-      - inference
   training:
     GB300:
       unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
@@ -32,8 +34,8 @@ model:
   architecture: DeepseekV3ForCausalLM
   min_transformers_version: "5.8.0"
 verification_environment:
-  base_container: nvcr.io/nvidia/nemo:26.08.rc5
-  bridge_commit: 79308d0d99fb8c09b3f1a22baa68a4ffa4f4ce1e  # pragma: allowlist secret
+  base_container: nvcr.io/nvidia/nemo:26.08
+  bridge_commit: c3836699a2e006528a1338902874f96da0f5d219  # pragma: allowlist secret
 
 items:
   hf_to_megatron_cpu:
@@ -48,15 +50,23 @@ items:
       by this card.
 
   hf_to_megatron_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    command: >
+      ./scripts/conversion/convert.sh import --executor slurm --device gpu
+      --nodes 4 --gpus-per-node 8
+      --hf-model deepseek-ai/DeepSeek-V3
+      --hf-revision e815299b0bcbac849fa540c768ef21845365c9eb
+      --megatron-path work/model-verification/deepseek-v3/imported-megatron
+      --torch-dtype bfloat16 --low-memory-save
+      --distributed-timeout-minutes 240
+      --tp 1 --pp 4 --ep 8 --etp 1
+    last_verified: 2026-08-25
     expected_result: >
-      A distributed GPU import of the pinned blockwise-FP8 Hugging Face
-      checkpoint must complete every mapping, persist a reloadable Megatron
-      checkpoint, and pass a complete tensor audit. This workflow is deferred
-      by this card.
+      The 32-GPU import completed all 4,583 mapping tasks, blockwise-dequantized
+      the pinned FP8 source into BF16, and persisted a reloadable 32-shard
+      distributed Megatron checkpoint. A strict paired export subsequently
+      matched all 46,183 model tensors and 684,489,845,504 values exactly.
 
   megatron_to_hf_cpu:
     status: unverified
@@ -69,14 +79,26 @@ items:
       is deferred by this card.
 
   megatron_to_hf_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device gpu
+      --nodes 4 --gpus-per-node 8
+      --hf-model deepseek-ai/DeepSeek-V3
+      --hf-revision e815299b0bcbac849fa540c768ef21845365c9eb
+      --megatron-path work/model-verification/deepseek-v3/imported-megatron/iter_0000000
+      --hf-path work/model-verification/deepseek-v3/hf-export
+      --torch-dtype bfloat16 --export-weight-dtype bfloat16
+      --distributed-save --save-every-n-ranks 1
+      --distributed-timeout-minutes 240
+      --tp 1 --pp 4 --ep 8 --etp 1
+    last_verified: 2026-08-25
     expected_result: >
-      A distributed GPU export from a verified Megatron checkpoint must
-      preserve every mapped tensor and strictly reload as
-      DeepseekV3ForCausalLM. This workflow is deferred by this card.
+      The command exited successfully and wrote all 163 source-shaped shards.
+      The index contained exactly 46,183 BF16 model tensors; an exhaustive
+      32-rank audit matched all 684,489,845,504 values against the pinned source
+      after blockwise dequantization of all 45,808 FP8 tensors. The exported
+      configuration instantiated natively as DeepseekV3ForCausalLM.
 
   manual_forward_pass:
     status: unverified
@@ -90,14 +112,26 @@ items:
       by this card.
 
   inference:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    command: >
+      ./scripts/inference/infer.sh --nodes 4 --gpus-per-node 8
+      --task legacy-full-prefix-generation
+      --hf_model_path deepseek-ai/DeepSeek-V3
+      --hf-revision e815299b0bcbac849fa540c768ef21845365c9eb
+      --megatron_model_path work/model-verification/deepseek-v3/imported-megatron/iter_0000000
+      --tp 1 --pp 4 --ep 8 --etp 1
+      --prompt "Explain why the sky appears blue in one sentence."
+      --max_new_tokens 32 --apply-chat-template --thinking-mode disabled
+      --legacy-full-prefix
+    last_verified: 2026-08-25
     expected_result: >
-      A synchronous deterministic Megatron generation from a verified
-      checkpoint must finish with finite logits and a recorded literal greedy
-      completion. This workflow is deferred by this card.
+      The distributed Megatron execution reloaded the verified BF16 checkpoint,
+      produced finite logits, and generated exactly 32 tokens with deterministic
+      greedy decoding, without an earlier EOS. The literal completion was "The sky appears
+      blue because shorter blue wavelengths of sunlight are scattered more
+      effectively by the Earth's atmosphere than longer red wavelengths, a
+      phenomenon known as Rayleigh scattering."
 
   pretrain:
     GB300:
@@ -216,6 +250,7 @@ items:
     H100:
       status: verified
       precision: bf16
+      bridge_commit: 79308d0d99fb8c09b3f1a22baa68a4ffa4f4ce1e  # pragma: allowlist secret
       command: >
         ./scripts/training/train.sh --wait --nodes 128 --gpus-per-node 8
         --recipe deepseek_v3_pretrain_1024gpu_h100_bf16_config
@@ -241,6 +276,7 @@ items:
     GB200:
       status: verified
       precision: fp8_mx
+      bridge_commit: 79308d0d99fb8c09b3f1a22baa68a4ffa4f4ce1e  # pragma: allowlist secret
       command: >
         ./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4
         --recipe deepseek_v3_pretrain_256gpu_gb200_fp8mx_config
@@ -266,6 +302,7 @@ items:
     GB300:
       status: verified
       precision: fp8_mx
+      bridge_commit: 79308d0d99fb8c09b3f1a22baa68a4ffa4f4ce1e  # pragma: allowlist secret
       command: >
         ./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4
         --recipe deepseek_v3_pretrain_256gpu_gb300_fp8mx_config

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1250,6 +1250,7 @@ class AutoBridge(Generic[MegatronModelT]):
                 distributed_save=distributed_save,
                 save_every_n_ranks=save_every_n_ranks,
                 ignored_source_key_prefixes=ignored_source_key_prefixes,
+                ignored_source_key_suffixes=("_scale_inv",) if weight_dtype is not None else None,
             )
         else:
             # Config-only path: shard and write safetensors directly

--- a/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v3_bridge.py
@@ -53,6 +53,36 @@ _dequant_fp8_blockwise = quantization_utils.dequantize_fp8_blockwise
 class DeepSeekV3Bridge(MegatronModelBridge):
     """Megatron Bridge for DeepSeek-V3."""
 
+    @staticmethod
+    def generate_pipeline_layout(num_layers: int, pp: int, mtp_layers: int = 1) -> list[list[str]]:
+        """Generate a pipeline-parallel layout for DeepSeek V3 conversion.
+
+        DeepSeek V3 has 61 decoder layers, so the model cannot use ordinary
+        pipeline partitioning for the practical PP sizes needed to hold the
+        full checkpoint. The conversion launcher calls this hook to distribute
+        decoder layers unevenly while keeping embeddings on the first stage and
+        MTP plus loss on the last stage.
+
+        Args:
+            num_layers: Number of decoder layers.
+            pp: Pipeline parallel size.
+            mtp_layers: Number of MTP layers.
+
+        Returns:
+            A flexible pipeline layout with exactly ``pp`` stages.
+        """
+        base_layers, extra_layers = divmod(num_layers, pp)
+        layout: list[list[str]] = []
+        for pp_rank in range(pp):
+            stage = ["decoder"] * (base_layers + int(pp_rank < extra_layers))
+            if pp_rank == 0:
+                stage.insert(0, "embedding")
+            if pp_rank == pp - 1:
+                stage.extend(["mtp"] * mtp_layers)
+                stage.append("loss")
+            layout.append(stage)
+        return layout
+
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MLAModelProvider:
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config
@@ -178,8 +208,26 @@ class DeepSeekV3Bridge(MegatronModelBridge):
         converted_weights_dict: Dict[str, torch.Tensor],
         hf_state_dict: Mapping[str, torch.Tensor],
     ) -> Dict[str, torch.Tensor]:
-        """Preserve a source rotary embedding inverse frequency tensor if present."""
+        """Preserve source-required shared MTP aliases and rotary frequencies."""
         global_name = task.global_param_name
+        num_layers = getattr(self.hf_config, "num_hidden_layers", None)
+        if isinstance(num_layers, int):
+            shared_mtp_aliases = {
+                "embedding.word_embeddings.weight": (
+                    "model.embed_tokens.weight",
+                    f"model.layers.{num_layers}.embed_tokens.weight",
+                ),
+                "output_layer.weight": (
+                    "lm_head.weight",
+                    f"model.layers.{num_layers}.shared_head.head.weight",
+                ),
+            }
+            alias = shared_mtp_aliases.get(global_name)
+            if alias is not None:
+                source_key, alias_key = alias
+                if source_key in converted_weights_dict and alias_key in hf_state_dict:
+                    converted_weights_dict[alias_key] = converted_weights_dict[source_key]
+
         if not global_name.startswith("decoder.layers.") or not global_name.endswith(".input_layernorm.weight"):
             return converted_weights_dict
 

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -452,17 +452,23 @@ class SafeTensorsStateSource(StateSource):
         self._key_to_filename_map_cache: Optional[Dict[str, str]] = None
 
     @staticmethod
-    def _ignore_source_key_prefixes(
+    def _filter_source_keys(
         key_to_filename_map: Mapping[str, str] | None,
         ignored_source_key_prefixes: Iterable[str] | None,
+        ignored_source_key_suffixes: Iterable[str] | None,
     ) -> Dict[str, str]:
         if not key_to_filename_map:
             return {}
-        if not ignored_source_key_prefixes:
+        if not ignored_source_key_prefixes and not ignored_source_key_suffixes:
             return dict(key_to_filename_map)
 
-        prefixes = tuple(ignored_source_key_prefixes)
-        return {key: filename for key, filename in key_to_filename_map.items() if not key.startswith(prefixes)}
+        prefixes = tuple(ignored_source_key_prefixes or ())
+        suffixes = tuple(ignored_source_key_suffixes or ())
+        return {
+            key: filename
+            for key, filename in key_to_filename_map.items()
+            if not key.startswith(prefixes) and not key.endswith(suffixes)
+        }
 
     @property
     def path(self) -> Path:
@@ -695,6 +701,7 @@ class SafeTensorsStateSource(StateSource):
         distributed_save: bool = False,
         save_every_n_ranks: int = 1,
         ignored_source_key_prefixes: Iterable[str] | None = None,
+        ignored_source_key_suffixes: Iterable[str] | None = None,
     ):
         """
         Saves tensors from a generator to `.safetensors` files, preserving the
@@ -723,6 +730,8 @@ class SafeTensorsStateSource(StateSource):
                 For example, if set to 2, only ranks 0, 2, 4, ... will save weights.
             ignored_source_key_prefixes: Source tensor key prefixes to omit from the expected
                 source sharding map when saving.
+            ignored_source_key_suffixes: Source tensor key suffixes to omit from the expected
+                source sharding map when saving.
 
         """
         if distributed_save:
@@ -732,6 +741,7 @@ class SafeTensorsStateSource(StateSource):
                 strict,
                 save_every_n_ranks=save_every_n_ranks,
                 ignored_source_key_prefixes=ignored_source_key_prefixes,
+                ignored_source_key_suffixes=ignored_source_key_suffixes,
             )
 
         # In a distributed environment, only rank 0 should write to disk.
@@ -751,7 +761,11 @@ class SafeTensorsStateSource(StateSource):
         output_path = Path(output_path)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        key_to_filename_map = self._ignore_source_key_prefixes(self.key_to_filename_map, ignored_source_key_prefixes)
+        key_to_filename_map = self._filter_source_keys(
+            self.key_to_filename_map,
+            ignored_source_key_prefixes,
+            ignored_source_key_suffixes,
+        )
         all_expected_keys = set(key_to_filename_map.keys())
 
         if not key_to_filename_map:
@@ -931,6 +945,7 @@ class SafeTensorsStateSource(StateSource):
         strict: bool = True,
         save_every_n_ranks: int = 1,
         ignored_source_key_prefixes: Iterable[str] | None = None,
+        ignored_source_key_suffixes: Iterable[str] | None = None,
     ):
         is_distributed = torch.distributed.is_available() and torch.distributed.is_initialized()
         if is_distributed:
@@ -957,7 +972,11 @@ class SafeTensorsStateSource(StateSource):
         if is_distributed:
             torch.distributed.barrier()
 
-        key_to_filename_map = self._ignore_source_key_prefixes(self.key_to_filename_map, ignored_source_key_prefixes)
+        key_to_filename_map = self._filter_source_keys(
+            self.key_to_filename_map,
+            ignored_source_key_prefixes,
+            ignored_source_key_suffixes,
+        )
 
         # Fallback: no sharding map, single-file save
         if not key_to_filename_map:

--- a/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_bridges.py
@@ -34,6 +34,15 @@ from megatron.bridge.models.mla_provider import MLAModelProvider
 class TestDeepSeekV3Bridge:
     """Test cases for DeepSeekV3Bridge."""
 
+    def test_generate_pipeline_layout_balances_uneven_decoder_layers(self):
+        layout = DeepSeekV3Bridge.generate_pipeline_layout(num_layers=7, pp=3, mtp_layers=2)
+
+        assert layout == [
+            ["embedding", "decoder", "decoder", "decoder"],
+            ["decoder", "decoder"],
+            ["decoder", "decoder", "mtp", "mtp", "loss"],
+        ]
+
     @pytest.fixture
     def ds_v3_config(self):
         return {
@@ -330,6 +339,46 @@ class TestDeepSeekV3MaybeModifyLoadedHFWeight:
         assert torch.all(result["gate"] == 2.0)
         # Non-FP8 entries pass through unchanged.
         assert result["up"] is w2
+
+
+class TestDeepSeekV3MaybeModifyConvertedHFWeight:
+    """Unit tests for DeepSeek V3 source-specific export aliases."""
+
+    @pytest.mark.parametrize(
+        ("global_name", "source_key", "alias_key"),
+        [
+            (
+                "embedding.word_embeddings.weight",
+                "model.embed_tokens.weight",
+                "model.layers.61.embed_tokens.weight",
+            ),
+            (
+                "output_layer.weight",
+                "lm_head.weight",
+                "model.layers.61.shared_head.head.weight",
+            ),
+        ],
+    )
+    def test_restores_shared_mtp_alias(self, global_name, source_key, alias_key):
+        bridge = DeepSeekV3Bridge()
+        bridge.hf_config = SimpleNamespace(num_hidden_layers=61)
+        task = SimpleNamespace(global_param_name=global_name)
+        weight = torch.randn(4, 4)
+
+        result = bridge.maybe_modify_converted_hf_weight(task, {source_key: weight}, {alias_key: torch.empty(0)})
+
+        assert result[alias_key] is weight
+
+    def test_does_not_add_mtp_alias_when_source_does_not_expect_it(self):
+        bridge = DeepSeekV3Bridge()
+        bridge.hf_config = SimpleNamespace(num_hidden_layers=61)
+        task = SimpleNamespace(global_param_name="embedding.word_embeddings.weight")
+        converted = {"model.embed_tokens.weight": torch.randn(4, 4)}
+
+        result = bridge.maybe_modify_converted_hf_weight(task, converted, {})
+
+        assert result is converted
+        assert set(result) == {"model.embed_tokens.weight"}
 
 
 class TestCommonMappingExpertBias:

--- a/tests/unit_tests/models/hf_pretrained/test_state_dict.py
+++ b/tests/unit_tests/models/hf_pretrained/test_state_dict.py
@@ -441,19 +441,62 @@ class TestSafeTensorsStateSourceSave:
             output_index = json.load(f)
         assert output_index["weight_map"] == {"model.weight": "model-00001-of-00001.safetensors"}
 
-    def test_ignore_source_key_prefixes_filters_expected_map(self):
+    def test_filter_source_keys_filters_expected_map(self):
         source_map = {
             "model.weight": "model.safetensors",
+            "model.weight_scale_inv": "model.safetensors",
             "mtp.0.weight": "model.safetensors",
             "mtp_extra.weight": "model.safetensors",
         }
 
-        assert SafeTensorsStateSource._ignore_source_key_prefixes(None, ("mtp.",)) == {}
-        assert SafeTensorsStateSource._ignore_source_key_prefixes(source_map, None) == source_map
-        assert SafeTensorsStateSource._ignore_source_key_prefixes(source_map, ("mtp.",)) == {
+        assert SafeTensorsStateSource._filter_source_keys(None, ("mtp.",), ("_scale_inv",)) == {}
+        assert SafeTensorsStateSource._filter_source_keys(source_map, None, None) == source_map
+        assert SafeTensorsStateSource._filter_source_keys(source_map, ("mtp.",), ("_scale_inv",)) == {
             "model.weight": "model.safetensors",
             "mtp_extra.weight": "model.safetensors",
         }
+
+    @pytest.mark.parametrize("distributed_save", [False, True])
+    def test_save_generator_ignores_source_key_suffixes(self, tmp_path, distributed_save):
+        from safetensors import safe_open
+        from safetensors.torch import save_file
+
+        source_dir = tmp_path / "source"
+        output_dir = tmp_path / "output"
+        source_dir.mkdir()
+        shard = "model-00001-of-00001.safetensors"
+        save_file(
+            {
+                "model.weight": torch.ones(1),
+                "model.weight_scale_inv": torch.ones(1),
+            },
+            source_dir / shard,
+        )
+        with open(source_dir / "model.safetensors.index.json", "w") as f:
+            json.dump(
+                {
+                    "metadata": {},
+                    "weight_map": {
+                        "model.weight": shard,
+                        "model.weight_scale_inv": shard,
+                    },
+                },
+                f,
+            )
+
+        source = SafeTensorsStateSource(source_dir)
+        source.save_generator(
+            iter([("model.weight", torch.zeros(1))]),
+            output_dir,
+            distributed_save=distributed_save,
+            ignored_source_key_suffixes=("_scale_inv",),
+        )
+
+        with safe_open(output_dir / shard, framework="pt") as output:
+            assert output.keys() == ["model.weight"]
+        with open(output_dir / "model.safetensors.index.json") as f:
+            output_index = json.load(f)
+        assert output_index["weight_map"] == {"model.weight": shard}
 
     def test_distributed_save_generator_ignores_source_key_prefixes_without_initialized_dist(self, tmp_path):
         from safetensors.torch import save_file

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -357,8 +357,16 @@ class TestAutoBridge:
         self._run_save_hf_weights(source, tmp_path, mtp_num_layers=1)
 
         assert source.save_generator_kwargs["ignored_source_key_prefixes"] is None
+        assert source.save_generator_kwargs["ignored_source_key_suffixes"] is None
 
-    def _run_save_hf_weights(self, source, tmp_path, *, mtp_num_layers):
+    def test_save_hf_weights_strips_scale_inv_for_plain_export(self, tmp_path):
+        """Plain-dtype export omits source-only FP8 scale tensors from strict shard accounting."""
+        source = _make_fake_source(present=set())
+        self._run_save_hf_weights(source, tmp_path, mtp_num_layers=1, weight_dtype=torch.bfloat16)
+
+        assert source.save_generator_kwargs["ignored_source_key_suffixes"] == ("_scale_inv",)
+
+    def _run_save_hf_weights(self, source, tmp_path, *, mtp_num_layers, weight_dtype=None):
         """Drive ``save_hf_weights`` with a stubbed bridge/model so the only
         behavior under test is the MTP prefix-resolution wiring.
 
@@ -391,7 +399,7 @@ class TestAutoBridge:
             patch("modelopt.torch.quantization.utils.is_quantized", return_value=False),
         ):
             mock_bridge.return_value = fake_model_bridge
-            bridge_obj.save_hf_weights([Mock()], tmp_path, show_progress=False)
+            bridge_obj.save_hf_weights([Mock()], tmp_path, show_progress=False, weight_dtype=weight_dtype)
 
     def test_can_handle_supported_model(self, llama_config_mock):
         """Test can_handle returns True for supported models."""


### PR DESCRIPTION
## Summary

- support uneven DeepSeek V3 pipeline layouts for distributed conversion
- preserve strict export accounting while handling FP8 scale-only source metadata and documented MTP aliases
- verify pinned DeepSeek V3 GPU import, BF16 export, and deterministic inference on 32 H100 GPUs with the 26.08 container

## Verification

- 4,583/4,583 import mapping tasks completed; reloadable 32-shard distributed checkpoint
- deterministic inference generated exactly 32 tokens with finite logits
- exhaustive paired export audit matched 46,183 tensors and 684,489,845,504 values; all 45,808 FP8 tensors dequantized to BF16
- `151 passed, 54 warnings` in the targeted 26.08 conversion tests
- model verification card validator: passed
- verification card unit tests: `38 passed`
- `pre-commit run --all-files`: passed

Linear: MB-1414