### PR TITLE
[skills] docs: codify recipe tuning workflow

### DIFF
--- a/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
+++ b/skills/nemo-mbridge-perf-activation-recompute/SKILL.md
@@ -84,6 +84,20 @@ Common performance configurations consequently fall into several patterns rather
 
 These are candidate patterns, not an ordering guarantee. Peak attribution and matched measurements decide the final list.
 
+### Qwen Family Boundary
+
+- Standard-attention Qwen2/Qwen3 models can usually start by testing
+  `core_attn`, subject to the fused/Flash Attention control above.
+- Qwen3.5 is a hybrid architecture with GDN layers. `core_attn` does not cover
+  the GDN normalization output; the current pinned Megatron Core provides
+  `gdn_norm_out`, and current Bridge recipes demonstrate it in a selective
+  list. Verify that label and the recipe's complete layer mix on the exact
+  revision rather than describing Qwen3.5 selective recompute as unsupported.
+- If the selected Qwen3.5 boundaries still OOM after optimizer initialization,
+  full-layer recompute is the valid capacity fallback. This is more likely at
+  lower EP because EP shards expert weights but not dense or activation state;
+  it is not proof that the selective boundary itself is broken.
+
 ## Measurement Contract
 
 For every candidate, capture:

--- a/skills/nemo-mbridge-perf-activation-recompute/card.yaml
+++ b/skills/nemo-mbridge-perf-activation-recompute/card.yaml
@@ -1,6 +1,5 @@
 title: activation_recompute
 validated_on: "2026-08-12"
-guidance_updated_on: "2026-08-25"
 summary: >
   Selective activation recompute trades replayed forward work for lower retained
   activation memory. The correct checkpoint boundary is architecture- and
@@ -17,8 +16,6 @@ validation_status:
     - code_verified  # transformer_config.py and transformer_block.py
   recompute_modules_enum:
     - code_verified  # transformer_config.py
-  qwen35_gdn_boundary:
-    - code_verified  # pinned MCore gdn_norm_out boundary and current Bridge recipe use
   llama3_70b_sft_fp8_cs_experiment:
     - measured  # historical PR #3107; contextual, not a cross-module ranking
   moonlight_16b_bf16_experiment:
@@ -121,7 +118,6 @@ recommended_path:
   standard_attention: test core_attn, but compare it with an empty list under fused or Flash Attention
   mla: test mla_up_proj first when expanded Q/K/V tensors dominate; add core_attn only with evidence
   grouped_moe: test moe_act and then layernorm when their outputs drive the peak
-  qwen35_gdn: test gdn_norm_out on the exact revision; core_attn alone does not cover the GDN normalization output
   dense_ffn: test mlp only when its broader replay cost is acceptable
   broader_moe: reserve whole moe for cases where narrower MoE boundaries do not fit
   last_resort: use full recompute with recompute_method and recompute_num_layers
@@ -339,3 +335,10 @@ follow_up_validation:
   - Add matched GDN measurements.
   - Measure context-parallel communication replay for attention and GDN boundaries.
   - Validate representative selective boundaries under the supported CUDA-graph scopes and FP8 recipes.
+
+guidance_updated_on: "2026-08-25"
+operational_guidance:
+  qwen35_gdn: >
+    Test gdn_norm_out on the exact revision; core_attn alone does not cover the
+    GDN normalization output. Use full-layer recompute when targeted boundaries
+    still do not make the complete optimizer step fit.

--- a/skills/nemo-mbridge-perf-activation-recompute/card.yaml
+++ b/skills/nemo-mbridge-perf-activation-recompute/card.yaml
@@ -1,5 +1,6 @@
 title: activation_recompute
 validated_on: "2026-08-12"
+guidance_updated_on: "2026-08-25"
 summary: >
   Selective activation recompute trades replayed forward work for lower retained
   activation memory. The correct checkpoint boundary is architecture- and
@@ -16,6 +17,8 @@ validation_status:
     - code_verified  # transformer_config.py and transformer_block.py
   recompute_modules_enum:
     - code_verified  # transformer_config.py
+  qwen35_gdn_boundary:
+    - code_verified  # pinned MCore gdn_norm_out boundary and current Bridge recipe use
   llama3_70b_sft_fp8_cs_experiment:
     - measured  # historical PR #3107; contextual, not a cross-module ranking
   moonlight_16b_bf16_experiment:
@@ -118,6 +121,7 @@ recommended_path:
   standard_attention: test core_attn, but compare it with an empty list under fused or Flash Attention
   mla: test mla_up_proj first when expanded Q/K/V tensors dominate; add core_attn only with evidence
   grouped_moe: test moe_act and then layernorm when their outputs drive the peak
+  qwen35_gdn: test gdn_norm_out on the exact revision; core_attn alone does not cover the GDN normalization output
   dense_ffn: test mlp only when its broader replay cost is acceptable
   broader_moe: reserve whole moe for cases where narrower MoE boundaries do not fit
   last_resort: use full recompute with recompute_method and recompute_num_layers

--- a/skills/nemo-mbridge-perf-memory-tuning/SKILL.md
+++ b/skills/nemo-mbridge-perf-memory-tuning/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: nemo-mbridge-perf-memory-tuning
-description: Techniques for reducing peak GPU memory in Megatron Bridge — expandable segments, PEFT + SP input re-gather, parallelism resizing, activation recompute, CPU offloading constraints, and common OOM fixes.
+description: >-
+  Techniques for reducing peak GPU memory in Megatron Bridge, including
+  expandable segments, PEFT plus sequence-parallel input re-gather,
+  parallelism resizing, activation recompute, CPU offloading constraints, and
+  common OOM fixes. Use for GPU OOMs, inadequate memory headroom, LoRA or PEFT
+  activation pressure, memory fragmentation, and memory regressions.
 license: Apache-2.0
-when_to_use: GPU OOM errors, reducing peak memory, reducing LoRA or PEFT activation memory with sequence parallelism, or tracing an OOM regression to a specific commit or config change; 'out of memory', 'OOM', 'memory fragmentation', 'expandable_segments', 'reduce GPU memory', 'LoRA memory', 'PEFT memory', 'sequence_parallel_input_regather', 'PYTORCH_CUDA_ALLOC_CONF'.
 ---
 
 # Memory Tuning
@@ -66,6 +70,26 @@ When a training run OOMs or is close to the memory limit:
 6. Consider `mlp` recompute if still OOM. Saves ~3 GB but costs ~16% GPU
    utilization on large dense models (Llama3 70B).
 7. CPU offloading is **blocked when PP > 1**.
+
+## After The First Configuration Fits
+
+Do not stop tuning at the first non-OOM layout. Run through optimizer-state
+initialization and several steady steps. Inspect W&B memory, then confirm every
+rank's peak allocated and reserved memory in the runtime logs; rank 0 can miss
+the hot EP or PP rank.
+
+If the hot rank has safe headroom, change one variable at a time:
+
+1. Lower TP by one legal step. This increases per-rank dense state, but can
+   remove expensive TP communication and improve efficiency when it still fits.
+2. Increase MBS. Adjust gradient accumulation so GBS, data order, and optimizer
+   boundaries remain fixed; otherwise this is a convergence change, not a pure
+   execution comparison.
+
+Accept the change only when end-to-end tokens/s/GPU or step time improves and
+loss remains finite with no skipped/NaN iterations. Do not target 100% reported
+memory use: keep margin for checkpoint/eval transients, MoE routing imbalance,
+dispatcher workspaces, and CUDA-graph private pools.
 
 ## Enablement
 
@@ -300,6 +324,8 @@ model_config = GPTModelProvider(
   profiling or CUDA memory reports
 - LoRA input re-gather does not cover row-parallel or expert adapters and may
   have negligible benefit when few eligible LoRA-A activations dominate memory
+- W&B or logger memory is an observation surface, not an automatic optimizer;
+  TP and MBS candidates still require matched steady-state validation
 
 ## Verification
 

--- a/skills/nemo-mbridge-perf-memory-tuning/card.yaml
+++ b/skills/nemo-mbridge-perf-memory-tuning/card.yaml
@@ -1,5 +1,6 @@
 title: memory_tuning
 validated_on: "2026-06-29"
+guidance_updated_on: "2026-08-25"
 summary: >
   Techniques for reducing peak GPU memory to fix OOM or increase headroom.
   Current coverage: expandable segments (fragmentation fix), parallelism
@@ -90,6 +91,7 @@ recommended_path:
   third: "add selective activation recompute (core_attn)"
   fourth: "increase PP or use distributed optimizer"
   last_resort: "increase TP (severe throughput cost)"
+  after_fit: "inspect per-rank peaks, then A/B one legal lower-TP step or higher MBS with fixed GBS"
 expected_metric_change:
   - metric: peak_memory
     direction: down
@@ -218,6 +220,7 @@ known_limitations:
   - no automatic memory profiling to recommend the optimal strategy
   - LoRA input re-gather adds a backward all-gather and may not improve throughput
   - LoRA input re-gather applies only to eligible non-expert column-parallel LoRA-A projections
+  - W&B and logger memory metrics expose headroom but do not select the optimal TP or MBS automatically
 evidence:
   - docs/parallelisms.md
   - docs/performance-guide.md

--- a/skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-dispatcher-selection/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: nemo-mbridge-perf-moe-dispatcher-selection
-description: Select and validate an MoE token dispatcher (`alltoall`, DeepEP, or HybridEP) for a fixed workload and runtime. Covers backend availability, topology, matched A/B evidence, routing semantics, and failure diagnosis.
+description: >-
+  Select and validate an MoE token dispatcher (`alltoall`, DeepEP, or
+  HybridEP) for a fixed workload and runtime. Covers backend availability,
+  topology, matched A/B evidence, routing semantics, and failure diagnosis.
+  Use when choosing a dispatcher or tracing a regression or crash to the MoE
+  dispatcher configuration.
 license: Apache-2.0
-when_to_use: Choosing a MoE token dispatcher, or tracing a MoE regression or crash to a dispatcher config change; 'which dispatcher', 'alltoall vs DeepEP', 'HybridEP', 'MoE dispatcher', 'flex backend', 'EP dispatcher selection'.
 ---
 
 # MoE Dispatcher Selection Guide
@@ -32,6 +36,10 @@ timing window fixed during the comparison.
 | Small EP | Dispatcher choice may be second-order; start with `alltoall` |
 | Medium EP | Profile first, then A/B the installed flex backends |
 | Large EP | Prioritize topology-aware candidates, but still require a matched A/B |
+
+On one NVL8 domain in BF16, treat `alltoall` and HybridEP as matched candidates:
+their throughput can be close once the full stack is held fixed. HybridEP is a
+high-priority tuning path, not a reason to skip the correctness baseline.
 
 ## Model-Family Patterns
 
@@ -190,6 +198,8 @@ winner again with natural routing.
 - NVL8 systems when the package supports the topology and a matched A/B wins
 - large EP degrees
 - memory headroom matters in addition to throughput
+- an NVL8 BF16 matched A/B beats or materially improves headroom over
+  `alltoall`; a small or negative delta is a valid reason to keep `alltoall`
 
 ## Pitfalls
 

--- a/skills/nemo-mbridge-perf-moe-dispatcher-selection/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-dispatcher-selection/card.yaml
@@ -1,5 +1,6 @@
 title: moe_dispatcher_selection
 validated_on: "2026-07-31"
+guidance_updated_on: "2026-08-25"
 summary: >
   Evidence-gated guide for selecting MoE token dispatchers (AlltoAll, DeepEP,
   HybridEP). Hardware and EP degree form a candidate set; matched target-stack
@@ -40,8 +41,14 @@ training_dimensions:
     rationale: >
       Higher EP means more communication; HybridEP's NVLink optimization
       benefits more at EP=32+ vs EP=8.
-
 dispatcher_recommendations:
+  nvl8_bf16:
+    bring_up: alltoall
+    tuned_candidates: [HybridEP]
+    rationale: >
+      Treat both as matched candidates on the exact stack. Their throughput
+      can be close, so a small or negative delta is a valid reason to keep the
+      simpler alltoall path.
   h100:
     bring_up: alltoall
     tuned_candidates: [DeepEP, HybridEP]

--- a/skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md
+++ b/skills/nemo-mbridge-perf-moe-optimization-workflow/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: nemo-mbridge-perf-moe-optimization-workflow
-description: Evidence-gated workflow for MoE performance optimization in Megatron Bridge. Covers measurement contracts, the Three Walls framework, parallel folding, profiling, matched A/B tuning, and final validation.
+description: >-
+  Evidence-gated workflow for MoE performance optimization in Megatron Bridge.
+  Covers measurement contracts, the Three Walls framework, parallel folding,
+  profiling, matched A/B tuning, and final validation. Use for full MoE
+  throughput tuning or diagnosing a regression involving memory,
+  communication, compute, or host/launch overhead.
 license: Apache-2.0
-when_to_use: Full MoE throughput tuning sweep, or diagnosing a MoE throughput regression after a commit or config change; 'optimize MoE throughput', 'MoE perf tuning', 'Three Walls', 'memory wall', 'communication wall', 'compute wall'.
 ---
 
 # MoE Training Optimization Workflow
@@ -37,9 +41,11 @@ For MoE optimization workflow prompts, present the response in this order:
    steady-state metric window. Label each candidate as training-equivalent or
    benchmark-only.
 2. **Fit**: make the model memory-feasible first. Use the smallest model
-   parallelism that fits, prefer selective recompute before full recompute, add
-   offloading only after recompute and parallelism are insufficient, and use
-   `--fake-init-process-group` to sanity-check large layouts.
+   parallelism that fits: keep dense TP as low as capacity allows while using
+   a large legal EP for expert weights. Prefer selective recompute before full
+   recompute, add offloading only after recompute and parallelism are
+   insufficient, and use `--fake-init-process-group` to sanity-check large
+   layouts.
 3. **Scale**: maximize DP after the model fits, keep hot communication inside
    the fastest interconnect, use PP plus VPP for multi-node scaling, prefer EP
    over extra TP for expert layers, and add CP when long context makes attention
@@ -86,10 +92,12 @@ Start with a configuration that fits reliably before chasing throughput.
 
 Recommended order:
 
-1. Use the smallest amount of model parallelism that still fits.
-2. Turn on selective recompute before falling back to full recompute.
-3. Add offloading only when recompute and parallelism are still insufficient.
-4. Use `--fake-init-process-group` to sanity-check large parallel layouts on a
+1. Use the lowest dense TP that still fits; avoid paying extra TP communication
+   merely to reduce activation memory.
+2. Use the largest legal EP that fits the expert count and intended topology.
+3. Turn on selective recompute before falling back to full recompute.
+4. Add offloading only when recompute and parallelism are still insufficient.
+5. Use `--fake-init-process-group` to sanity-check large parallel layouts on a
    single GPU before burning cluster time.
 
 ### Recompute guidance
@@ -106,6 +114,13 @@ As a rule of thumb, fine-grained recompute often recovers most of the needed
 memory while keeping throughput much closer to the non-recompute baseline than
 full-layer recompute does.
 
+For Qwen-family models, choose boundaries by architecture. Standard-attention
+Qwen recipes can often start with `core_attn`. Qwen3.5 includes GDN layers, so
+`core_attn` alone does not cover their retained normalization output; the
+current pinned Megatron Core exposes `gdn_norm_out`. Test it on the exact stack,
+and fall back to full-layer recompute when selective boundaries still do not
+make the complete optimizer step fit.
+
 ## Phase 2: Choose Parallelism For Scale
 
 Priority order:
@@ -115,6 +130,13 @@ Priority order:
 3. Use PP, plus VPP if needed, for multi-node scaling.
 4. Prefer EP over extra TP for expert layers.
 5. Add CP for long context once sequence length makes attention memory dominant.
+
+For common MoE allocations, EP=8 is a strong first candidate on an 8-GPU node
+and EP=32 is a strong first candidate on 32 GPUs when the expert count and mesh
+are divisible. This is a capacity heuristic, not a correctness rule. EP shards
+only expert parameters: EP=8 can still leave a large model dependent on full
+recompute, while EP=32 often creates enough expert-weight headroom to retest
+selective recompute.
 
 ### Parallel Folding
 
@@ -133,6 +155,21 @@ Key knobs:
 
 Use it when attention prefers some TP or CP, but expert layers benefit from a
 larger EP degree than the dense layers can tolerate.
+
+### Fill Available Headroom
+
+Once the run completes optimizer initialization and several steady steps,
+inspect W&B memory and confirm every rank's peak allocated and reserved memory
+in the runtime logs; rank 0 can miss the hot EP or PP rank. Use any safe
+headroom to A/B one of these changes at a time:
+
+- lower TP by one legal step, if the additional dense state still fits;
+- increase MBS, while adjusting gradient accumulation to keep GBS and
+  optimizer boundaries unchanged.
+
+Judge the result by end-to-end tokens/s/GPU or step time, not memory utilization
+alone. Preserve margin for checkpoint/eval transients, routing imbalance,
+dispatcher workspaces, and CUDA-graph private pools.
 
 ## Phase 3: Profile The Dominant Bottleneck
 
@@ -185,6 +222,10 @@ HybridEP plus plain EP overlap is the current measured winner for the canonical
 uses standard `alltoall` plus overlap. Benchmark backend compatibility and
 throughput in the target container; neither GPU name nor EP degree determines
 the winner by itself.
+
+On a single NVL8 domain in BF16, `alltoall` and HybridEP can be close enough
+that the simpler baseline wins after setup overhead. Prefer HybridEP as a tuned
+candidate, not an assumption, and keep a matched `alltoall` control.
 
 If the all-to-all path is visible in profiles, combine dispatcher tuning with:
 
@@ -287,4 +328,4 @@ HybridEP tuning. They answer different questions.
    backend can fall back, a graph can capture without helping, or a lower-
    precision recipe can miss the intended kernels.
 
-_Last signature refresh: 2026-08-03._
+_Last guidance refresh: 2026-08-25._

--- a/skills/nemo-mbridge-perf-moe-optimization-workflow/card.yaml
+++ b/skills/nemo-mbridge-perf-moe-optimization-workflow/card.yaml
@@ -1,5 +1,6 @@
 title: moe_optimization_workflow
 validated_on: "2026-07-31"
+guidance_updated_on: "2026-08-25"
 summary: >
   Evidence-gated workflow for optimizing MoE training performance. It freezes
   a measurement contract, follows fit -> scale -> profile -> retune -> validate,
@@ -76,7 +77,7 @@ optimization_phases:
       shape, parallelism, graph scopes, and timing window fixed.
   phase_1_memory:
     goal: "Fit training in GPU memory"
-    key_action: "Choose parallelism that keeps memory within GPU capacity"
+    key_action: "Keep dense TP low, use a large legal EP, and prefer selective recompute before full recompute"
     quick_test: "--fake-init-process-group for single-GPU emulation"
   phase_2_parallelism:
     goal: "Minimize communication overhead"
@@ -86,6 +87,8 @@ optimization_phases:
       - "Use PP for multi-node scaling"
       - "Prefer EP over TP for experts (Parallel Folding)"
       - "Enable CP for sequences ≥ 8K"
+      - "Treat EP8 on 8 GPUs and EP32 on 32 GPUs as candidates only when the expert count and both meshes are legal"
+      - "After fit, use per-rank memory headroom to A/B lower TP or higher MBS while holding GBS fixed"
   phase_3_bottleneck:
     goal: "Profile and apply targeted optimizations"
     approach: "Identify which wall dominates, apply targeted fix, re-profile"

--- a/skills/nemo-mbridge-recipe-recommender/SKILL.md
+++ b/skills/nemo-mbridge-recipe-recommender/SKILL.md
@@ -34,9 +34,10 @@ index details:
    recommendations, use `--dataset mock`. Do not pair the pretraining-only
    `mock` preset with an SFT or PEFT mode.
 5. After the recipe and dataset, give the required resizing rules: TP must
-   divide `num_key_value_heads`, keep TP within one node unless using
-   NVL72-class interconnect, enable SP when TP > 1, configure CP for long
-   context, DP is implicit, and reduce `micro_batch_size` first on OOM.
+   divide `num_key_value_heads`, use the lowest TP that still fits the dense
+   state, keep TP within one node unless using NVL72-class interconnect, enable
+   SP when TP > 1, configure CP for long context, and make both dense and
+   expert meshes divide the allocation.
 6. State whether each proposed override changes the convergence contract or
    only the execution/performance mapping. Do not trade convergence semantics
    for throughput without calling it a new experiment.
@@ -249,9 +250,40 @@ When the user's GPU count differs from the recipe default:
    `world_size / (PP × EP × ETP)`; both quotients must be integral, and the
    expert count must be divisible by EP.
 
+### Fit-First, Then Fill Tuning Loop
+
+For an MoE recipe on a fixed allocation, use this practical order:
+
+1. Start with the lowest legal TP that can hold the dense parameters,
+   optimizer state, and workspaces. Do not raise TP only to reduce activation
+   memory; TP communication is expensive, so try recompute first.
+2. Use the largest legal EP that matches the expert count and topology. EP=8
+   is a common first candidate on one 8-GPU node, and EP=32 is a common first
+   candidate on a 32-GPU allocation. These are starting points, not universal
+   defaults: EP shards expert weights only, not dense layers or activations.
+3. Prefer architecture-specific selective recompute. For Qwen3.5 GDN layers,
+   verify `gdn_norm_out` on the exact Megatron Core revision instead of
+   assuming `core_attn` covers the GDN peak. Use full-layer recompute only when
+   the targeted boundaries still do not make the complete step fit.
+4. After a stable baseline completes optimizer initialization and several
+   steady steps, inspect W&B memory and confirm every rank's peak allocated and
+   reserved memory in the runtime logs; rank 0 can miss the hot EP or PP rank.
+   If there is safe headroom, test one change at a time: lower TP by one legal
+   step or increase MBS while keeping GBS, data order, and optimizer boundaries
+   fixed.
+5. Keep the candidate only when it improves end-to-end tokens/s/GPU or step
+   time with healthy loss and no skipped/NaN iterations. Leave headroom for
+   checkpointing, evaluation, routing imbalance, and optional CUDA graphs.
+
+On EP=8, a large expert footprint can remain capacity-limited enough to need
+full recompute. EP=32 usually reduces expert-weight pressure substantially,
+making selective recompute a better candidate, but Qwen3.5 GDN coverage and
+the hot rank's measured peak still decide.
+
 ### Batch Size Tuning
 
-- Start with the recipe's `micro_batch_size`. If OOM, reduce to 1.
+- Start with the recipe's `micro_batch_size`. If OOM, reduce to 1; after the
+  run fits, use measured headroom to sweep MBS upward again.
 - `global_batch_size` determines learning dynamics. Scale with DP:
   `GBS = micro_batch_size × DP × gradient_accumulation_steps`.
 - For MoE, `micro_batch_size=1` is typical at scale.

--- a/skills/nemo-mbridge-recipe-recommender/evals/evals.json
+++ b/skills/nemo-mbridge-recipe-recommender/evals/evals.json
@@ -14,5 +14,20 @@
       "Distinguish library recipes from benchmark recipes and name the benchmark launcher paths.",
       "Distinguish convergence-contract changes from semantics-preserving execution changes and benchmark-only shortcuts."
     ]
+  },
+  {
+    "id": "recipe-recommender-moe-fit-then-fill",
+    "question": "Use the nemo-mbridge-recipe-recommender skill. Give me a rule-of-thumb tuning loop for a Qwen MoE recipe on 8 versus 32 GPUs. Cover TP, EP, selective versus full recompute including Qwen3.5 GDN, HybridEP versus alltoall on NVL8 BF16, and what to do after the first config fits.",
+    "expected_skill": "nemo-mbridge-recipe-recommender",
+    "expected_script": null,
+    "ground_truth": "The answer should use the lowest legal TP that still fits dense state and prefer recompute over raising TP solely for activation memory. It should use the largest legal EP supported by expert divisibility and both parallel meshes, with EP8 on one 8-GPU node and EP32 on 32 GPUs described as starting candidates rather than universal defaults. It must state that EP shards expert weights only, so EP8 can still require full recompute. It should prefer architecture-specific selective recompute; standard-attention Qwen can start with core_attn, while Qwen3.5 GDN needs the exact revision's gdn_norm_out boundary to be tested and can fall back to full recompute when the complete optimizer step still does not fit. It should keep alltoall as the correctness baseline and treat HybridEP as a matched candidate because NVL8 BF16 results can be close. After the run fits, it should inspect W&B memory and confirm every rank's peak allocated and reserved memory in runtime logs because rank 0 can miss the hot EP or PP rank, then A/B one lower-TP step or higher MBS while keeping GBS and optimizer boundaries fixed. Acceptance requires improved end-to-end tokens/s/GPU or step time, healthy loss, no skipped or NaN iterations, and memory margin for transients.",
+    "expected_behavior": [
+      "Read the nemo-mbridge-recipe-recommender skill before answering.",
+      "Keep dense TP as low as capacity allows and make EP as large as the legal expert mesh permits.",
+      "Scope EP8 and EP32 as starting candidates and explain that EP does not shard dense or activation state.",
+      "Prefer selective recompute, distinguish standard Qwen attention from Qwen3.5 GDN, and retain full recompute as a measured fallback.",
+      "Use a matched alltoall control when testing HybridEP on NVL8 BF16.",
+      "After fit, use per-rank memory evidence to A/B lower TP or higher MBS with fixed GBS and explicit safety headroom."
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- codify a fit-first, then fill recipe-tuning loop: keep dense TP as low as capacity allows, use the largest legal EP candidate, and prefer architecture-specific selective recompute
- document Qwen3.5 GDN handling through `gdn_norm_out`, with full-layer recompute retained as a measured capacity fallback
- require post-fit W&B plus per-rank memory review before A/B testing lower TP or higher MBS at fixed GBS
- keep `alltoall` as the correctness baseline and treat HybridEP as a matched candidate on NVL8 BF16

The EP8-on-8-GPU and EP32-on-32-GPU guidance is explicitly scoped to legal expert counts and parallel meshes. EP is documented as sharding expert weights only, not dense or activation state.

## Validation

- five updated skills pass the standard skill validator
- modified JSON/YAML artifacts parse successfully
- `uv run --no-project --active pre-commit run --all-files`
- `git diff --check origin/main...HEAD`

No training recipe or product code changed, and no performance experiment was rerun. Existing measured dates remain unchanged; cards record a separate 2026-08-25 guidance refresh.
