### PR TITLE
[recipe, peft] fix: Honor DoRA selection for Qwen3.5-VL

### DIFF
--- a/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
@@ -28,6 +28,7 @@ import torch
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.data.builders import MockVLMSFTDatasetConfig
+from megatron.bridge.peft.base import PEFT
 from megatron.bridge.recipes.common import _peft_common_vlm, _pretrain_common, _sft_common_vlm
 from megatron.bridge.recipes.utils.dataset_utils import default_peft_config
 from megatron.bridge.recipes.utils.environment_utils import COMMON_RECIPE_ENV_VARS
@@ -1499,7 +1500,9 @@ def qwen35_vl_397b_a17b_sft_128gpu_h100_bf16_config() -> ConfigContainer:
 # =============================================================================
 
 
-def qwen35_vl_800m_peft_1gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_800m_peft_1gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5-VL 800M (dense).
 
     Default configuration: 1 GPU
@@ -1508,7 +1511,7 @@ def qwen35_vl_800m_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-0.8B"
@@ -1598,7 +1601,9 @@ def qwen35_vl_800m_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def qwen35_vl_2b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_2b_peft_1gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5-VL 2B (dense).
 
     Default configuration: 1 GPU
@@ -1607,7 +1612,7 @@ def qwen35_vl_2b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-2B"
@@ -1697,7 +1702,9 @@ def qwen35_vl_2b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def qwen35_vl_4b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_4b_peft_1gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5-VL 4B (dense).
 
     Default configuration: 1 GPU
@@ -1706,7 +1713,7 @@ def qwen35_vl_4b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-4B"
@@ -1796,7 +1803,9 @@ def qwen35_vl_4b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def qwen35_vl_9b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_9b_peft_1gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5-VL 9B (dense).
 
     Default configuration: 1 GPU
@@ -1805,7 +1814,7 @@ def qwen35_vl_9b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-9B"
@@ -1895,7 +1904,9 @@ def qwen35_vl_9b_peft_1gpu_h100_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def qwen35_vl_27b_peft_2gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_27b_peft_2gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5-VL 27B (dense).
 
     Default configuration: 2 GPUs
@@ -1904,7 +1915,7 @@ def qwen35_vl_27b_peft_2gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-27B"
@@ -1999,7 +2010,9 @@ def qwen35_vl_27b_peft_2gpu_h100_bf16_config() -> ConfigContainer:
 # =============================================================================
 
 
-def qwen35_vl_35b_a3b_peft_4gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_35b_a3b_peft_4gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5/Qwen3.6-VL 35B-A3B (MoE).
 
     Default configuration: 4 GPUs
@@ -2008,7 +2021,7 @@ def qwen35_vl_35b_a3b_peft_4gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-35B-A3B"
@@ -2139,7 +2152,9 @@ def qwen35_vl_35b_a3b_peft_16gpu_h100_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def qwen35_vl_122b_a10b_peft_8gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_122b_a10b_peft_8gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5-VL 122B-A10B (MoE).
 
     Default configuration: 8 GPUs
@@ -2148,7 +2163,7 @@ def qwen35_vl_122b_a10b_peft_8gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-122B-A10B"
@@ -2252,7 +2267,9 @@ def qwen35_vl_122b_a10b_peft_8gpu_h100_bf16_config() -> ConfigContainer:
     return cfg
 
 
-def qwen35_vl_397b_a17b_peft_32gpu_h100_bf16_config() -> ConfigContainer:
+def qwen35_vl_397b_a17b_peft_32gpu_h100_bf16_config(
+    peft_scheme: str | PEFT = "lora",
+) -> ConfigContainer:
     """Return a PEFT config for Qwen3.5-VL 397B-A17B (MoE).
 
     Default configuration: 32 GPUs
@@ -2261,7 +2278,7 @@ def qwen35_vl_397b_a17b_peft_32gpu_h100_bf16_config() -> ConfigContainer:
     - Sequence length: 4096
     """
     cfg = _peft_common_vlm()
-    cfg.peft = default_peft_config("lora")
+    cfg.peft = default_peft_config(peft_scheme)
 
     # Model config
     hf_path = "Qwen/Qwen3.5-397B-A17B"

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -27,6 +27,7 @@ from typing import Callable
 import pytest
 import torch
 
+from megatron.bridge.peft.dora import DoRA
 from megatron.bridge.utils.cuda_graph import cuda_graph_module_names
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
 
@@ -218,6 +219,15 @@ def test_each_qwen35_vl_peft_recipe_builds_config(recipe_func: Callable, monkeyp
     assert hasattr(cfg.peft, "alpha")
 
 
+def test_qwen35_vl_model_selector_supports_dora(monkeypatch: pytest.MonkeyPatch):
+    """Qwen3.5-VL model selectors should honor the requested DoRA scheme."""
+    patch_recipe_module_global(monkeypatch, _qwen35_vl_module, "AutoBridge", _FakeAutoBridge)
+
+    cfg = _qwen35_vl_module.qwen35_vl_800m_peft_config(peft_scheme="dora")
+
+    assert isinstance(cfg.peft, DoRA)
+
+
 # ---------------------------------------------------------------------------
 # Recipe API shape
 # ---------------------------------------------------------------------------
@@ -229,13 +239,20 @@ def test_each_qwen35_vl_peft_recipe_builds_config(recipe_func: Callable, monkeyp
     + _QWEN35_VL_H100_PRETRAIN_MOCK_FUNCS
     + _QWEN35_VL_SFT_FUNCS
     + _QWEN35_VL_H100_SFT_FUNCS
-    + _QWEN35_VL_PEFT_FUNCS
-    + _QWEN35_VL_H100_PEFT_FUNCS
+    + [_qwen35_vl_h100_module.qwen35_vl_35b_a3b_peft_16gpu_h100_bf16_config]
     + _QWEN35_VL_GB200_FUNCS,
 )
 def test_qwen35_vl_recipe_entry_points_are_parameterless(recipe_func: Callable):
     """Qwen3.5-VL public recipe entry points should be fixed configs."""
     assert not inspect.signature(recipe_func).parameters
+
+
+@pytest.mark.parametrize("recipe_func", _QWEN35_VL_PEFT_FUNCS)
+def test_qwen35_vl_selectable_peft_recipes_accept_a_peft_scheme(recipe_func: Callable):
+    """Model-selectable PEFT recipes should accept an optional PEFT scheme."""
+    parameter = inspect.signature(recipe_func).parameters["peft_scheme"]
+
+    assert parameter.default == "lora"
 
 
 def test_qwen35_vl_h100_module_has_no_parameterized_recipe_helpers():


### PR DESCRIPTION
## Summary

The documented model-selector launch path rejects DoRA for every Qwen3.5-VL PEFT recipe. For example:

```bash
./scripts/training/train.sh --model qwen35_vl_800m --mode dora --dataset cord-v2
```

fails during recipe loading, before model or dataset initialization.

The selector forwards `peft_scheme="dora"` to the exported compatibility alias, but that alias currently resolves to a parameterless H100 factory that hard-codes LoRA. `recipe_runner` therefore reports that the recipe does not accept a configurable PEFT scheme.

## Fix

- Accept `peft_scheme: str | PEFT = "lora"` in the eight H100 factories exported through Qwen3.5-VL model selectors.
- Forward the selection to the existing `default_peft_config` helper.
- Preserve LoRA defaults and leave the separately tuned 16-GPU fixed-LoRA recipe unchanged.
- Add regression coverage for DoRA construction through the compatibility alias and for the selectable-recipe signature contract.

This restores the launcher contract without changing training, model, dataset, or distributed behavior.

## Validation

A deterministic CPU contract reproducer that combines the real runner selection logic with the actual factory signature failed before the change:

```text
ValueError: Recipe 'qwen35_vl_800m_peft_1gpu_h100_bf16_config' does not accept a configurable PEFT scheme; --mode dora is unsupported.
```

The unchanged reproducer exits successfully after the fix and verifies that `peft_scheme="dora"` is forwarded to `default_peft_config`.

Focused and adjacent tests:

```bash
uv run python -m pytest tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py -q
# 117 passed

git diff --check
# passed

uv run pre-commit run --all-files
# passed
```

No full test suite, distributed training, convergence, or performance validation was run; the failure and fix occur entirely during CPU-side recipe selection and construction.
