### PR TITLE
[data] fix: Handle disabled evaluation sample counts

### DIFF
--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -126,13 +126,14 @@ def get_train_valid_test_num_samples(cfg: ConfigContainer) -> tuple[int, int, in
         # Otherwise fallback to calculating samples based on iterations and global batch size
         train_samples = cfg.train.train_iters * cfg.train.global_batch_size
 
+    eval_iters_per_eval = cfg.validation.eval_iters or 0
     if cfg.validation.eval_interval:
-        eval_iters = (cfg.train.train_iters // cfg.validation.eval_interval + 1) * cfg.validation.eval_iters
+        eval_iters = (cfg.train.train_iters // cfg.validation.eval_interval + 1) * eval_iters_per_eval
     elif cfg.validation.eval_interval is None:
-        eval_iters = cfg.validation.eval_iters or 0
+        eval_iters = eval_iters_per_eval
     else:
         eval_iters = 0
-    test_iters = cfg.validation.eval_iters
+    test_iters = eval_iters_per_eval
 
     eval_gbs = (
         cfg.validation.eval_global_batch_size
@@ -226,6 +227,7 @@ def build_train_valid_test_data_loaders(
     from megatron.bridge.data.megatron_mimo.base_provider import MegatronMIMODatasetProvider
     from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
 
+    eval_iters = cfg.validation.eval_iters or 0
     if isinstance(cfg.model, MegatronMIMOProvider):
         if not isinstance(cfg.dataset, MegatronMIMODatasetProvider):
             raise ValueError(
@@ -247,8 +249,8 @@ def build_train_valid_test_data_loaders(
         # Sync train_state flags across all ranks.
         # Use all_reduce(MAX) since some ranks may not have loaders in heterogeneous MegatronMIMO.
         do_train = train_dataloader is not None and cfg.train.train_iters > 0
-        do_valid = valid_dataloader is not None and cfg.validation.eval_iters > 0
-        do_test = test_dataloader is not None and cfg.validation.eval_iters > 0
+        do_valid = valid_dataloader is not None and eval_iters > 0
+        do_test = test_dataloader is not None and eval_iters > 0
         flags = torch.tensor([int(do_train), int(do_valid), int(do_test)], dtype=torch.long, device="cuda")
         torch.distributed.all_reduce(flags, op=torch.distributed.ReduceOp.MAX)
         train_state.do_train = flags[0].item()
@@ -347,7 +349,7 @@ def build_train_valid_test_data_loaders(
         if cfg.validation.eval_micro_batch_size is not None
         else cfg.train.micro_batch_size
     )
-    if cfg.validation.skip_train and cfg.validation.eval_iters > 0:
+    if cfg.validation.skip_train and eval_iters > 0:
         valid_dataloader = build_pretraining_data_loader(
             valid_ds,
             0,
@@ -365,7 +367,7 @@ def build_train_valid_test_data_loaders(
             drop_last=not (isinstance(cfg.dataset, GPTSFTDatasetConfig) and cfg.dataset.dataloader_type == "batch"),
             seed=sampler_seed,
         )
-    elif cfg.validation.eval_iters > 0:
+    elif eval_iters > 0:
         val_dataloader_type = "cyclic" if isinstance(cfg.dataset, GPTDatasetConfig) else cfg.dataset.dataloader_type
         valid_dataloader = build_pretraining_data_loader(
             valid_ds,
@@ -385,7 +387,7 @@ def build_train_valid_test_data_loaders(
             seed=sampler_seed,
         )
 
-    if cfg.validation.eval_iters > 0:
+    if eval_iters > 0:
         test_dataloader = build_pretraining_data_loader(
             test_ds,
             0,
@@ -406,8 +408,8 @@ def build_train_valid_test_data_loaders(
 
     # Flags to know if we need to do training/validation/testing.
     do_train = train_dataloader is not None and cfg.train.train_iters > 0
-    do_valid = valid_dataloader is not None and cfg.validation.eval_iters > 0
-    do_test = test_dataloader is not None and cfg.validation.eval_iters > 0
+    do_valid = valid_dataloader is not None and eval_iters > 0
+    do_test = test_dataloader is not None and eval_iters > 0
     flags = torch.tensor([int(do_train), int(do_valid), int(do_test)], dtype=torch.long, device="cuda")
 
     torch.distributed.broadcast(flags, 0)

--- a/tests/functional_tests/test_groups/data/test_loaders.py
+++ b/tests/functional_tests/test_groups/data/test_loaders.py
@@ -194,14 +194,15 @@ class TestDataLoaders:
     @mock.patch("torch.distributed.get_world_size")
     @mock.patch("torch.distributed.get_rank")
     @mock.patch("torch.distributed.broadcast")
-    def test_build_train_valid_test_data_loaders_eval_iters_0(
-        self, mock_broadcast, mock_get_rank, mock_get_world_size
+    @pytest.mark.parametrize("eval_iters", [0, None])
+    def test_build_train_valid_test_data_loaders_disabled_evaluation(
+        self, mock_broadcast, mock_get_rank, mock_get_world_size, eval_iters
     ):
         mock_get_rank.return_value = 0
         mock_get_world_size.return_value = 1
 
         cfg = create_simple_test_config()
-        cfg.validation.eval_iters = 0
+        cfg.validation.eval_iters = eval_iters
         cfg.dataset.tokenizer = _mock_tokenizer()
         cfg.dataset.finalize()
         dataset_provider = get_dataset_provider(cfg.dataset)
@@ -444,6 +445,17 @@ class TestDataLoaders:
 
 class TestSampleBasedDataLoaders:
     """Tests for sample-based training data loader functionality."""
+
+    def test_get_train_valid_test_num_samples_disabled_evaluation(self):
+        cfg = create_simple_test_config()
+        cfg.validation.eval_interval = None
+        cfg.validation.eval_iters = None
+
+        train_samples, valid_samples, test_samples = get_train_valid_test_num_samples(cfg)
+
+        assert train_samples == cfg.train.train_iters * cfg.train.global_batch_size
+        assert valid_samples == 0
+        assert test_samples == 0
 
     def test_get_train_valid_test_num_samples_final_only_validation(self):
         cfg = create_simple_test_config()


### PR DESCRIPTION
## Summary

- treat `ValidationConfig.eval_iters=None` as disabled evaluation throughout sample sizing and loader construction
- preserve the existing `eval_iters=0`, periodic-validation, and final-only-validation behavior
- cover both zero and `None` disabled-evaluation configurations at the loader boundary

## User impact and root cause

The directly exposed Megatron-Core validation config types `eval_iters` as `int | None` and documents an unset value as disabling evaluation. Bridge normalized that value for one validation-sample branch, but still multiplied `None` by the evaluation batch size and later compared `None > 0`. Supported training setup therefore crashed before completing data-loader construction.

The fix normalizes the per-evaluation iteration count to zero at the two owning data boundaries, then consistently uses the normalized value for validation/test loader creation and distributed ownership flags. No configuration or public API is changed.

This boundary was identified while reviewing the omitted disabled-evaluation case adjacent to merged PR #5789.

## Validation

Fail before / pass after:

- `uv run --no-sync python <deterministic-loader-reproducer> git:<base-sha>:src/megatron/bridge/data/loaders.py`
  - before: failed at the loader decision with `TypeError: '>' not supported between instances of 'NoneType' and 'int'`
- `uv run --no-sync python <deterministic-loader-reproducer> src/megatron/bridge/data/loaders.py`
  - after: passed; only the training loader was created and validation/test flags were zero
- `uv run --no-sync python <deterministic-sample-count-reproducer> src/megatron/bridge/data/loaders.py`
  - after: passed; disabled evaluation produced zero validation and test samples
- `uv run --no-sync python <adjacent-sample-count-check> src/megatron/bridge/data/loaders.py`
  - passed; final-only, periodic, and `eval_iters=0` behavior was unchanged
- `git diff --check`
  - passed
- `uv run --no-sync pre-commit run --all-files`
  - passed

The focused local pytest module could not collect in the available CPU environment because optional accelerator packages initialized CUDA/Triton during package import. That collection failure was not counted as reproduction or passing evidence; the added test is expected to run in the project CI environment.

## Scope

This changes only evaluation sample arithmetic, evaluation loader selection, and their focused tests. It does not change evaluation scheduling, batch-size resolution, dataset construction, or any model/parallelism behavior.
