### PR TITLE
[training] fix: Reject empty profiling ranges

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -782,8 +782,8 @@ class ProfilingConfig(MTrainProfilingConfig):
         )
         assert self.profile_step_start >= 0, f"profile_step_start must be >= 0, got {self.profile_step_start}"
         assert self.profile_step_end >= 0, f"profile_step_end must be >= 0, got {self.profile_step_end}"
-        assert self.profile_step_end >= self.profile_step_start, (
-            f"profile_step_end ({self.profile_step_end}) must be >= profile_step_start ({self.profile_step_start})"
+        assert self.profile_step_end > self.profile_step_start, (
+            f"profile_step_end ({self.profile_step_end}) must be > profile_step_start ({self.profile_step_start})"
         )
 
 

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -915,9 +915,9 @@ class TestConfigContainerValidation:
         "profile_step_start, profile_step_end, expect_assertion_error, expected_error_match",
         [
             (10, 20, False, None),  # Valid: end > start
-            (10, 10, False, None),  # Valid: end == start (single step)
+            (10, 10, True, "profile_step_end .* must be > profile_step_start"),  # Invalid: empty range
             (0, 5, False, None),  # Valid: start at 0
-            (20, 10, True, "profile_step_end .* must be >= profile_step_start"),  # Invalid: end < start
+            (20, 10, True, "profile_step_end .* must be > profile_step_start"),  # Invalid: end < start
             (-1, 10, True, "profile_step_start must be >= 0"),  # Invalid: start < 0
             (10, -1, True, "profile_step_end must be >= 0"),  # Invalid: end < 0
             (-5, -1, True, "profile_step_start must be >= 0"),  # Invalid: both < 0


### PR DESCRIPTION
## Problem

`ProfilingConfig` accepted `profile_step_start == profile_step_end` as a valid single-step range. This reaches supported standard and MegatronMIMO training paths unchanged.

The PyTorch profiler computes `active` as `profile_step_end - profile_step_start`, so an equal range passes `active=0` to `torch.profiler.schedule` and crashes before training with `Invalid profiler schedule arguments`. Nsys starts at the configured pre-step value, but both training loops increment the step before checking the exact end value, so the same equal range misses its stop point.

## Root cause and fix

The shared config validator allowed a zero-width half-open range even though every profiler backend requires at least one step. Require `profile_step_end > profile_step_start` in `ProfilingConfig.finalize()` and update the focused range-validation expectations.

This keeps the fix at the owning boundary. A one-step profile remains expressible as `profile_step_end = profile_step_start + 1`; no backend-specific special cases are added.

## Verification

Fail before the production fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_config.py::TestConfigContainerValidation::test_profiling_config_step_range_validation -q
1 failed, 6 passed
Failed: DID NOT RAISE AssertionError (start=10, end=10)
```

Pass after the fix, including adjacent profiler coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_config.py tests/unit_tests/training/test_profiling.py -k profiling -q
45 passed, 262 deselected
```

Additional checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

No profiler loop behavior, public API signatures, dependencies, lockfiles, workflows, documentation, or Megatron-Core files are changed.
