### PR TITLE
fix(models): preserve Nemotron Omni export modules

### DIFF
--- a/examples/model_verification_cards/nemotron-3-nano-omni-30b-a3b-reasoning/card.yaml
+++ b/examples/model_verification_cards/nemotron-3-nano-omni-30b-a3b-reasoning/card.yaml
@@ -6,14 +6,13 @@ summary: >
   Performance disclaimer: this model has not been performance-tuned; reported
   timing and throughput metrics are sanity checks, not optimized performance
   results. Verification uses the immutable public model and CORD v2 revisions.
-  CPU and distributed GPU import, deterministic Megatron inference, 100-step
+  CPU and distributed GPU import and export, deterministic Megatron inference, 100-step
   one-node H100 full-model SFT, in-batch-packed 8K SFT, and LoRA PEFT runs
   completed. The H100 fine-tuning variants preserve real image-text samples and
   natural routing while using lower-precision optimizer state; 4K SFT and PEFT
   use HybridEP, while packed CP2 uses the standard all-to-all dispatcher. Strict
-  CPU and GPU round trips preserved all 7,349 tensors bitwise, but Transformers
-  5.8.0 cannot natively reload the local custom-code exports because its
-  dynamic-module cache omits transitive configuration imports. The one-step
+  CPU and GPU round trips preserve all 7,349 tensors bitwise and reload with
+  the same native-loader notices as the pinned Hugging Face source. The one-step
   HF/Megatron comparison predicts the same token but remains below the 0.99
   cosine gate. Unsupported and incomplete workflows remain explicitly
   identified rather than inferred from focused unit coverage.
@@ -22,10 +21,10 @@ verification_index:
     verified:
       - hf_to_megatron_cpu
       - hf_to_megatron_gpu
-      - inference
-    unverified:
       - megatron_to_hf_cpu
       - megatron_to_hf_gpu
+      - inference
+    unverified:
       - manual_forward_pass
   training:
     H100:
@@ -79,8 +78,9 @@ items:
       the source checkpoint's exact 7,349-key set, shapes, dtypes, and values.
 
   megatron_to_hf_cpu:
-    status: unverified
+    status: verified
     precision: bf16
+    bridge_commit: 7783fc356b7d4768525eabf9825f9108c6544f4c  # pragma: allowlist secret
     command: >
       ./scripts/conversion/convert.sh export --executor slurm --device cpu --nodes 1
       --hf-model nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16
@@ -90,18 +90,20 @@ items:
       --hf-path
       work/model-verification/nemotron-3-nano-omni-30b-a3b-reasoning/cpu-hf-export-clean
       --torch-dtype bfloat16 --trust-remote-code
-    last_verified: null
+    last_verified: 2026-08-25
     expected_result: >
-      CPU export completes in 14 indexed shards. Its exact comparison contains
-      all 7,349 source tensors (7,300 BF16, 24 int64, and 25 float32), with
-      identical keys, shapes, dtypes, and values and maximum difference zero.
-      The item remains unverified because the Transformers 5.8.0 local
-      custom-code loader omits transitive configuration modules before
-      from_pretrained can reload the otherwise bitwise-identical export.
+      CPU export completes in 14 indexed shards totaling 66,031,270,520 bytes.
+      Its exact comparison contains all 7,349 source tensors and
+      33,015,632,238 values, with identical keys, shapes, dtypes, and values
+      and no dtype conversions. Transformers reloads the local custom-code
+      export natively with the source-equivalent warning set: one generated
+      vision summary buffer is missing and four source-only audio/vision
+      buffers are unexpected.
 
   megatron_to_hf_gpu:
-    status: unverified
+    status: verified
     precision: bf16
+    bridge_commit: 7783fc356b7d4768525eabf9825f9108c6544f4c  # pragma: allowlist secret
     command: >
       ./scripts/conversion/convert.sh export --executor slurm --device gpu
       --nodes 1 --gpus-per-node 8
@@ -113,14 +115,14 @@ items:
       work/model-verification/nemotron-3-nano-omni-30b-a3b-reasoning/gpu-hf-export-clean
       --torch-dtype bfloat16 --tp 2 --pp 1 --ep 4 --etp 1
       --trust-remote-code --distributed-save --save-every-n-ranks 1
-    last_verified: null
+    last_verified: 2026-08-25
     expected_result: >
-      Strict export completed in 17 indexed shards. All 7,349 tensors match the
-      immutable HF source in keys, shapes, dtypes, and values, with maximum
-      difference zero. The item remains unverified because Transformers 5.8.0
-      local custom-code loading omits the transitive configuration_nemotron_h
-      and configuration_radio modules from the model cache, preventing a native
-      from_pretrained reload even though those files exist in the export.
+      Distributed export completes in 17 indexed shards totaling
+      66,031,270,520 bytes. All 7,349 tensors and 33,015,632,238 values match
+      the immutable HF source exactly in keys, shapes, dtypes, and values with
+      no dtype conversions. Transformers reloads the local custom-code export
+      natively with the same one missing generated buffer and four unexpected
+      source-only buffers reported when reloading the pinned source itself.
 
   manual_forward_pass:
     status: unverified

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1126,6 +1126,11 @@ class AutoBridge(Generic[MegatronModelT]):
                     path, original_source_path=source_path, additional_files=additional_files
                 )
 
+            if model_bridge is not None:
+                artifact_postprocessor = getattr(type(model_bridge), "postprocess_hf_export_artifacts", None)
+                if artifact_postprocessor is not None:
+                    artifact_postprocessor(model_bridge, Path(path))
+
         if dist.is_initialized():
             if dist.get_rank() == 0:
                 _save_artifacts()

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -22,6 +22,7 @@ import math
 import re
 import warnings
 from dataclasses import dataclass, field, fields, is_dataclass
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -442,6 +443,13 @@ class MegatronModelBridge(
     # Leave unset unless HF export must copy nonstandard files in addition to the usual artifacts,
     # for example ``["*reasoning_parser.py"]``.
     ADDITIONAL_FILE_PATTERNS = None
+
+    def postprocess_hf_export_artifacts(self, path: Path) -> None:
+        """Apply model-specific fixes after Hugging Face artifacts are saved.
+
+        Args:
+            path: Directory containing the exported Hugging Face artifacts.
+        """
 
     # HuggingFace PretrainedConfig, set by register_bridge_implementation dispatch.
     # Available in mapping_registry(), stream_weights_*(), and build_conversion_tasks().

--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
@@ -130,7 +130,12 @@ from .configuration_radio import RADIOConfig as _RADIOConfig
     ]
 
     def postprocess_hf_export_artifacts(self, path: Path) -> None:
-        """Make transitive Omni configuration modules discoverable on local reload."""
+        """Make transitive Omni configuration modules discoverable on local reload.
+
+        The pinned Nemotron Omni Hugging Face repositories expose ``modeling.py``
+        as their ``auto_map`` entrypoint. Fail explicitly if that required export
+        artifact is absent so an incomplete checkpoint is never reported as saved.
+        """
         modeling_path = path / "modeling.py"
         if not modeling_path.is_file():
             raise FileNotFoundError(f"Nemotron Omni export is missing required artifact: {modeling_path}")

--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
@@ -36,6 +36,7 @@ import copy
 import warnings
 from collections.abc import Iterable
 from dataclasses import fields
+from pathlib import Path
 
 import torch
 from megatron.core.activations import squared_relu
@@ -86,6 +87,14 @@ def _copy_mapping_with_prefixes(mapping, *, megatron_prefix: str, hf_prefix: str
 class NemotronOmniBridge(NemotronVLBridge):
     """Bridge for the canonical expanded-sequence Nemotron-3 Omni model."""
 
+    _HF_DYNAMIC_MODULE_IMPORTS = """
+
+# Transformers copies only direct relative imports into its local dynamic-module cache.
+# Keep these transitive configuration dependencies visible from this auto_map entrypoint.
+from .configuration_nemotron_h import NemotronHConfig as _NemotronHConfig
+from .configuration_radio import RADIOConfig as _RADIOConfig
+"""
+
     _HF_PASSTHROUGH_KEYS = (
         "sound_encoder.encoder.feature_extractor.featurizer.fb",
         "sound_encoder.encoder.feature_extractor.featurizer.window",
@@ -119,6 +128,16 @@ class NemotronOmniBridge(NemotronVLBridge):
         "audio_model.py",
         "evs.py",
     ]
+
+    def postprocess_hf_export_artifacts(self, path: Path) -> None:
+        """Make transitive Omni configuration modules discoverable on local reload."""
+        modeling_path = path / "modeling.py"
+        if not modeling_path.is_file():
+            raise FileNotFoundError(f"Nemotron Omni export is missing required artifact: {modeling_path}")
+
+        modeling_source = modeling_path.read_text()
+        if self._HF_DYNAMIC_MODULE_IMPORTS.strip() not in modeling_source:
+            modeling_path.write_text(modeling_source.rstrip() + self._HF_DYNAMIC_MODULE_IMPORTS + "\n")
 
     # ------------------------------------------------------------------
     # Provider translation

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
@@ -390,6 +390,19 @@ def test_nemotron_omni_export_preserves_source_only_buffers():
         assert torch.equal(exported_buffers[name], source_tensor)
 
 
+def test_nemotron_omni_export_exposes_transitive_dynamic_modules(tmp_path):
+    modeling_path = tmp_path / "modeling.py"
+    modeling_path.write_text("from .configuration import NemotronOmniConfig\n")
+    bridge = NemotronOmniBridge()
+
+    bridge.postprocess_hf_export_artifacts(tmp_path)
+    bridge.postprocess_hf_export_artifacts(tmp_path)
+
+    modeling_source = modeling_path.read_text()
+    assert modeling_source.count("from .configuration_nemotron_h import NemotronHConfig") == 1
+    assert modeling_source.count("from .configuration_radio import RADIOConfig") == 1
+
+
 def test_nemotron_omni_config_only_export_preserves_source_only_buffers(tmp_path):
     bridge = NemotronOmniBridge()
     source_tensors = {

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
@@ -403,6 +403,13 @@ def test_nemotron_omni_export_exposes_transitive_dynamic_modules(tmp_path):
     assert modeling_source.count("from .configuration_radio import RADIOConfig") == 1
 
 
+def test_nemotron_omni_export_requires_modeling_entrypoint(tmp_path):
+    bridge = NemotronOmniBridge()
+
+    with pytest.raises(FileNotFoundError, match="missing required artifact.*modeling.py"):
+        bridge.postprocess_hf_export_artifacts(tmp_path)
+
+
 def test_nemotron_omni_config_only_export_preserves_source_only_buffers(tmp_path):
     bridge = NemotronOmniBridge()
     source_tensors = {

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1350,6 +1350,32 @@ class TestAutoBridge:
 
     @patch("torch.distributed.is_initialized", return_value=False)
     @patch("torch.distributed.is_available", return_value=False)
+    def test_save_hf_pretrained_postprocesses_artifacts(self, _mock_dist_avail, _mock_dist_init, tmp_path):
+        """Model bridges can postprocess copied Hugging Face artifacts before weight export."""
+
+        class _ArtifactPostprocessor:
+            SUPPORTS_HF_PRETRAINED_EXPORT = True
+            ADDITIONAL_FILE_PATTERNS = None
+
+            def postprocess_hf_export_artifacts(self, path):
+                (path / "postprocessed").touch()
+
+        mock_hf_model = Mock(spec=PreTrainedCausalLM)
+        mock_hf_model.save_artifacts.side_effect = lambda path, **_: Path(path).mkdir(parents=True, exist_ok=True)
+        model_bridge = _ArtifactPostprocessor()
+        bridge = AutoBridge(mock_hf_model)
+
+        with (
+            patch.object(type(bridge), "_model_bridge", PropertyMock(return_value=model_bridge)),
+            patch.object(AutoBridge, "save_hf_weights") as mock_save_hf_weights,
+        ):
+            bridge.save_hf_pretrained([Mock()], tmp_path)
+
+        assert (tmp_path / "postprocessed").is_file()
+        mock_save_hf_weights.assert_called_once()
+
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.is_available", return_value=False)
     def test_save_hf_pretrained_config_only(self, _mock_dist_avail, _mock_dist_init, tmp_path):
         """Config-only save without a reference writes config.json and calls save_hf_weights."""
         bridge = AutoBridge(PretrainedConfig())


### PR DESCRIPTION
## Summary
- add a post-export artifact hook and use it to preserve Nemotron Omni transitive dynamic-module imports
- cover the generic hook and Omni-specific postprocessing with targeted unit tests
- verify CPU and distributed GPU export against the immutable HF source
- record source-equivalent native Transformers reload behavior

## Evidence
- CPU and GPU: 7,349 tensors / 33,015,632,238 values / 66,031,270,520 bytes
- exact keys, shapes, dtypes, and values; no dtype conversions
- native reload reaches model construction and reports the same one missing generated buffer plus four unexpected source-only buffers as the pinned HF source

## Validation
- targeted AutoBridge and Omni conversion tests in `nvcr.io/nvidia/nemo:26.06`: 2 passed
- model-card validator and YAML safe-load
- `git diff --check`
- repository pre-commit hooks via the no-project fallback (the exact project command cannot install Linux-only NVIDIA dependencies on macOS)