### PR TITLE
fix(model): pin fp32 MoE routing for Qwen3.5 text bridge

### DIFF
--- a/src/megatron/bridge/models/qwen/qwen35_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen35_bridge.py
@@ -100,6 +100,7 @@ def _apply_qwen35_moe_config(provider: GPTModelProvider, text_config) -> None:
     provider.moe_router_pre_softmax = False
     provider.moe_token_dispatcher_type = "alltoall"
     provider.moe_permute_fusion = True
+    provider.moe_router_dtype = "fp32"
 
 
 def _moe_routed_expert_mappings(hf_prefix, megatron_prefix, experts_packed, transpose_on_export=False):

--- a/tests/unit_tests/models/qwen/test_qwen35_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen35_bridge.py
@@ -518,6 +518,7 @@ class TestQwen35MoEBridge:
         assert result.moe_grouped_gemm is True
         assert result.moe_shared_expert_intermediate_size == mock_qwen3_5_moe_config.shared_expert_intermediate_size
         assert result.moe_shared_expert_gate is True
+        assert result.moe_router_dtype == "fp32"
 
     def test_provider_bridge_normalization(self, mock_pretrained_qwen3_5_moe, mock_qwen3_5_moe_config):
         """Test normalization configuration."""


### PR DESCRIPTION
# What does this PR do ?

`Qwen35MoEBridge` was the only Qwen GDN+MoE path still routing in bf16, which made expert selection unstable between identical runs. Sets `moe_router_dtype="fp32"` to match the `Qwen3.5 VL` provider and the `Qwen3-Next` bridge.
