### PR TITLE
[ckpt] fix: Preserve release checkpoints during retention

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1487,7 +1487,9 @@ def save_checkpoint(
                     else:
                         open_file = open
                     with open_file(tracker_filename, "r") as f:
-                        previous_step = int(f.read().strip())
+                        previous_metadata = f.read().strip()
+                        if previous_metadata != "release":
+                            previous_step = int(previous_metadata)
 
                 train_state_dict["floating_point_operations_so_far"] = torch.tensor(
                     num_floating_point_operations_so_far, dtype=torch.float32

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -891,14 +891,27 @@ class TestSaveCheckpoint:
         assert future_incomplete_checkpoint.is_dir()
         assert torch.load(latest_train_state, weights_only=True)["step"].item() == 1000
 
-    @pytest.mark.parametrize("previous_step, previous_checkpoint_remains", [(10, False), (20, True)])
+    @pytest.mark.parametrize(
+        "previous_tracker, previous_checkpoint_name, previous_checkpoint_remains",
+        [
+            ("10", "iter_0000010", False),
+            ("20", "iter_0000020", True),
+            ("release", "release", True),
+        ],
+    )
     def test_sync_persistent_save_honors_retain_interval(
-        self, tmp_path, save_checkpoint_fixtures, previous_step, previous_checkpoint_remains
+        self,
+        tmp_path,
+        save_checkpoint_fixtures,
+        previous_tracker,
+        previous_checkpoint_name,
+        previous_checkpoint_remains,
     ):
         """Persistent saves retain only interval checkpoints and the latest checkpoint."""
-        previous_checkpoint = tmp_path / f"iter_{previous_step:07d}"
+        previous_checkpoint = tmp_path / previous_checkpoint_name
         previous_checkpoint.mkdir()
-        (tmp_path / "latest_checkpointed_iteration.txt").write_text(str(previous_step))
+        tracker = tmp_path / "latest_checkpointed_iteration.txt"
+        tracker.write_text(previous_tracker)
         current_checkpoint = tmp_path / "iter_0000030"
 
         state = save_checkpoint_fixtures["mock_state"]
@@ -956,6 +969,7 @@ class TestSaveCheckpoint:
 
         assert previous_checkpoint.exists() is previous_checkpoint_remains
         assert current_checkpoint.is_dir()
+        assert tracker.read_text() == "30"
 
     def test_async_persistent_save_defers_retain_interval_cleanup(self, tmp_path, save_checkpoint_fixtures):
         """The previous checkpoint remains available until its async replacement is durable."""


### PR DESCRIPTION
## Problem

When training loads a release checkpoint and saves persistent checkpoints back to the same directory, enabling `save_retain_interval` makes the first save parse the legacy tracker value `release` as an integer. The save raises after writing the checkpoint payload but before publishing its train state and compatibility selector, so restart continues to select the release checkpoint.

This is an omitted lifecycle boundary from #5778.

## Root cause and fix

The retention finalizer assumed every existing legacy tracker value was a numeric iteration. Release checkpoints use the supported `release` sentinel instead.

The fix leaves `previous_step` unset for that sentinel, preserving the release checkpoint while still applying the existing retention policy to numeric checkpoints. Other invalid tracker values continue to raise.

The existing synchronous retention test now covers numeric delete/retain behavior and the release predecessor, including successful publication of the new numeric tracker.

## Validation

Fail before, pass after (the CPU environment used a pytest plugin only to disable unavailable optional GPU imports):

```shell
uv run --no-sync python -m pytest -p prepare_te tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_sync_persistent_save_honors_retain_interval -q
```

- Before: `1 failed, 2 passed`; `ValueError: invalid literal for int() with base 10: 'release'`
- After: `3 passed`

Adjacent checkpoint lifecycle coverage:

```shell
uv run --no-sync python -m pytest -p prepare_te \
  tests/unit_tests/training/test_checkpointing.py::TestCheckpointUtilities::test_read_metadata_release \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_metadata_failure_does_not_publish_incomplete_checkpoint \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_retention_keeps_tracker_checkpoint_until_finalize \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_sync_persistent_save_honors_retain_interval \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_async_persistent_save_defers_retain_interval_cleanup \
  tests/unit_tests/training/test_checkpointing.py::TestSaveCheckpoint::test_sync_global_non_persistent_honors_configured_retention -q
```

Result: `9 passed`.

Also passed:

```shell
git diff --check
uv run pre-commit run --all-files
```

## Scope

This only handles the existing `release` tracker sentinel in persistent retention cleanup. It does not change retention intervals, async behavior, non-persistent checkpoints, custom checkpoint managers, or checkpoint metadata formats.
