### PR TITLE
fix(conversion): verify DeepSeek V3 CPU export

### DIFF
--- a/examples/model_verification_cards/deepseek-v3/card.yaml
+++ b/examples/model_verification_cards/deepseek-v3/card.yaml
@@ -7,19 +7,20 @@ summary: >
   verified against the pinned blockwise-FP8 checkpoint. The canonical
   pretrain_performance.H100 1024-GPU BF16, pretrain_performance.GB200 256-GPU
   MXFP8, and pretrain_performance.GB300 256-GPU MXFP8 recipes are also verified.
+  A distributed CPU export of the same pinned checkpoint is also verified.
   Timing and throughput metrics from future functional training items remain
-  sanity checks rather than optimized performance results. CPU conversion,
-  forward correlation, functional training, fine-tuning, and checkpoint-resume
+  sanity checks rather than optimized performance results. CPU import, forward
+  correlation, functional training, fine-tuning, and checkpoint-resume
   verification remain deferred.
 verification_index:
   model_level:
     verified:
       - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
       - megatron_to_hf_gpu
       - inference
     unverified:
       - hf_to_megatron_cpu
-      - megatron_to_hf_cpu
       - manual_forward_pass
   training:
     GB300:
@@ -69,14 +70,28 @@ items:
       matched all 46,183 model tensors and 684,489,845,504 values exactly.
 
   megatron_to_hf_cpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    bridge_commit: b758d52cb3d12e3ca316d41d9527e6072a1c325b  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device cpu
+      --nodes 4 --cpu-processes-per-node 8 --cpus-per-task 16 --mem 0
+      --exclusive --hf-model deepseek-ai/DeepSeek-V3
+      --hf-revision e815299b0bcbac849fa540c768ef21845365c9eb
+      --megatron-path work/model-verification/deepseek-v3/imported-megatron/iter_0000000
+      --hf-path work/model-verification/deepseek-v3/cpu-hf-export
+      --torch-dtype bfloat16 --export-weight-dtype bfloat16
+      --tp 1 --pp 4 --ep 8 --etp 1 --distributed-timeout-minutes 240
+      --distributed-save --save-every-n-ranks 1 --no-progress
+    last_verified: 2026-08-26
     expected_result: >
-      A CPU export from a verified Megatron checkpoint must preserve every
-      mapped tensor and strictly reload as DeepseekV3ForCausalLM. This workflow
-      is deferred by this card.
+      The 32-process distributed CPU export exits successfully and writes all
+      163 source-shaped shards. The index contains exactly 46,183 BF16 model
+      tensors; an exhaustive audit matches all 684,489,845,504 values against
+      the pinned source after blockwise dequantization of all 45,808 FP8
+      tensors and 59 other declared dtype normalizations. Transformers strictly
+      reloads the output as DeepseekV3ForCausalLM with all 967 state tensors and
+      no loading discrepancies.
 
   megatron_to_hf_gpu:
     status: verified

--- a/scripts/conversion/run_conversion.py
+++ b/scripts/conversion/run_conversion.py
@@ -74,8 +74,8 @@ def _validate_args(args: argparse.Namespace) -> None:
             raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
-        if args.device == "cpu" and args.export_weight_dtype is not None:
-            raise ValueError("--export-weight-dtype is only supported by the GPU backend.")
+        if args.device == "cpu" and not distributed_cpu and args.export_weight_dtype is not None:
+            raise ValueError("--export-weight-dtype requires distributed CPU export or the GPU backend.")
 
 
 def _run_import(args: argparse.Namespace) -> None:

--- a/scripts/conversion/setup_conversion.py
+++ b/scripts/conversion/setup_conversion.py
@@ -161,8 +161,8 @@ def _validate_args(args: argparse.Namespace) -> None:
             raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
-        if args.device == "cpu" and args.export_weight_dtype is not None:
-            raise ValueError("--export-weight-dtype is only supported by the GPU backend.")
+        if args.device == "cpu" and not distributed_cpu and args.export_weight_dtype is not None:
+            raise ValueError("--export-weight-dtype requires distributed CPU export or the GPU backend.")
 
 
 def _build_executor(

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -262,10 +262,13 @@ def test_distributed_cpu_export_uses_gloo_backend(monkeypatch):
             "--ep",
             "2",
             "--distributed-save",
+            "--export-weight-dtype",
+            "bfloat16",
         ]
     )
 
     assert calls[0]["distributed_save"] is True
+    assert calls[0]["export_weight_dtype"] == "bfloat16"
     assert calls[0]["use_cpu"] is True
 
 
@@ -350,7 +353,7 @@ def test_cpu_worker_rejects_parallelism():
 def test_cpu_worker_rejects_export_weight_dtype():
     module, _, _ = _load_run_conversion_module()
 
-    with pytest.raises(ValueError, match="only supported by the GPU backend"):
+    with pytest.raises(ValueError, match="requires distributed CPU export or the GPU backend"):
         module.main(
             [
                 "export",

--- a/tests/unit_tests/conversion/launcher/test_setup_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_setup_conversion.py
@@ -130,6 +130,8 @@ def test_distributed_cpu_export_accepts_compatible_topology():
         "2",
         "--ep",
         "4",
+        "--export-weight-dtype",
+        "bfloat16",
     )
 
     module._validate_args(args)
@@ -217,7 +219,7 @@ def test_cpu_export_rejects_export_weight_dtype():
     module = _load_setup_conversion_module()
     args = _parse_export(module, "--export-weight-dtype", "float32")
 
-    with pytest.raises(ValueError, match="only supported by the GPU backend"):
+    with pytest.raises(ValueError, match="requires distributed CPU export or the GPU backend"):
         module._validate_args(args)
 
 


### PR DESCRIPTION
## Summary

- allow explicit BF16 output for distributed CPU export of blockwise-FP8 checkpoints
- verify the complete DeepSeek V3 CPU export in its model card
- stack shared distributed CPU export support on #5830

## Verification

- 32-process CPU export completed and wrote all 163 source-shaped shards
- exact audit passed for 46,183 tensors and 684,489,845,504 values after 45,808 blockwise-FP8 dequantizations and 59 declared dtype normalizations
- native Transformers reload passed as DeepseekV3ForCausalLM with 967 state tensors
- 51 focused launcher tests passed
- model verification card validator passed
- uv run pre-commit run --all-files passed

Depends on #5830.