### PR TITLE
docs(model): verify GPT-OSS 120B CPU export

### DIFF
--- a/examples/model_verification_cards/gpt-oss-120b/card.yaml
+++ b/examples/model_verification_cards/gpt-oss-120b/card.yaml
@@ -12,17 +12,18 @@ summary: >
   inference, bounded H100 pretraining, H100 SFT, H100 PEFT, and H100
   checkpoint resume, H100 SFT export/inference, and H100 long-context SFT are
   verified. GB200 and GB300 pretraining performance are verified. CPU
-  conversion remains planned but not yet verified.
+  Megatron-to-Hugging-Face export is verified; CPU Hugging-Face-to-Megatron
+  import remains planned.
 verification_index:
   model_level:
     verified:
       - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
       - megatron_to_hf_gpu
       - manual_forward_pass
       - inference
     unverified:
       - hf_to_megatron_cpu
-      - megatron_to_hf_cpu
   training:
     H100:
       verified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
@@ -74,20 +75,25 @@ items:
       latest-marker artifacts.
 
   megatron_to_hf_cpu:
-    status: unverified
+    status: verified
     precision: bf16
+    bridge_commit: 60442bb9adb5435b47db22c6c20aacdf772fbddc  # pragma: allowlist secret
     command: >
       ./scripts/conversion/convert.sh export --executor slurm --device cpu --nodes 1
       --hf-model unsloth/gpt-oss-120b-BF16
-      --megatron-path work/model-verification/gpt-oss-120b/cpu-megatron/iter_0000000
+      --hf-revision e7523373bc44b42296b43202e265a1eebf2ee16f
+      --megatron-path work/model-verification/gpt-oss-120b/imported-megatron/iter_0000000
       --hf-path work/model-verification/gpt-oss-120b/cpu-hf-export
       --torch-dtype bfloat16 --trust-remote-code
-    last_verified: null
+    last_verified: 2026-08-25
     expected_result: >
-      Future verification must export the CPU-imported checkpoint to a public
-      BF16 Hugging Face layout, strictly reload it as GptOssForCausalLM with
-      attention_bias=true, and audit keys, shapes, dtypes, and values against
-      the BF16 reference semantics.
+      The single-process CPU export exits successfully and writes the complete
+      BF16 Hugging Face checkpoint. Exhaustive comparison against the pinned
+      unsloth/gpt-oss-120b-BF16 reference covers all 615 tensors and
+      116,829,156,672 values with exact keys, shapes, dtypes, and bitwise-equal
+      values. Transformers strictly reloads all 615 state tensors natively as
+      GptOssForCausalLM with no loading discrepancies, and the tokenizer also
+      reloads successfully.
 
   megatron_to_hf_gpu:
     status: verified

--- a/examples/model_verification_cards/gpt-oss-120b/card.yaml
+++ b/examples/model_verification_cards/gpt-oss-120b/card.yaml
@@ -92,8 +92,8 @@ items:
       unsloth/gpt-oss-120b-BF16 reference covers all 615 tensors and
       116,829,156,672 values with exact keys, shapes, dtypes, and bitwise-equal
       values. Transformers strictly reloads all 615 state tensors natively as
-      GptOssForCausalLM with no loading discrepancies, and the tokenizer also
-      reloads successfully.
+      GptOssForCausalLM with attention_bias=true and no loading discrepancies,
+      and the tokenizer also reloads successfully.
 
   megatron_to_hf_gpu:
     status: verified


### PR DESCRIPTION
## Summary
- promote the GPT-OSS 120B CPU Megatron-to-Hugging-Face export leaf
- pin the BF16 reference revision used for exact comparison
- record exhaustive tensor and native reload evidence

## Verification
- CPU export completed synchronously in `nvcr.io/nvidia/nemo:26.06`
- 615 tensors and 116,829,156,672 values matched bitwise
- strict native `GptOssForCausalLM` reload completed with no discrepancies
- model-card validator and YAML parse passed
- repository pre-commit hooks passed using the platform-independent environment (the project environment is unavailable on macOS)