### PR TITLE
[ckpt] fix: clear incompatible saved pipeline layouts

### DIFF
--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -458,6 +458,7 @@ def load_megatron_model(
         otherwise returns a dictionary containing the full, unsharded model state_dict.
     """
     model_cfg, mlm_args = load_model_config(checkpoint_path)
+    saved_pipeline_model_parallel_size = model_cfg.pipeline_model_parallel_size
     # If in single GPU environment, reset additional parallel settings
     model_cfg.tensor_model_parallel_size = 1
     model_cfg.pipeline_model_parallel_size = 1
@@ -482,8 +483,15 @@ def load_megatron_model(
     # Apply model-parallel overrides if provided
     if mp_overrides:
         for key, value in mp_overrides.items():
-            if hasattr(model_cfg, key) and value is not None:
+            if hasattr(model_cfg, key) and (value is not None or key == "pipeline_model_parallel_layout"):
                 setattr(model_cfg, key, value)
+
+        if (
+            "pipeline_model_parallel_size" in mp_overrides
+            and model_cfg.pipeline_model_parallel_size != saved_pipeline_model_parallel_size
+            and "pipeline_model_parallel_layout" not in mp_overrides
+        ):
+            model_cfg.pipeline_model_parallel_layout = None
 
     # A saved flexible layout describes PP/VPP stage ownership. It must not be
     # reinterpreted as virtual pipeline chunks after collapsing to one rank.

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -310,6 +310,56 @@ class TestLoadMegatronModel:
 
         assert built_layer_count == provider.num_layers
 
+    @pytest.mark.parametrize(
+        ("mp_overrides", "expect_saved_layout"),
+        [
+            ({"pipeline_model_parallel_size": 2}, True),
+            ({"pipeline_model_parallel_size": 4}, False),
+            (
+                {
+                    "pipeline_model_parallel_size": 2,
+                    "pipeline_model_parallel_layout": None,
+                },
+                False,
+            ),
+        ],
+        ids=["same-pp", "changed-pp", "explicit-clear"],
+    )
+    @patch("megatron.bridge.training.model_load_save.build_and_load_model")
+    @patch("megatron.bridge.training.model_load_save.load_model_config")
+    def test_pipeline_override_does_not_reuse_incompatible_saved_layout(
+        self,
+        mock_load_model_config,
+        mock_build_and_load_model,
+        mp_overrides,
+        expect_saved_layout,
+    ):
+        """A saved PP layout is retained only for a compatible requested topology."""
+        provider = GPTModelProvider(
+            num_layers=4,
+            hidden_size=16,
+            num_attention_heads=2,
+            pipeline_model_parallel_size=2,
+            pipeline_model_parallel_layout=[
+                ["embedding", "decoder", "decoder"],
+                ["decoder", "decoder", "loss"],
+            ],
+        )
+        mock_load_model_config.return_value = (provider, None)
+
+        def _finalized_layout(checkpoint_path, model_cfg, *args):
+            model_cfg.finalize()
+            return model_cfg.pipeline_model_parallel_layout
+
+        mock_build_and_load_model.side_effect = _finalized_layout
+
+        result = load_megatron_model("/ckpt", mp_overrides=mp_overrides)
+
+        if expect_saved_layout:
+            assert isinstance(result, PipelineParallelLayerLayout)
+        else:
+            assert result is None
+
     @patch("megatron.bridge.training.model_load_save.temporary_distributed_context")
     @patch("megatron.bridge.training.checkpointing._load_model_weights_from_checkpoint")
     @patch("megatron.bridge.utils.instantiate_utils.instantiate")


### PR DESCRIPTION
## Problem

Loading a checkpoint with a saved flexible pipeline layout and overriding its pipeline-parallel size retains the old layout. The old stage ownership can then be rejected by Megatron-Core or interpreted under the wrong topology. Passing `pipeline_model_parallel_layout=None` also did not clear the layout because generic override handling skipped `None` values.

A supported trigger is a checkpoint saved with PP=2 and a two-stage layout, then loaded through `load_megatron_model(..., mp_overrides={"pipeline_model_parallel_size": 4})`.

## Fix

Remember the checkpoint's pipeline-parallel size and clear its saved layout when the requested PP size changes unless the caller supplies a replacement layout. Treat an explicit `pipeline_model_parallel_layout=None` as a meaningful override. Same-PP loads continue to preserve the saved layout.

## Validation

Fail-before deterministic reproducer (exit 1 for changed PP and explicit clear):

```shell
cd /tmp/mb-base && uv run --project /tmp/mbridge-env --no-sync python /tmp/reproduce_pipeline_layout_override.py
```

Pass-after unchanged reproducer (exit 0):

```shell
cd /tmp/mb-fix && uv run --project /tmp/mbridge-env --no-sync python /tmp/reproduce_pipeline_layout_override.py
```

Focused regression and adjacent layout/default-load tests (7 passed, 56 deselected):

```shell
PYTHONPATH="/tmp/mbridge-cpu-test-stubs:/tmp/mb-fix/src:/tmp/mcore-pinned" uv run --project /tmp/mbridge-env --no-sync python -m pytest /tmp/mb-fix/tests/unit_tests/training/test_model_load_save.py -q --tb=short -k 'load_model_config_preserves_finalized_pipeline_layout or default_load_builds_all_layers_on_one_rank or pipeline_override_does_not_reuse_incompatible_saved_layout or load_megatron_model_resets_defaults'
```

The temporary CPU shim only bypassed imports for optional GPU leaves that these configuration tests do not execute. The source-under-test and pinned Megatron-Core tree were unchanged.

Additional checks:

```shell
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This does not infer or generate a new flexible layout for a changed topology. It only prevents a checkpoint-owned layout from being reused after PP changes and honors an explicit request to clear it.
