### PR TITLE
Minor updates to Omni and Qwen inference wrappers.

### DIFF
--- a/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
+++ b/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
@@ -37,6 +37,11 @@ class QwenVLInferenceWrapper(AbstractModelInferenceWrapper):
         model (Qwen2VLModel): The Qwen2VL model
     """
 
+    supports_text = True
+    supports_image = True
+    supports_video = False
+    supports_audio = False
+
     def __init__(self, model, inference_context=None):
         super().__init__(model, inference_context=inference_context)
 

--- a/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
+++ b/src/megatron/bridge/inference/vlm/qwenvl_inference_wrapper.py
@@ -15,6 +15,7 @@
 from typing import Any, Dict, List, Optional
 
 import torch
+from megatron.core.inference.config import MediaPromptSpec, MultimodalPromptConfig
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
     AbstractModelInferenceWrapper,
 )
@@ -41,6 +42,19 @@ class QwenVLInferenceWrapper(AbstractModelInferenceWrapper):
     supports_image = True
     supports_video = False
     supports_audio = False
+
+    multimodal_prompt_config = MultimodalPromptConfig(
+        image_spec=MediaPromptSpec(
+            model_token="<|image_pad|>",
+            prefix="<|vision_start|>",
+            suffix="<|vision_end|>",
+        ),
+        video_spec=MediaPromptSpec(
+            model_token="<|video_pad|>",
+            prefix="<|vision_start|>",
+            suffix="<|vision_end|>",
+        ),
+    )
 
     def __init__(self, model, inference_context=None):
         super().__init__(model, inference_context=inference_context)

--- a/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
+++ b/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni.py
@@ -219,6 +219,9 @@ class NemotronOmniModel(MegatronModule):
         self.post_process = post_process
         self.add_encoder = add_encoder
         self.add_decoder = add_decoder
+        # Inference controllers inspect the top-level model for the padded
+        # vocabulary size. Keep it consistent with the nested HybridModel.
+        self.vocab_size = language_vocab_size
         self.image_token_index = image_token_index
         self.sound_token_index = sound_token_index
         self.patch_dim = patch_dim

--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
@@ -343,8 +343,16 @@ from .configuration_radio import RADIOConfig as _RADIOConfig
             state = StateDict(source)
         source_keys = set(source.get_all_keys())
         for name in self._HF_PASSTHROUGH_KEYS:
-            if name in source_keys:
-                yield from HFWeightTuple(name, state[name]).iter_finalized(cpu=cpu)
+            if name not in source_keys:
+                continue
+            tensor = state[name]
+            # These come straight off disk, so they are on CPU while every
+            # mapped tensor in the stream above is on the current device when
+            # cpu=False. Consumers that batch the whole stream together (RL
+            # refit packs it into one buffer) cannot mix devices.
+            if not cpu and tensor.device.type == "cpu" and torch.cuda.is_available():
+                tensor = tensor.to(device=torch.cuda.current_device())
+            yield from HFWeightTuple(name, tensor).iter_finalized(cpu=cpu)
 
 
 class NemotronOmniLlavaBridge(NemotronOmniBridge):

--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_provider.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_provider.py
@@ -21,20 +21,25 @@ from typing import Callable, Literal, Optional
 
 from megatron.core import parallel_state
 from megatron.core.activations import fast_gelu, squared_relu
-from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.models.gpt.gpt_layer_specs import get_mlp_module_spec
 from megatron.core.models.multimodal.llava_model import LLaVAModel
 from megatron.core.models.vision.multimodal_projector import MultimodalProjector
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.transformer.spec_utils import get_submodules
 
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.logit_dtype import logit_dtype_kwarg
 from megatron.bridge.models.nemotron_omni.modeling_nemotron_omni import NemotronOmniModel
 from megatron.bridge.models.nemotron_omni.modeling_nemotron_omni_llava import NemotronOmniLlavaModel
-from megatron.bridge.models.nemotron_vl.nemotron_vl_provider import get_language_mlp_submodules
 
 
 NEMOTRON_OMNI_EXPANDED_SEQUENCE_CONTRACT = "expanded_sequence_v1"
 NEMOTRON_OMNI_LLAVA_CONTRACT = "llava_collapse_expand_v1"
+
+
+def _get_transformer_engine_projection_submodules():
+    """Build the standard dense TE MLP submodules used by media projectors."""
+    return copy.deepcopy(get_submodules(get_mlp_module_spec(use_te=True)))
 
 
 @dataclass
@@ -290,7 +295,7 @@ class _NemotronOmniModelProviderBase(NemotronVLModelProvider):
         )
         return BridgeSoundEncoder(config)
 
-    def _build_sound_modules(self, language_cfg, language_spec, *, add_encoder: bool):
+    def _build_sound_modules(self, language_cfg, *, add_encoder: bool):
         """Build optional sound modules on the encoder pipeline stage."""
         if not (self.has_sound and add_encoder):
             return None, None
@@ -298,7 +303,7 @@ class _NemotronOmniModelProviderBase(NemotronVLModelProvider):
         sound_model = self._build_sound_encoder()
         sound_projection = MultimodalProjector(
             config=self._build_sound_projection_config(language_cfg),
-            submodules=copy.deepcopy(get_language_mlp_submodules(language_spec)),
+            submodules=_get_transformer_engine_projection_submodules(),
             projector_type="mlp",
             input_size=self.sound_hidden_size,
         )
@@ -321,9 +326,12 @@ class _NemotronOmniModelProviderBase(NemotronVLModelProvider):
         vision_cfg.class_token_len = self.vision_class_token_len or 10
         vision_proj_cfg = self._build_vision_projection_config(language_cfg)
 
-        language_spec = hybrid_stack_spec
+        # LLM decoder spec, which can be TE or Megatron inference-optimized.
+        language_spec = self._resolve_hybrid_stack_spec()
+        # ViT spec for the vision component of this model.
         vision_spec = get_vit_layer_with_transformer_engine_spec()
-        vision_proj_spec = copy.deepcopy(get_language_mlp_submodules(language_spec))
+        # Vision projection spec that maps vision embeddings to language embeddings.
+        vision_proj_spec = _get_transformer_engine_projection_submodules()
 
         add_encoder_flag = parallel_state.is_pipeline_first_stage() if self.pipeline_model_parallel_size > 1 else True
         add_decoder_flag = True
@@ -331,7 +339,6 @@ class _NemotronOmniModelProviderBase(NemotronVLModelProvider):
         sound_token_index = self.sound_context_token_id
         sound_model, sound_projection = self._build_sound_modules(
             language_cfg,
-            language_spec,
             add_encoder=add_encoder_flag,
         )
 
@@ -434,15 +441,17 @@ class NemotronOmniModelProvider(_NemotronOmniModelProviderBase):
         vision_cfg = self._build_vision_config(language_cfg)
         vision_proj_cfg = self._build_vision_projection_config(language_cfg)
 
-        language_spec = hybrid_stack_spec
+        # LLM decoder spec, which can be TE or Megatron inference-optimized.
+        language_spec = self._resolve_hybrid_stack_spec()
+        # ViT spec for the vision component of this model.
         vision_spec = get_vit_layer_with_transformer_engine_spec()
-        vision_proj_spec = copy.deepcopy(get_language_mlp_submodules(language_spec))
+        # Vision projection spec that maps vision embeddings to language embeddings.
+        vision_proj_spec = _get_transformer_engine_projection_submodules()
 
         add_encoder = parallel_state.is_pipeline_first_stage() if self.pipeline_model_parallel_size > 1 else True
 
         sound_model, sound_projection = self._build_sound_modules(
             language_cfg,
-            language_spec,
             add_encoder=add_encoder,
         )
 

--- a/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
+++ b/tests/unit_tests/inference/vlm/test_qwenvl_inference_wrapper.py
@@ -38,6 +38,14 @@ class TestQwenVLInferenceWrapper:
             wrapper.inference_params = None
             return wrapper
 
+    def test_multimodal_prompt_config_uses_qwen_visual_tokens(self):
+        prompt_config = QwenVLInferenceWrapper.multimodal_prompt_config
+
+        assert prompt_config.image_spec.model_token == "<|image_pad|>"
+        assert prompt_config.image_spec.prefix == "<|vision_start|>"
+        assert prompt_config.image_spec.suffix == "<|vision_end|>"
+        assert prompt_config.video_spec.model_token == "<|video_pad|>"
+
     def test_prep_inference_input(self, wrapper):
         prompts_tokens = torch.tensor([[1, 2, 3]])
         pixel_values = torch.randn(1, 3, 224, 224)

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
@@ -300,25 +300,39 @@ def test_canonical_provider_builds_dedicated_model(monkeypatch):
     provider = NemotronOmniModelProvider(
         image_token_index=18,
         nemotron_omni_contract=NEMOTRON_OMNI_EXPANDED_SEQUENCE_CONTRACT,
+        transformer_impl="inference_optimized",
     )
     model = SimpleNamespace()
     model_factory = Mock(return_value=model)
     llava_factory = Mock()
+    inference_spec = object()
+    resolve_hybrid_stack_spec = Mock(return_value=inference_spec)
+    projection_submodules = object()
+    get_projection_submodules = Mock(return_value=projection_submodules)
 
+    monkeypatch.setattr(provider, "_resolve_hybrid_stack_spec", resolve_hybrid_stack_spec)
     monkeypatch.setattr(provider_module, "LLaVAModel", llava_factory)
     monkeypatch.setattr(provider_module, "get_vit_layer_with_transformer_engine_spec", Mock(return_value=object()))
-    monkeypatch.setattr(provider_module, "get_language_mlp_submodules", Mock(return_value=object()))
+    monkeypatch.setattr(
+        provider_module,
+        "_get_transformer_engine_projection_submodules",
+        get_projection_submodules,
+    )
     monkeypatch.setattr(provider_module, "NemotronOmniModel", model_factory)
 
     assert provider.provide() is model
     model_factory.assert_called_once()
+    resolve_hybrid_stack_spec.assert_called_once_with()
+    assert model_factory.call_args.kwargs["language_transformer_layer_spec"] is inference_spec
+    assert model_factory.call_args.kwargs["vision_projection_layer_spec"] is projection_submodules
+    get_projection_submodules.assert_called_once_with()
     llava_factory.assert_not_called()
 
 
 def test_nemotron_omni_provider_can_omit_sound_modules():
     provider = NemotronOmniModelProvider(has_sound=False)
 
-    sound_model, sound_projection = provider._build_sound_modules(None, None, add_encoder=True)
+    sound_model, sound_projection = provider._build_sound_modules(None, add_encoder=True)
 
     assert provider.has_sound is False
     assert sound_model is None
@@ -331,10 +345,14 @@ def test_nemotron_omni_provider_builds_sound_modules_when_enabled(monkeypatch):
     expected_sound_projection = object()
     monkeypatch.setattr(provider, "_build_sound_encoder", lambda: expected_sound_model)
     monkeypatch.setattr(provider, "_build_sound_projection_config", lambda _: object())
-    monkeypatch.setattr(provider_module, "get_language_mlp_submodules", lambda _: object())
+    monkeypatch.setattr(
+        provider_module,
+        "_get_transformer_engine_projection_submodules",
+        lambda: object(),
+    )
     monkeypatch.setattr(provider_module, "MultimodalProjector", lambda **_: expected_sound_projection)
 
-    sound_model, sound_projection = provider._build_sound_modules(None, None, add_encoder=True)
+    sound_model, sound_projection = provider._build_sound_modules(None, add_encoder=True)
 
     assert sound_model is expected_sound_model
     assert sound_projection is expected_sound_projection

--- a/tests/unit_tests/models/test_logit_dtype_wrapper_propagation.py
+++ b/tests/unit_tests/models/test_logit_dtype_wrapper_propagation.py
@@ -209,9 +209,10 @@ def test_legacy_nemotron_omni_provider_rejects_requested_dtype_at_llava_boundary
             return_value=object(),
         ),
         patch(
-            "megatron.bridge.models.nemotron_omni.nemotron_omni_provider.get_language_mlp_submodules",
+            "megatron.bridge.models.nemotron_omni.nemotron_omni_provider._get_transformer_engine_projection_submodules",
             return_value=object(),
         ),
+        patch.object(provider, "_resolve_hybrid_stack_spec", return_value=object()),
     ):
         with pytest.raises(RuntimeError, match="LLaVAModel does not support logit_dtype"):
             provider._provide_llava()


### PR DESCRIPTION
# What does this PR do ?

- Minor edits to some inference wrappers to support multimodal Megatron Inference in NeMo-RL.
- Waiting on a bump from MCore after this PR is merged: https://github.com/NVIDIA/Megatron-LM/pull/6809

# Changelog

- Add some new inference wrapper class attrs to define what the wrapper is capable of multi-modally.
- Some bridge fix with some Tensors not matching devices. (This could use some review...)

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
