### PR TITLE
perf(recipes): optimize DeepSeek V4 B200 topology

### DIFF
--- a/examples/model_verification_cards/deepseek-v4-flash/card.yaml
+++ b/examples/model_verification_cards/deepseek-v4-flash/card.yaml
@@ -37,6 +37,12 @@ summary: >
   A separate 100-step CP2 run verifies offline packing with contiguous context
   parallelism.
 
+  The B200 long-context SFT recipe uses offline-packed 128K THD sequences,
+  contiguous CP16, natural HybridEP routing, selective mHC and MLA-up-projection
+  recompute, fused-group-MLP activation offload, and attention-scoped Transformer
+  Engine CUDA graphs. Its 160-GPU validation completed 50 finite steps with zero
+  skipped or NaN iterations.
+
   The GB200 packed PEFT recipe applies rank-32 LoRA to the DeepSeek MLA projections
   and to separate routed/shared expert FC1/FC2 projections. Its execution path uses
   scoped Transformer Engine CUDA graphs and tuned HybridEP dispatch. It completed
@@ -54,6 +60,9 @@ verification_index:
       - manual_forward_pass
       - megatron_to_hf_cpu
   training:
+    B200:
+      verified: [sft_long_context]
+      unverified: [pretrain, sft, sft_export_inference, peft, checkpoint_resume]
     GB200:
       verified: [pretrain, sft, sft_long_context, sft_export_inference, peft, checkpoint_resume]
   performance:
@@ -315,6 +324,44 @@ items:
         cultural center, and a symbol of French history, art, and architecture."
 
   sft_long_context:
+    B200:
+      status: verified
+      precision: bf16
+      bridge_commit: 4acf05343becaec3bc48ffcbecad82f7e7f85840  # pragma: allowlist secret
+      enabled_features:
+        sequence_packing: offline
+        cuda_graph:
+          implementation: transformer_engine
+          scopes: [attn]
+        context_parallel_size: 16
+        moe_dispatcher: hybridep
+      command: >
+        ./scripts/training/train.sh --nodes 20 --gpus-per-node 8
+        --recipe deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config
+        --mode sft --dataset coderforge --step-func dsv4_step
+        --pretrained_checkpoint work/model-verification/dsv4-flash/import-gpu/iter_0000000
+        --max_steps 50
+        logger.save_config_filepath=work/model-verification/dsv4-flash/sft-long-context-b200/resolved-config.yaml
+      last_verified: 2026-09-04
+      metrics:
+        initial_loss: 0.3149361
+        final_loss: 0.1525988
+        last_10_steps_step_time_ms_avg: 45726.000
+        last_10_steps_model_tflops_per_gpu_avg: 283.110
+        last_10_steps_tokens_per_second_per_gpu_avg: 2293.172
+        peak_allocated_memory_gib: 140.99
+        peak_reserved_memory_gib: 172.23
+      expected_result: >
+        The 160-B200 run completed exactly 50 full-parameter SFT steps at
+        TP1/PP5/CP16/EP16/ETP1, MBS1/GBS128, and 64-way gradient accumulation.
+        It used offline-packed 131072-token THD sequences, contiguous context
+        parallelism, a pretrained BF16 checkpoint, natural HybridEP routing,
+        selective recompute for mHC and MLA up-projection, fused-group-MLP
+        activation offload, and attention-scoped Transformer Engine CUDA graphs.
+        Loss remained finite from 0.3149361 to 0.1525988 with zero skipped or NaN
+        iterations. Steps 41-50 averaged 45,726.000 ms, 283.110 model TFLOP/s/GPU,
+        and 2,293.172 token slots/s/GPU; the process exited successfully.
+
     GB200:
       status: verified
       precision: bf16

--- a/examples/models/deepseek_v4/README.md
+++ b/examples/models/deepseek_v4/README.md
@@ -94,6 +94,7 @@ launcher. Hardware-qualified library recipes are defined under
 | H100, 32 GPUs | `deepseek_v4_flash_pretrain_32gpu_h100_bf16_config` | BF16 Adam |
 | H100, 32 GPUs | `deepseek_v4_flash_pretrain_32gpu_h100_fp8mx_config` | MXFP8 Adam |
 | H100, 32 GPUs | `deepseek_v4_flash_pretrain_32gpu_h100_bf16_muon_config` | BF16 Muon |
+| B200, 64 GPUs | `deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config` | MXFP8 Adam |
 | GB200, 64 GPUs | `deepseek_v4_flash_pretrain_64gpu_gb200_bf16_config` | BF16 Adam |
 | GB200, 64 GPUs | `deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_config` | MXFP8 Adam |
 | GB200, 64 GPUs | `deepseek_v4_flash_pretrain_64gpu_gb200_bf16_muon_config` | BF16 Muon |
@@ -117,6 +118,11 @@ the recipe defaults and override only the dataset, run length, logging, pretrain
 checkpoint, and output paths. The latest 100-step real-data candidate and its
 checkpoint evidence are recorded in the verification card.
 
+The B200 recipes require node-major rank assignment with eight ranks per
+physical NVL8 system. Their HybridEP runtime and topology-correct NIC mapping
+must be supplied by the site launcher; Megatron Bridge does not install or
+configure that external runtime.
+
 Compatibility aliases such as `deepseek_v4_flash_pretrain_mxfp8_config` remain
 exported, but new launches should use the hardware-qualified names above.
 Canonical benchmark recipes under `src/megatron/bridge/perf_recipes/` are
@@ -132,11 +138,27 @@ DeepSeek-V4-Flash provides BF16 Adam full-parameter SFT recipes:
 | `deepseek_v4_flash_no_mtp_sft_config` | Unpacked SBHD | Off | Hopper or Blackwell |
 | `deepseek_v4_flash_sft_openmath_thinking_packed_config` | Offline-packed THD | On | Portable base |
 | `deepseek_v4_flash_sft_openmath_thinking_packed_gb200_config` | Offline-packed THD | On | 32-GPU GB200 |
+| `deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config` | Offline-packed 128K THD | Off | 160-GPU B200 NVL8 |
 
 The recipes select fused mHC only when the runtime supports the Blackwell
 kernel; Hopper uses the unfused fallback. The GB200 packed recipe additionally
 enables HybridEP, uneven-dispatch padding, DSA fusion, grouped GEMM, selective
 recompute, and attention activation offload.
+
+The 160-GPU B200 recipe owns the validated `TP1/PP5/CP16/EP16` topology,
+`MBS1/GBS128`, `8/9/9/9/8` pipeline split, natural HybridEP routing,
+attention-only TE CUDA graphs, and fused-group-MLP activation offload. It does
+not enable forced routing, token dropping, expert capacity limits, paged stash,
+or low-precision training. Supply a BF16 pretrained checkpoint and the packed
+training dataset from the launcher.
+
+```bash
+./scripts/training/train.sh --nodes 20 --gpus-per-node 8 \
+  --recipe deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config \
+  --mode sft --step-func dsv4_step \
+  --pretrained_checkpoint work/models/deepseek-v4-flash \
+  --max_steps 50
+```
 
 Launch the verified GB200 packed recipe from an imported BF16 checkpoint:
 

--- a/skills/nemo-mbridge-recipe-recommender/references/recipe-index.md
+++ b/skills/nemo-mbridge-recipe-recommender/references/recipe-index.md
@@ -74,6 +74,8 @@ All recipes live under `src/megatron/bridge/recipes/`. Each function returns a
 | `deepseek_v2_pretrain_config` | Pretrain | 1 | 4 | 32 | 128 |
 | `deepseek_v3_pretrain_config` | Pretrain | 2 | 16 | 64 | 2048 |
 | `deepseek_v3_pretrain_config_32nodes` | Pretrain | 2 | 8 | 32 | 256 |
+| `deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config` | Pretrain | 1 | 4 | 16 | 64 (B200 NVL8; VPP4) |
+| `deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config` | SFT | 1 | 5 | 16 | 160 (B200 NVL8; CP16; packed 128K) |
 | `deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_library_config` | Pretrain | 1 | 4 | 16 | 64 (GB200; VPP4; natural unlimited capacity) |
 | `deepseek_v4_flash_sft_openmath_thinking_packed_gb200_config` | SFT | 1 | 4 | 8 | 32 (GB200; offline packed) |
 | `deepseek_v4_flash_peft_openmath_thinking_packed_config` | PEFT | 1 | 4 | 8 | 32 (offline packed) |

--- a/src/megatron/bridge/models/deepseek/deepseek_v4_step.py
+++ b/src/megatron/bridge/models/deepseek/deepseek_v4_step.py
@@ -25,7 +25,7 @@ DSv4 SFT/pretrain with CP > 1.
 """
 
 import logging
-from typing import Iterable
+from typing import Any, Iterable
 
 import torch
 from megatron.core import parallel_state
@@ -63,6 +63,8 @@ _DSV4_CURRENT_PACKED_SEQ_PARAM_KEYS = (
     "cu_seqlens_kv_padded",
     "max_seqlen_q",
     "max_seqlen_kv",
+    "pad_between_seqs",
+    "padding_mask",
     "total_tokens",
     "cp_partition_mode",
 )
@@ -72,6 +74,7 @@ _DSV4_LEGACY_PACKED_SEQ_PARAM_KEYS = (
     "cu_seqlens_argmin",
     "max_seqlen",
     "cu_seqlens_unpadded_argmin",
+    "padding_mask",
     "total_tokens",
     "cp_partition_mode",
 )
@@ -100,6 +103,7 @@ _SEQLEN_KEYS = frozenset(
         "cu_seqlens_kv_padded",
         "max_seqlen_q",
         "max_seqlen_kv",
+        "pad_between_seqs",
         "token_count",
         "attention_mask",
     }
@@ -107,9 +111,9 @@ _SEQLEN_KEYS = frozenset(
 
 
 def _partition_packed_batch_contiguous(
-    batch: dict[str, torch.Tensor],
+    batch: dict[str, Any],
     cp_size: int,
-) -> dict[str, torch.Tensor]:
+) -> dict[str, Any]:
     """Slice a consecutive [start, end) token window for this CP rank.
 
     Only data tensors (tokens, labels, loss_mask, position_ids, etc.) are sliced.
@@ -123,7 +127,10 @@ def _partition_packed_batch_contiguous(
     """
     cp_rank = parallel_state.get_context_parallel_rank()
 
-    _data_val = next((v for k, v in batch.items() if v is not None and k not in _SEQLEN_KEYS), None)
+    _data_val = next(
+        (v for k, v in batch.items() if isinstance(v, torch.Tensor) and k not in _SEQLEN_KEYS),
+        None,
+    )
     if _data_val is None:
         return batch  # middle PP stage with no data tensors — nothing to slice
 
@@ -139,7 +146,7 @@ def _partition_packed_batch_contiguous(
     end = start + local_len
 
     for key, val in batch.items():
-        if val is None or key in _SEQLEN_KEYS:
+        if not isinstance(val, torch.Tensor) or key in _SEQLEN_KEYS:
             continue
         batch[key] = val[:, start:end].contiguous()
 

--- a/src/megatron/bridge/recipes/deepseek/__init__.py
+++ b/src/megatron/bridge/recipes/deepseek/__init__.py
@@ -18,6 +18,12 @@ This module re-exports AutoBridge-based pretrain config helpers for DeepSeek
 models (V2, V2-Lite, V3, V4).
 """
 
+# DeepSeek V4 B200
+from .b200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config,
+    deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config,
+)
+
 # DeepSeek V2/V2-Lite
 from .deepseek_v2 import (
     deepseek_v2_lite_pretrain_config,
@@ -83,10 +89,12 @@ __all__ = [
     "deepseek_v4_flash_no_mtp_sft_config",
     "deepseek_v4_pro_pretrain_config",
     "deepseek_v4_pro_pretrain_mxfp8_config",
+    "deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config",
     "deepseek_v4_flash_pretrain_64gpu_gb200_bf16_config",
     "deepseek_v4_flash_pretrain_64gpu_gb200_bf16_muon_config",
     "deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_config",
     "deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_library_config",
+    "deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config",
     "deepseek_v4_flash_sft_openmath_thinking_packed_gb200_config",
     "deepseek_v4_pro_pretrain_32gpu_gb300_bf16_config",
     "deepseek_v4_pro_pretrain_32gpu_gb300_fp8mx_config",

--- a/src/megatron/bridge/recipes/deepseek/b200/__init__.py
+++ b/src/megatron/bridge/recipes/deepseek/b200/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""B200 recipes for DeepSeek V4 Flash."""
+
+from megatron.bridge.recipes.deepseek.b200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config,
+    deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config,
+)
+
+
+__all__ = [
+    "deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config",
+    "deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config",
+]

--- a/src/megatron/bridge/recipes/deepseek/b200/deepseek_v4.py
+++ b/src/megatron/bridge/recipes/deepseek/b200/deepseek_v4.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""B200 NVL8 recipes for DeepSeek V4 Flash."""
+
+from megatron.bridge.recipes.deepseek.gb200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_library_config,
+)
+from megatron.bridge.recipes.deepseek.h100.deepseek_v4 import (
+    deepseek_v4_flash_no_mtp_sft_32gpu_h100_bf16_config,
+)
+from megatron.bridge.recipes.utils.dataset_utils import default_squad_config
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.utils.cuda_graph import set_cuda_graph_modules
+
+
+_DSV4_FLASH_PP4_VP4_LAYOUT = "Et*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*2|t*2|t*2|t*2|t*2mL"
+_DSV4_FLASH_PP5_128K_LAYOUT = "Et*8|t*9|t*9|t*9|t*8L"
+
+
+def deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config() -> ConfigContainer:
+    """Return real-training DeepSeek V4 Flash for 64 B200 GPUs.
+
+    Requires eight physical NVL8 systems with eight contiguous, node-major
+    ranks per system. Each EP16 group spans two NVL8 domains, with eight ranks
+    per domain. The runtime must expose ``deep_ep.HybridEPBuffer``. Natural,
+    unlimited-capacity routing is preserved without paged stash, activation
+    offload, or CUDA graphs.
+    """
+    cfg = deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_library_config()
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.virtual_pipeline_model_parallel_size = 4
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 16
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.pipeline_model_parallel_layout = _DSV4_FLASH_PP4_VP4_LAYOUT
+
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_flex_dispatcher_num_sms = 32
+    cfg.model.moe_deepep_num_sms = None
+    cfg.model.moe_hybridep_num_sms = None
+    cfg.model.moe_hybridep_num_sms_preprocessing = 108
+    cfg.model.moe_shared_expert_overlap = False
+
+    cfg.model.recompute_modules = ["mhc", "mla_up_proj"]
+    cfg.model.fine_grained_activation_offloading = False
+    cfg.model.offload_modules = []
+    cfg.model.fine_grained_offloading_max_inflight_offloads = None
+    cfg.model.moe_pad_experts_for_cuda_graph_inference = False
+    cfg.model.cuda_graph_impl = "none"
+    set_cuda_graph_modules(cfg.model, [])
+    cfg.model.use_te_rng_tracker = False
+    cfg.rng.te_rng_tracker = False
+
+    cfg.env_vars = {
+        **{key: value for key, value in cfg.env_vars.items() if key != "NVTE_CPU_OFFLOAD_V1"},
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
+    }
+    return cfg
+
+
+def deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config() -> ConfigContainer:
+    """Return packed 128K BF16 SFT for 160 B200 GPUs.
+
+    The validated topology uses 20 physical NVL8 systems with node-major rank
+    assignment. Each EP16 group spans two NVL8 domains. The caller must supply
+    the pretrained checkpoint and may replace the default packed SFT dataset.
+    The HybridEP runtime and topology-correct NIC mapping are site-provided.
+    """
+    cfg = deepseek_v4_flash_no_mtp_sft_32gpu_h100_bf16_config()
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 5
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 16
+    cfg.model.expert_model_parallel_size = 16
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.pipeline_model_parallel_layout = _DSV4_FLASH_PP5_128K_LAYOUT
+
+    cfg.model.seq_length = 131072
+    cfg.model.cp_partition_mode = "contiguous"
+    cfg.model.sequence_packing_scheduler = "dp_balanced"
+    cfg.model.max_seqlen_per_dp_cp_rank = 8192
+    cfg.model.thd_max_packed_sequences = 6
+    cfg.model.thd_tail_padding_policy = "append_dummy_seq"
+    cfg.model.pad_packed_seq_alignment = "max"
+    cfg.model.variable_seq_lengths = True
+    cfg.model.calculate_per_token_loss = True
+
+    cfg.model.apply_dsa_kernel_fusion = True
+    cfg.model.dsa_indexer_loss_coeff = 0.0
+    cfg.model.dsa_indexer_use_sparse_loss = True
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "hybridep"
+    cfg.model.moe_flex_dispatcher_num_sms = 32
+    cfg.model.moe_hybridep_num_sms_preprocessing = 108
+    cfg.model.moe_router_bias_update_rate = 0.001
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_expert_capacity_factor = None
+    cfg.model.moe_expert_rank_capacity_factor = None
+    cfg.model.moe_token_dropping = False
+    cfg.model.moe_paged_stash = False
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_router_fusion = True
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.mlp_chunks_for_training = 1
+    cfg.model.use_transformer_engine_op_fuser = True
+
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_modules = ["mhc", "mla_up_proj"]
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.mhc_recompute_attn_cuda_graph_split = False
+    cfg.model.fine_grained_activation_offloading = True
+    cfg.model.offload_modules = ["fused_group_mlp"]
+    cfg.model.activation_offload_fraction = 1.0
+    cfg.model.fine_grained_offloading_max_inflight_offloads = 2
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    set_cuda_graph_modules(cfg.model, ["attn"])
+    cfg.model.cuda_graph_warmup_steps = 1
+    cfg.model.use_te_rng_tracker = True
+    cfg.rng.te_rng_tracker = True
+
+    cfg.dataset = default_squad_config(seq_length=131072, enable_offline_packing=True, pad_seq_to_mult=64)
+    assert cfg.dataset.offline_packing_specs is not None
+    cfg.dataset.offline_packing_specs.pad_cu_seqlens = True
+    cfg.dataset.offline_packing_specs.num_tokenizer_workers = 1
+    cfg.dataset.num_workers = 2
+    cfg.dataset.do_validation = False
+    cfg.dataset.do_test = False
+
+    cfg.train.train_iters = 50
+    cfg.train.micro_batch_size = 1
+    cfg.train.global_batch_size = 128
+    cfg.train.empty_unused_memory_level = 2
+    cfg.validation.eval_interval = 0
+    cfg.validation.eval_iters = 0
+    cfg.logger.log_interval = 1
+    cfg.logger.log_throughput = True
+
+    cfg.checkpoint.save = None
+    cfg.checkpoint.load = None
+    cfg.checkpoint.async_save = False
+    cfg.checkpoint.save_optim = False
+    cfg.checkpoint.load_optim = False
+    cfg.checkpoint.load_rng = False
+    cfg.ddp.average_in_collective = False
+    cfg.dist.distributed_timeout_minutes = 120
+    cfg.env_vars = {
+        **cfg.env_vars,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "HYBRID_EP_DOCA_WRITE_FLAGS": 1,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "NVTE_CPU_OFFLOAD_V1": 1,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "USE_MNNVL": 0,
+    }
+    return cfg

--- a/tests/unit_tests/models/deepseek/test_deepseek_v4_step.py
+++ b/tests/unit_tests/models/deepseek/test_deepseek_v4_step.py
@@ -77,6 +77,24 @@ class TestPartitionPackedBatchContiguous:
         result = self._run(monkeypatch, batch, cp_size=2)
         assert result is batch
 
+    def test_slices_tensor_metadata_and_preserves_scalar_metadata(self, monkeypatch):
+        """Token-aligned masks are sliced while scalar batch metadata is preserved."""
+        tokens = torch.arange(8, dtype=torch.long).unsqueeze(0)
+        padding_mask = torch.tensor([[False, False, False, False, True, True, True, True]])
+        batch = _make_batch(
+            tokens=tokens,
+            cu_seqlens=torch.tensor([[0, 4, 8]], dtype=torch.int32),
+            padding_mask=padding_mask,
+            pad_between_seqs=True,
+            is_padding_sample=False,
+        )
+
+        result = self._run(monkeypatch, batch, cp_rank=1, cp_size=2)
+
+        assert result["padding_mask"].tolist() == [[True, True, True, True]]
+        assert result["pad_between_seqs"] is True
+        assert result["is_padding_sample"] is False
+
 
 class TestPackedMetadataForForward:
     """Tests for _packed_metadata_for_forward."""
@@ -90,9 +108,11 @@ class TestPackedMetadataForForward:
     def test_legacy_path_extracts_cu_seqlens_and_cp_partition_mode(self):
         from megatron.bridge.models.deepseek.deepseek_v4_step import _packed_metadata_for_forward
 
+        padding_mask = torch.tensor([[False, False, False, True]])
         batch = {
             "cu_seqlens": torch.tensor([[0, 4, 8]], dtype=torch.int32),
             "max_seqlen": torch.tensor([[8]]),
+            "padding_mask": padding_mask,
             "cp_partition_mode": "contiguous",
             "total_tokens": 8,
         }
@@ -100,16 +120,22 @@ class TestPackedMetadataForForward:
         assert meta is not None
         assert meta["cp_partition_mode"] == "contiguous"
         assert "cu_seqlens" in meta
+        assert meta["padding_mask"] is padding_mask
 
     def test_current_path_with_cu_seqlens_q(self):
         from megatron.bridge.models.deepseek.deepseek_v4_step import _packed_metadata_for_forward
 
+        padding_mask = torch.tensor([[False, False, False, True]])
         batch = {
             "cu_seqlens_q": torch.tensor([[0, 4]], dtype=torch.int32),
             "max_seqlen_q": torch.tensor([[4]]),
+            "pad_between_seqs": True,
+            "padding_mask": padding_mask,
             "cp_partition_mode": "contiguous",
         }
         meta = _packed_metadata_for_forward(batch)
         assert meta is not None
         assert meta.get("cp_partition_mode") == "contiguous"
         assert "cu_seqlens_q" in meta
+        assert meta["pad_between_seqs"] is True
+        assert meta["padding_mask"] is padding_mask

--- a/tests/unit_tests/recipes/test_deepseek_v4_hardware_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_hardware_recipes.py
@@ -20,6 +20,12 @@ import pytest
 import torch
 
 import megatron.bridge.recipes as recipes
+from megatron.bridge.recipes.deepseek.b200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config as flash_b200_library_config,
+)
+from megatron.bridge.recipes.deepseek.b200.deepseek_v4 import (
+    deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config as flash_b200_128k_config,
+)
 from megatron.bridge.recipes.deepseek.gb200.deepseek_v4 import (
     deepseek_v4_flash_peft_openmath_thinking_packed_gb200_config as flash_packed_peft_config,
 )
@@ -238,7 +244,128 @@ def test_flash_high_scale_recipe_preserves_real_training_contract() -> None:
     assert cfg.env_vars["NVTE_CPU_OFFLOAD_V1"] == 0
 
 
+def test_flash_b200_nvl8_recipe_preserves_real_training_contract() -> None:
+    cfg = flash_b200_library_config()
+
+    assert cfg.train.train_iters == 1_000_000
+    assert cfg.train.global_batch_size == 256
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 4
+    assert cfg.model.virtual_pipeline_model_parallel_size == 4
+    assert cfg.model.expert_model_parallel_size == 16
+    assert cfg.model.pipeline_model_parallel_layout == (
+        "Et*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*3|t*2|t*2|t*2|t*2|t*2mL"
+    )
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_flex_dispatcher_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 108
+    assert cfg.model.moe_router_force_load_balancing is False
+    assert cfg.model.recompute_modules == ["mhc", "mla_up_proj"]
+    assert cfg.model.fine_grained_activation_offloading is False
+    assert cfg.model.offload_modules == []
+    assert cfg.mixed_precision.fp8_param_gather is True
+    assert cfg.mixed_precision.reuse_grad_buf_for_mxfp8_param_ag is True
+    assert getattr(cfg.model, "moe_expert_rank_capacity_factor", None) is None
+    assert getattr(cfg.model, "moe_paged_stash", False) is False
+    assert cfg.model.cuda_graph_impl == "none"
+    assert cuda_graph_module_names(cfg.model) == []
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+    assert cfg.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] == 128
+    assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
+    assert cfg.env_vars["USE_MNNVL"] == 0
+    assert "NVTE_CPU_OFFLOAD_V1" not in cfg.env_vars
+
+
+def test_flash_b200_128k_recipe_matches_validated_training_contract() -> None:
+    cfg = flash_b200_128k_config()
+
+    assert cfg.model.seq_length == 131072
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 5
+    assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.context_parallel_size == 16
+    assert cfg.model.expert_model_parallel_size == 16
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_layout == "Et*8|t*9|t*9|t*9|t*8L"
+    assert cfg.model.mtp_num_layers is None
+    assert cfg.model.cp_partition_mode == "contiguous"
+    assert cfg.model.sequence_packing_scheduler == "dp_balanced"
+    assert cfg.model.max_seqlen_per_dp_cp_rank == 8192
+    assert cfg.model.thd_max_packed_sequences == 6
+    assert cfg.model.thd_tail_padding_policy == "append_dummy_seq"
+    assert cfg.model.pad_packed_seq_alignment == "max"
+    assert cfg.model.variable_seq_lengths is True
+    assert cfg.model.calculate_per_token_loss is True
+    assert cfg.model.apply_dsa_kernel_fusion is True
+    assert cfg.model.dsa_indexer_loss_coeff == 0.0
+    assert cfg.model.dsa_indexer_use_sparse_loss is True
+
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_flex_dispatcher_num_sms == 32
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 108
+    assert cfg.model.moe_router_bias_update_rate == 0.001
+    assert cfg.model.moe_router_force_load_balancing is False
+    assert cfg.model.moe_expert_capacity_factor is None
+    assert cfg.model.moe_expert_rank_capacity_factor is None
+    assert cfg.model.moe_token_dropping is False
+    assert cfg.model.moe_paged_stash is False
+    assert cfg.model.moe_grouped_gemm is True
+    assert cfg.model.moe_permute_fusion is True
+    assert cfg.model.moe_router_fusion is True
+    assert cfg.model.moe_shared_expert_overlap is False
+    assert cfg.model.mlp_chunks_for_training == 1
+    assert cfg.model.use_transformer_engine_op_fuser is True
+
+    assert cfg.model.recompute_granularity == "selective"
+    assert cfg.model.recompute_modules == ["mhc", "mla_up_proj"]
+    assert cfg.model.mhc_recompute_attn_cuda_graph_split is False
+    assert cfg.model.fine_grained_activation_offloading is True
+    assert cfg.model.offload_modules == ["fused_group_mlp"]
+    assert cfg.model.activation_offload_fraction == 1.0
+    assert cfg.model.fine_grained_offloading_max_inflight_offloads == 2
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cuda_graph_module_names(cfg.model) == ["attn"]
+    assert cfg.model.cuda_graph_warmup_steps == 1
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+
+    assert cfg.dataset.seq_length == 131072
+    assert cfg.dataset.enable_offline_packing is True
+    assert cfg.dataset.offline_packing_specs is not None
+    assert cfg.dataset.offline_packing_specs.packed_sequence_size == 131072
+    assert cfg.dataset.offline_packing_specs.pad_seq_to_mult == 64
+    assert cfg.dataset.offline_packing_specs.pad_cu_seqlens is True
+    assert cfg.dataset.dataset_kwargs == {"pad_to_max_length": True}
+    assert cfg.train.train_iters == 50
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size == 128
+    assert cfg.train.empty_unused_memory_level == 2
+    assert cfg.validation.eval_interval == 0
+    assert cfg.validation.eval_iters == 0
+    assert cfg.checkpoint.pretrained_checkpoint is None
+    assert cfg.checkpoint.save is None
+    assert cfg.checkpoint.load is None
+    assert cfg.checkpoint.save_optim is False
+    assert cfg.checkpoint.load_optim is False
+    assert cfg.checkpoint.load_rng is False
+    assert cfg.ddp.average_in_collective is False
+    assert cfg.dist.distributed_timeout_minutes == 120
+    assert not getattr(cfg.model, "fp8", False)
+    assert getattr(cfg.model, "quant_recipe", None) is None
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+    assert cfg.env_vars["NUM_OF_TOKENS_PER_CHUNK_COMBINE_API"] == 128
+    assert cfg.env_vars["HYBRID_EP_DOCA_WRITE_FLAGS"] == 1
+    assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
+    assert cfg.env_vars["NVTE_CPU_OFFLOAD_V1"] == 1
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
+    assert cfg.env_vars["USE_MNNVL"] == 0
+
+
 def test_high_scale_deepseek_v4_recipes_are_exported() -> None:
+    assert recipes.deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config is flash_b200_library_config
+    assert recipes.deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config is flash_b200_128k_config
     assert recipes.deepseek_v4_flash_peft_openmath_thinking_packed_gb200_config is flash_packed_peft_config
     assert recipes.deepseek_v4_flash_pretrain_64gpu_gb200_fp8mx_library_config is flash_library_config
     assert recipes.deepseek_v4_flash_sft_openmath_thinking_packed_gb200_config is flash_packed_sft_config

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -25,6 +25,7 @@ TRAINING_THROUGHPUT_INPUTS = {
     ("deepseek-v4-flash", "checkpoint_resume", "GB200"): (4096, 256, 64),
     ("deepseek-v4-flash", "sft", "GB200"): (1024, 128, 32),
     ("deepseek-v4-flash", "peft", "GB200"): (1024, 128, 32),
+    ("deepseek-v4-flash", "sft_long_context", "B200"): (131072, 128, 160),
     ("deepseek-v4-flash", "sft_long_context", "GB200"): (1024, 128, 64),
     ("deepseek-v4-flash", "pretrain_performance", "GB200"): (4096, 2048, 128),
     ("deepseek-v4-flash", "pretrain_performance", "GB300"): (4096, 2048, 128),


### PR DESCRIPTION
## Summary

- add hardware-qualified DeepSeek V4 Flash recipes for physical B200 NVL8 systems
- publish the exact packed 128K BF16 configuration validated on 160 B200 GPUs
- preserve packed-sequence padding metadata through the DeepSeek contiguous-CP step
- record the result as `sft_long_context.B200` in the DeepSeek V4 Flash verification card

DeepSeek V4 training requires the documented Megatron-Core `dev` switch. The B200 recipes also require node-major rank assignment and a site-provided HybridEP runtime with topology-correct NIC mapping.

## Packed 128K configuration

Recipe: `deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config`

| GPUs | Precision | Sequence | TP | PP | VPP | CP | EP | ETP | MBS | GBS |
|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 160 B200 | BF16 | 131072 THD | 1 | 5 | none | 16 | 16 | 1 | 1 | 128 |

- pipeline split: `8/9/9/9/8`
- pipeline layout: `Et*8|t*9|t*9|t*9|t*8L`
- 64 microbatches per optimizer step
- natural HybridEP routing with 32 communication SMs, 108 preprocessing SMs, router-bias update rate `0.001`, and combine chunk size `128`
- grouped GEMM, permute fusion, router fusion, Transformer Engine op fusion, and `mlp_chunks_for_training=1`
- selective recompute: `[mhc, mla_up_proj]`
- fused-group-MLP activation offload with fraction `1.0` and two in-flight offloads
- attention-scoped Transformer Engine CUDA graphs with one warmup step and the TE RNG tracker
- packed-THD mHC graph split disabled, as required by the packed-sequence path
- `empty_unused_memory_level=2`, per-token loss, and no averaging in the gradient collective
- no forced routing, expert capacity limit, rank capacity limit, token dropping, paged stash, or low-precision training
- caller-supplied packed training data and BF16 pretrained checkpoint

Example:

```bash
./scripts/switch_mcore.sh dev
uv sync
./scripts/training/train.sh --nodes 20 --gpus-per-node 8 \
  --recipe deepseek_v4_flash_sft_160gpu_b200_bf16_128k_config \
  --mode sft --step-func dsv4_step \
  --pretrained_checkpoint work/models/deepseek-v4-flash \
  --max_steps 50
```

## 128K result

| Window | Mean step time | Mean TFLOP/s/GPU | Peak step | Losses |
|---|---:|---:|---:|---|
| Steps 31-50 | 45,887.050 ms | **281.854** | 292.7 TFLOP/s/GPU | finite |

The run completed all 50 steps with zero skipped or NaN iterations. Peak memory was 140.99 GiB allocated and 172.23 GiB reserved.

## 64-GPU B200 recipe

The PR also retains `deepseek_v4_flash_pretrain_64gpu_b200_fp8mx_library_config`, selected from the following natural-routing 4K screens. No candidate used forced routing, token dropping, expert capacity limits, paged stash, or CUDA graphs.

| PP / VPP / EP | Activation offload | Selective recompute modules | Mean TFLOP/s/GPU |
|---|---|---|---:|
| **4 / 4 / 16** | **No** | **`mhc`, `mla_up_proj`** | **287.114** |
| 4 / 5 / 16 | No | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 239.971 |
| 4 / 4 / 16 | No | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 239.129 |
| 4 / 6 / 16 | No | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 239.071 |
| 4 / 3 / 16 | No | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 224.914 |
| 8 / 4 / 8 | No | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 218.014 |
| 8 / 5 / 8 | No | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 211.000 |
| 8 / 3 / 8 | No | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 208.329 |
| 4 / 2 / 16 | Yes | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 154.914 |
| 2 / 2 / 32 | Yes | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 136.000 |
| 1 / none / 64 | Yes | `moe`, `mhc`, `mla_up_proj`, `layernorm` | 103.471 |

The selected PP4/VPP4/EP16 recipe sustained 295.268 mean and 303.800 median TFLOP/s/GPU over steps 2-100, with 100 finite steps and zero skipped or NaN iterations.

## Validation

- packed 128K BF16 training: 50/50 finite steps, zero skipped or NaN iterations
- 64-GPU MXFP8 training: 100 finite steps plus fresh-process checkpoint resume through step 105
- model verification card validator: passed
- model verification card tests: 42 passed
- `pre-commit run --all-files`: passed
- focused recipe and packed-step unit coverage added
- independent final diff review: no merge-blocking findings

Focused recipe and packed-step unit test collection was unavailable in the local environment because its installed Transformer Engine and Megatron-Core dependencies were incompatible with the current checkout; CI remains required before merge.
