### PR TITLE
fix(conversion): verify K-EXAONE 2 CPU and GPU export

### DIFF
--- a/examples/model_verification_cards/k-exaone-2/card.yaml
+++ b/examples/model_verification_cards/k-exaone-2/card.yaml
@@ -6,8 +6,8 @@ summary: >
   Performance disclaimer: this model has not been performance-tuned; reported
   timing and throughput metrics are sanity checks, not optimized performance
   results. K-EXAONE 2.0 750B-A37B has public H100 recipes for pretraining,
-  full SFT, and PEFT in this Bridge revision. CPU conversion, GPU export,
-  training, export-after-SFT, long-context SFT, and checkpoint resume remain
+  full SFT, and PEFT in this Bridge revision. CPU import, training,
+  export-after-SFT, long-context SFT, and checkpoint resume remain
   unverified. A complete 750B GPU import from a clean commit persisted and
   reloaded successfully, and a full 59,396-tensor audit is bitwise exact. A
   2-GPU structural MoE/MTP proxy also completed three
@@ -16,18 +16,18 @@ summary: >
   78 Hugging Face decoder layers for a Korean prompt; Megatron matched its
   next token with 0.999993 cosine similarity. Complete-model deterministic
   inference generated and independently confirmed exactly 16 new tokens. The
-  implementation fixes are committed; GPU export remains unverified pending
-  its own clean-commit rerun and exact audit.
+  implementation fixes are committed, and complete distributed CPU and GPU
+  exports are verified by clean-commit exact audits and native reloads.
 verification_index:
   model_level:
     verified:
       - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
       - manual_forward_pass
       - inference
     unverified:
       - hf_to_megatron_cpu
-      - megatron_to_hf_cpu
-      - megatron_to_hf_gpu
   training:
     H100:
       unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
@@ -72,19 +72,34 @@ items:
       unexpected, duplicate, shape, dtype, or value mismatches.
 
   megatron_to_hf_cpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    bridge_commit: 578e777ccb07180c7805c7cfeb619c7119602cb9  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device cpu
+      --nodes 6 --cpu-processes-per-node 8 --cpus-per-task 16 --mem 0
+      --exclusive --hf-model LGAI-EXAONE/K-EXAONE-2.0-750B-A37B
+      --hf-revision 4bb394fd12f57be7174be7c80c30cc05472bf9e1
+      --megatron-path work/model-verification/k-exaone-2/imported-megatron/iter_0000000
+      --hf-path work/model-verification/k-exaone-2/cpu-hf-export
+      --torch-dtype bfloat16 --tp 1 --pp 3 --ep 16 --etp 1
+      --trust-remote-code --distributed-timeout-minutes 240
+      --distributed-save --save-every-n-ranks 1 --no-progress
+    last_verified: 2026-08-26
     expected_result: >
-      No CPU Megatron-to-Hugging-Face conversion result is claimed. Future
-      verification depends on a complete CPU import and must export, strictly
-      reload, and compare all lossless tensors against the pinned source
-      revision.
+      The 48-process distributed CPU export exits successfully and writes 17
+      safetensors shards containing exactly 59,396 indexed keys. Every
+      exported tensor matches the pinned source bitwise across
+      749,357,484,800 values and 1,498,715,008,512 payload bytes, including
+      every FP32 expert-score correction bias. The configuration and tokenizer
+      reload successfully, and Transformers strictly reloads the output as
+      ExaoneMoeForCausalLM with all 1,165 state tensors and no loading
+      discrepancies.
 
   megatron_to_hf_gpu:
-    status: unverified
+    status: verified
     precision: bf16
+    bridge_commit: 9cd9f6dc7d5b48ed74e7dadd24866542db637a2d  # pragma: allowlist secret
     command: >
       ./scripts/conversion/convert.sh export --executor slurm --device gpu
       --nodes 6 --gpus-per-node 8
@@ -95,15 +110,16 @@ items:
       --torch-dtype bfloat16 --tp 1 --pp 3 --ep 16 --etp 1
       --distributed-timeout-minutes 180 --distributed-save
       --save-every-n-ranks 1 --no-progress
-    last_verified: null
+    last_verified: 2026-08-26
     expected_result: >
       A complete distributed export produced 59,396 indexed keys in 17
       safetensors shards. Every exported tensor matches the pinned source
       bitwise across 1,498,715,008,512 payload bytes, and the corrected
-      config/tokenizer reload successfully. The run exposed and fixed
+      config and tokenizer reload successfully. Transformers strictly reloads
+      the output as ExaoneMoeForCausalLM with all 1,165 state tensors and no
+      loading discrepancies. The run exposed and fixed
       preservation of one physical repeated MTP layer across four speculative
-      steps. The config fix is committed; this item remains unverified until
-      the clean-commit export and exact audit rerun complete.
+      steps, and preserves every FP32 expert-score correction bias.
 
   manual_forward_pass:
     status: verified

--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -4,8 +4,8 @@
 Megatron checkpoint conversion. It uses NeMo Run for both local execution and
 Slurm submission and selects one of two conversion backends:
 
-- `--device cpu`: one process on one node, with model construction and export
-  on CPU;
+- `--device cpu`: CPU conversion, with optional distributed export across
+  Gloo ranks for checkpoints that cannot be exported on one host;
 - `--device gpu`: distributed conversion with one process per GPU and TP, PP,
   EP, and ETP support.
 
@@ -49,8 +49,9 @@ conversion to finish.
   --hf-path /workspace/models/llama32-1b-hf
 ```
 
-CPU conversion intentionally supports one process on one node. Allocate more
-host memory and CPUs for large checkpoints rather than increasing `--nodes`.
+CPU import and the default CPU export use one process on one node. Distributed
+CPU export is available through the Slurm workflow below for checkpoints that
+cannot be loaded on one host within the available memory or wall-time limit.
 
 ## Distributed GPU conversion on Slurm
 
@@ -162,6 +163,34 @@ CPU mode submits one task and does not request GPUs or GRES:
   --hf-model meta-llama/Llama-3.2-1B \
   --megatron-path /workspace/models/llama32-1b
 ```
+
+For a very large Megatron checkpoint, distribute only the export load and save
+across CPU processes. This uses Gloo, initializes every model shard on CPU, and
+enables distributed Hugging Face saving by default. It does not request GPUs:
+
+```bash
+./scripts/conversion/convert.sh export \
+  --executor slurm \
+  --device cpu \
+  --nodes 4 \
+  --cpu-processes-per-node 8 \
+  --cpus-per-task 16 \
+  --mem 0 \
+  --exclusive \
+  --account ACCOUNT \
+  --partition CPU_PARTITION \
+  --container-image /path/to/megatron-bridge.sqsh \
+  --mount /workspace \
+  --hf-model MODEL \
+  --megatron-path /workspace/models/model/iter_0000000 \
+  --hf-path /workspace/models/model-hf \
+  --tp 1 --pp 4 --ep 8 --etp 1
+```
+
+The topology must satisfy
+`nodes * cpu-processes-per-node % (TP * PP) == 0` and
+`nodes * cpu-processes-per-node % (ETP * EP * PP) == 0`. Distributed CPU
+conversion currently supports export only and requires distributed saving.
 
 `--env` accepts names only. Export values in the launcher environment so
 secrets are inherited by Slurm without being materialized in generated job

--- a/scripts/conversion/arguments.py
+++ b/scripts/conversion/arguments.py
@@ -43,6 +43,20 @@ def _add_execution_arguments(parser: argparse.ArgumentParser, *, default_device:
         dest="gpus_per_node",
         help="GPUs per node; required for the GPU backend and optional as a CPU-backend runtime resource.",
     )
+    execution.add_argument(
+        "--cpu-processes-per-node",
+        type=int,
+        default=1,
+        help=(
+            "CPU conversion processes per node (default: 1). Values above 1 enable distributed CPU export "
+            "and require model parallelism compatible with nodes*cpu-processes-per-node."
+        ),
+    )
+    execution.add_argument(
+        "--cpus-per-task",
+        type=int,
+        help="Slurm CPU cores per conversion process.",
+    )
     execution.add_argument("--mem", default="0", help="Slurm memory request (default: 0, all node memory).")
     execution.add_argument("--account", default=os.environ.get("SLURM_ACCOUNT"), help="Slurm account.")
     execution.add_argument("--partition", default=os.environ.get("SLURM_PARTITION"), help="Slurm partition.")
@@ -104,7 +118,7 @@ def _add_parallelism_arguments(
     include_distributed_timeout: bool,
 ) -> None:
     """Add distributed model-parallel arguments."""
-    parallelism = parser.add_argument_group("Distributed GPU parallelism")
+    parallelism = parser.add_argument_group("Distributed parallelism")
     parallelism.add_argument(
         "-tp",
         "--tp",
@@ -275,7 +289,10 @@ Examples:
         "--distributed-save",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Let GPU ranks save assigned Hugging Face shards independently (default: enabled for GPU).",
+        help=(
+            "Let distributed ranks save assigned Hugging Face shards independently "
+            "(default: enabled for GPU and distributed CPU export)."
+        ),
     )
     export_parser.add_argument(
         "--save-every-n-ranks",
@@ -369,7 +386,10 @@ def conversion_worker_args(args: argparse.Namespace) -> list[str]:
             worker_args.append("--no-progress")
         if args.not_strict:
             worker_args.append("--not-strict")
-        distributed_save = args.distributed_save if args.distributed_save is not None else args.device == "gpu"
+        distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
+        distributed_save = (
+            args.distributed_save if args.distributed_save is not None else (args.device == "gpu" or distributed_cpu)
+        )
         worker_args.append("--distributed-save" if distributed_save else "--no-distributed-save")
         worker_args.extend(["--save-every-n-ranks", str(args.save_every_n_ranks)])
         if args.export_weight_dtype is not None:

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -14,6 +14,7 @@
 """Single-process CPU checkpoint conversion backend."""
 
 import logging
+import os
 import shutil
 from pathlib import Path
 
@@ -25,6 +26,7 @@ from megatron.bridge.training.model_load_save import low_memory_model_load_conte
 
 
 logger = logging.getLogger(__name__)
+_CPU_EXPORT_MMAP_DIRECTORY_ENV = "MEGATRON_BRIDGE_CPU_EXPORT_MMAP_DIRECTORY"
 
 
 def _find_run_config(checkpoint_path: Path) -> Path:
@@ -42,6 +44,12 @@ def _find_run_config(checkpoint_path: Path) -> Path:
     raise FileNotFoundError(
         f"Could not find run_config.yaml in {checkpoint_path}. Ensure this is a valid Megatron checkpoint."
     )
+
+
+def _cpu_export_mmap_directory(hf_path: str) -> Path:
+    """Return an explicit staging directory or default to the output parent."""
+    override = os.environ.get(_CPU_EXPORT_MMAP_DIRECTORY_ENV)
+    return Path(override).expanduser() if override else Path(hf_path).parent
 
 
 def import_checkpoint(
@@ -121,8 +129,10 @@ def export_checkpoint(
     # Preserve the reference wrapper's state source and shard map so model
     # families with packed HF weights export in their canonical representation.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
+    mmap_directory = _cpu_export_mmap_directory(hf_path)
+    logger.info("Using CPU export mmap directory: %s", mmap_directory)
     try:
-        with low_memory_model_load_context(mmap_directory=Path(hf_path).parent):
+        with low_memory_model_load_context(mmap_directory=mmap_directory):
             bridge.export_ckpt(
                 megatron_path=megatron_path,
                 hf_path=hf_path,

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -21,6 +21,7 @@ from utils import parse_dtype, prepare_output_directory
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
+from megatron.bridge.training.model_load_save import low_memory_model_load_context
 
 
 logger = logging.getLogger(__name__)
@@ -117,12 +118,13 @@ def export_checkpoint(
     # families with packed HF weights export in their canonical representation.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
     try:
-        bridge.export_ckpt(
-            megatron_path=megatron_path,
-            hf_path=hf_path,
-            show_progress=show_progress,
-            strict=strict,
-        )
+        with low_memory_model_load_context():
+            bridge.export_ckpt(
+                megatron_path=megatron_path,
+                hf_path=hf_path,
+                show_progress=show_progress,
+                strict=strict,
+            )
     except Exception as error:
         if strict:
             shutil.rmtree(Path(hf_path), ignore_errors=True)

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -118,7 +118,7 @@ def export_checkpoint(
     # families with packed HF weights export in their canonical representation.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
     try:
-        with low_memory_model_load_context():
+        with low_memory_model_load_context(mmap_directory=Path(hf_path).parent):
             bridge.export_ckpt(
                 megatron_path=megatron_path,
                 hf_path=hf_path,

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -17,7 +17,7 @@ import logging
 import shutil
 from pathlib import Path
 
-from utils import parse_dtype, prepare_output_directory
+from utils import parse_dtype, prepare_output_directory, resolve_hf_model_revision
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
@@ -81,6 +81,7 @@ def import_checkpoint(
 def export_checkpoint(
     *,
     hf_model: str,
+    hf_revision: str | None,
     megatron_path: str,
     hf_path: str,
     show_progress: bool,
@@ -92,6 +93,7 @@ def export_checkpoint(
 
     Args:
         hf_model: Hugging Face model ID or local config reference.
+        hf_revision: Immutable Hugging Face Hub revision to load.
         megatron_path: Source Megatron checkpoint path.
         hf_path: Destination Hugging Face checkpoint path.
         show_progress: Display conversion progress.
@@ -108,10 +110,12 @@ def export_checkpoint(
     trusted = is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model)
     logger.info("CPU export: %s -> %s", megatron_path, hf_path)
     logger.info("Using Megatron run config: %s", config_path)
-    bridge = AutoBridge.from_hf_pretrained(hf_model, trust_remote_code=trusted)
+    revision_kwargs = {"revision": hf_revision} if hf_revision is not None else {}
+    bridge = AutoBridge.from_hf_pretrained(hf_model, trust_remote_code=trusted, **revision_kwargs)
+    reference_model = resolve_hf_model_revision(hf_model, hf_revision)
     checkpoint_config_bridge = AutoBridge.from_auto_config(
         megatron_path,
-        hf_model,
+        reference_model,
         trust_remote_code=trusted,
     )
     # Preserve the reference wrapper's state source and shard map so model

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -49,8 +49,8 @@ _ROUNDTRIP_RTOL = 1e-5
 _CONSOLE = Console()
 
 
-def _ensure_distributed_initialized(timeout_minutes: int | None) -> None:
-    """Initialize NCCL from NeMo Run's torchrun or Slurm task environment."""
+def _ensure_distributed_initialized(timeout_minutes: int | None, *, use_cpu: bool = False) -> None:
+    """Initialize a distributed process group from torchrun or Slurm task state."""
     if torch.distributed.is_initialized():
         return
     if os.environ.get("WORLD_SIZE") is None and os.environ.get("SLURM_NTASKS") is not None:
@@ -64,10 +64,11 @@ def _ensure_distributed_initialized(timeout_minutes: int | None) -> None:
         if master_port is not None:
             os.environ["MASTER_PORT"] = str(master_port)
     if os.environ.get("WORLD_SIZE") is None:
-        raise RuntimeError("GPU conversion must be launched through NeMo Run's local or Slurm executor.")
-    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    torch.cuda.set_device(local_rank)
-    kwargs: dict[str, object] = {"backend": "nccl"}
+        raise RuntimeError("Distributed conversion must be launched through NeMo Run's local or Slurm executor.")
+    if not use_cpu:
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        torch.cuda.set_device(local_rank)
+    kwargs: dict[str, object] = {"backend": "gloo" if use_cpu else "nccl"}
     if timeout_minutes is not None:
         kwargs["timeout"] = datetime.timedelta(minutes=timeout_minutes)
     torch.distributed.init_process_group(**kwargs)
@@ -166,6 +167,7 @@ def _configure_model_provider(
     ep: int,
     etp: int,
     dtype: torch.dtype,
+    use_cpu: bool = False,
 ) -> None:
     """Apply distributed parallelism and dtype settings to a model provider."""
     model_provider.tensor_model_parallel_size = tp
@@ -174,6 +176,8 @@ def _configure_model_provider(
     model_provider.expert_tensor_parallel_size = etp
     model_provider.pipeline_dtype = dtype
     model_provider.params_dtype = dtype
+    if use_cpu:
+        model_provider.use_cpu_initialization = True
 
 
 def _hf_tokenizer_kwargs(bridge: AutoBridge, *, trust_remote_code: bool) -> dict[str, object]:
@@ -349,6 +353,7 @@ def export_checkpoint(
     distributed_timeout_minutes: int | None,
     export_weight_dtype: str | None,
     overwrite: bool,
+    use_cpu: bool = False,
 ) -> None:
     """Export a distributed Megatron checkpoint to Hugging Face format.
 
@@ -369,14 +374,19 @@ def export_checkpoint(
         distributed_timeout_minutes: Process-group timeout in minutes.
         export_weight_dtype: Optional dtype for exported weights.
         overwrite: Delete a non-empty destination before conversion.
+        use_cpu: Use Gloo and CPU model initialization instead of NCCL/CUDA.
     """
-    _ensure_distributed_initialized(distributed_timeout_minutes)
+    if use_cpu:
+        _ensure_distributed_initialized(distributed_timeout_minutes, use_cpu=True)
+    else:
+        _ensure_distributed_initialized(distributed_timeout_minutes)
     if not Path(megatron_path).exists():
         raise FileNotFoundError(f"Megatron checkpoint does not exist: {megatron_path}")
     _prepare_distributed_output(hf_path, overwrite=overwrite, source_paths=[megatron_path, hf_model])
     dtype = parse_dtype(torch_dtype)
 
-    print_rank_0(f"GPU export: {megatron_path} -> {hf_path}")
+    device_label = "CPU" if use_cpu else "GPU"
+    print_rank_0(f"Distributed {device_label} export: {megatron_path} -> {hf_path}")
     print_rank_0(f"Parallelism: TP={tp} PP={pp} EP={ep} ETP={etp}; dtype={torch_dtype}")
     trusted = is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model)
     bridge = AutoBridge.from_hf_pretrained(
@@ -393,7 +403,7 @@ def export_checkpoint(
     # exporting the checkpoint-derived architecture and vocabulary configuration.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
     model_provider = bridge.to_megatron_provider(load_weights=False)
-    _configure_model_provider(model_provider, tp=tp, pp=pp, ep=ep, etp=etp, dtype=dtype)
+    _configure_model_provider(model_provider, tp=tp, pp=pp, ep=ep, etp=etp, dtype=dtype, use_cpu=use_cpu)
     _maybe_restore_pipeline_layout(bridge, model_provider, megatron_path, pp)
     resolved_pipeline_layout = model_provider.pipeline_model_parallel_layout
     model_provider.finalize()
@@ -424,7 +434,7 @@ def export_checkpoint(
         save_every_n_ranks=save_every_n_ranks,
         weight_dtype=parse_dtype(export_weight_dtype) if export_weight_dtype else None,
     )
-    print_rank_0(f"GPU export complete: {hf_path}")
+    print_rank_0(f"Distributed {device_label} export complete: {hf_path}")
 
 
 @torchrun_main

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import torch
 import yaml
 from rich.console import Console
-from utils import parse_dtype, prepare_output_directory, validate_output_path
+from utils import parse_dtype, prepare_output_directory, resolve_hf_model_revision, validate_output_path
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
@@ -338,6 +338,7 @@ def import_checkpoint(
 def export_checkpoint(
     *,
     hf_model: str,
+    hf_revision: str | None,
     megatron_path: str,
     hf_path: str,
     tp: int,
@@ -359,6 +360,7 @@ def export_checkpoint(
 
     Args:
         hf_model: Hugging Face model ID or local config reference.
+        hf_revision: Immutable Hugging Face Hub revision to load.
         megatron_path: Source Megatron checkpoint path.
         hf_path: Destination Hugging Face checkpoint path.
         tp: Tensor parallelism size.
@@ -389,14 +391,17 @@ def export_checkpoint(
     print_rank_0(f"Distributed {device_label} export: {megatron_path} -> {hf_path}")
     print_rank_0(f"Parallelism: TP={tp} PP={pp} EP={ep} ETP={etp}; dtype={torch_dtype}")
     trusted = is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model)
+    revision_kwargs = {"revision": hf_revision} if hf_revision is not None else {}
     bridge = AutoBridge.from_hf_pretrained(
         hf_model,
         trust_remote_code=trusted,
         torch_dtype=dtype,
+        **revision_kwargs,
     )
+    reference_model = resolve_hf_model_revision(hf_model, hf_revision)
     checkpoint_config_bridge = AutoBridge.from_auto_config(
         megatron_path,
-        hf_model,
+        reference_model,
         trust_remote_code=trusted,
     )
     # Preserve the reference wrapper's streaming state source and shard map while

--- a/scripts/conversion/run_conversion.py
+++ b/scripts/conversion/run_conversion.py
@@ -21,7 +21,7 @@ import os
 import cpu_backend
 import gpu_backend
 from arguments import build_parser
-from utils import resolve_hf_commit_revision, resolve_hf_model_revision
+from utils import resolve_hf_commit_revision
 
 
 logger = logging.getLogger(__name__)
@@ -106,6 +106,7 @@ def _run_export(args: argparse.Namespace) -> None:
     """Dispatch an export to the selected backend."""
     common_args = {
         "hf_model": args.hf_model,
+        "hf_revision": args.hf_revision,
         "megatron_path": args.megatron_path,
         "hf_path": args.hf_path,
         "show_progress": not args.no_progress,
@@ -151,16 +152,8 @@ def main(argv: list[str] | None = None) -> None:
     args = build_parser(include_execution=False).parse_args(argv)
     _validate_args(args)
     if args.hf_revision is not None:
-        if args.command == "import":
-            args.hf_revision = resolve_hf_commit_revision(args.hf_model, args.hf_revision)
-            logger.info("Resolved Hugging Face import to immutable revision %s", args.hf_revision)
-        else:
-            args.hf_model = resolve_hf_model_revision(args.hf_model, args.hf_revision)
-            logger.info(
-                "Resolved Hugging Face revision %s to immutable local snapshot %s",
-                args.hf_revision,
-                args.hf_model,
-            )
+        args.hf_revision = resolve_hf_commit_revision(args.hf_model, args.hf_revision)
+        logger.info("Resolved Hugging Face model to immutable revision %s", args.hf_revision)
     logger.info("Selected %s backend for %s conversion", args.device.upper(), args.command)
     if args.command == "import":
         _run_import(args)

--- a/scripts/conversion/run_conversion.py
+++ b/scripts/conversion/run_conversion.py
@@ -16,6 +16,7 @@
 
 import argparse
 import logging
+import os
 
 import cpu_backend
 import gpu_backend
@@ -24,6 +25,11 @@ from utils import resolve_hf_commit_revision, resolve_hf_model_revision
 
 
 logger = logging.getLogger(__name__)
+
+
+def _distributed_world_size() -> int:
+    """Return the launcher-provided world size, defaulting to one process."""
+    return int(os.environ.get("WORLD_SIZE", os.environ.get("SLURM_NTASKS", "1")))
 
 
 def _configure_logging() -> None:
@@ -39,16 +45,33 @@ def _validate_args(args: argparse.Namespace) -> None:
     distributed_timeout_minutes = getattr(args, "distributed_timeout_minutes", None)
     if distributed_timeout_minutes is not None and distributed_timeout_minutes < 1:
         raise ValueError("--distributed-timeout-minutes must be at least 1.")
-    if args.device == "cpu" and any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp")):
+    distributed_cpu = args.device == "cpu" and _distributed_world_size() > 1
+    if (
+        args.device == "cpu"
+        and not distributed_cpu
+        and any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp"))
+    ):
         raise ValueError("CPU conversion requires TP=PP=EP=ETP=1.")
+    if distributed_cpu and args.command != "export":
+        raise ValueError("Distributed CPU conversion currently supports export only.")
+    if distributed_cpu:
+        world_size = _distributed_world_size()
+        if world_size % (args.tp * args.pp) != 0:
+            raise ValueError("WORLD_SIZE must be divisible by TP*PP for distributed CPU export.")
+        if world_size % (args.etp * args.ep * args.pp) != 0:
+            raise ValueError("WORLD_SIZE must be divisible by ETP*EP*PP for distributed CPU export.")
     if args.command == "import" and args.device == "cpu" and args.low_memory_save:
         raise ValueError("--low-memory-save is only supported by the GPU backend.")
     if args.command == "export":
         if args.save_every_n_ranks < 1:
             raise ValueError("--save-every-n-ranks must be at least 1.")
-        distributed_save = args.distributed_save if args.distributed_save is not None else args.device == "gpu"
-        if args.device == "cpu" and distributed_save:
-            raise ValueError("--distributed-save is only supported by the GPU backend.")
+        distributed_save = (
+            args.distributed_save if args.distributed_save is not None else (args.device == "gpu" or distributed_cpu)
+        )
+        if args.device == "cpu" and distributed_save and not distributed_cpu:
+            raise ValueError("--distributed-save requires distributed CPU export or the GPU backend.")
+        if distributed_cpu and not distributed_save:
+            raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
         if args.device == "cpu" and args.export_weight_dtype is not None:
@@ -90,7 +113,8 @@ def _run_export(args: argparse.Namespace) -> None:
         "trust_remote_code": args.trust_remote_code,
         "overwrite": args.overwrite,
     }
-    if args.device == "cpu":
+    distributed_cpu = args.device == "cpu" and _distributed_world_size() > 1
+    if args.device == "cpu" and not distributed_cpu:
         cpu_backend.export_checkpoint(**common_args)
         return
     distributed_save = args.distributed_save if args.distributed_save is not None else True
@@ -105,6 +129,7 @@ def _run_export(args: argparse.Namespace) -> None:
         save_every_n_ranks=args.save_every_n_ranks,
         distributed_timeout_minutes=args.distributed_timeout_minutes,
         export_weight_dtype=args.export_weight_dtype,
+        use_cpu=distributed_cpu,
     )
 
 

--- a/scripts/conversion/setup_conversion.py
+++ b/scripts/conversion/setup_conversion.py
@@ -69,6 +69,10 @@ def _validate_args(args: argparse.Namespace) -> None:
     """Validate execution resources and conversion parallelism before launch."""
     if args.nodes < 1:
         raise ValueError("--nodes must be at least 1.")
+    if args.cpu_processes_per_node < 1:
+        raise ValueError("--cpu-processes-per-node must be at least 1.")
+    if args.cpus_per_task is not None and args.cpus_per_task < 1:
+        raise ValueError("--cpus-per-task must be at least 1.")
     distributed_timeout_minutes = getattr(args, "distributed_timeout_minutes", None)
     if distributed_timeout_minutes is not None and distributed_timeout_minutes < 1:
         raise ValueError("--distributed-timeout-minutes must be at least 1.")
@@ -99,16 +103,31 @@ def _validate_args(args: argparse.Namespace) -> None:
     if args.command == "import" and args.device == "cpu" and args.low_memory_save:
         raise ValueError("--low-memory-save is only supported by the GPU backend.")
 
+    distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
     if args.device == "cpu":
-        if args.nodes != 1:
-            raise ValueError("CPU conversion supports exactly one node and one process.")
+        if distributed_cpu and args.command != "export":
+            raise ValueError("Distributed CPU conversion currently supports export only.")
+        if not distributed_cpu and args.nodes != 1:
+            raise ValueError("Single-process CPU conversion supports exactly one node.")
         if args.gpus_per_node is not None and args.gpus_per_node < 0:
             raise ValueError("--gpus-per-node must not be negative.")
+        if distributed_cpu and args.gpus_per_node not in (None, 0):
+            raise ValueError("Distributed CPU export does not request GPU resources.")
         if args.gres:
             raise ValueError("CPU conversion does not accept --gres.")
-        if any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp")):
+        if not distributed_cpu and any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp")):
             raise ValueError("CPU conversion requires TP=PP=EP=ETP=1.")
+        if distributed_cpu:
+            world_size = args.nodes * args.cpu_processes_per_node
+            model_parallel_size = args.tp * args.pp
+            if world_size % model_parallel_size != 0:
+                raise ValueError("nodes*cpu-processes-per-node must be divisible by TP*PP.")
+            expert_model_parallel_size = args.etp * args.ep * args.pp
+            if world_size % expert_model_parallel_size != 0:
+                raise ValueError("nodes*cpu-processes-per-node must be divisible by ETP*EP*PP.")
     else:
+        if args.cpu_processes_per_node != 1:
+            raise ValueError("--cpu-processes-per-node is only supported by the CPU backend.")
         if args.gpus_per_node is None or args.gpus_per_node < 1:
             raise ValueError("GPU conversion requires --gpus-per-node of at least 1.")
         if args.executor == "local":
@@ -133,9 +152,13 @@ def _validate_args(args: argparse.Namespace) -> None:
     if args.command == "export":
         if args.save_every_n_ranks < 1:
             raise ValueError("--save-every-n-ranks must be at least 1.")
-        distributed_save = args.distributed_save if args.distributed_save is not None else args.device == "gpu"
-        if args.device == "cpu" and distributed_save:
-            raise ValueError("--distributed-save is only supported by the GPU backend.")
+        distributed_save = (
+            args.distributed_save if args.distributed_save is not None else (args.device == "gpu" or distributed_cpu)
+        )
+        if args.device == "cpu" and distributed_save and not distributed_cpu:
+            raise ValueError("--distributed-save requires distributed CPU export or the GPU backend.")
+        if distributed_cpu and not distributed_save:
+            raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
         if args.device == "cpu" and args.export_weight_dtype is not None:
@@ -148,8 +171,9 @@ def _build_executor(
     mounts: list[str],
 ) -> object:
     """Build a Local or Slurm NeMo Run executor."""
-    task_count = args.gpus_per_node if args.device == "gpu" else 1
-    launcher = run.Torchrun() if args.executor == "local" and args.device == "gpu" else None
+    distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
+    task_count = args.gpus_per_node if args.device == "gpu" else args.cpu_processes_per_node
+    launcher = run.Torchrun() if args.executor == "local" and (args.device == "gpu" or distributed_cpu) else None
     if args.executor == "local":
         executor = run.LocalExecutor(
             ntasks_per_node=task_count,
@@ -162,6 +186,9 @@ def _build_executor(
     gpu_kwargs = {}
     if args.gpus_per_node and not args.no_gpu_resource_request:
         gpu_kwargs["gpus_per_node"] = args.gpus_per_node
+    cpu_kwargs = {}
+    if args.cpus_per_task is not None:
+        cpu_kwargs["cpus_per_task"] = args.cpus_per_task
     container_env = [*env_names]
     if "PYTHONPATH" not in container_env:
         container_env.append("PYTHONPATH")
@@ -184,6 +211,7 @@ def _build_executor(
         container_env=container_env,
         additional_parameters={"export": ",".join(container_env)},
         srun_args=args.srun_args,
+        **cpu_kwargs,
         **gpu_kwargs,
     )
     # Values are inherited by Slurm and selected by name for the container;
@@ -206,7 +234,8 @@ def _build_task(args: argparse.Namespace) -> tuple[run.Script, list[str]]:
     else:
         pythonpath = f"{repo_root}/src:{repo_root}/3rdparty/Megatron-LM:$PYTHONPATH"
     task_env = {"PYTHONPATH": pythonpath}
-    if args.executor == "local" and args.device == "gpu":
+    distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
+    if args.executor == "local" and (args.device == "gpu" or distributed_cpu):
         # The torchrun console script can belong to a different Python than the
         # uv environment running this launcher. PyTorch honors PYTHON_EXEC for
         # workers, so keep conversion dependencies from this environment.

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -157,6 +157,9 @@ TRACKER_PREFIX = "latest"
 _CHECKPOINT_VERSION = None
 
 logger = getLogger(__name__)
+# DCP factory expansion can add roughly one third of the model payload at peak.
+_FILE_BACKED_LOAD_MEMORY_FRACTION = 0.6
+_FILE_BACKED_STORAGE_BLOCK_BYTES = 16 * 1024**3
 _NON_PERSISTENT_CKPT_SUBDIR = "non_persistent"
 _DIRECT_ITERATION_DIR_SENTINEL = -2
 _CHECKPOINT_CLEANUP_LOCK = threading.Lock()
@@ -166,6 +169,58 @@ HF_WEIGHTS_SUBDIR = "hf"
 # default (currently only Megatron Energon). Used to derive dataloader_save / dataloader_load when
 # those config fields are left unset.
 DATALOADER_STATE_SUBDIR = "energon"
+
+
+@dataclass
+class _FileBackedStorageBlock:
+    """One sparse file mapping used by low-memory CPU checkpoint loading."""
+
+    storage: torch.UntypedStorage
+    capacity_bytes: int
+    used_bytes: int = 0
+
+
+class _FileBackedTensorAllocator:
+    """Allocate CPU tensors from a small set of sparse file mappings."""
+
+    def __init__(self, directory: Path, *, block_bytes: int = _FILE_BACKED_STORAGE_BLOCK_BYTES) -> None:
+        self.directory = directory
+        self.block_bytes = block_bytes
+        self.blocks: list[_FileBackedStorageBlock] = []
+
+    @staticmethod
+    def _align(value: int, alignment: int) -> int:
+        return (value + alignment - 1) // alignment * alignment
+
+    def allocate_like(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Return a contiguous file-backed CPU tensor with matching shape and dtype."""
+        if tensor.numel() == 0:
+            return torch.empty(tensor.shape, dtype=tensor.dtype, device="cpu")
+        if tensor.layout != torch.strided:
+            raise TypeError(f"File-backed checkpoint tensors require strided layout, got {tensor.layout}")
+
+        element_bytes = tensor.element_size()
+        required_bytes = tensor.numel() * element_bytes
+        block = next(
+            (
+                candidate
+                for candidate in reversed(self.blocks)
+                if self._align(candidate.used_bytes, element_bytes) + required_bytes <= candidate.capacity_bytes
+            ),
+            None,
+        )
+        if block is None:
+            capacity_bytes = max(self.block_bytes, self._align(required_bytes, 4096))
+            path = self.directory / f"block-{len(self.blocks):05d}.bin"
+            storage = torch.UntypedStorage.from_file(str(path), shared=True, nbytes=capacity_bytes)
+            block = _FileBackedStorageBlock(storage=storage, capacity_bytes=capacity_bytes)
+            self.blocks.append(block)
+
+        byte_offset = self._align(block.used_bytes, element_bytes)
+        block.used_bytes = byte_offset + required_bytes
+        result = torch.empty(0, dtype=tensor.dtype, device="cpu")
+        result.set_(block.storage, byte_offset // element_bytes, tensor.shape)
+        return result
 
 
 # ============================================================================
@@ -2339,6 +2394,7 @@ def _load_model_weights_from_checkpoint(
     ] = "assume_ok_unexpected",
     strict: bool = True,
     assign_loaded_tensors: bool = False,
+    file_backed_allocator: _FileBackedTensorAllocator | None = None,
 ) -> Optional[Union[StateDict, tuple[StateDict, set[str], set[str]]]]:
     """Load model weights from a checkpoint.
 
@@ -2356,6 +2412,9 @@ def _load_model_weights_from_checkpoint(
         strict: Whether to enforce strict loading (see torch.nn.Module.load_state_dict).
         assign_loaded_tensors: Load into a meta-device model by assigning the
             checkpoint tensors instead of copying them into existing storage.
+        file_backed_allocator: Optional sparse-file allocator used when the
+            model payload is too close to available host memory for anonymous
+            checkpoint staging.
     """
 
     state_dict = dist_checkpointing.load_common_state_dict(checkpoint_path)
@@ -2373,7 +2432,13 @@ def _load_model_weights_from_checkpoint(
     sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs, pg_collection=pg_collection)
 
     if assign_loaded_tensors:
-        sharded_state_dict = _strip_sharded_tensor_data(sharded_state_dict)
+        if file_backed_allocator is not None and _requires_file_backed_checkpoint_load(model):
+            logger.info("Using file-backed checkpoint tensors for the low-memory CPU load")
+            sharded_state_dict = _replace_sharded_tensor_data_with_file_backed(
+                sharded_state_dict, file_backed_allocator
+            )
+        else:
+            sharded_state_dict = _strip_sharded_tensor_data(sharded_state_dict)
 
     load_strategy = TorchDistLoadShardedStrategy()
     if fully_parallel_load:
@@ -2755,6 +2820,75 @@ def _strip_sharded_tensor_data(sharded_state_dict: ShardedStateDict) -> ShardedS
         return value
 
     return dict_list_map_inplace(strip_data, sharded_state_dict)
+
+
+def _available_memory_bytes() -> int:
+    """Return Linux MemAvailable, with a portable sysconf fallback."""
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+
+
+def _requires_file_backed_checkpoint_load(model: list[MegatronModule]) -> bool:
+    """Choose mapped checkpoint storage when anonymous tensors risk host OOM."""
+    seen: set[int] = set()
+    model_bytes = 0
+    for module in model:
+        for tensor in (*module.parameters(), *module.buffers()):
+            if id(tensor) in seen:
+                continue
+            seen.add(id(tensor))
+            model_bytes += tensor.numel() * tensor.element_size()
+    return model_bytes >= _available_memory_bytes() * _FILE_BACKED_LOAD_MEMORY_FRACTION
+
+
+def _replace_sharded_tensor_data_with_file_backed(
+    sharded_state_dict: ShardedStateDict,
+    allocator: _FileBackedTensorAllocator,
+) -> ShardedStateDict:
+    """Back checkpoint targets and factory results with reclaimable file mappings."""
+
+    def allocate_sharded_tensor(value: Any) -> Any:
+        if not isinstance(value, ShardedTensor):
+            return value
+        template = value.data
+        if template is None:
+            template = torch.empty(value.local_shape, dtype=value.dtype, device="meta")
+        return replace(value, data=allocator.allocate_like(template))
+
+    def replace_data(value: Any) -> Any:
+        if isinstance(value, ShardedTensor):
+            return allocate_sharded_tensor(value)
+        if isinstance(value, ShardedTensorFactory):
+            original_build_fn = value.build_fn
+            original_merge_fn = value.merge_fn
+
+            def build_file_backed(key: str, data: torch.Tensor, replica_id: Any, flattened_range: Any) -> Any:
+                result = original_build_fn(key, data, replica_id, flattened_range)
+                return dict_list_map_inplace(allocate_sharded_tensor, result)
+
+            def merge_file_backed(loaded: Any) -> torch.Tensor:
+                merged = original_merge_fn(loaded)
+                mapped = allocator.allocate_like(merged)
+                mapped.copy_(merged)
+                return mapped
+
+            factory_data = value.data
+            if factory_data is not None and not factory_data.is_meta:
+                factory_data = torch.empty_like(factory_data, device="meta")
+            return replace(
+                value,
+                data=factory_data,
+                build_fn=build_file_backed,
+                merge_fn=merge_file_backed,
+            )
+        return value
+
+    return dict_list_map_inplace(replace_data, sharded_state_dict)
 
 
 def _load_model_state_dict(

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -34,7 +34,13 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from megatron.core import dist_checkpointing, tensor_parallel
-from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedStateDict, ShardedTensor
+from megatron.core.dist_checkpointing.dict_utils import dict_list_map_inplace
+from megatron.core.dist_checkpointing.mapping import (
+    ShardedObject,
+    ShardedStateDict,
+    ShardedTensor,
+    ShardedTensorFactory,
+)
 from megatron.core.dist_checkpointing.serialization import StateDict
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
 from megatron.core.dist_checkpointing.strategies.fully_parallel import (
@@ -2332,6 +2338,7 @@ def _load_model_weights_from_checkpoint(
         "ignore_all",
     ] = "assume_ok_unexpected",
     strict: bool = True,
+    assign_loaded_tensors: bool = False,
 ) -> Optional[Union[StateDict, tuple[StateDict, set[str], set[str]]]]:
     """Load model weights from a checkpoint.
 
@@ -2347,6 +2354,8 @@ def _load_model_weights_from_checkpoint(
             itself. Default False.
         dist_ckpt_strictness: Determine handling of key mismatch during checkpoint load.
         strict: Whether to enforce strict loading (see torch.nn.Module.load_state_dict).
+        assign_loaded_tensors: Load into a meta-device model by assigning the
+            checkpoint tensors instead of copying them into existing storage.
     """
 
     state_dict = dist_checkpointing.load_common_state_dict(checkpoint_path)
@@ -2363,6 +2372,9 @@ def _load_model_weights_from_checkpoint(
     pg_collection = get_pg_collection(model)
     sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs, pg_collection=pg_collection)
 
+    if assign_loaded_tensors:
+        sharded_state_dict = _strip_sharded_tensor_data(sharded_state_dict)
+
     load_strategy = TorchDistLoadShardedStrategy()
     if fully_parallel_load:
         pg_collection = get_pg_collection(model)
@@ -2376,8 +2388,9 @@ def _load_model_weights_from_checkpoint(
     if return_state_dict:
         return state_dict
 
+    load_kwargs = {"assign": True} if assign_loaded_tensors else {}
     if len(model) == 1:
-        _load_model_state_dict(model[0], state_dict["model"], strict)
+        _load_model_state_dict(model[0], state_dict["model"], strict, **load_kwargs)
     else:
         for i in range(len(model)):
             # If there is no corresponding model in the state_dict, it will be ignored.
@@ -2385,7 +2398,7 @@ def _load_model_weights_from_checkpoint(
             model_key = "model%d" % i
             if model_key not in state_dict:
                 continue
-            _load_model_state_dict(model[i], state_dict[model_key], strict)
+            _load_model_state_dict(model[i], state_dict[model_key], strict, **load_kwargs)
 
     # The loaded state dict can own checkpoint staging tensors distinct from
     # the model parameters. Release both state-dict structures before the
@@ -2722,7 +2735,35 @@ def _process_state_dict_for_model_glu_interleaving(
     return model_state_dict
 
 
-def _load_model_state_dict(module: torch.nn.Module, state_dict: dict[str, Any], strict: bool):
+def _strip_sharded_tensor_data(sharded_state_dict: ShardedStateDict) -> ShardedStateDict:
+    """Remove meta tensor data so distributed checkpoint load allocates CPU tensors."""
+
+    def strip_data(value: Any) -> Any:
+        if isinstance(value, ShardedTensor):
+            return value.without_data()
+        if isinstance(value, ShardedTensorFactory):
+            original_build_fn = value.build_fn
+
+            def build_without_data(key: str, data: torch.Tensor, replica_id: Any, flattened_range: Any) -> Any:
+                result = original_build_fn(key, data, replica_id, flattened_range)
+                return dict_list_map_inplace(strip_data, result)
+
+            factory_data = value.data
+            if factory_data is not None and not factory_data.is_meta:
+                factory_data = torch.empty_like(factory_data, device="meta")
+            return replace(value, data=factory_data, build_fn=build_without_data)
+        return value
+
+    return dict_list_map_inplace(strip_data, sharded_state_dict)
+
+
+def _load_model_state_dict(
+    module: torch.nn.Module,
+    state_dict: dict[str, Any],
+    strict: bool,
+    *,
+    assign: bool = False,
+) -> None:
     """Helper function to load state dict with fallback for missing extra states."""
     if HAVE_MEGATRON_FSDP and isinstance(module, MegatronFSDP):
         # Because the state dictionary was generated from the nested module of Megatron-FSDP,
@@ -2730,12 +2771,13 @@ def _load_model_state_dict(module: torch.nn.Module, state_dict: dict[str, Any], 
         # In Megatron-LM, handled via adapter: FullyShardedDataParallel.load_state_dict().
         for key in list(state_dict.keys()):
             state_dict[f"module.{key}"] = state_dict.pop(key)
+    load_kwargs = {"assign": True} if assign else {}
     try:
-        module.load_state_dict(state_dict, strict=strict)
+        module.load_state_dict(state_dict, strict=strict, **load_kwargs)
     except Exception as e:
         if strict:
             # Fallback support for backward compatibility breaking changes in TransformerEngine
-            load_return = module.load_state_dict(state_dict, strict=False)
+            load_return = module.load_state_dict(state_dict, strict=False, **load_kwargs)
             missing = load_return.missing_keys
             unexpected = load_return.unexpected_keys
             non_extra = [k for k in missing + unexpected if not k.endswith("._extra_state")]

--- a/src/megatron/bridge/training/mlm_compat/model.py
+++ b/src/megatron/bridge/training/mlm_compat/model.py
@@ -42,6 +42,7 @@ from megatron.core.transformer.spec_utils import import_module
 from megatron.core.utils import get_model_config
 
 from megatron.bridge.models.logit_dtype import logit_dtype_kwarg
+from megatron.bridge.models.model_provider import _apply_mixed_precision_wrapper
 from megatron.bridge.training.mlm_compat.arguments import _transformer_config_from_args
 from megatron.bridge.utils.instantiate_utils import _validate_target_prefix
 
@@ -318,7 +319,7 @@ def _get_model(
     # Fp16 conversion.
     if args.fp16 or args.bf16:
         config = get_model_config(model[0])
-        model = [Float16Module(config, model_module) for model_module in model]
+        model = _apply_mixed_precision_wrapper(model, config, Float16Module)
 
     # Before TE2.x: The model_module.bfloat16()/model_module.half() above will call the inplace
     #               copy of TE's Float8Tensor, which will write an unwanted value (amax calculated

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -17,6 +17,7 @@ import logging
 import os
 import socket
 from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Generator, Literal, Optional, Union
 
@@ -41,12 +42,24 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 
 logger = logging.getLogger(__name__)
 
+_LOW_MEMORY_MODEL_LOAD = ContextVar("_LOW_MEMORY_MODEL_LOAD", default=False)
+
 HF_BASED_TOKENIZERS = [
     "BertWordPieceLowerCase",
     "BertWordPieceCase",
     "GPT2BPETokenizer",
     "HuggingFaceTokenizer",
 ]
+
+
+@contextmanager
+def low_memory_model_load_context() -> Generator[None, None, None]:
+    """Build CPU-loaded models on meta and assign checkpoint tensors directly."""
+    token = _LOW_MEMORY_MODEL_LOAD.set(True)
+    try:
+        yield
+    finally:
+        _LOW_MEMORY_MODEL_LOAD.reset(token)
 
 
 def _uses_hybrid_rng_tracker(model_cfg: Any) -> bool:
@@ -107,6 +120,17 @@ def megatron_cpu_init_context(config: Any) -> Generator[None, None, None]:
     original_use_cpu_initialization = config.use_cpu_initialization
     config.use_cpu_initialization = True
 
+    try:
+        yield
+    finally:
+        config.use_cpu_initialization = original_use_cpu_initialization
+
+
+@contextmanager
+def megatron_meta_init_context(config: Any) -> Generator[None, None, None]:
+    """Disable CPU master-weight initialization while constructing on meta."""
+    original_use_cpu_initialization = config.use_cpu_initialization
+    config.use_cpu_initialization = False
     try:
         yield
     finally:
@@ -347,10 +371,14 @@ def build_and_load_model(
 
     def _call_model_provider(model_cfg):
         """Handles provider call for both MBridge and MLM providers."""
+        use_meta_init = getattr(model_cfg, "init_model_with_meta_device", False) is True
         if isinstance(model_cfg, ModelProviderMixin):
             if hasattr(model_cfg, "finalize"):
                 model_cfg.finalize()
-            return model_cfg.provide_distributed_model(wrap_with_ddp=False, use_cpu_initialization=use_cpu_init)
+            return model_cfg.provide_distributed_model(
+                wrap_with_ddp=False,
+                use_cpu_initialization=use_cpu_init and not use_meta_init,
+            )
         elif isinstance(model_cfg, ModelConfig):
             if hasattr(model_cfg, "finalize"):
                 model_cfg.finalize()
@@ -396,7 +424,12 @@ def build_and_load_model(
             model_cfg.params_dtype = target_dtype
 
         if use_cpu_init:
-            with megatron_cpu_init_context(model_cfg):
+            init_context = (
+                megatron_meta_init_context(model_cfg)
+                if getattr(model_cfg, "init_model_with_meta_device", False) is True
+                else megatron_cpu_init_context(model_cfg)
+            )
+            with init_context:
                 model = _call_model_provider(model_cfg)
         else:
             model = _call_model_provider(model_cfg)
@@ -408,9 +441,10 @@ def build_and_load_model(
 
             load_modelopt_state(model, checkpoint_path)
 
-        maybe_state_dict = _load_model_weights_from_checkpoint(
-            checkpoint_path, model, return_state_dict=return_state_dict
-        )
+        load_kwargs = {"return_state_dict": return_state_dict}
+        if getattr(model_cfg, "init_model_with_meta_device", False) is True:
+            load_kwargs["assign_loaded_tensors"] = True
+        maybe_state_dict = _load_model_weights_from_checkpoint(checkpoint_path, model, **load_kwargs)
 
         if return_state_dict:
             del model
@@ -478,6 +512,8 @@ def load_megatron_model(
     if use_cpu_init:
         model_cfg.fp8 = None
         model_cfg.fp8_param = False
+        if _LOW_MEMORY_MODEL_LOAD.get():
+            model_cfg.init_model_with_meta_device = True
 
     # Apply model-parallel overrides if provided
     if mp_overrides:

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -532,12 +532,15 @@ def load_megatron_model(
     if model_cfg.pipeline_model_parallel_size == 1 and model_cfg.virtual_pipeline_model_parallel_size is None:
         model_cfg.pipeline_model_parallel_layout = None
 
-    # Flex dispatcher requires TPxEP > 1; fall back to allgather for single-rank export
+    # Flex dispatcher requires TPxEP > 1; fall back to allgather for single-rank export.
+    # Shared-expert overlap is only valid with alltoall/flex and must follow that fallback.
     if getattr(model_cfg, "moe_token_dispatcher_type", None) == "flex":
         tp = getattr(model_cfg, "tensor_model_parallel_size", 1)
         ep = getattr(model_cfg, "expert_model_parallel_size", 1)
         if tp * ep == 1:
             model_cfg.moe_token_dispatcher_type = "allgather"
+            if getattr(model_cfg, "moe_shared_expert_overlap", False):
+                model_cfg.moe_shared_expert_overlap = False
 
     return build_and_load_model(
         checkpoint_path, model_cfg, model_type, mlm_args, return_state_dict, use_cpu_init, skip_temp_dist_context

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -19,6 +19,7 @@ import socket
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Generator, Literal, Optional, Union
 
 import torch
@@ -31,7 +32,7 @@ from megatron.core.utils import get_model_config
 from megatron.training.models.base import ModelConfig
 
 from megatron.bridge.models.model_provider import ModelParallelKwargs, ModelProviderMixin
-from megatron.bridge.training.checkpointing import save_checkpoint
+from megatron.bridge.training.checkpointing import _FileBackedTensorAllocator, save_checkpoint
 from megatron.bridge.training.config import CheckpointConfig, ConfigContainer, LoggerConfig
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer, build_tokenizer
@@ -42,7 +43,9 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 
 logger = logging.getLogger(__name__)
 
-_LOW_MEMORY_MODEL_LOAD = ContextVar("_LOW_MEMORY_MODEL_LOAD", default=False)
+_LOW_MEMORY_MODEL_LOAD: ContextVar[_FileBackedTensorAllocator | None] = ContextVar(
+    "_LOW_MEMORY_MODEL_LOAD", default=None
+)
 
 HF_BASED_TOKENIZERS = [
     "BertWordPieceLowerCase",
@@ -53,13 +56,15 @@ HF_BASED_TOKENIZERS = [
 
 
 @contextmanager
-def low_memory_model_load_context() -> Generator[None, None, None]:
-    """Build CPU-loaded models on meta and assign checkpoint tensors directly."""
-    token = _LOW_MEMORY_MODEL_LOAD.set(True)
-    try:
-        yield
-    finally:
-        _LOW_MEMORY_MODEL_LOAD.reset(token)
+def low_memory_model_load_context(*, mmap_directory: Path | None = None) -> Generator[None, None, None]:
+    """Build CPU models on meta and make oversized checkpoint storage file-backed."""
+    with TemporaryDirectory(prefix=".mbridge-checkpoint-mmap-", dir=mmap_directory) as temporary_directory:
+        allocator = _FileBackedTensorAllocator(Path(temporary_directory))
+        token = _LOW_MEMORY_MODEL_LOAD.set(allocator)
+        try:
+            yield
+        finally:
+            _LOW_MEMORY_MODEL_LOAD.reset(token)
 
 
 def _uses_hybrid_rng_tracker(model_cfg: Any) -> bool:
@@ -444,6 +449,7 @@ def build_and_load_model(
         load_kwargs = {"return_state_dict": return_state_dict}
         if getattr(model_cfg, "init_model_with_meta_device", False) is True:
             load_kwargs["assign_loaded_tensors"] = True
+            load_kwargs["file_backed_allocator"] = _LOW_MEMORY_MODEL_LOAD.get()
         maybe_state_dict = _load_model_weights_from_checkpoint(checkpoint_path, model, **load_kwargs)
 
         if return_state_dict:
@@ -512,7 +518,7 @@ def load_megatron_model(
     if use_cpu_init:
         model_cfg.fp8 = None
         model_cfg.fp8_param = False
-        if _LOW_MEMORY_MODEL_LOAD.get():
+        if _LOW_MEMORY_MODEL_LOAD.get() is not None:
             model_cfg.init_model_with_meta_device = True
 
     # Apply model-parallel overrides if provided

--- a/tests/unit_tests/conversion/launcher/test_arguments.py
+++ b/tests/unit_tests/conversion/launcher/test_arguments.py
@@ -138,6 +138,30 @@ def test_worker_args_disable_distributed_save_for_cpu_export():
     assert "--no-distributed-save" in worker_args
 
 
+def test_worker_args_enable_distributed_save_for_distributed_cpu_export():
+    module = _load_arguments_module()
+    args = module.build_parser(include_execution=True).parse_args(
+        [
+            "export",
+            "--device",
+            "cpu",
+            "--cpu-processes-per-node",
+            "4",
+            "--hf-model",
+            "hf/model",
+            "--megatron-path",
+            "/megatron",
+            "--hf-path",
+            "/hf",
+        ]
+    )
+
+    worker_args = module.conversion_worker_args(args)
+
+    assert "--distributed-save" in worker_args
+    assert "--cpu-processes-per-node" not in worker_args
+
+
 def test_roundtrip_alias_and_worker_args():
     module = _load_arguments_module()
     args = module.build_parser(include_execution=True).parse_args(

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -39,8 +39,8 @@ def _load_cpu_backend():
             return types.SimpleNamespace(hf_pretrained="checkpoint-config")
 
     @contextmanager
-    def low_memory_model_load_context():
-        calls.append(("low_memory_model_load", "enter"))
+    def low_memory_model_load_context(**kwargs):
+        calls.append(("low_memory_model_load", "enter", kwargs))
         try:
             yield
         finally:
@@ -132,7 +132,7 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
         ),
         ("from_hf_pretrained", ("hf/model",), {"trust_remote_code": False}),
         ("from_auto_config", (str(checkpoint), "hf/model"), {"trust_remote_code": False}),
-        ("low_memory_model_load", "enter"),
+        ("low_memory_model_load", "enter", {"mmap_directory": Path("/")}),
         (
             "export_ckpt",
             "checkpoint-config",

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -5,6 +5,7 @@
 import importlib.util
 import sys
 import types
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -37,16 +38,27 @@ def _load_cpu_backend():
             calls.append(("from_auto_config", args, kwargs))
             return types.SimpleNamespace(hf_pretrained="checkpoint-config")
 
+    @contextmanager
+    def low_memory_model_load_context():
+        calls.append(("low_memory_model_load", "enter"))
+        try:
+            yield
+        finally:
+            calls.append(("low_memory_model_load", "exit"))
+
     modules = {
         "megatron": types.ModuleType("megatron"),
         "megatron.bridge": types.ModuleType("megatron.bridge"),
         "megatron.bridge.models": types.ModuleType("megatron.bridge.models"),
         "megatron.bridge.models.hf_pretrained": types.ModuleType("megatron.bridge.models.hf_pretrained"),
         "megatron.bridge.models.hf_pretrained.utils": types.ModuleType("megatron.bridge.models.hf_pretrained.utils"),
+        "megatron.bridge.training": types.ModuleType("megatron.bridge.training"),
+        "megatron.bridge.training.model_load_save": types.ModuleType("megatron.bridge.training.model_load_save"),
         "utils": types.ModuleType("utils"),
     }
     modules["megatron.bridge"].AutoBridge = AutoBridge
     modules["megatron.bridge.models.hf_pretrained.utils"].is_safe_repo = lambda **kwargs: kwargs["trust_remote_code"]
+    modules["megatron.bridge.training.model_load_save"].low_memory_model_load_context = low_memory_model_load_context
     modules["utils"].parse_dtype = lambda value: f"dtype:{value}"
     modules["utils"].prepare_output_directory = lambda *args, **kwargs: calls.append(
         ("prepare_output_directory", args, kwargs)
@@ -120,6 +132,7 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
         ),
         ("from_hf_pretrained", ("hf/model",), {"trust_remote_code": False}),
         ("from_auto_config", (str(checkpoint), "hf/model"), {"trust_remote_code": False}),
+        ("low_memory_model_load", "enter"),
         (
             "export_ckpt",
             "checkpoint-config",
@@ -130,4 +143,5 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
                 "strict": True,
             },
         ),
+        ("low_memory_model_load", "exit"),
     ]

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -63,6 +63,7 @@ def _load_cpu_backend():
     modules["utils"].prepare_output_directory = lambda *args, **kwargs: calls.append(
         ("prepare_output_directory", args, kwargs)
     )
+    modules["utils"].resolve_hf_model_revision = lambda model, revision: f"{model}@{revision}" if revision else model
 
     previous_modules = {name: sys.modules.get(name) for name in modules}
     sys.modules.update(modules)
@@ -116,6 +117,7 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
 
     module.export_checkpoint(
         hf_model="hf/model",
+        hf_revision="0123456789abcdef",  # pragma: allowlist secret
         megatron_path=str(checkpoint),
         hf_path="/hf-export",
         show_progress=False,
@@ -130,8 +132,16 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
             ("/hf-export",),
             {"overwrite": False, "source_paths": [str(checkpoint), "hf/model"]},
         ),
-        ("from_hf_pretrained", ("hf/model",), {"trust_remote_code": False}),
-        ("from_auto_config", (str(checkpoint), "hf/model"), {"trust_remote_code": False}),
+        (
+            "from_hf_pretrained",
+            ("hf/model",),
+            {"trust_remote_code": False, "revision": "0123456789abcdef"},  # pragma: allowlist secret
+        ),
+        (
+            "from_auto_config",
+            (str(checkpoint), "hf/model@0123456789abcdef"),  # pragma: allowlist secret
+            {"trust_remote_code": False},
+        ),
         ("low_memory_model_load", "enter", {"mmap_directory": Path("/")}),
         (
             "export_ckpt",
@@ -145,3 +155,26 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
         ),
         ("low_memory_model_load", "exit"),
     ]
+
+
+def test_export_honors_file_backed_staging_directory(tmp_path, monkeypatch):
+    module, calls = _load_cpu_backend()
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "run_config.yaml").touch()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    monkeypatch.setenv("MEGATRON_BRIDGE_CPU_EXPORT_MMAP_DIRECTORY", str(staging))
+
+    module.export_checkpoint(
+        hf_model="hf/model",
+        hf_revision=None,
+        megatron_path=str(checkpoint),
+        hf_path=str(tmp_path / "hf-export"),
+        show_progress=False,
+        strict=True,
+        trust_remote_code=False,
+        overwrite=False,
+    )
+
+    assert ("low_memory_model_load", "enter", {"mmap_directory": staging}) in calls

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -184,6 +184,11 @@ class TestImportHfToMegatron:
             lambda *args, **kwargs: prepared_outputs.append((args, kwargs)),
         )
         monkeypatch.setattr(cli, "is_safe_repo", lambda *, trust_remote_code, hf_path: trust_remote_code)
+        monkeypatch.setattr(
+            cli,
+            "resolve_hf_model_revision",
+            lambda model, revision: f"{model}@{revision}" if revision else model,
+        )
         monkeypatch.setattr(cli.AutoBridge, "from_hf_pretrained", fake_from_hf_pretrained)
 
         cli.import_checkpoint.__wrapped__(
@@ -261,6 +266,11 @@ class TestExportMegatronToHf:
             lambda *args, **kwargs: prepared_outputs.append((args, kwargs)),
         )
         monkeypatch.setattr(cli, "is_safe_repo", lambda *, trust_remote_code, hf_path: trust_remote_code)
+        monkeypatch.setattr(
+            cli,
+            "resolve_hf_model_revision",
+            lambda model, revision: f"{model}@{revision}" if revision else model,
+        )
         monkeypatch.setattr(cli.AutoBridge, "from_hf_pretrained", fake_from_hf_pretrained)
         monkeypatch.setattr(cli.AutoBridge, "from_auto_config", fake_from_auto_config)
 
@@ -268,6 +278,7 @@ class TestExportMegatronToHf:
         checkpoint_path.mkdir()
         cli.export_checkpoint.__wrapped__(
             hf_model="hf",
+            hf_revision="0123456789abcdef",  # pragma: allowlist secret
             megatron_path=str(checkpoint_path),
             hf_path="/hf-export",
             tp=1,
@@ -291,10 +302,14 @@ class TestExportMegatronToHf:
 
         reference_call = next(call for call in calls if call[0] == "from_hf_pretrained")
         assert reference_call[1] == ("hf",)
-        assert reference_call[2] == {"trust_remote_code": True, "torch_dtype": torch.bfloat16}
+        assert reference_call[2] == {
+            "trust_remote_code": True,
+            "torch_dtype": torch.bfloat16,
+            "revision": "0123456789abcdef",  # pragma: allowlist secret
+        }
 
         bridge_call = next(call for call in calls if call[0] == "from_auto_config")
-        assert bridge_call[1] == (str(checkpoint_path), "hf")
+        assert bridge_call[1] == (str(checkpoint_path), "hf@0123456789abcdef")  # pragma: allowlist secret
         assert bridge_call[2] == {"trust_remote_code": True}
         assert FakeStateBackedBridge.hf_pretrained is reference_pretrained
         assert reference_pretrained.config is checkpoint_config

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -122,6 +122,39 @@ class _FakeHfPretrained:
     config = type("Config", (), {"num_hidden_layers": 1, "num_nextn_predict_layers": 0})()
 
 
+def test_distributed_cpu_initialization_uses_gloo(cli, monkeypatch):
+    calls = []
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setattr(cli.torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.setattr(cli.torch.distributed, "init_process_group", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(
+        cli.torch.cuda,
+        "set_device",
+        lambda *_args, **_kwargs: pytest.fail("distributed CPU export must not initialize CUDA"),
+    )
+
+    cli._ensure_distributed_initialized(45, use_cpu=True)
+
+    assert calls[0]["backend"] == "gloo"
+    assert calls[0]["timeout"].total_seconds() == 45 * 60
+
+
+def test_distributed_cpu_provider_uses_cpu_initialization(cli):
+    provider = _FakeProvider([])
+
+    cli._configure_model_provider(
+        provider,
+        tp=1,
+        pp=2,
+        ep=4,
+        etp=1,
+        dtype=torch.bfloat16,
+        use_cpu=True,
+    )
+
+    assert provider.use_cpu_initialization is True
+
+
 class TestImportHfToMegatron:
     @pytest.mark.parametrize("low_memory_save", [False, True])
     def test_import_saves_megatron_checkpoint_with_tokenizer_metadata(self, cli, monkeypatch, low_memory_save):

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -211,6 +211,34 @@ def test_gpu_export_enables_distributed_save_by_default():
     assert calls[0]["hf_path"] == "/hf"
 
 
+def test_distributed_cpu_export_uses_gloo_backend(monkeypatch):
+    module, cpu_backend, gpu_backend = _load_run_conversion_module()
+    calls = []
+    cpu_backend.export_checkpoint = lambda **kwargs: pytest.fail("must not use the single-process backend")
+    gpu_backend.export_checkpoint = lambda **kwargs: calls.append(kwargs)
+    monkeypatch.setenv("WORLD_SIZE", "2")
+
+    module.main(
+        [
+            "export",
+            "--device",
+            "cpu",
+            "--hf-model",
+            "hf/model",
+            "--megatron-path",
+            "/megatron",
+            "--hf-path",
+            "/hf",
+            "--ep",
+            "2",
+            "--distributed-save",
+        ]
+    )
+
+    assert calls[0]["distributed_save"] is True
+    assert calls[0]["use_cpu"] is True
+
+
 def test_gpu_roundtrip_dispatches_to_gpu_backend():
     module, _, gpu_backend = _load_run_conversion_module()
     calls = []

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -158,6 +158,36 @@ def test_cpu_import_forwards_hf_revision_without_replacing_model_id(monkeypatch)
     assert calls[0]["hf_revision"] == "0123456789abcdef0123456789abcdef01234567"  # pragma: allowlist secret
 
 
+def test_export_forwards_hf_revision_without_replacing_model_id(monkeypatch):
+    module, cpu_backend, _ = _load_run_conversion_module()
+    calls = []
+    cpu_backend.export_checkpoint = lambda **kwargs: calls.append(kwargs)
+    monkeypatch.setattr(
+        module,
+        "resolve_hf_commit_revision",
+        lambda model, revision: "0123456789abcdef0123456789abcdef01234567",  # pragma: allowlist secret
+    )
+
+    module.main(
+        [
+            "export",
+            "--device",
+            "cpu",
+            "--hf-model",
+            "hf/model",
+            "--hf-revision",
+            "release-tag",
+            "--megatron-path",
+            "/checkpoint",
+            "--hf-path",
+            "/hf-export",
+        ]
+    )
+
+    assert calls[0]["hf_model"] == "hf/model"
+    assert calls[0]["hf_revision"] == "0123456789abcdef0123456789abcdef01234567"  # pragma: allowlist secret
+
+
 def test_cpu_import_rejects_hf_revision_for_local_path(tmp_path, monkeypatch):
     module, cpu_backend, _ = _load_run_conversion_module()
     calls = []

--- a/tests/unit_tests/conversion/launcher/test_setup_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_setup_conversion.py
@@ -110,6 +110,47 @@ def test_cpu_backend_rejects_distributed_parallelism():
         module._validate_args(args)
 
 
+def test_distributed_cpu_export_accepts_compatible_topology():
+    module = _load_setup_conversion_module()
+    args = _parse_export(
+        module,
+        "--executor",
+        "slurm",
+        "--nodes",
+        "2",
+        "--cpu-processes-per-node",
+        "4",
+        "--account",
+        "account",
+        "--partition",
+        "partition",
+        "--container-image",
+        "image.sqsh",
+        "--pp",
+        "2",
+        "--ep",
+        "4",
+    )
+
+    module._validate_args(args)
+
+
+def test_distributed_cpu_export_rejects_non_export_command():
+    module = _load_setup_conversion_module()
+    args = _parse(module, "--cpu-processes-per-node", "2")
+
+    with pytest.raises(ValueError, match="supports export only"):
+        module._validate_args(args)
+
+
+def test_distributed_cpu_export_requires_distributed_save():
+    module = _load_setup_conversion_module()
+    args = _parse_export(module, "--cpu-processes-per-node", "2", "--no-distributed-save")
+
+    with pytest.raises(ValueError, match="requires --distributed-save"):
+        module._validate_args(args)
+
+
 def test_cpu_backend_rejects_low_memory_save():
     module = _load_setup_conversion_module()
     args = _parse(module, "--low-memory-save")
@@ -394,6 +435,48 @@ def test_slurm_cpu_executor_does_not_request_gpus(tmp_path, monkeypatch):
     assert executor.kwargs["additional_parameters"] == {"export": "HF_TOKEN,PYTHONPATH"}
     assert executor.kwargs["srun_args"] == []
     assert executor.env_vars == {}
+
+
+def test_slurm_distributed_cpu_executor_uses_cpu_tasks(tmp_path, monkeypatch):
+    module = _load_setup_conversion_module()
+
+    class _SlurmExecutor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    module.run.Packager = lambda: "packager"
+    module.run.LocalTunnel = lambda **kwargs: types.SimpleNamespace(**kwargs)
+    module.run.SlurmExecutor = _SlurmExecutor
+    monkeypatch.setattr(module, "get_nemorun_home", lambda: str(tmp_path))
+    args = _parse_export(
+        module,
+        "--executor",
+        "slurm",
+        "--nodes",
+        "2",
+        "--cpu-processes-per-node",
+        "4",
+        "--cpus-per-task",
+        "16",
+        "--account",
+        "account",
+        "--partition",
+        "partition",
+        "--container-image",
+        "image.sqsh",
+        "--pp",
+        "2",
+        "--ep",
+        "4",
+    )
+    module._validate_args(args)
+
+    executor = module._build_executor(args, [], [])
+
+    assert executor.kwargs["nodes"] == 2
+    assert executor.kwargs["ntasks_per_node"] == 4
+    assert executor.kwargs["cpus_per_task"] == 16
+    assert "gpus_per_node" not in executor.kwargs
 
 
 def test_slurm_cpu_executor_can_request_gpu_runtime(tmp_path, monkeypatch):

--- a/tests/unit_tests/training/mlm_compat/test_get_model.py
+++ b/tests/unit_tests/training/mlm_compat/test_get_model.py
@@ -16,6 +16,7 @@ import argparse
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+import torch
 from megatron.core.enums import ModelType
 from megatron.core.transformer import TransformerConfig
 
@@ -347,6 +348,49 @@ class TestGetModel:
 
         # Verify Float16Module was created
         mock_float16_module.assert_called_once_with(mock_config, mock_model)
+
+    @patch("megatron.bridge.training.mlm_compat.model.mpu")
+    @patch("megatron.bridge.training.mlm_compat.model.tensor_parallel")
+    @patch("megatron.bridge.training.mlm_compat.model.get_model_config")
+    @patch("megatron.bridge.training.mlm_compat.model.correct_amax_history_if_needed")
+    def test_get_model_bf16_preserves_float32_expert_bias(
+        self,
+        mock_correct_amax,
+        mock_get_model_config,
+        mock_tensor_parallel,
+        mock_mpu,
+        mock_args,
+        mock_config,
+    ):
+        """The legacy checkpoint path must preserve the router bias in FP32."""
+        mock_args.bf16 = True
+        mock_mpu.get_pipeline_model_parallel_world_size.return_value = 1
+        mock_mpu.is_pipeline_first_stage.return_value = True
+        mock_mpu.is_pipeline_last_stage.return_value = True
+        mock_mpu.get_data_parallel_rank.return_value = 0
+        mock_mpu.get_context_parallel_rank.return_value = 0
+        mock_mpu.get_tensor_model_parallel_rank.return_value = 0
+        mock_mpu.get_pipeline_model_parallel_rank.return_value = 0
+
+        router = torch.nn.Module()
+        router._maintain_float32_expert_bias = True
+        router.expert_bias = torch.nn.Parameter(torch.tensor([0.1, -0.2], dtype=torch.float32))
+        model = torch.nn.Module()
+        model.router = router
+        model.model_type = ModelType.encoder_or_decoder
+        model.cuda = MagicMock(return_value=model)
+        provider = MagicMock(return_value=model)
+        mock_get_model_config.return_value = mock_config
+
+        class BFloat16Wrapper(torch.nn.Module):
+            def __init__(self, config, module):
+                super().__init__()
+                self.module = module.bfloat16()
+
+        with patch("megatron.bridge.training.mlm_compat.model.Float16Module", BFloat16Wrapper):
+            result = _get_model(mock_args, provider, mock_config)
+
+        assert result[0].module.router.expert_bias.dtype is torch.float32
 
     @patch("megatron.bridge.training.mlm_compat.model.mpu")
     @patch("megatron.bridge.training.mlm_compat.model.tensor_parallel")

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -23,6 +23,7 @@ from unittest.mock import Mock, mock_open, patch
 import numpy as np
 import pytest
 import torch
+from megatron.core.dist_checkpointing.mapping import ShardedTensor, ShardedTensorFactory
 from megatron.core.msc_utils import MultiStorageClientFeature
 
 from megatron.bridge.training.checkpointing import (
@@ -47,6 +48,7 @@ from megatron.bridge.training.checkpointing import (
     _record_dataloader_state_dir,
     _save_hf_adapter_weights,
     _save_hf_weights,
+    _strip_sharded_tensor_data,
     checkpoint_exists,
     cleanup_old_non_persistent_checkpoint,
     create_checkpoint_manager,
@@ -3380,6 +3382,48 @@ class TestLoadModelStateDictHelper:
 
         with pytest.raises(Exception):
             _load_model_state_dict(module, {"w": 1}, strict=False)
+
+    def test_load_model_state_dict_assigns_into_meta_module(self):
+        """Assignment materializes a meta module without copying checkpoint storage."""
+        module = torch.nn.Linear(3, 2, device="meta")
+        state_dict = {
+            "weight": torch.randn(2, 3),
+            "bias": torch.randn(2),
+        }
+
+        _load_model_state_dict(module, state_dict, strict=True, assign=True)
+
+        assert module.weight.device.type == "cpu"
+        assert module.bias.device.type == "cpu"
+        assert module.weight.data_ptr() == state_dict["weight"].data_ptr()
+        assert module.bias.data_ptr() == state_dict["bias"].data_ptr()
+
+
+class TestStripShardedTensorData:
+    """Tests for low-memory distributed checkpoint load metadata."""
+
+    def test_strips_direct_sharded_tensor_data(self):
+        tensor = ShardedTensor.from_rank_offsets("weight", torch.empty(2, 3, device="meta"))
+
+        result = _strip_sharded_tensor_data({"model": {"weight": tensor}})
+
+        assert result["model"]["weight"].data is None
+
+    def test_factory_builds_sharded_tensors_without_data(self):
+        data = torch.empty(2, 3, device="meta")
+        factory = ShardedTensorFactory(
+            key="weight",
+            data=data,
+            build_fn=lambda key, tensor, replica_id, flattened_range: ShardedTensor.from_rank_offsets(key, tensor),
+            merge_fn=lambda value: value,
+        )
+
+        result = _strip_sharded_tensor_data({"model": {"weight": factory}})
+        stripped_factory = result["model"]["weight"]
+        built = stripped_factory.build()
+
+        assert stripped_factory.data.is_meta
+        assert built.data is None
 
 
 class TestMegatronLMCompatibility:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -37,6 +37,7 @@ from megatron.bridge.training.checkpointing import (
     _build_auto_bridge_for_save,
     _clear_auto_bridge_cache,
     _extract_megatron_lm_args_from_state_dict,
+    _FileBackedTensorAllocator,
     _get_checkpoint_format,
     _get_non_persistent_iteration,
     _has_global_non_persistent_checkpoint,
@@ -46,6 +47,8 @@ from megatron.bridge.training.checkpointing import (
     _load_model_state_dict,
     _load_non_persistent_base_checkpoint,
     _record_dataloader_state_dir,
+    _replace_sharded_tensor_data_with_file_backed,
+    _requires_file_backed_checkpoint_load,
     _save_hf_adapter_weights,
     _save_hf_weights,
     _strip_sharded_tensor_data,
@@ -3424,6 +3427,56 @@ class TestStripShardedTensorData:
 
         assert stripped_factory.data.is_meta
         assert built.data is None
+
+
+class TestFileBackedCheckpointTensors:
+    """Tests for oversized CPU checkpoint storage backed by sparse files."""
+
+    def test_allocator_reuses_sparse_storage_block(self, tmp_path):
+        allocator = _FileBackedTensorAllocator(tmp_path, block_bytes=4096)
+
+        first = allocator.allocate_like(torch.empty(2, 3, dtype=torch.float32, device="meta"))
+        second = allocator.allocate_like(torch.empty(4, dtype=torch.bfloat16, device="meta"))
+        first.copy_(torch.arange(6, dtype=torch.float32).view(2, 3))
+        second.fill_(2)
+
+        assert first.device.type == "cpu"
+        assert second.device.type == "cpu"
+        assert len(allocator.blocks) == 1
+        assert (tmp_path / "block-00000.bin").stat().st_size == 4096
+        assert first.tolist() == [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+        assert second.tolist() == [2.0, 2.0, 2.0, 2.0]
+
+    def test_factory_build_and_merge_results_are_file_backed(self, tmp_path):
+        allocator = _FileBackedTensorAllocator(tmp_path, block_bytes=4096)
+        data = torch.empty(2, 3, device="meta")
+        factory = ShardedTensorFactory(
+            key="weight",
+            data=data,
+            build_fn=lambda key, tensor, replica_id, flattened_range: ShardedTensor.from_rank_offsets(key, tensor),
+            merge_fn=lambda value: value,
+        )
+
+        result = _replace_sharded_tensor_data_with_file_backed({"model": {"weight": factory}}, allocator)
+        mapped_factory = result["model"]["weight"]
+        built = mapped_factory.build()
+        merged = mapped_factory.merge_fn(torch.full((2, 3), 7.0))
+
+        assert mapped_factory.data.is_meta
+        assert built.data.device.type == "cpu"
+        assert merged.device.type == "cpu"
+        assert merged.tolist() == [[7.0, 7.0, 7.0], [7.0, 7.0, 7.0]]
+        assert len(allocator.blocks) == 1
+
+    def test_large_model_selects_file_backed_load(self, monkeypatch):
+        model = [torch.nn.Linear(4, 4, device="meta")]
+        model_bytes = sum(tensor.numel() * tensor.element_size() for tensor in model[0].parameters())
+        monkeypatch.setattr(
+            "megatron.bridge.training.checkpointing._available_memory_bytes",
+            lambda: model_bytes,
+        )
+
+        assert _requires_file_backed_checkpoint_load(model)
 
 
 class TestMegatronLMCompatibility:

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -33,7 +33,9 @@ from megatron.bridge.training.model_load_save import (
     load_megatron_model,
     load_model_config,
     load_tokenizer,
+    low_memory_model_load_context,
     megatron_cpu_init_context,
+    megatron_meta_init_context,
     save_megatron_model,
     temporary_distributed_context,
     torch_dtype_from_mcore_config,
@@ -152,6 +154,15 @@ class TestMegatronCpuInitContext:
             assert config.use_cpu_initialization is True
 
         assert config.use_cpu_initialization is False
+
+    def test_meta_context_disables_cpu_master_weight_initialization(self):
+        """Meta construction must not allocate or copy temporary CPU master weights."""
+        config = SimpleNamespace(use_cpu_initialization=True)
+
+        with megatron_meta_init_context(config):
+            assert config.use_cpu_initialization is False
+
+        assert config.use_cpu_initialization is True
 
     def test_megatron_cpu_init_context_with_already_true(self):
         """Test context manager when use_cpu_initialization is already True."""
@@ -747,6 +758,31 @@ class TestLoadMegatronModel:
         assert cfg.sequence_parallel is False
         assert cfg.virtual_pipeline_model_parallel_size is None
         assert cfg.hierarchical_context_parallel_sizes is None
+
+    @patch("megatron.bridge.training.model_load_save.build_and_load_model")
+    @patch("megatron.bridge.training.model_load_save.load_model_config")
+    def test_low_memory_context_enables_meta_device_for_cpu_load(self, mock_load_model_config, mock_build_and_load):
+        """Verify the CPU-export context builds checkpoint models on meta."""
+        cfg = SimpleNamespace(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            sequence_parallel=False,
+            virtual_pipeline_model_parallel_size=None,
+            hierarchical_context_parallel_sizes=None,
+            init_model_with_meta_device=False,
+            fp8=None,
+            fp8_param=False,
+        )
+        mock_load_model_config.return_value = (cfg, None)
+        mock_build_and_load.return_value = Mock()
+
+        with low_memory_model_load_context():
+            load_megatron_model("/ckpt", use_cpu_init=True)
+
+        assert cfg.init_model_with_meta_device is True
 
     @patch("megatron.bridge.training.model_load_save.build_and_load_model")
     @patch("megatron.bridge.training.model_load_save.load_model_config")

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -786,6 +786,32 @@ class TestLoadMegatronModel:
 
     @patch("megatron.bridge.training.model_load_save.build_and_load_model")
     @patch("megatron.bridge.training.model_load_save.load_model_config")
+    def test_load_megatron_model_disables_shared_expert_overlap_on_flex_fallback(
+        self, mock_load_model_config, mock_build_and_load
+    ):
+        """Verify single-rank flex fallback also disables its incompatible overlap."""
+        cfg = SimpleNamespace(
+            tensor_model_parallel_size=8,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=8,
+            expert_tensor_parallel_size=1,
+            sequence_parallel=True,
+            virtual_pipeline_model_parallel_size=None,
+            hierarchical_context_parallel_sizes=None,
+            moe_token_dispatcher_type="flex",
+            moe_shared_expert_overlap=True,
+        )
+        mock_load_model_config.return_value = (cfg, None)
+        mock_build_and_load.return_value = Mock()
+
+        load_megatron_model("/ckpt")
+
+        assert cfg.moe_token_dispatcher_type == "allgather"
+        assert cfg.moe_shared_expert_overlap is False
+
+    @patch("megatron.bridge.training.model_load_save.build_and_load_model")
+    @patch("megatron.bridge.training.model_load_save.load_model_config")
     def test_load_megatron_model_disables_cuda_graphs_for_hybrid_configs(
         self, mock_load_model_config, mock_build_and_load
     ):


### PR DESCRIPTION
## Summary

- preserve K-EXAONE's FP32 expert-score correction bias during export
- add memory-bounded distributed CPU checkpoint loading and Hugging Face export support
- verify complete CPU and GPU exports in the K-EXAONE 2 model card

## Verification

- 48-GPU export: all 59,396 tensors matched the pinned source bitwise across 1,498,715,008,512 payload bytes; native Transformers reload passed with 1,165 state tensors
- 48-process CPU export: all 59,396 tensors and 749,357,484,800 values matched bitwise with zero dtype conversions; native Transformers reload passed with 1,165 state tensors
- dense two-rank distributed CPU round trip matched exactly
- `uv run --no-project --with pre-commit pre-commit run --all-files`
