### PR TITLE
feat(conversion): support distributed CPU exports

### DIFF
--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -4,8 +4,8 @@
 Megatron checkpoint conversion. It uses NeMo Run for both local execution and
 Slurm submission and selects one of two conversion backends:
 
-- `--device cpu`: one process on one node, with model construction and export
-  on CPU;
+- `--device cpu`: CPU conversion, with optional distributed export across
+  Gloo ranks for checkpoints that cannot be exported on one host;
 - `--device gpu`: distributed conversion with one process per GPU and TP, PP,
   EP, and ETP support.
 
@@ -49,8 +49,9 @@ conversion to finish.
   --hf-path /workspace/models/llama32-1b-hf
 ```
 
-CPU conversion intentionally supports one process on one node. Allocate more
-host memory and CPUs for large checkpoints rather than increasing `--nodes`.
+CPU import and the default CPU export use one process on one node. Distributed
+CPU export is available through the Slurm workflow below for checkpoints that
+cannot be loaded on one host within the available memory or wall-time limit.
 
 ## Distributed GPU conversion on Slurm
 
@@ -162,6 +163,34 @@ CPU mode submits one task and does not request GPUs or GRES:
   --hf-model meta-llama/Llama-3.2-1B \
   --megatron-path /workspace/models/llama32-1b
 ```
+
+For a very large Megatron checkpoint, distribute only the export load and save
+across CPU processes. This uses Gloo, initializes every model shard on CPU, and
+enables distributed Hugging Face saving by default. It does not request GPUs:
+
+```bash
+./scripts/conversion/convert.sh export \
+  --executor slurm \
+  --device cpu \
+  --nodes 4 \
+  --cpu-processes-per-node 8 \
+  --cpus-per-task 16 \
+  --mem 0 \
+  --exclusive \
+  --account ACCOUNT \
+  --partition CPU_PARTITION \
+  --container-image /path/to/megatron-bridge.sqsh \
+  --mount /workspace \
+  --hf-model MODEL \
+  --megatron-path /workspace/models/model/iter_0000000 \
+  --hf-path /workspace/models/model-hf \
+  --tp 1 --pp 4 --ep 8 --etp 1
+```
+
+The topology must satisfy
+`nodes * cpu-processes-per-node % (TP * PP) == 0` and
+`nodes * cpu-processes-per-node % (ETP * EP * PP) == 0`. Distributed CPU
+conversion currently supports export only and requires distributed saving.
 
 `--env` accepts names only. Export values in the launcher environment so
 secrets are inherited by Slurm without being materialized in generated job

--- a/scripts/conversion/arguments.py
+++ b/scripts/conversion/arguments.py
@@ -43,6 +43,20 @@ def _add_execution_arguments(parser: argparse.ArgumentParser, *, default_device:
         dest="gpus_per_node",
         help="GPUs per node; required for the GPU backend and optional as a CPU-backend runtime resource.",
     )
+    execution.add_argument(
+        "--cpu-processes-per-node",
+        type=int,
+        default=1,
+        help=(
+            "CPU conversion processes per node (default: 1). Values above 1 enable distributed CPU export "
+            "and require model parallelism compatible with nodes*cpu-processes-per-node."
+        ),
+    )
+    execution.add_argument(
+        "--cpus-per-task",
+        type=int,
+        help="Slurm CPU cores per conversion process.",
+    )
     execution.add_argument("--mem", default="0", help="Slurm memory request (default: 0, all node memory).")
     execution.add_argument("--account", default=os.environ.get("SLURM_ACCOUNT"), help="Slurm account.")
     execution.add_argument("--partition", default=os.environ.get("SLURM_PARTITION"), help="Slurm partition.")
@@ -104,7 +118,7 @@ def _add_parallelism_arguments(
     include_distributed_timeout: bool,
 ) -> None:
     """Add distributed model-parallel arguments."""
-    parallelism = parser.add_argument_group("Distributed GPU parallelism")
+    parallelism = parser.add_argument_group("Distributed parallelism")
     parallelism.add_argument(
         "-tp",
         "--tp",
@@ -275,7 +289,10 @@ Examples:
         "--distributed-save",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Let GPU ranks save assigned Hugging Face shards independently (default: enabled for GPU).",
+        help=(
+            "Let distributed ranks save assigned Hugging Face shards independently "
+            "(default: enabled for GPU and distributed CPU export)."
+        ),
     )
     export_parser.add_argument(
         "--save-every-n-ranks",
@@ -369,7 +386,10 @@ def conversion_worker_args(args: argparse.Namespace) -> list[str]:
             worker_args.append("--no-progress")
         if args.not_strict:
             worker_args.append("--not-strict")
-        distributed_save = args.distributed_save if args.distributed_save is not None else args.device == "gpu"
+        distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
+        distributed_save = (
+            args.distributed_save if args.distributed_save is not None else (args.device == "gpu" or distributed_cpu)
+        )
         worker_args.append("--distributed-save" if distributed_save else "--no-distributed-save")
         worker_args.extend(["--save-every-n-ranks", str(args.save_every_n_ranks)])
         if args.export_weight_dtype is not None:

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -17,7 +17,7 @@ import logging
 import shutil
 from pathlib import Path
 
-from utils import parse_dtype, prepare_output_directory
+from utils import parse_dtype, prepare_output_directory, resolve_hf_model_revision
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
@@ -80,6 +80,7 @@ def import_checkpoint(
 def export_checkpoint(
     *,
     hf_model: str,
+    hf_revision: str | None,
     megatron_path: str,
     hf_path: str,
     show_progress: bool,
@@ -91,6 +92,7 @@ def export_checkpoint(
 
     Args:
         hf_model: Hugging Face model ID or local config reference.
+        hf_revision: Immutable Hugging Face Hub revision to load.
         megatron_path: Source Megatron checkpoint path.
         hf_path: Destination Hugging Face checkpoint path.
         show_progress: Display conversion progress.
@@ -107,10 +109,12 @@ def export_checkpoint(
     trusted = is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model)
     logger.info("CPU export: %s -> %s", megatron_path, hf_path)
     logger.info("Using Megatron run config: %s", config_path)
-    bridge = AutoBridge.from_hf_pretrained(hf_model, trust_remote_code=trusted)
+    revision_kwargs = {"revision": hf_revision} if hf_revision is not None else {}
+    bridge = AutoBridge.from_hf_pretrained(hf_model, trust_remote_code=trusted, **revision_kwargs)
+    reference_model = resolve_hf_model_revision(hf_model, hf_revision)
     checkpoint_config_bridge = AutoBridge.from_auto_config(
         megatron_path,
-        hf_model,
+        reference_model,
         trust_remote_code=trusted,
     )
     # Preserve the reference wrapper's state source and shard map so model

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -49,8 +49,8 @@ _ROUNDTRIP_RTOL = 1e-5
 _CONSOLE = Console()
 
 
-def _ensure_distributed_initialized(timeout_minutes: int | None) -> None:
-    """Initialize NCCL from NeMo Run's torchrun or Slurm task environment."""
+def _ensure_distributed_initialized(timeout_minutes: int | None, *, use_cpu: bool = False) -> None:
+    """Initialize a distributed process group from torchrun or Slurm task state."""
     if torch.distributed.is_initialized():
         return
     if os.environ.get("WORLD_SIZE") is None and os.environ.get("SLURM_NTASKS") is not None:
@@ -64,10 +64,11 @@ def _ensure_distributed_initialized(timeout_minutes: int | None) -> None:
         if master_port is not None:
             os.environ["MASTER_PORT"] = str(master_port)
     if os.environ.get("WORLD_SIZE") is None:
-        raise RuntimeError("GPU conversion must be launched through NeMo Run's local or Slurm executor.")
-    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    torch.cuda.set_device(local_rank)
-    kwargs: dict[str, object] = {"backend": "nccl"}
+        raise RuntimeError("Distributed conversion must be launched through NeMo Run's local or Slurm executor.")
+    if not use_cpu:
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        torch.cuda.set_device(local_rank)
+    kwargs: dict[str, object] = {"backend": "gloo" if use_cpu else "nccl"}
     if timeout_minutes is not None:
         kwargs["timeout"] = datetime.timedelta(minutes=timeout_minutes)
     torch.distributed.init_process_group(**kwargs)
@@ -166,6 +167,7 @@ def _configure_model_provider(
     ep: int,
     etp: int,
     dtype: torch.dtype,
+    use_cpu: bool = False,
 ) -> None:
     """Apply distributed parallelism and dtype settings to a model provider."""
     model_provider.tensor_model_parallel_size = tp
@@ -174,6 +176,8 @@ def _configure_model_provider(
     model_provider.expert_tensor_parallel_size = etp
     model_provider.pipeline_dtype = dtype
     model_provider.params_dtype = dtype
+    if use_cpu:
+        model_provider.use_cpu_initialization = True
 
 
 def _hf_tokenizer_kwargs(bridge: AutoBridge, *, trust_remote_code: bool) -> dict[str, object]:
@@ -349,6 +353,7 @@ def export_checkpoint(
     distributed_timeout_minutes: int | None,
     export_weight_dtype: str | None,
     overwrite: bool,
+    use_cpu: bool = False,
 ) -> None:
     """Export a distributed Megatron checkpoint to Hugging Face format.
 
@@ -369,14 +374,19 @@ def export_checkpoint(
         distributed_timeout_minutes: Process-group timeout in minutes.
         export_weight_dtype: Optional dtype for exported weights.
         overwrite: Delete a non-empty destination before conversion.
+        use_cpu: Use Gloo and CPU model initialization instead of NCCL/CUDA.
     """
-    _ensure_distributed_initialized(distributed_timeout_minutes)
+    if use_cpu:
+        _ensure_distributed_initialized(distributed_timeout_minutes, use_cpu=True)
+    else:
+        _ensure_distributed_initialized(distributed_timeout_minutes)
     if not Path(megatron_path).exists():
         raise FileNotFoundError(f"Megatron checkpoint does not exist: {megatron_path}")
     _prepare_distributed_output(hf_path, overwrite=overwrite, source_paths=[megatron_path, hf_model])
     dtype = parse_dtype(torch_dtype)
 
-    print_rank_0(f"GPU export: {megatron_path} -> {hf_path}")
+    device_label = "CPU" if use_cpu else "GPU"
+    print_rank_0(f"Distributed {device_label} export: {megatron_path} -> {hf_path}")
     print_rank_0(f"Parallelism: TP={tp} PP={pp} EP={ep} ETP={etp}; dtype={torch_dtype}")
     trusted = is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model)
     bridge = AutoBridge.from_hf_pretrained(
@@ -393,7 +403,7 @@ def export_checkpoint(
     # exporting the checkpoint-derived architecture and vocabulary configuration.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
     model_provider = bridge.to_megatron_provider(load_weights=False)
-    _configure_model_provider(model_provider, tp=tp, pp=pp, ep=ep, etp=etp, dtype=dtype)
+    _configure_model_provider(model_provider, tp=tp, pp=pp, ep=ep, etp=etp, dtype=dtype, use_cpu=use_cpu)
     _maybe_restore_pipeline_layout(bridge, model_provider, megatron_path, pp)
     resolved_pipeline_layout = model_provider.pipeline_model_parallel_layout
     model_provider.finalize()
@@ -424,7 +434,7 @@ def export_checkpoint(
         save_every_n_ranks=save_every_n_ranks,
         weight_dtype=parse_dtype(export_weight_dtype) if export_weight_dtype else None,
     )
-    print_rank_0(f"GPU export complete: {hf_path}")
+    print_rank_0(f"Distributed {device_label} export complete: {hf_path}")
 
 
 @torchrun_main

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -317,7 +317,7 @@ def import_checkpoint(
     _configure_model_provider(model_provider, tp=tp, pp=pp, ep=ep, etp=etp, dtype=dtype)
     _maybe_generate_pipeline_layout(bridge, model_provider, pp)
     model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
+    model_provider.initialize_model_parallel(seed=0, create_gloo_process_groups=False)
     megatron_model = model_provider.provide_distributed_model(wrap_with_ddp=False)
 
     bridge.save_megatron_model(
@@ -397,7 +397,7 @@ def export_checkpoint(
     _maybe_restore_pipeline_layout(bridge, model_provider, megatron_path, pp)
     resolved_pipeline_layout = model_provider.pipeline_model_parallel_layout
     model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
+    model_provider.initialize_model_parallel(seed=0, create_gloo_process_groups=False)
 
     model_parallel_overrides: dict[str, object] = {
         "tensor_model_parallel_size": tp,
@@ -470,7 +470,7 @@ def roundtrip_checkpoint(
     _configure_model_provider(model_provider, tp=tp, pp=pp, ep=ep, etp=etp, dtype=dtype)
     _maybe_generate_pipeline_layout(bridge, model_provider, pp)
     model_provider.finalize()
-    model_provider.initialize_model_parallel(seed=0)
+    model_provider.initialize_model_parallel(seed=0, create_gloo_process_groups=False)
     megatron_model = model_provider.provide_distributed_model(wrap_with_ddp=False)
     _verify_roundtrip_weights(bridge, megatron_model)
     print_rank_0("GPU round-trip validation complete")

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -89,7 +89,10 @@ def _prepare_distributed_output(path: str, *, overwrite: bool, source_paths: Ite
     # torch.cuda.set_device in _ensure_distributed_initialized) avoids the
     # guess, matching the pattern used by training/initialize.py's own
     # first post-init barrier.
-    torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
+    if torch.distributed.get_backend() == "gloo":
+        torch.distributed.barrier()
+    else:
+        torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
 
 
 def _maybe_generate_pipeline_layout(bridge: AutoBridge, model_provider: GPTModelProvider, pp: int) -> bool:

--- a/scripts/conversion/gpu_backend.py
+++ b/scripts/conversion/gpu_backend.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import torch
 import yaml
 from rich.console import Console
-from utils import parse_dtype, prepare_output_directory, validate_output_path
+from utils import parse_dtype, prepare_output_directory, resolve_hf_model_revision, validate_output_path
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.decorators import torchrun_main
@@ -338,6 +338,7 @@ def import_checkpoint(
 def export_checkpoint(
     *,
     hf_model: str,
+    hf_revision: str | None,
     megatron_path: str,
     hf_path: str,
     tp: int,
@@ -359,6 +360,7 @@ def export_checkpoint(
 
     Args:
         hf_model: Hugging Face model ID or local config reference.
+        hf_revision: Immutable Hugging Face Hub revision to load.
         megatron_path: Source Megatron checkpoint path.
         hf_path: Destination Hugging Face checkpoint path.
         tp: Tensor parallelism size.
@@ -389,14 +391,17 @@ def export_checkpoint(
     print_rank_0(f"Distributed {device_label} export: {megatron_path} -> {hf_path}")
     print_rank_0(f"Parallelism: TP={tp} PP={pp} EP={ep} ETP={etp}; dtype={torch_dtype}")
     trusted = is_safe_repo(trust_remote_code=trust_remote_code, hf_path=hf_model)
+    revision_kwargs = {"revision": hf_revision} if hf_revision is not None else {}
     bridge = AutoBridge.from_hf_pretrained(
         hf_model,
         trust_remote_code=trusted,
         torch_dtype=dtype,
+        **revision_kwargs,
     )
+    reference_model = resolve_hf_model_revision(hf_model, hf_revision)
     checkpoint_config_bridge = AutoBridge.from_auto_config(
         megatron_path,
-        hf_model,
+        reference_model,
         trust_remote_code=trusted,
     )
     # Preserve the reference wrapper's streaming state source and shard map while

--- a/scripts/conversion/run_conversion.py
+++ b/scripts/conversion/run_conversion.py
@@ -21,7 +21,7 @@ import os
 import cpu_backend
 import gpu_backend
 from arguments import build_parser
-from utils import resolve_hf_commit_revision, resolve_hf_model_revision
+from utils import resolve_hf_commit_revision
 
 
 logger = logging.getLogger(__name__)
@@ -106,6 +106,7 @@ def _run_export(args: argparse.Namespace) -> None:
     """Dispatch an export to the selected backend."""
     common_args = {
         "hf_model": args.hf_model,
+        "hf_revision": args.hf_revision,
         "megatron_path": args.megatron_path,
         "hf_path": args.hf_path,
         "show_progress": not args.no_progress,
@@ -151,16 +152,8 @@ def main(argv: list[str] | None = None) -> None:
     args = build_parser(include_execution=False).parse_args(argv)
     _validate_args(args)
     if args.hf_revision is not None:
-        if args.command == "import":
-            args.hf_revision = resolve_hf_commit_revision(args.hf_model, args.hf_revision)
-            logger.info("Resolved Hugging Face import to immutable revision %s", args.hf_revision)
-        else:
-            args.hf_model = resolve_hf_model_revision(args.hf_model, args.hf_revision)
-            logger.info(
-                "Resolved Hugging Face revision %s to immutable local snapshot %s",
-                args.hf_revision,
-                args.hf_model,
-            )
+        args.hf_revision = resolve_hf_commit_revision(args.hf_model, args.hf_revision)
+        logger.info("Resolved Hugging Face model to immutable revision %s", args.hf_revision)
     logger.info("Selected %s backend for %s conversion", args.device.upper(), args.command)
     if args.command == "import":
         _run_import(args)

--- a/scripts/conversion/run_conversion.py
+++ b/scripts/conversion/run_conversion.py
@@ -16,6 +16,7 @@
 
 import argparse
 import logging
+import os
 
 import cpu_backend
 import gpu_backend
@@ -24,6 +25,11 @@ from utils import resolve_hf_commit_revision, resolve_hf_model_revision
 
 
 logger = logging.getLogger(__name__)
+
+
+def _distributed_world_size() -> int:
+    """Return the launcher-provided world size, defaulting to one process."""
+    return int(os.environ.get("WORLD_SIZE", os.environ.get("SLURM_NTASKS", "1")))
 
 
 def _configure_logging() -> None:
@@ -39,16 +45,33 @@ def _validate_args(args: argparse.Namespace) -> None:
     distributed_timeout_minutes = getattr(args, "distributed_timeout_minutes", None)
     if distributed_timeout_minutes is not None and distributed_timeout_minutes < 1:
         raise ValueError("--distributed-timeout-minutes must be at least 1.")
-    if args.device == "cpu" and any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp")):
+    distributed_cpu = args.device == "cpu" and _distributed_world_size() > 1
+    if (
+        args.device == "cpu"
+        and not distributed_cpu
+        and any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp"))
+    ):
         raise ValueError("CPU conversion requires TP=PP=EP=ETP=1.")
+    if distributed_cpu and args.command != "export":
+        raise ValueError("Distributed CPU conversion currently supports export only.")
+    if distributed_cpu:
+        world_size = _distributed_world_size()
+        if world_size % (args.tp * args.pp) != 0:
+            raise ValueError("WORLD_SIZE must be divisible by TP*PP for distributed CPU export.")
+        if world_size % (args.etp * args.ep * args.pp) != 0:
+            raise ValueError("WORLD_SIZE must be divisible by ETP*EP*PP for distributed CPU export.")
     if args.command == "import" and args.device == "cpu" and args.low_memory_save:
         raise ValueError("--low-memory-save is only supported by the GPU backend.")
     if args.command == "export":
         if args.save_every_n_ranks < 1:
             raise ValueError("--save-every-n-ranks must be at least 1.")
-        distributed_save = args.distributed_save if args.distributed_save is not None else args.device == "gpu"
-        if args.device == "cpu" and distributed_save:
-            raise ValueError("--distributed-save is only supported by the GPU backend.")
+        distributed_save = (
+            args.distributed_save if args.distributed_save is not None else (args.device == "gpu" or distributed_cpu)
+        )
+        if args.device == "cpu" and distributed_save and not distributed_cpu:
+            raise ValueError("--distributed-save requires distributed CPU export or the GPU backend.")
+        if distributed_cpu and not distributed_save:
+            raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
         if args.device == "cpu" and args.export_weight_dtype is not None:
@@ -90,7 +113,8 @@ def _run_export(args: argparse.Namespace) -> None:
         "trust_remote_code": args.trust_remote_code,
         "overwrite": args.overwrite,
     }
-    if args.device == "cpu":
+    distributed_cpu = args.device == "cpu" and _distributed_world_size() > 1
+    if args.device == "cpu" and not distributed_cpu:
         cpu_backend.export_checkpoint(**common_args)
         return
     distributed_save = args.distributed_save if args.distributed_save is not None else True
@@ -105,6 +129,7 @@ def _run_export(args: argparse.Namespace) -> None:
         save_every_n_ranks=args.save_every_n_ranks,
         distributed_timeout_minutes=args.distributed_timeout_minutes,
         export_weight_dtype=args.export_weight_dtype,
+        use_cpu=distributed_cpu,
     )
 
 

--- a/scripts/conversion/setup_conversion.py
+++ b/scripts/conversion/setup_conversion.py
@@ -69,6 +69,10 @@ def _validate_args(args: argparse.Namespace) -> None:
     """Validate execution resources and conversion parallelism before launch."""
     if args.nodes < 1:
         raise ValueError("--nodes must be at least 1.")
+    if args.cpu_processes_per_node < 1:
+        raise ValueError("--cpu-processes-per-node must be at least 1.")
+    if args.cpus_per_task is not None and args.cpus_per_task < 1:
+        raise ValueError("--cpus-per-task must be at least 1.")
     distributed_timeout_minutes = getattr(args, "distributed_timeout_minutes", None)
     if distributed_timeout_minutes is not None and distributed_timeout_minutes < 1:
         raise ValueError("--distributed-timeout-minutes must be at least 1.")
@@ -99,16 +103,31 @@ def _validate_args(args: argparse.Namespace) -> None:
     if args.command == "import" and args.device == "cpu" and args.low_memory_save:
         raise ValueError("--low-memory-save is only supported by the GPU backend.")
 
+    distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
     if args.device == "cpu":
-        if args.nodes != 1:
-            raise ValueError("CPU conversion supports exactly one node and one process.")
+        if distributed_cpu and args.command != "export":
+            raise ValueError("Distributed CPU conversion currently supports export only.")
+        if not distributed_cpu and args.nodes != 1:
+            raise ValueError("Single-process CPU conversion supports exactly one node.")
         if args.gpus_per_node is not None and args.gpus_per_node < 0:
             raise ValueError("--gpus-per-node must not be negative.")
+        if distributed_cpu and args.gpus_per_node not in (None, 0):
+            raise ValueError("Distributed CPU export does not request GPU resources.")
         if args.gres:
             raise ValueError("CPU conversion does not accept --gres.")
-        if any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp")):
+        if not distributed_cpu and any(getattr(args, name) != 1 for name in ("tp", "pp", "ep", "etp")):
             raise ValueError("CPU conversion requires TP=PP=EP=ETP=1.")
+        if distributed_cpu:
+            world_size = args.nodes * args.cpu_processes_per_node
+            model_parallel_size = args.tp * args.pp
+            if world_size % model_parallel_size != 0:
+                raise ValueError("nodes*cpu-processes-per-node must be divisible by TP*PP.")
+            expert_model_parallel_size = args.etp * args.ep * args.pp
+            if world_size % expert_model_parallel_size != 0:
+                raise ValueError("nodes*cpu-processes-per-node must be divisible by ETP*EP*PP.")
     else:
+        if args.cpu_processes_per_node != 1:
+            raise ValueError("--cpu-processes-per-node is only supported by the CPU backend.")
         if args.gpus_per_node is None or args.gpus_per_node < 1:
             raise ValueError("GPU conversion requires --gpus-per-node of at least 1.")
         if args.executor == "local":
@@ -133,9 +152,13 @@ def _validate_args(args: argparse.Namespace) -> None:
     if args.command == "export":
         if args.save_every_n_ranks < 1:
             raise ValueError("--save-every-n-ranks must be at least 1.")
-        distributed_save = args.distributed_save if args.distributed_save is not None else args.device == "gpu"
-        if args.device == "cpu" and distributed_save:
-            raise ValueError("--distributed-save is only supported by the GPU backend.")
+        distributed_save = (
+            args.distributed_save if args.distributed_save is not None else (args.device == "gpu" or distributed_cpu)
+        )
+        if args.device == "cpu" and distributed_save and not distributed_cpu:
+            raise ValueError("--distributed-save requires distributed CPU export or the GPU backend.")
+        if distributed_cpu and not distributed_save:
+            raise ValueError("Distributed CPU export requires --distributed-save.")
         if not distributed_save and args.save_every_n_ranks != 1:
             raise ValueError("--save-every-n-ranks requires --distributed-save.")
         if args.device == "cpu" and args.export_weight_dtype is not None:
@@ -148,8 +171,9 @@ def _build_executor(
     mounts: list[str],
 ) -> object:
     """Build a Local or Slurm NeMo Run executor."""
-    task_count = args.gpus_per_node if args.device == "gpu" else 1
-    launcher = run.Torchrun() if args.executor == "local" and args.device == "gpu" else None
+    distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
+    task_count = args.gpus_per_node if args.device == "gpu" else args.cpu_processes_per_node
+    launcher = run.Torchrun() if args.executor == "local" and (args.device == "gpu" or distributed_cpu) else None
     if args.executor == "local":
         executor = run.LocalExecutor(
             ntasks_per_node=task_count,
@@ -162,6 +186,9 @@ def _build_executor(
     gpu_kwargs = {}
     if args.gpus_per_node and not args.no_gpu_resource_request:
         gpu_kwargs["gpus_per_node"] = args.gpus_per_node
+    cpu_kwargs = {}
+    if args.cpus_per_task is not None:
+        cpu_kwargs["cpus_per_task"] = args.cpus_per_task
     container_env = [*env_names]
     if "PYTHONPATH" not in container_env:
         container_env.append("PYTHONPATH")
@@ -184,6 +211,7 @@ def _build_executor(
         container_env=container_env,
         additional_parameters={"export": ",".join(container_env)},
         srun_args=args.srun_args,
+        **cpu_kwargs,
         **gpu_kwargs,
     )
     # Values are inherited by Slurm and selected by name for the container;
@@ -206,7 +234,8 @@ def _build_task(args: argparse.Namespace) -> tuple[run.Script, list[str]]:
     else:
         pythonpath = f"{repo_root}/src:{repo_root}/3rdparty/Megatron-LM:$PYTHONPATH"
     task_env = {"PYTHONPATH": pythonpath}
-    if args.executor == "local" and args.device == "gpu":
+    distributed_cpu = args.device == "cpu" and args.cpu_processes_per_node > 1
+    if args.executor == "local" and (args.device == "gpu" or distributed_cpu):
         # The torchrun console script can belong to a different Python than the
         # uv environment running this launcher. PyTorch honors PYTHON_EXEC for
         # workers, so keep conversion dependencies from this environment.

--- a/tests/unit_tests/conversion/launcher/test_arguments.py
+++ b/tests/unit_tests/conversion/launcher/test_arguments.py
@@ -138,6 +138,30 @@ def test_worker_args_disable_distributed_save_for_cpu_export():
     assert "--no-distributed-save" in worker_args
 
 
+def test_worker_args_enable_distributed_save_for_distributed_cpu_export():
+    module = _load_arguments_module()
+    args = module.build_parser(include_execution=True).parse_args(
+        [
+            "export",
+            "--device",
+            "cpu",
+            "--cpu-processes-per-node",
+            "4",
+            "--hf-model",
+            "hf/model",
+            "--megatron-path",
+            "/megatron",
+            "--hf-path",
+            "/hf",
+        ]
+    )
+
+    worker_args = module.conversion_worker_args(args)
+
+    assert "--distributed-save" in worker_args
+    assert "--cpu-processes-per-node" not in worker_args
+
+
 def test_roundtrip_alias_and_worker_args():
     module = _load_arguments_module()
     args = module.build_parser(include_execution=True).parse_args(

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -51,6 +51,7 @@ def _load_cpu_backend():
     modules["utils"].prepare_output_directory = lambda *args, **kwargs: calls.append(
         ("prepare_output_directory", args, kwargs)
     )
+    modules["utils"].resolve_hf_model_revision = lambda model, revision: f"{model}@{revision}" if revision else model
 
     previous_modules = {name: sys.modules.get(name) for name in modules}
     sys.modules.update(modules)
@@ -104,6 +105,7 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
 
     module.export_checkpoint(
         hf_model="hf/model",
+        hf_revision="0123456789abcdef",  # pragma: allowlist secret
         megatron_path=str(checkpoint),
         hf_path="/hf-export",
         show_progress=False,
@@ -118,8 +120,16 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
             ("/hf-export",),
             {"overwrite": False, "source_paths": [str(checkpoint), "hf/model"]},
         ),
-        ("from_hf_pretrained", ("hf/model",), {"trust_remote_code": False}),
-        ("from_auto_config", (str(checkpoint), "hf/model"), {"trust_remote_code": False}),
+        (
+            "from_hf_pretrained",
+            ("hf/model",),
+            {"trust_remote_code": False, "revision": "0123456789abcdef"},  # pragma: allowlist secret
+        ),
+        (
+            "from_auto_config",
+            (str(checkpoint), "hf/model@0123456789abcdef"),  # pragma: allowlist secret
+            {"trust_remote_code": False},
+        ),
         (
             "export_ckpt",
             "checkpoint-config",

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -70,7 +70,7 @@ def _fake_megatron_modules():
     return modules
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def cli():
     """Load the conversion script as a module under a stable test name."""
     spec = importlib.util.spec_from_file_location("gpu_backend_under_test", _CLI_PATH)
@@ -180,6 +180,8 @@ class TestImportHfToMegatron:
         from_hf_call = next(call for call in calls if call[0] == "from_hf_pretrained")
         assert from_hf_call[1] == ("hf",)
         assert from_hf_call[2]["revision"] == "0123456789abcdef"  # pragma: allowlist secret
+        initialize_call = next(call for call in calls if call[0] == "initialize_model_parallel")
+        assert initialize_call[2] == {"seed": 0, "create_gloo_process_groups": False}
         assert prepared_outputs == [(("/ckpt",), {"overwrite": False, "source_paths": ["hf"]})]
 
 
@@ -255,6 +257,8 @@ class TestExportMegatronToHf:
         load_call = next(call for call in calls if call[0] == "load_megatron_model")
         assert load_call[1] == (str(checkpoint_path),)
         assert load_call[2]["mp_overrides"]["expert_model_parallel_size"] == 2
+        initialize_call = next(call for call in calls if call[0] == "initialize_model_parallel")
+        assert initialize_call[2] == {"seed": 0, "create_gloo_process_groups": False}
 
         reference_call = next(call for call in calls if call[0] == "from_hf_pretrained")
         assert reference_call[1] == ("hf",)
@@ -406,6 +410,8 @@ class TestRoundtrip:
 
         provider_call = next(call for call in calls if call[0] == "to_megatron_provider")
         assert provider_call[2] == {"load_weights": True}
+        initialize_call = next(call for call in calls if call[0] == "initialize_model_parallel")
+        assert initialize_call[2] == {"seed": 0, "create_gloo_process_groups": False}
         assert verified_models == [["megatron-model"]]
         assert initialized_timeouts == [45]
 

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -139,6 +139,26 @@ def test_distributed_cpu_initialization_uses_gloo(cli, monkeypatch):
     assert calls[0]["timeout"].total_seconds() == 45 * 60
 
 
+def test_distributed_cpu_output_barrier_does_not_query_cuda(cli, monkeypatch, tmp_path):
+    barrier_calls = []
+    monkeypatch.setattr(cli.torch.distributed, "get_rank", lambda: 1)
+    monkeypatch.setattr(cli.torch.distributed, "get_backend", lambda: "gloo")
+    monkeypatch.setattr(
+        cli.torch.distributed,
+        "barrier",
+        lambda *args, **kwargs: barrier_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        cli.torch.cuda,
+        "current_device",
+        lambda: pytest.fail("distributed CPU export must not query CUDA"),
+    )
+
+    cli._prepare_distributed_output(str(tmp_path / "output"), overwrite=False)
+
+    assert barrier_calls == [((), {})]
+
+
 def test_distributed_cpu_provider_uses_cpu_initialization(cli):
     provider = _FakeProvider([])
 

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -122,6 +122,39 @@ class _FakeHfPretrained:
     config = type("Config", (), {"num_hidden_layers": 1, "num_nextn_predict_layers": 0})()
 
 
+def test_distributed_cpu_initialization_uses_gloo(cli, monkeypatch):
+    calls = []
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    monkeypatch.setattr(cli.torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.setattr(cli.torch.distributed, "init_process_group", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(
+        cli.torch.cuda,
+        "set_device",
+        lambda *_args, **_kwargs: pytest.fail("distributed CPU export must not initialize CUDA"),
+    )
+
+    cli._ensure_distributed_initialized(45, use_cpu=True)
+
+    assert calls[0]["backend"] == "gloo"
+    assert calls[0]["timeout"].total_seconds() == 45 * 60
+
+
+def test_distributed_cpu_provider_uses_cpu_initialization(cli):
+    provider = _FakeProvider([])
+
+    cli._configure_model_provider(
+        provider,
+        tp=1,
+        pp=2,
+        ep=4,
+        etp=1,
+        dtype=torch.bfloat16,
+        use_cpu=True,
+    )
+
+    assert provider.use_cpu_initialization is True
+
+
 class TestImportHfToMegatron:
     @pytest.mark.parametrize("low_memory_save", [False, True])
     def test_import_saves_megatron_checkpoint_with_tokenizer_metadata(self, cli, monkeypatch, low_memory_save):

--- a/tests/unit_tests/conversion/launcher/test_gpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_gpu_backend.py
@@ -184,6 +184,11 @@ class TestImportHfToMegatron:
             lambda *args, **kwargs: prepared_outputs.append((args, kwargs)),
         )
         monkeypatch.setattr(cli, "is_safe_repo", lambda *, trust_remote_code, hf_path: trust_remote_code)
+        monkeypatch.setattr(
+            cli,
+            "resolve_hf_model_revision",
+            lambda model, revision: f"{model}@{revision}" if revision else model,
+        )
         monkeypatch.setattr(cli.AutoBridge, "from_hf_pretrained", fake_from_hf_pretrained)
 
         cli.import_checkpoint.__wrapped__(
@@ -263,6 +268,11 @@ class TestExportMegatronToHf:
             lambda *args, **kwargs: prepared_outputs.append((args, kwargs)),
         )
         monkeypatch.setattr(cli, "is_safe_repo", lambda *, trust_remote_code, hf_path: trust_remote_code)
+        monkeypatch.setattr(
+            cli,
+            "resolve_hf_model_revision",
+            lambda model, revision: f"{model}@{revision}" if revision else model,
+        )
         monkeypatch.setattr(cli.AutoBridge, "from_hf_pretrained", fake_from_hf_pretrained)
         monkeypatch.setattr(cli.AutoBridge, "from_auto_config", fake_from_auto_config)
 
@@ -270,6 +280,7 @@ class TestExportMegatronToHf:
         checkpoint_path.mkdir()
         cli.export_checkpoint.__wrapped__(
             hf_model="hf",
+            hf_revision="0123456789abcdef",  # pragma: allowlist secret
             megatron_path=str(checkpoint_path),
             hf_path="/hf-export",
             tp=1,
@@ -295,10 +306,14 @@ class TestExportMegatronToHf:
 
         reference_call = next(call for call in calls if call[0] == "from_hf_pretrained")
         assert reference_call[1] == ("hf",)
-        assert reference_call[2] == {"trust_remote_code": True, "torch_dtype": torch.bfloat16}
+        assert reference_call[2] == {
+            "trust_remote_code": True,
+            "torch_dtype": torch.bfloat16,
+            "revision": "0123456789abcdef",  # pragma: allowlist secret
+        }
 
         bridge_call = next(call for call in calls if call[0] == "from_auto_config")
-        assert bridge_call[1] == (str(checkpoint_path), "hf")
+        assert bridge_call[1] == (str(checkpoint_path), "hf@0123456789abcdef")  # pragma: allowlist secret
         assert bridge_call[2] == {"trust_remote_code": True}
         assert FakeStateBackedBridge.hf_pretrained is reference_pretrained
         assert reference_pretrained.config is checkpoint_config

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -211,6 +211,34 @@ def test_gpu_export_enables_distributed_save_by_default():
     assert calls[0]["hf_path"] == "/hf"
 
 
+def test_distributed_cpu_export_uses_gloo_backend(monkeypatch):
+    module, cpu_backend, gpu_backend = _load_run_conversion_module()
+    calls = []
+    cpu_backend.export_checkpoint = lambda **kwargs: pytest.fail("must not use the single-process backend")
+    gpu_backend.export_checkpoint = lambda **kwargs: calls.append(kwargs)
+    monkeypatch.setenv("WORLD_SIZE", "2")
+
+    module.main(
+        [
+            "export",
+            "--device",
+            "cpu",
+            "--hf-model",
+            "hf/model",
+            "--megatron-path",
+            "/megatron",
+            "--hf-path",
+            "/hf",
+            "--ep",
+            "2",
+            "--distributed-save",
+        ]
+    )
+
+    assert calls[0]["distributed_save"] is True
+    assert calls[0]["use_cpu"] is True
+
+
 def test_gpu_roundtrip_dispatches_to_gpu_backend():
     module, _, gpu_backend = _load_run_conversion_module()
     calls = []

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -158,6 +158,36 @@ def test_cpu_import_forwards_hf_revision_without_replacing_model_id(monkeypatch)
     assert calls[0]["hf_revision"] == "0123456789abcdef0123456789abcdef01234567"  # pragma: allowlist secret
 
 
+def test_export_forwards_hf_revision_without_replacing_model_id(monkeypatch):
+    module, cpu_backend, _ = _load_run_conversion_module()
+    calls = []
+    cpu_backend.export_checkpoint = lambda **kwargs: calls.append(kwargs)
+    monkeypatch.setattr(
+        module,
+        "resolve_hf_commit_revision",
+        lambda model, revision: "0123456789abcdef0123456789abcdef01234567",  # pragma: allowlist secret
+    )
+
+    module.main(
+        [
+            "export",
+            "--device",
+            "cpu",
+            "--hf-model",
+            "hf/model",
+            "--hf-revision",
+            "release-tag",
+            "--megatron-path",
+            "/checkpoint",
+            "--hf-path",
+            "/hf-export",
+        ]
+    )
+
+    assert calls[0]["hf_model"] == "hf/model"
+    assert calls[0]["hf_revision"] == "0123456789abcdef0123456789abcdef01234567"  # pragma: allowlist secret
+
+
 def test_cpu_import_rejects_hf_revision_for_local_path(tmp_path, monkeypatch):
     module, cpu_backend, _ = _load_run_conversion_module()
     calls = []

--- a/tests/unit_tests/conversion/launcher/test_run_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_run_conversion.py
@@ -269,6 +269,35 @@ def test_distributed_cpu_export_uses_gloo_backend(monkeypatch):
     assert calls[0]["use_cpu"] is True
 
 
+@pytest.mark.parametrize(
+    ("parallelism_args", "message"),
+    [
+        (["--tp", "3"], r"WORLD_SIZE must be divisible by TP\*PP"),
+        (["--ep", "3"], r"WORLD_SIZE must be divisible by ETP\*EP\*PP"),
+    ],
+)
+def test_distributed_cpu_export_rejects_incompatible_world_size(monkeypatch, parallelism_args, message):
+    module, _, _ = _load_run_conversion_module()
+    monkeypatch.setenv("WORLD_SIZE", "4")
+
+    with pytest.raises(ValueError, match=message):
+        module.main(
+            [
+                "export",
+                "--device",
+                "cpu",
+                "--hf-model",
+                "hf/model",
+                "--megatron-path",
+                "/megatron",
+                "--hf-path",
+                "/hf",
+                "--distributed-save",
+                *parallelism_args,
+            ]
+        )
+
+
 def test_gpu_roundtrip_dispatches_to_gpu_backend():
     module, _, gpu_backend = _load_run_conversion_module()
     calls = []

--- a/tests/unit_tests/conversion/launcher/test_setup_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_setup_conversion.py
@@ -135,6 +135,36 @@ def test_distributed_cpu_export_accepts_compatible_topology():
     module._validate_args(args)
 
 
+@pytest.mark.parametrize(
+    ("parallelism_args", "message"),
+    [
+        (["--pp", "3"], r"nodes\*cpu-processes-per-node must be divisible by TP\*PP"),
+        (["--ep", "3"], r"nodes\*cpu-processes-per-node must be divisible by ETP\*EP\*PP"),
+    ],
+)
+def test_distributed_cpu_export_rejects_incompatible_topology(parallelism_args, message):
+    module = _load_setup_conversion_module()
+    args = _parse_export(
+        module,
+        "--executor",
+        "slurm",
+        "--nodes",
+        "2",
+        "--cpu-processes-per-node",
+        "4",
+        "--account",
+        "account",
+        "--partition",
+        "partition",
+        "--container-image",
+        "image.sqsh",
+        *parallelism_args,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        module._validate_args(args)
+
+
 def test_distributed_cpu_export_rejects_non_export_command():
     module = _load_setup_conversion_module()
     args = _parse(module, "--cpu-processes-per-node", "2")

--- a/tests/unit_tests/conversion/launcher/test_setup_conversion.py
+++ b/tests/unit_tests/conversion/launcher/test_setup_conversion.py
@@ -110,6 +110,47 @@ def test_cpu_backend_rejects_distributed_parallelism():
         module._validate_args(args)
 
 
+def test_distributed_cpu_export_accepts_compatible_topology():
+    module = _load_setup_conversion_module()
+    args = _parse_export(
+        module,
+        "--executor",
+        "slurm",
+        "--nodes",
+        "2",
+        "--cpu-processes-per-node",
+        "4",
+        "--account",
+        "account",
+        "--partition",
+        "partition",
+        "--container-image",
+        "image.sqsh",
+        "--pp",
+        "2",
+        "--ep",
+        "4",
+    )
+
+    module._validate_args(args)
+
+
+def test_distributed_cpu_export_rejects_non_export_command():
+    module = _load_setup_conversion_module()
+    args = _parse(module, "--cpu-processes-per-node", "2")
+
+    with pytest.raises(ValueError, match="supports export only"):
+        module._validate_args(args)
+
+
+def test_distributed_cpu_export_requires_distributed_save():
+    module = _load_setup_conversion_module()
+    args = _parse_export(module, "--cpu-processes-per-node", "2", "--no-distributed-save")
+
+    with pytest.raises(ValueError, match="requires --distributed-save"):
+        module._validate_args(args)
+
+
 def test_cpu_backend_rejects_low_memory_save():
     module = _load_setup_conversion_module()
     args = _parse(module, "--low-memory-save")
@@ -394,6 +435,48 @@ def test_slurm_cpu_executor_does_not_request_gpus(tmp_path, monkeypatch):
     assert executor.kwargs["additional_parameters"] == {"export": "HF_TOKEN,PYTHONPATH"}
     assert executor.kwargs["srun_args"] == []
     assert executor.env_vars == {}
+
+
+def test_slurm_distributed_cpu_executor_uses_cpu_tasks(tmp_path, monkeypatch):
+    module = _load_setup_conversion_module()
+
+    class _SlurmExecutor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    module.run.Packager = lambda: "packager"
+    module.run.LocalTunnel = lambda **kwargs: types.SimpleNamespace(**kwargs)
+    module.run.SlurmExecutor = _SlurmExecutor
+    monkeypatch.setattr(module, "get_nemorun_home", lambda: str(tmp_path))
+    args = _parse_export(
+        module,
+        "--executor",
+        "slurm",
+        "--nodes",
+        "2",
+        "--cpu-processes-per-node",
+        "4",
+        "--cpus-per-task",
+        "16",
+        "--account",
+        "account",
+        "--partition",
+        "partition",
+        "--container-image",
+        "image.sqsh",
+        "--pp",
+        "2",
+        "--ep",
+        "4",
+    )
+    module._validate_args(args)
+
+    executor = module._build_executor(args, [], [])
+
+    assert executor.kwargs["nodes"] == 2
+    assert executor.kwargs["ntasks_per_node"] == 4
+    assert executor.kwargs["cpus_per_task"] == 16
+    assert "gpus_per_node" not in executor.kwargs
 
 
 def test_slurm_cpu_executor_can_request_gpu_runtime(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add multi-process CPU export through the existing distributed conversion backend
- validate TP/PP/EP/ETP topology at launcher and worker boundaries
- avoid unused conversion-only Gloo process groups
- preserve immutable Hugging Face revisions during export

This is the shared prerequisite split out of #5821, #5822, and #5823. The model verification PRs are stacked on this branch and contain only model-specific changes.

## Tests

- 76 focused conversion launcher tests passed
- uv run pre-commit run --all-files passed

Signed-off commits are preserved.