### PR TITLE
docs(qwen): verify 235B import, export, and inference

### DIFF
--- a/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
+++ b/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
@@ -3,18 +3,21 @@
 
 title: qwen3_235b_a22b
 summary: >
-  Performance scope: pretrain_performance.GB200 and pretrain_performance.GB300
-  are verified with their tuned canonical 256-GPU MXFP8 recipes. Model-level
-  and functional training workflows remain unverified in this card.
+  H100 GPU import and deterministic Megatron inference are verified in BF16
+  against the pinned Hugging Face revision. Performance scope:
+  pretrain_performance.GB200 and pretrain_performance.GB300 are verified with
+  their tuned canonical 256-GPU MXFP8 recipes. Other model-level and functional
+  training workflows remain unverified in this card.
 verification_index:
   model_level:
+    verified:
+      - hf_to_megatron_gpu
+      - inference
     unverified:
       - hf_to_megatron_cpu
-      - hf_to_megatron_gpu
       - megatron_to_hf_cpu
       - megatron_to_hf_gpu
       - manual_forward_pass
-      - inference
   training:
     H100:
       unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
@@ -28,7 +31,7 @@ model:
   min_transformers_version: "5.8.1"
 verification_environment:
   base_container: nvcr.io/nvidia/nemo:26.08
-  bridge_commit: bc09410353986ac7255ffd31fb2b720fb9007107  # pragma: allowlist secret
+  bridge_commit: d352aceda8ed4136f1db787bcf449c1b210a2438  # pragma: allowlist secret
 
 items:
   hf_to_megatron_cpu:
@@ -41,13 +44,25 @@ items:
       pinned Hugging Face revision with all applicable verification gates.
 
   hf_to_megatron_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    command: >
+      ./scripts/conversion/convert.sh import --executor slurm --device gpu
+      --nodes 1 --gpus-per-node 8
+      --hf-model Qwen/Qwen3-235B-A22B
+      --hf-revision 8efa61729e24bd65b1d152b5ab5409052aa80e65
+      --megatron-path work/model-verification/qwen3-235b-a22b/imported-megatron
+      --torch-dtype bfloat16 --tp 1 --pp 1 --ep 8 --etp 1
+      --distributed-timeout-minutes 240 --low-memory-save
+    last_verified: 2026-08-25
     expected_result: >
-      This workflow remains unverified and requires a public run against the
-      pinned Hugging Face revision with all applicable verification gates.
+      The eight-H100 pinned-revision import completed all 3,669 mapping
+      operations at TP1/PP1/EP8/ETP1 and cloned 5,173 local tensors per rank
+      through the low-memory path. The immutable source index contained all
+      118 expected weight shards, 36,945 tensors, and 470,187,269,120 tensor
+      payload bytes with no missing shard. The resulting iter_0000000 persisted
+      eight distributed-checkpoint shards totaling 470,282,357,753 bytes and
+      reloaded successfully in the subsequent verified inference workload.
 
   megatron_to_hf_cpu:
     status: unverified
@@ -77,13 +92,25 @@ items:
       pinned Hugging Face revision with all applicable verification gates.
 
   inference:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    command: >
+      ./scripts/inference/infer.sh --nodes 2 --gpus-per-node 8
+      --task legacy-full-prefix-generation
+      --hf_model_path Qwen/Qwen3-235B-A22B
+      --hf-revision 8efa61729e24bd65b1d152b5ab5409052aa80e65
+      --megatron_model_path
+      work/model-verification/qwen3-235b-a22b/imported-megatron/iter_0000000
+      --tp 2 --pp 1 --ep 8 --etp 2
+      --prompt "Explain why the sky appears blue in one sentence."
+      --max_new_tokens 32 --legacy-full-prefix
+    last_verified: 2026-08-25
     expected_result: >
-      This workflow remains unverified and requires a public run against the
-      pinned Hugging Face revision with all applicable verification gates.
+      The 16-H100 TP2/PP1/EP8/ETP2 run reloaded the imported BF16 checkpoint,
+      produced finite logits, generated exactly 32 greedy tokens without an
+      earlier EOS, and exited successfully. The JSON-escaped literal completion
+      was " The high sky half and the the way the the sky is blue lcm and the
+      blue is way sky is the skyy\n\n the sky the blue is sky is".
 
   pretrain:
     H100:

--- a/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
+++ b/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
@@ -3,8 +3,9 @@
 
 title: qwen3_235b_a22b
 summary: >
-  H100 GPU import and deterministic Megatron inference are verified in BF16
-  against the pinned Hugging Face revision. Performance scope:
+  H100 GPU import, CPU and distributed GPU export, and deterministic Megatron
+  inference are verified in BF16 against the pinned Hugging Face revision.
+  CPU import and manual forward parity remain unverified. Performance scope:
   pretrain_performance.GB200 and pretrain_performance.GB300 are verified with
   their tuned canonical 256-GPU MXFP8 recipes. Other model-level and functional
   training workflows remain unverified in this card.
@@ -12,11 +13,11 @@ verification_index:
   model_level:
     verified:
       - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
       - inference
     unverified:
       - hf_to_megatron_cpu
-      - megatron_to_hf_cpu
-      - megatron_to_hf_gpu
       - manual_forward_pass
   training:
     H100:
@@ -65,22 +66,48 @@ items:
       reloaded successfully in the subsequent verified inference workload.
 
   megatron_to_hf_cpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    bridge_commit: 60442bb9adb5435b47db22c6c20aacdf772fbddc  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device cpu
+      --nodes 1 --hf-model Qwen/Qwen3-235B-A22B
+      --hf-revision 8efa61729e24bd65b1d152b5ab5409052aa80e65
+      --megatron-path
+      work/model-verification/qwen3-235b-a22b/imported-megatron/iter_0000000
+      --hf-path work/model-verification/qwen3-235b-a22b/cpu-hf-export
+      --torch-dtype bfloat16 --distributed-timeout-minutes 240
+    last_verified: 2026-08-25
     expected_result: >
-      This workflow remains unverified and requires a public run against the
-      pinned Hugging Face revision with all applicable verification gates.
+      The single-process CPU export exits successfully and writes all 36,945
+      tensors, 235,093,634,560 values, and 470,187,269,120 tensor-payload
+      bytes. Keys, shapes, dtypes, and values are bitwise identical to the
+      pinned BF16 source with no dtype conversions. Transformers strictly
+      reloads the output natively as Qwen3MoeForCausalLM with all 1,037 state
+      tensors and no loading discrepancies.
 
   megatron_to_hf_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    bridge_commit: 60442bb9adb5435b47db22c6c20aacdf772fbddc  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device gpu
+      --nodes 1 --gpus-per-node 8 --hf-model Qwen/Qwen3-235B-A22B
+      --hf-revision 8efa61729e24bd65b1d152b5ab5409052aa80e65
+      --megatron-path
+      work/model-verification/qwen3-235b-a22b/imported-megatron/iter_0000000
+      --hf-path work/model-verification/qwen3-235b-a22b/gpu-hf-export
+      --torch-dtype bfloat16 --distributed-save
+      --tp 1 --pp 1 --ep 8 --etp 1 --distributed-timeout-minutes 240
+    last_verified: 2026-08-25
     expected_result: >
-      This workflow remains unverified and requires a public run against the
-      pinned Hugging Face revision with all applicable verification gates.
+      The eight-H100 distributed export exits successfully and writes all
+      36,945 tensors, 235,093,634,560 values, and 470,187,269,120
+      tensor-payload bytes. Keys, shapes, dtypes, and values are bitwise
+      identical to the pinned BF16 source with no dtype conversions.
+      Transformers strictly reloads the output natively as
+      Qwen3MoeForCausalLM with all 1,037 state tensors and no loading
+      discrepancies.
 
   manual_forward_pass:
     status: unverified

--- a/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
+++ b/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
@@ -101,16 +101,17 @@ items:
       --hf-revision 8efa61729e24bd65b1d152b5ab5409052aa80e65
       --megatron_model_path
       work/model-verification/qwen3-235b-a22b/imported-megatron/iter_0000000
-      --tp 2 --pp 1 --ep 8 --etp 2
+      --tp 1 --pp 2 --ep 8 --etp 1
       --prompt "Explain why the sky appears blue in one sentence."
       --max_new_tokens 32 --legacy-full-prefix
     last_verified: 2026-08-25
     expected_result: >
-      The 16-H100 TP2/PP1/EP8/ETP2 run reloaded the imported BF16 checkpoint,
-      produced finite logits, generated exactly 32 greedy tokens without an
-      earlier EOS, and exited successfully. The JSON-escaped literal completion
-      was " The high sky half and the the way the the sky is blue lcm and the
-      blue is way sky is the skyy\n\n the sky the blue is sky is".
+      The 16-H100 TP1/PP2/EP8/ETP1 run reloaded the imported BF16 checkpoint,
+      generated exactly 32 greedy tokens without an earlier EOS, and exited
+      successfully. The literal completion was " The sky appears blue because
+      Earth's atmosphere scatters shorter wavelengths of sunlight (blue and
+      violet) more effectively than longer wavelengths, a phenomenon known as
+      Rayleigh scattering".
 
   pretrain:
     H100:


### PR DESCRIPTION
## Summary

- verify Qwen3-235B-A22B GPU import, CPU export, distributed GPU export, and deterministic Megatron inference against an immutable Hugging Face revision
- record public launcher commands, topology, checkpoint-integrity evidence, exhaustive export parity, and literal generation output
- preserve the existing verified GB200 and GB300 performance results and leave unrun workflows unverified

## Verification evidence

- source: `Qwen/Qwen3-235B-A22B` at revision `8efa61729e24bd65b1d152b5ab5409052aa80e65`; all 118 indexed shards, 36,945 tensors, and 470,187,269,120 tensor-payload bytes were present
- import: NeMo 26.08, eight H100s, BF16 TP1/PP1/EP8/ETP1 low-memory import; all 3,669 mapping operations completed and eight distributed-checkpoint shards totaling 470,282,357,753 bytes were persisted
- CPU export: all 36,945 tensors and 235,093,634,560 values were bitwise identical to the pinned source; strict native reload passed with 1,037 state tensors and no loading discrepancies
- GPU export: the eight-H100 distributed export produced the same exhaustive bitwise parity and strict native reload result
- inference: NeMo 26.08, 16 H100s, BF16 TP1/PP2/EP8/ETP1 checkpoint reload; exactly 32 greedy tokens were generated without earlier EOS, with finite logits and successful exit

## Tests

- `uv run --no-project --python 3.12 --with pyyaml python skills/create-model-verification-card/scripts/validate_card.py examples/model_verification_cards/qwen3-235b-a22b/card.yaml`
- `uv run --no-project --python 3.12 --with pytest --with pyyaml python -m pytest --confcutdir=tests/unit_tests/skills/create_model_verification_card tests/unit_tests/skills/create_model_verification_card/test_validate_card.py` (38 passed)
- `uv run --no-project --python 3.12 --with pre-commit pre-commit run --all-files`

Linear: MB-1414
