### PR TITLE
fix(conversion): verify Kimi K3 CPU and GPU export

### DIFF
--- a/examples/model_verification_cards/kimi-k3/card.yaml
+++ b/examples/model_verification_cards/kimi-k3/card.yaml
@@ -7,19 +7,19 @@ summary: >
   timing and throughput metrics are sanity checks, not optimized performance
   results. This card covers the Kimi K3 language backbone in the published
   multimodal checkpoint. It does not claim support for the vision tower or
-  multimodal inputs. Full-checkpoint GPU import and deterministic Megatron
-  greedy text generation are verified. CPU conversion, GPU export,
-  full-model Hugging Face/Megatron forward correlation, and every training
-  workflow remain unverified.
+  multimodal inputs. Full-checkpoint GPU import, deterministic Megatron greedy
+  text generation, and complete distributed CPU and GPU exports are verified.
+  CPU import, full-model Hugging Face/Megatron forward correlation, and every
+  training workflow remain unverified.
 verification_index:
   model_level:
     verified:
       - hf_to_megatron_gpu
+      - megatron_to_hf_cpu
+      - megatron_to_hf_gpu
       - inference
     unverified:
       - hf_to_megatron_cpu
-      - megatron_to_hf_cpu
-      - megatron_to_hf_gpu
       - manual_forward_pass
   training:
     GB300:
@@ -67,39 +67,73 @@ items:
       parity is tracked separately by megatron_to_hf_gpu.
 
   megatron_to_hf_cpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    bridge_commit: 5336903ad2095bcc6308f41216f8551068d39ba3  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device cpu
+      --nodes 16 --cpu-processes-per-node 8 --cpus-per-task 16 --mem 0
+      --exclusive --hf-model moonshotai/Kimi-K3
+      --hf-revision 9f62e4e9fffbd0a83ddd60e1c209d828994b3569
+      --megatron-path work/model-verification/kimi-k3/imported-megatron/iter_0000000
+      --hf-path work/model-verification/kimi-k3/cpu-hf-export
+      --torch-dtype bfloat16 --export-weight-dtype bfloat16
+      --tp 4 --pp 4 --ep 8 --etp 4 --trust-remote-code
+      --distributed-timeout-minutes 240 --distributed-save
+      --save-every-n-ranks 1 --no-progress
+    last_verified: 2026-08-26
     expected_result: >
-      No CPU Megatron-to-Hugging-Face conversion result is claimed. Future
-      verification depends on a complete persisted Megatron import and must
-      write, strictly reload, and exactly audit the exported Hugging Face
-      language-backbone weights against the pinned source revision.
+      The 128-process distributed CPU export writes a plain BF16 language
+      backbone with exactly 249,924 indexed keys and 2,779,931,837,184 values.
+      An exhaustive audit matches every value exactly after reference
+      dequantization of all 247,296 source MXFP4 expert weights and 506 declared
+      FP32-to-BF16 dtype normalizations among the other 2,628 tensors: 92 MoE
+      gate correction biases, plus 69 each for A_log, dt_bias, k_conv1d,
+      q_conv1d, v_conv1d, and o_norm. The exported configuration contains no
+      quantization_config. Under
+      Transformers 4.56.2, a strict metadata reload instantiates the plain
+      architecture and tokenizer. It validates the documented 69 A_log
+      checkpoint tensors with 96 active plus 32 zero padding values against the
+      runtime's 96-value shapes, and every other exported state key and shape
+      matches exactly. A scoped Transformers 4.56.2 compatibility override
+      registers the exported eight-item extra_special_tokens list as additional
+      special tokens, and a tokenizer encode/decode round trip is exact;
+      exhaustive tensor values are covered by the independent audit above.
 
   megatron_to_hf_gpu:
-    status: unverified
+    status: verified
     precision: bf16
-    command: null
-    last_verified: null
+    bridge_commit: 619c5a75ec40ce5e6b9dc7074ffb774bf3bc91aa  # pragma: allowlist secret
+    command: >
+      ./scripts/conversion/convert.sh export --executor slurm --device gpu
+      --nodes 16 --gpus-per-node 8 --hf-model moonshotai/Kimi-K3
+      --hf-revision 9f62e4e9fffbd0a83ddd60e1c209d828994b3569
+      --megatron-path work/model-verification/kimi-k3/imported-megatron/iter_0000000
+      --hf-path work/model-verification/kimi-k3/gpu-hf-export
+      --torch-dtype bfloat16 --tp 4 --pp 4 --ep 8 --etp 4
+      --trust-remote-code --distributed-timeout-minutes 240
+      --distributed-save --save-every-n-ranks 1 --no-progress
+    last_verified: 2026-08-26
     expected_result: >
-      No GPU Megatron-to-Hugging-Face conversion result is claimed. All 69
-      source KDA A_log tensors were audited: each stores 96 active heads plus
-      32 zero-valued inactive entries, for 2,208 checked padding values.
-      Import validation drops only this zero padding, and export unit tests
-      restore it with zeros. A four-layer diagnostic proxy completed
-      low-memory GPU import and distributed streaming export. Its seven
-      safetensors shards and index, totaling 58,482,941,904 bytes, were
-      byte-identical to an export from the previous default-save import; this
-      validates the low-memory I/O behavior, not full-model parity. Against the
-      published proxy source, all 16,402 keys and shapes matched and A_log
-      padding was valid. Three o_norm tensors changed from FP32 to BF16, and
-      16,128 value mismatches were concentrated in MXFP4 expert packed weights
-      and scales because import dequantizes them to BF16 before export
-      requantizes them. Full verification therefore still requires the pinned
-      complete model to export and strictly reload, exact comparison of
-      lossless tensors, and a declared numerical criterion for lossy MXFP4
-      reconstruction.
+      The complete 128-GPU distributed export writes 96 safetensors shards and
+      all 497,220 source keys. All 2,628 non-MXFP4 tensors and
+      57,191,006,976 values match exactly after 69 declared FP32-to-BF16 dtype
+      normalizations. All 247,296 re-quantized MXFP4 expert pairs and
+      2,722,740,830,208 dequantized values also match exactly: minimum and
+      aggregate cosine similarity are both 1.0, with zero normalized RMSE and
+      zero maximum absolute error. Under the model's pinned Transformers 4.56.2
+      runtime, a strict metadata reload instantiates the configuration,
+      tokenizer, and ModelOpt-compressed architecture. It accounts for the 371
+      dense checkpoint weights that ModelOpt represents as 742 packed/scale
+      runtime states and validates their MXFP4 geometry. It also validates the
+      69 A_log tensors whose checkpoint shapes contain 96 active values plus 32
+      zero padding values while the runtime exposes only the active values;
+      every other state key and shape matches exactly. The model compatibility
+      guard skips meta initialization for Linear weights ModelOpt has already
+      replaced. A scoped Transformers 4.56.2 compatibility override registers
+      the exported eight-item extra_special_tokens list as additional special
+      tokens, and a tokenizer encode/decode round trip is exact; exhaustive
+      tensor values are covered by the independent audit above.
 
   manual_forward_pass:
     status: unverified

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -100,8 +100,9 @@ def _maybe_generate_pipeline_layout(bridge: AutoBridge, model_provider: GPTModel
     if pp <= 1 or not hasattr(bridge._model_bridge, "generate_pipeline_layout"):
         return False
     hf_config = bridge.hf_pretrained.config
-    num_layers = hf_config.num_hidden_layers
-    mtp_layers = getattr(hf_config, "num_nextn_predict_layers", 0) or 0
+    model_config = getattr(hf_config, "text_config", hf_config)
+    num_layers = model_config.num_hidden_layers
+    mtp_layers = getattr(model_config, "num_nextn_predict_layers", 0) or 0
     model_provider.pipeline_model_parallel_layout = bridge._model_bridge.generate_pipeline_layout(
         num_layers, pp, mtp_layers
     )

--- a/scripts/conversion/run_conversion.py
+++ b/scripts/conversion/run_conversion.py
@@ -74,8 +74,8 @@ def _validate_args(args: argparse.Namespace) -> None:
             raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
-        if args.device == "cpu" and args.export_weight_dtype is not None:
-            raise ValueError("--export-weight-dtype is only supported by the GPU backend.")
+        if args.device == "cpu" and not distributed_cpu and args.export_weight_dtype is not None:
+            raise ValueError("--export-weight-dtype requires distributed CPU export or the GPU backend.")
 
 
 def _run_import(args: argparse.Namespace) -> None:

--- a/scripts/conversion/setup_conversion.py
+++ b/scripts/conversion/setup_conversion.py
@@ -161,8 +161,8 @@ def _validate_args(args: argparse.Namespace) -> None:
             raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
-        if args.device == "cpu" and args.export_weight_dtype is not None:
-            raise ValueError("--export-weight-dtype is only supported by the GPU backend.")
+        if args.device == "cpu" and not distributed_cpu and args.export_weight_dtype is not None:
+            raise ValueError("--export-weight-dtype requires distributed CPU export or the GPU backend.")
 
 
 def _build_executor(

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1248,6 +1248,10 @@ class AutoBridge(Generic[MegatronModelT]):
             ignored_source_key_prefixes = (
                 _mtp_source_key_prefixes(source, hf_config, model_config) if mtp_disabled else ()
             ) or None
+            key_to_filename_map_override = None
+            export_key_map = getattr(type(bridge), "get_hf_export_key_to_filename_map", None)
+            if weight_dtype is not None and export_key_map is not None:
+                key_to_filename_map_override = export_key_map(source.key_to_filename_map, weight_dtype)
             source.save_generator(
                 generator,
                 path,
@@ -1256,6 +1260,7 @@ class AutoBridge(Generic[MegatronModelT]):
                 save_every_n_ranks=save_every_n_ranks,
                 ignored_source_key_prefixes=ignored_source_key_prefixes,
                 ignored_source_key_suffixes=("_scale_inv",) if weight_dtype is not None else None,
+                key_to_filename_map_override=key_to_filename_map_override,
             )
         else:
             # Config-only path: shard and write safetensors directly

--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -49,6 +49,7 @@ from megatron.bridge.models.conversion.model_bridge import (
 )
 from megatron.bridge.models.conversion.utils import get_causal_lm_class_name_via_auto_map
 from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hf_pretrained.base import _strip_quantization_config
 from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM, _ConfigOnlyPretrainedShim
 from megatron.bridge.models.hf_pretrained.masked_lm import PreTrainedMaskedLM
 from megatron.bridge.models.hf_pretrained.safe_config_loader import safe_load_config_with_retry
@@ -1107,6 +1108,7 @@ class AutoBridge(Generic[MegatronModelT]):
                         path,
                         original_source_path=source_path,
                         additional_files=additional_files,
+                        strip_quantization_config=weight_dtype is not None,
                     )
                 else:
                     import json
@@ -1114,6 +1116,8 @@ class AutoBridge(Generic[MegatronModelT]):
                     # A bridge built directly from a config has no reference artifacts to preserve.
                     Path(path).mkdir(parents=True, exist_ok=True)
                     config_dict = self.hf_pretrained.to_dict()
+                    if weight_dtype is not None:
+                        _strip_quantization_config(config_dict)
                     if not self.trust_remote_code:
                         config_dict.pop("auto_map", None)
                     with open(Path(path) / "config.json", "w") as _f:
@@ -1123,7 +1127,10 @@ class AutoBridge(Generic[MegatronModelT]):
                 # Get bridge-level ADDITIONAL_FILE_PATTERNS if configured
                 additional_files = getattr(self._model_bridge, "ADDITIONAL_FILE_PATTERNS", None) or None
                 self.hf_pretrained.save_artifacts(
-                    path, original_source_path=source_path, additional_files=additional_files
+                    path,
+                    original_source_path=source_path,
+                    additional_files=additional_files,
+                    strip_quantization_config=weight_dtype is not None,
                 )
 
             if model_bridge is not None:

--- a/src/megatron/bridge/models/hf_pretrained/base.py
+++ b/src/megatron/bridge/models/hf_pretrained/base.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 import shutil
 from abc import ABC, abstractmethod
@@ -20,12 +21,35 @@ from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Union
 
 import torch
-from transformers import AutoConfig, PreTrainedModel
+from transformers import AutoConfig, PretrainedConfig, PreTrainedModel
 
 from megatron.bridge.models.hf_pretrained.state import SafeTensorsStateSource, StateDict, StateSource
 
 
 logger = logging.getLogger(__name__)
+
+
+def _strip_quantization_config(value: object, seen: set[int] | None = None) -> None:
+    """Recursively remove Hugging Face quantization metadata in place."""
+    if seen is None:
+        seen = set()
+    value_id = id(value)
+    if value_id in seen:
+        return
+    seen.add(value_id)
+
+    if isinstance(value, dict):
+        value.pop("quantization_config", None)
+        for nested_value in value.values():
+            _strip_quantization_config(nested_value, seen)
+    elif isinstance(value, (list, tuple)):
+        for nested_value in value:
+            _strip_quantization_config(nested_value, seen)
+    elif isinstance(value, PretrainedConfig):
+        if "quantization_config" in vars(value):
+            delattr(value, "quantization_config")
+        for nested_value in vars(value).values():
+            _strip_quantization_config(nested_value, seen)
 
 
 class PreTrainedBase(ABC):
@@ -167,6 +191,8 @@ class PreTrainedBase(ABC):
         save_directory: Union[str, Path],
         original_source_path: Optional[Union[str, Path]] = None,
         additional_files: Optional[List[str]] = None,
+        *,
+        strip_quantization_config: bool = True,
     ):
         """
         Saves all loaded, generic artifacts that have a `save_pretrained` method
@@ -182,6 +208,9 @@ class PreTrainedBase(ABC):
             additional_files: Optional list of additional file names or patterns to download/copy
                 from the source. Supports both exact file names (e.g., "vocab.json") and glob
                 patterns (e.g., "*.json"). These files will be copied from the source path.
+            strip_quantization_config: Remove quantization metadata from the saved config,
+                including nested text or vision configs. Plain-weight exports must enable this;
+                quantized exports must disable it.
         """
         save_path = Path(save_directory)
         save_path.mkdir(parents=True, exist_ok=True)
@@ -190,19 +219,17 @@ class PreTrainedBase(ABC):
 
         _ = getattr(self, "config")  # trigger lazy loading of config
         if hasattr(self, "_config") and self._config is not None:
-            if hasattr(self._config, "quantization_config"):
-                # quantized export is not supported currently
-                del self._config.quantization_config
+            config_to_save = self._config
+            if isinstance(config_to_save, PretrainedConfig):
+                config_to_save = copy.deepcopy(config_to_save)
+                if strip_quantization_config:
+                    _strip_quantization_config(config_to_save)
             auto_map_missing = object()
-            auto_map = vars(self._config).get("auto_map", auto_map_missing)
+            auto_map = vars(config_to_save).get("auto_map", auto_map_missing)
             strip_auto_map = auto_map is not auto_map_missing and getattr(self, "trust_remote_code", False) is not True
             if strip_auto_map:
-                delattr(self._config, "auto_map")
-            try:
-                self._config.save_pretrained(save_path)
-            finally:
-                if strip_auto_map:
-                    self._config.auto_map = auto_map
+                delattr(config_to_save, "auto_map")
+            config_to_save.save_pretrained(save_path)
 
         # Iterate over required artifacts to save them in a predictable order
         for name in self.ARTIFACTS:

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -702,6 +702,7 @@ class SafeTensorsStateSource(StateSource):
         save_every_n_ranks: int = 1,
         ignored_source_key_prefixes: Iterable[str] | None = None,
         ignored_source_key_suffixes: Iterable[str] | None = None,
+        key_to_filename_map_override: Mapping[str, str] | None = None,
     ):
         """
         Saves tensors from a generator to `.safetensors` files, preserving the
@@ -732,6 +733,8 @@ class SafeTensorsStateSource(StateSource):
                 source sharding map when saving.
             ignored_source_key_suffixes: Source tensor key suffixes to omit from the expected
                 source sharding map when saving.
+            key_to_filename_map_override: Optional export-specific key-to-shard map. This supports
+                plain-dtype exports whose keys differ from a quantized source checkpoint.
 
         """
         if distributed_save:
@@ -742,6 +745,7 @@ class SafeTensorsStateSource(StateSource):
                 save_every_n_ranks=save_every_n_ranks,
                 ignored_source_key_prefixes=ignored_source_key_prefixes,
                 ignored_source_key_suffixes=ignored_source_key_suffixes,
+                key_to_filename_map_override=key_to_filename_map_override,
             )
 
         # In a distributed environment, only rank 0 should write to disk.
@@ -761,10 +765,14 @@ class SafeTensorsStateSource(StateSource):
         output_path = Path(output_path)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        key_to_filename_map = self._filter_source_keys(
-            self.key_to_filename_map,
-            ignored_source_key_prefixes,
-            ignored_source_key_suffixes,
+        key_to_filename_map = (
+            dict(key_to_filename_map_override)
+            if key_to_filename_map_override is not None
+            else self._filter_source_keys(
+                self.key_to_filename_map,
+                ignored_source_key_prefixes,
+                ignored_source_key_suffixes,
+            )
         )
         all_expected_keys = set(key_to_filename_map.keys())
 
@@ -946,6 +954,7 @@ class SafeTensorsStateSource(StateSource):
         save_every_n_ranks: int = 1,
         ignored_source_key_prefixes: Iterable[str] | None = None,
         ignored_source_key_suffixes: Iterable[str] | None = None,
+        key_to_filename_map_override: Mapping[str, str] | None = None,
     ):
         is_distributed = torch.distributed.is_available() and torch.distributed.is_initialized()
         if is_distributed:
@@ -972,10 +981,14 @@ class SafeTensorsStateSource(StateSource):
         if is_distributed:
             torch.distributed.barrier()
 
-        key_to_filename_map = self._filter_source_keys(
-            self.key_to_filename_map,
-            ignored_source_key_prefixes,
-            ignored_source_key_suffixes,
+        key_to_filename_map = (
+            dict(key_to_filename_map_override)
+            if key_to_filename_map_override is not None
+            else self._filter_source_keys(
+                self.key_to_filename_map,
+                ignored_source_key_prefixes,
+                ignored_source_key_suffixes,
+            )
         )
 
         # Fallback: no sharding map, single-file save

--- a/src/megatron/bridge/models/hf_pretrained/state.py
+++ b/src/megatron/bridge/models/hf_pretrained/state.py
@@ -1009,6 +1009,11 @@ class SafeTensorsStateSource(StateSource):
         else:
             all_filenames = []
 
+        # When every saver owns at most one shard, keep that shard buffered
+        # until the generator is drained. Writing inside the lockstep generator
+        # would otherwise serialize all ranks behind each saver rank's I/O.
+        defer_complete_shard_writes = is_saver_rank and num_savers >= len(all_filenames)
+
         # Distribute files among saver ranks (one per node)
         if is_saver_rank:
             assigned_filenames = [fname for idx, fname in enumerate(all_filenames) if idx % num_savers == saver_index]
@@ -1026,6 +1031,7 @@ class SafeTensorsStateSource(StateSource):
         files_to_save = {fname: filename_to_keys_map[fname] for fname in assigned_filenames}
         remaining_keys_by_file = {fname: set(keys) for fname, keys in files_to_save.items()}
         buffered_tensors: Dict[str, torch.Tensor] = {}
+        deferred_shards: Dict[str, Dict[str, torch.Tensor]] = {}
         local_saved_tensor_bytes = 0
         local_saved_filenames: Set[str] = set()
         local_export_error: str | None = None
@@ -1088,12 +1094,28 @@ class SafeTensorsStateSource(StateSource):
                 if not remaining_keys:
                     keys_for_file = files_to_save[fname]
                     tensors_to_save = {key: buffered_tensors[key] for key in keys_for_file}
-                    if write_shard(fname, tensors_to_save):
+                    if defer_complete_shard_writes:
+                        deferred_shards[fname] = tensors_to_save
                         for key in keys_for_file:
                             del buffered_tensors[key]
                         del files_to_save[fname]
                         del remaining_keys_by_file[fname]
-                    del tensors_to_save
+                    else:
+                        if write_shard(fname, tensors_to_save):
+                            for key in keys_for_file:
+                                del buffered_tensors[key]
+                            del files_to_save[fname]
+                            del remaining_keys_by_file[fname]
+                        del tensors_to_save
+
+        # All ranks have now consumed the conversion generator, so saver ranks
+        # can write their single assigned shard concurrently without stalling
+        # collectives needed by other ranks.
+        if deferred_shards:
+            for fname, tensors_to_save in deferred_shards.items():
+                if not write_shard(fname, tensors_to_save):
+                    break
+            deferred_shards.clear()
 
         missing_keys = set().union(*remaining_keys_by_file.values()) if remaining_keys_by_file else set()
         if is_saver_rank and missing_keys:

--- a/src/megatron/bridge/models/kimi/kimi_k3_bridge.py
+++ b/src/megatron/bridge/models/kimi/kimi_k3_bridge.py
@@ -376,6 +376,28 @@ class KimiK3Bridge(MegatronModelBridge):
         finally:
             hf_pretrained.state.source.get_all_keys = original_get_all_keys
 
+    @staticmethod
+    def get_hf_export_key_to_filename_map(
+        key_to_filename_map: Mapping[str, str],
+        weight_dtype: torch.dtype,
+    ) -> dict[str, str]:
+        """Replace routed-expert MXFP4 pairs with their virtual plain-weight keys."""
+        del weight_dtype
+        export_map: dict[str, str] = {}
+        source_keys = set(key_to_filename_map)
+        for key, filename in key_to_filename_map.items():
+            if key.endswith(".weight_packed"):
+                weight_key = key.removesuffix("_packed")
+                if f"{weight_key}_scale" in source_keys:
+                    export_map[weight_key] = filename
+                    continue
+            if key.endswith(".weight_scale"):
+                weight_key = key.removesuffix("_scale")
+                if f"{weight_key}_packed" in source_keys:
+                    continue
+            export_map[key] = filename
+        return export_map
+
     @torch.no_grad()
     def stream_weights_megatron_to_hf(
         self,

--- a/src/megatron/bridge/models/kimi/kimi_k3_bridge.py
+++ b/src/megatron/bridge/models/kimi/kimi_k3_bridge.py
@@ -50,6 +50,21 @@ class KimiK3Bridge(MegatronModelBridge):
 
     _HF_PASSTHROUGH_PREFIXES = ("vision_tower.", "mm_projector.")
 
+    @staticmethod
+    def generate_pipeline_layout(num_layers: int, pp: int, mtp_layers: int = 0) -> list[list[str]]:
+        """Distribute K3's 93 language layers across arbitrary PP sizes."""
+        base_layers, extra_layers = divmod(num_layers, pp)
+        layout: list[list[str]] = []
+        for pp_rank in range(pp):
+            stage = ["decoder"] * (base_layers + int(pp_rank < extra_layers))
+            if pp_rank == 0:
+                stage.insert(0, "embedding")
+            if pp_rank == pp - 1:
+                stage.extend(["mtp"] * mtp_layers)
+                stage.append("loss")
+            layout.append(stage)
+        return layout
+
     @classmethod
     def hf_to_megatron_activation(cls, hidden_act: str):
         """Use SiLU as the config marker; the K3 spec installs the exact SiTU module."""

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -350,6 +350,28 @@ class TestExportMegatronToHf:
 
 
 class TestPipelineLayout:
+    def test_generate_reads_nested_text_config(self, cli):
+        class ModelBridge:
+            def generate_pipeline_layout(self, num_layers, pp, mtp_layers):
+                assert (num_layers, pp, mtp_layers) == (93, 4, 0)
+                return [[f"stage-{index}"] for index in range(pp)]
+
+        provider = _FakeProvider([])
+        bridge = types.SimpleNamespace(
+            _model_bridge=ModelBridge(),
+            hf_pretrained=types.SimpleNamespace(
+                config=types.SimpleNamespace(text_config=types.SimpleNamespace(num_hidden_layers=93))
+            ),
+        )
+
+        assert cli._maybe_generate_pipeline_layout(bridge, provider, pp=4)
+        assert provider.pipeline_model_parallel_layout == [
+            ["stage-0"],
+            ["stage-1"],
+            ["stage-2"],
+            ["stage-3"],
+        ]
+
     def test_restore_uses_latest_checkpoint_iteration(self, cli, tmp_path):
         for iteration, marker in ((1, "old"), (2, "latest")):
             iteration_path = tmp_path / f"iter_{iteration:07d}"

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -262,10 +262,13 @@ def test_distributed_cpu_export_uses_gloo_backend(monkeypatch):
             "--ep",
             "2",
             "--distributed-save",
+            "--export-weight-dtype",
+            "bfloat16",
         ]
     )
 
     assert calls[0]["distributed_save"] is True
+    assert calls[0]["export_weight_dtype"] == "bfloat16"
     assert calls[0]["use_cpu"] is True
 
 
@@ -350,7 +353,7 @@ def test_cpu_worker_rejects_parallelism():
 def test_cpu_worker_rejects_export_weight_dtype():
     module, _, _ = _load_run_conversion_module()
 
-    with pytest.raises(ValueError, match="only supported by the GPU backend"):
+    with pytest.raises(ValueError, match="requires distributed CPU export or the GPU backend"):
         module.main(
             [
                 "export",

--- a/tests/unit_tests/conversion/launcher/test_setup_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_setup_conversion.py
@@ -130,6 +130,8 @@ def test_distributed_cpu_export_accepts_compatible_topology():
         "2",
         "--ep",
         "4",
+        "--export-weight-dtype",
+        "bfloat16",
     )
 
     module._validate_args(args)
@@ -217,7 +219,7 @@ def test_cpu_export_rejects_export_weight_dtype():
     module = _load_setup_conversion_module()
     args = _parse_export(module, "--export-weight-dtype", "float32")
 
-    with pytest.raises(ValueError, match="only supported by the GPU backend"):
+    with pytest.raises(ValueError, match="requires distributed CPU export or the GPU backend"):
         module._validate_args(args)
 
 

--- a/tests/unit_tests/models/hf_pretrained/test_base.py
+++ b/tests/unit_tests/models/hf_pretrained/test_base.py
@@ -255,6 +255,38 @@ def test_save_artifacts_preserves_auto_map_with_trust_remote_code():
         }
 
 
+def test_save_artifacts_strips_nested_quantization_config(tmp_path):
+    """Test plain artifact saves remove quantization metadata from nested configs."""
+    base = MockPreTrainedBase()
+    config = PretrainedConfig()
+    config.quantization_config = {"quant_method": "root"}
+    config.text_config = PretrainedConfig()
+    config.text_config.quantization_config = {"quant_method": "mxfp4"}
+    base._config = config
+
+    base.save_artifacts(tmp_path)
+
+    saved_config = json.loads((tmp_path / "config.json").read_text())
+    assert "quantization_config" not in saved_config
+    assert "quantization_config" not in saved_config["text_config"]
+    assert config.quantization_config == {"quant_method": "root"}
+    assert config.text_config.quantization_config == {"quant_method": "mxfp4"}
+
+
+def test_save_artifacts_preserves_nested_quantization_config_for_quantized_export(tmp_path):
+    """Test quantized artifact saves retain nested quantization metadata."""
+    base = MockPreTrainedBase()
+    config = PretrainedConfig()
+    config.text_config = PretrainedConfig()
+    config.text_config.quantization_config = {"quant_method": "mxfp4"}
+    base._config = config
+
+    base.save_artifacts(tmp_path, strip_quantization_config=False)
+
+    saved_config = json.loads((tmp_path / "config.json").read_text())
+    assert saved_config["text_config"]["quantization_config"] == {"quant_method": "mxfp4"}
+
+
 def test_save_artifacts_without_model_name_or_path():
     """Test save_artifacts handles missing model_name_or_path gracefully."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/unit_tests/models/kimi/test_kimi_k3_bridge.py
+++ b/tests/unit_tests/models/kimi/test_kimi_k3_bridge.py
@@ -203,6 +203,26 @@ def test_kda_a_log_export_restores_zero_padding() -> None:
     assert torch.count_nonzero(result[name][96:]).item() == 0
 
 
+def test_plain_export_replaces_mxfp4_keys_in_shard_map() -> None:
+    """Plain exports must shard virtual BF16 expert weights without MXFP4 companions."""
+    bridge = KimiK3Bridge()
+    weight_key = "language_model.model.layers.1.mlp.experts.0.gate_proj.weight"
+    packed_key = f"{weight_key}_packed"
+    scale_key = f"{weight_key}_scale"
+    source_map = {
+        packed_key: "model-00001-of-00002.safetensors",
+        scale_key: "model-00001-of-00002.safetensors",
+        "language_model.model.norm.weight": "model-00002-of-00002.safetensors",
+    }
+
+    export_map = bridge.get_hf_export_key_to_filename_map(source_map, torch.bfloat16)
+
+    assert export_map == {
+        weight_key: "model-00001-of-00002.safetensors",
+        "language_model.model.norm.weight": "model-00002-of-00002.safetensors",
+    }
+
+
 def test_export_preserves_unconverted_multimodal_weights(monkeypatch: pytest.MonkeyPatch) -> None:
     """K3 keeps the published vision tower and projector in strict HF exports."""
     language = torch.tensor([1.0])

--- a/tests/unit_tests/models/kimi/test_kimi_k3_bridge.py
+++ b/tests/unit_tests/models/kimi/test_kimi_k3_bridge.py
@@ -123,6 +123,15 @@ def test_provider_bridge_configures_four_layer_proxy(kimi_k3_pretrained: Mock) -
     assert provider.params_dtype == torch.bfloat16
 
 
+def test_pipeline_layout_distributes_official_layer_count_across_pp_four() -> None:
+    """K3's 93 layers use a valid uneven four-stage conversion layout."""
+    layout = KimiK3Bridge.generate_pipeline_layout(num_layers=93, pp=4)
+
+    assert [stage.count("decoder") for stage in layout] == [24, 23, 23, 23]
+    assert layout[0][0] == "embedding"
+    assert layout[-1][-1] == "loss"
+
+
 def test_mapping_registry_covers_kda_latent_moe_and_attn_res(kimi_k3_pretrained: Mock) -> None:
     """Custom K3 weights resolve in both conversion directions."""
     bridge = KimiK3Bridge()

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1335,7 +1335,10 @@ class TestAutoBridge:
 
                 # Check artifacts were saved on rank 0
                 mock_hf_model.save_artifacts.assert_called_once_with(
-                    "./output_dir", original_source_path=None, additional_files=None
+                    "./output_dir",
+                    original_source_path=None,
+                    additional_files=None,
+                    strip_quantization_config=False,
                 )
                 mock_save_hf_weights.assert_called_once_with(
                     mock_megatron_model,
@@ -1385,6 +1388,24 @@ class TestAutoBridge:
 
         assert (tmp_path / "config.json").exists()
         mock_save_hf_weights.assert_called_once()
+
+    @patch("torch.distributed.is_initialized", return_value=False)
+    @patch("torch.distributed.is_available", return_value=False)
+    def test_save_hf_pretrained_config_only_strips_nested_quantization_for_plain_export(
+        self, _mock_dist_avail, _mock_dist_init, tmp_path
+    ):
+        """Config-only plain exports remove nested quantization metadata."""
+        config = PretrainedConfig()
+        config.text_config = PretrainedConfig()
+        config.text_config.quantization_config = {"quant_method": "mxfp4"}
+        bridge = AutoBridge(config)
+
+        with patch.object(AutoBridge, "save_hf_weights"):
+            bridge.save_hf_pretrained([Mock()], str(tmp_path), weight_dtype=torch.bfloat16)
+
+        saved_config = json.loads((tmp_path / "config.json").read_text())
+        assert "quantization_config" not in saved_config["text_config"]
+        assert config.text_config.quantization_config == {"quant_method": "mxfp4"}
 
     @pytest.mark.parametrize("tie_word_embeddings", [True, False])
     def test_save_hf_pretrained_truncates_vocab_padding(self, tmp_path, tie_word_embeddings):
@@ -1532,6 +1553,7 @@ class TestAutoBridge:
             "./output_dir",
             original_source_path="./custom_files",
             additional_files=["chat_template.jinja"],
+            strip_quantization_config=False,
         )
 
     @patch("torch.distributed.is_initialized", return_value=False)

--- a/tests/unit_tests/models/test_hf_pretrained_state.py
+++ b/tests/unit_tests/models/test_hf_pretrained_state.py
@@ -126,6 +126,34 @@ def test_save_generator_strict_false_writes_nested_partial_shard(tmp_path) -> No
 
 
 @pytest.mark.parametrize("distributed_save", [False, True])
+def test_save_generator_accepts_export_key_map_override(tmp_path, monkeypatch, distributed_save: bool) -> None:
+    shard = "model-00001-of-00001.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.weight_packed": shard,
+            "model.weight_scale": shard,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    output_path = tmp_path / "output"
+    if distributed_save:
+        _mock_single_rank_distributed(monkeypatch)
+
+    source.save_generator(
+        iter([("model.weight", torch.ones((2, 2), dtype=torch.bfloat16))]),
+        output_path,
+        distributed_save=distributed_save,
+        key_to_filename_map_override={"model.weight": shard},
+    )
+
+    with safe_open(output_path / shard, framework="pt", device="cpu") as saved:
+        assert set(saved.keys()) == {"model.weight"}
+    index_data = json.loads((output_path / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    assert index_data["weight_map"] == {"model.weight": shard}
+
+
+@pytest.mark.parametrize("distributed_save", [False, True])
 def test_save_generator_recomputes_index_total_size(tmp_path, monkeypatch, distributed_save: bool) -> None:
     first_shard = "model-00001-of-00002.safetensors"
     second_shard = "model-00002-of-00002.safetensors"

--- a/tests/unit_tests/models/test_hf_pretrained_state.py
+++ b/tests/unit_tests/models/test_hf_pretrained_state.py
@@ -298,6 +298,46 @@ def test_distributed_save_generator_writes_shard_before_generator_is_exhausted(t
     ]
 
 
+def test_distributed_save_defers_single_shard_per_saver_until_generator_is_exhausted(tmp_path, monkeypatch) -> None:
+    first_shard = "model-00001-of-00002.safetensors"
+    second_shard = "model-00002-of-00002.safetensors"
+    _write_safetensors_index(
+        tmp_path,
+        {
+            "model.first": first_shard,
+            "model.second": second_shard,
+        },
+    )
+    source = SafeTensorsStateSource(tmp_path)
+    saved_shards: list[tuple[str, set[str]]] = []
+
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 2)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+
+    def gather_rank_zero(output: list[object | None], value: object) -> None:
+        output[0] = value
+        output[1] = (0, 0, None, ())
+
+    def record_save(tensors: dict[str, torch.Tensor], output_file: str | Path) -> None:
+        saved_shards.append((str(output_file), set(tensors)))
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather_rank_zero)
+    monkeypatch.setattr("safetensors.torch.save_file", record_save)
+
+    def tensors() -> Iterator[tuple[str, torch.Tensor]]:
+        yield "model.first", torch.ones(1)
+        assert saved_shards == []
+        yield "model.second", torch.full((1,), 2.0)
+        assert saved_shards == []
+
+    source.save_generator(tensors(), tmp_path / "output", distributed_save=True)
+
+    assert saved_shards == [(str(tmp_path / "output" / first_shard), {"model.first"})]
+
+
 def test_distributed_save_strict_rejects_incomplete_multi_key_shard(tmp_path, monkeypatch) -> None:
     shard_filename = "model-00001-of-00001.safetensors"
     _write_safetensors_index(


### PR DESCRIPTION
## Summary

- generate Kimi K3 pipeline layouts for its 93-layer topology
- export quantized checkpoints as plain BF16 CPU weights while preserving quantized GPU exports
- recursively remove quantization metadata only from plain-weight exports
- parallelize the 128-rank to 96-shard saver case
- stack shared distributed CPU export support on #5830

## Verification evidence

- GPU export: 96 safetensors shards and all 497,220 source keys; all 2,628 non-MXFP4 tensors and 57,191,006,976 values matched exactly after 69 declared FP32-to-BF16 normalizations
- GPU MXFP4 audit: all 247,296 packed/scale pairs and 2,722,740,830,208 dequantized values matched exactly; minimum and aggregate cosine were 1.0, normalized RMSE was 0, and maximum absolute error was 0
- GPU state contract: Transformers 4.56.2 instantiated the ModelOpt-compressed architecture and validated the expected dense-to-packed transformation
- CPU export: 249,924 plain BF16 keys and 2,779,931,837,184 values; all 247,296 dequantized expert weights and the remaining 2,628 tensors matched exactly
- CPU state contract: the exported config contains no quantization_config; Transformers 4.56.2 instantiated the plain architecture and matched every unaffected state key and shape

## Tests

- 158 targeted artifact-saving, conversion, Hugging Face state, and Kimi bridge tests passed in the target container
- 65 focused launcher tests passed after the split
- model verification card validator passed
- uv run pre-commit run --all-files passed

Depends on #5830.

Linear: MB-1414