### PR TITLE
fix(conversion): bound single-process CPU export memory

### DIFF
--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -55,8 +55,8 @@ cannot be loaded on one host within the available memory or wall-time limit.
 Single-process CPU export stages file-backed tensors next to `--hf-path` by
 default. Set `MEGATRON_BRIDGE_CPU_EXPORT_MMAP_DIRECTORY` to a directory on a
 larger or faster local filesystem when the output filesystem does not have
-enough temporary space. The staging files are removed after each tensor is
-loaded.
+enough temporary space. The staging files are removed when the export
+completes.
 
 ## Distributed GPU conversion on Slurm
 

--- a/scripts/conversion/README.md
+++ b/scripts/conversion/README.md
@@ -52,6 +52,11 @@ conversion to finish.
 CPU import and the default CPU export use one process on one node. Distributed
 CPU export is available through the Slurm workflow below for checkpoints that
 cannot be loaded on one host within the available memory or wall-time limit.
+Single-process CPU export stages file-backed tensors next to `--hf-path` by
+default. Set `MEGATRON_BRIDGE_CPU_EXPORT_MMAP_DIRECTORY` to a directory on a
+larger or faster local filesystem when the output filesystem does not have
+enough temporary space. The staging files are removed after each tensor is
+loaded.
 
 ## Distributed GPU conversion on Slurm
 

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -21,6 +21,7 @@ from utils import parse_dtype, prepare_output_directory, resolve_hf_model_revisi
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
+from megatron.bridge.training.model_load_save import low_memory_model_load_context
 
 
 logger = logging.getLogger(__name__)
@@ -121,12 +122,13 @@ def export_checkpoint(
     # families with packed HF weights export in their canonical representation.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
     try:
-        bridge.export_ckpt(
-            megatron_path=megatron_path,
-            hf_path=hf_path,
-            show_progress=show_progress,
-            strict=strict,
-        )
+        with low_memory_model_load_context():
+            bridge.export_ckpt(
+                megatron_path=megatron_path,
+                hf_path=hf_path,
+                show_progress=show_progress,
+                strict=strict,
+            )
     except Exception as error:
         if strict:
             shutil.rmtree(Path(hf_path), ignore_errors=True)

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -14,6 +14,7 @@
 """Single-process CPU checkpoint conversion backend."""
 
 import logging
+import os
 import shutil
 from pathlib import Path
 
@@ -25,6 +26,7 @@ from megatron.bridge.training.model_load_save import low_memory_model_load_conte
 
 
 logger = logging.getLogger(__name__)
+_CPU_EXPORT_MMAP_DIRECTORY_ENV = "MEGATRON_BRIDGE_CPU_EXPORT_MMAP_DIRECTORY"
 
 
 def _find_run_config(checkpoint_path: Path) -> Path:
@@ -42,6 +44,12 @@ def _find_run_config(checkpoint_path: Path) -> Path:
     raise FileNotFoundError(
         f"Could not find run_config.yaml in {checkpoint_path}. Ensure this is a valid Megatron checkpoint."
     )
+
+
+def _cpu_export_mmap_directory(hf_path: str) -> Path:
+    """Return an explicit staging directory or default to the output parent."""
+    override = os.environ.get(_CPU_EXPORT_MMAP_DIRECTORY_ENV)
+    return Path(override).expanduser() if override else Path(hf_path).parent
 
 
 def import_checkpoint(
@@ -121,8 +129,10 @@ def export_checkpoint(
     # Preserve the reference wrapper's state source and shard map so model
     # families with packed HF weights export in their canonical representation.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
+    mmap_directory = _cpu_export_mmap_directory(hf_path)
+    logger.info("Using CPU export mmap directory: %s", mmap_directory)
     try:
-        with low_memory_model_load_context(mmap_directory=Path(hf_path).parent):
+        with low_memory_model_load_context(mmap_directory=mmap_directory):
             bridge.export_ckpt(
                 megatron_path=megatron_path,
                 hf_path=hf_path,

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -49,7 +49,9 @@ def _find_run_config(checkpoint_path: Path) -> Path:
 def _cpu_export_mmap_directory(hf_path: str) -> Path:
     """Return an explicit staging directory or default to the output parent."""
     override = os.environ.get(_CPU_EXPORT_MMAP_DIRECTORY_ENV)
-    return Path(override).expanduser() if override else Path(hf_path).parent
+    mmap_directory = Path(override).expanduser() if override else Path(hf_path).parent
+    mmap_directory.mkdir(parents=True, exist_ok=True)
+    return mmap_directory
 
 
 def import_checkpoint(

--- a/scripts/conversion/cpu_backend.py
+++ b/scripts/conversion/cpu_backend.py
@@ -122,7 +122,7 @@ def export_checkpoint(
     # families with packed HF weights export in their canonical representation.
     bridge.hf_pretrained.config = checkpoint_config_bridge.hf_pretrained
     try:
-        with low_memory_model_load_context():
+        with low_memory_model_load_context(mmap_directory=Path(hf_path).parent):
             bridge.export_ckpt(
                 megatron_path=megatron_path,
                 hf_path=hf_path,

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -157,6 +157,9 @@ TRACKER_PREFIX = "latest"
 _CHECKPOINT_VERSION = None
 
 logger = getLogger(__name__)
+# DCP factory expansion can add roughly one third of the model payload at peak.
+_FILE_BACKED_LOAD_MEMORY_FRACTION = 0.6
+_FILE_BACKED_STORAGE_BLOCK_BYTES = 16 * 1024**3
 _NON_PERSISTENT_CKPT_SUBDIR = "non_persistent"
 _DIRECT_ITERATION_DIR_SENTINEL = -2
 _CHECKPOINT_CLEANUP_LOCK = threading.Lock()
@@ -166,6 +169,58 @@ HF_WEIGHTS_SUBDIR = "hf"
 # default (currently only Megatron Energon). Used to derive dataloader_save / dataloader_load when
 # those config fields are left unset.
 DATALOADER_STATE_SUBDIR = "energon"
+
+
+@dataclass
+class _FileBackedStorageBlock:
+    """One sparse file mapping used by low-memory CPU checkpoint loading."""
+
+    storage: torch.UntypedStorage
+    capacity_bytes: int
+    used_bytes: int = 0
+
+
+class _FileBackedTensorAllocator:
+    """Allocate CPU tensors from a small set of sparse file mappings."""
+
+    def __init__(self, directory: Path, *, block_bytes: int = _FILE_BACKED_STORAGE_BLOCK_BYTES) -> None:
+        self.directory = directory
+        self.block_bytes = block_bytes
+        self.blocks: list[_FileBackedStorageBlock] = []
+
+    @staticmethod
+    def _align(value: int, alignment: int) -> int:
+        return (value + alignment - 1) // alignment * alignment
+
+    def allocate_like(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Return a contiguous file-backed CPU tensor with matching shape and dtype."""
+        if tensor.numel() == 0:
+            return torch.empty(tensor.shape, dtype=tensor.dtype, device="cpu")
+        if tensor.layout != torch.strided:
+            raise TypeError(f"File-backed checkpoint tensors require strided layout, got {tensor.layout}")
+
+        element_bytes = tensor.element_size()
+        required_bytes = tensor.numel() * element_bytes
+        block = next(
+            (
+                candidate
+                for candidate in reversed(self.blocks)
+                if self._align(candidate.used_bytes, element_bytes) + required_bytes <= candidate.capacity_bytes
+            ),
+            None,
+        )
+        if block is None:
+            capacity_bytes = max(self.block_bytes, self._align(required_bytes, 4096))
+            path = self.directory / f"block-{len(self.blocks):05d}.bin"
+            storage = torch.UntypedStorage.from_file(str(path), shared=True, nbytes=capacity_bytes)
+            block = _FileBackedStorageBlock(storage=storage, capacity_bytes=capacity_bytes)
+            self.blocks.append(block)
+
+        byte_offset = self._align(block.used_bytes, element_bytes)
+        block.used_bytes = byte_offset + required_bytes
+        result = torch.empty(0, dtype=tensor.dtype, device="cpu")
+        result.set_(block.storage, byte_offset // element_bytes, tensor.shape)
+        return result
 
 
 # ============================================================================
@@ -2341,6 +2396,7 @@ def _load_model_weights_from_checkpoint(
     ] = "assume_ok_unexpected",
     strict: bool = True,
     assign_loaded_tensors: bool = False,
+    file_backed_allocator: _FileBackedTensorAllocator | None = None,
 ) -> Optional[Union[StateDict, tuple[StateDict, set[str], set[str]]]]:
     """Load model weights from a checkpoint.
 
@@ -2358,6 +2414,9 @@ def _load_model_weights_from_checkpoint(
         strict: Whether to enforce strict loading (see torch.nn.Module.load_state_dict).
         assign_loaded_tensors: Load into a meta-device model by assigning the
             checkpoint tensors instead of copying them into existing storage.
+        file_backed_allocator: Optional sparse-file allocator used when the
+            model payload is too close to available host memory for anonymous
+            checkpoint staging.
     """
 
     state_dict = dist_checkpointing.load_common_state_dict(checkpoint_path)
@@ -2375,7 +2434,13 @@ def _load_model_weights_from_checkpoint(
     sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs, pg_collection=pg_collection)
 
     if assign_loaded_tensors:
-        sharded_state_dict = _strip_sharded_tensor_data(sharded_state_dict)
+        if file_backed_allocator is not None and _requires_file_backed_checkpoint_load(model):
+            logger.info("Using file-backed checkpoint tensors for the low-memory CPU load")
+            sharded_state_dict = _replace_sharded_tensor_data_with_file_backed(
+                sharded_state_dict, file_backed_allocator
+            )
+        else:
+            sharded_state_dict = _strip_sharded_tensor_data(sharded_state_dict)
 
     load_strategy = TorchDistLoadShardedStrategy()
     if fully_parallel_load:
@@ -2757,6 +2822,75 @@ def _strip_sharded_tensor_data(sharded_state_dict: ShardedStateDict) -> ShardedS
         return value
 
     return dict_list_map_inplace(strip_data, sharded_state_dict)
+
+
+def _available_memory_bytes() -> int:
+    """Return Linux MemAvailable, with a portable sysconf fallback."""
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+
+
+def _requires_file_backed_checkpoint_load(model: list[MegatronModule]) -> bool:
+    """Choose mapped checkpoint storage when anonymous tensors risk host OOM."""
+    seen: set[int] = set()
+    model_bytes = 0
+    for module in model:
+        for tensor in (*module.parameters(), *module.buffers()):
+            if id(tensor) in seen:
+                continue
+            seen.add(id(tensor))
+            model_bytes += tensor.numel() * tensor.element_size()
+    return model_bytes >= _available_memory_bytes() * _FILE_BACKED_LOAD_MEMORY_FRACTION
+
+
+def _replace_sharded_tensor_data_with_file_backed(
+    sharded_state_dict: ShardedStateDict,
+    allocator: _FileBackedTensorAllocator,
+) -> ShardedStateDict:
+    """Back checkpoint targets and factory results with reclaimable file mappings."""
+
+    def allocate_sharded_tensor(value: Any) -> Any:
+        if not isinstance(value, ShardedTensor):
+            return value
+        template = value.data
+        if template is None:
+            template = torch.empty(value.local_shape, dtype=value.dtype, device="meta")
+        return replace(value, data=allocator.allocate_like(template))
+
+    def replace_data(value: Any) -> Any:
+        if isinstance(value, ShardedTensor):
+            return allocate_sharded_tensor(value)
+        if isinstance(value, ShardedTensorFactory):
+            original_build_fn = value.build_fn
+            original_merge_fn = value.merge_fn
+
+            def build_file_backed(key: str, data: torch.Tensor, replica_id: Any, flattened_range: Any) -> Any:
+                result = original_build_fn(key, data, replica_id, flattened_range)
+                return dict_list_map_inplace(allocate_sharded_tensor, result)
+
+            def merge_file_backed(loaded: Any) -> torch.Tensor:
+                merged = original_merge_fn(loaded)
+                mapped = allocator.allocate_like(merged)
+                mapped.copy_(merged)
+                return mapped
+
+            factory_data = value.data
+            if factory_data is not None and not factory_data.is_meta:
+                factory_data = torch.empty_like(factory_data, device="meta")
+            return replace(
+                value,
+                data=factory_data,
+                build_fn=build_file_backed,
+                merge_fn=merge_file_backed,
+            )
+        return value
+
+    return dict_list_map_inplace(replace_data, sharded_state_dict)
 
 
 def _load_model_state_dict(

--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -34,7 +34,13 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from megatron.core import dist_checkpointing, tensor_parallel
-from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedStateDict, ShardedTensor
+from megatron.core.dist_checkpointing.dict_utils import dict_list_map_inplace
+from megatron.core.dist_checkpointing.mapping import (
+    ShardedObject,
+    ShardedStateDict,
+    ShardedTensor,
+    ShardedTensorFactory,
+)
 from megatron.core.dist_checkpointing.serialization import StateDict
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
 from megatron.core.dist_checkpointing.strategies.fully_parallel import (
@@ -2334,6 +2340,7 @@ def _load_model_weights_from_checkpoint(
         "ignore_all",
     ] = "assume_ok_unexpected",
     strict: bool = True,
+    assign_loaded_tensors: bool = False,
 ) -> Optional[Union[StateDict, tuple[StateDict, set[str], set[str]]]]:
     """Load model weights from a checkpoint.
 
@@ -2349,6 +2356,8 @@ def _load_model_weights_from_checkpoint(
             itself. Default False.
         dist_ckpt_strictness: Determine handling of key mismatch during checkpoint load.
         strict: Whether to enforce strict loading (see torch.nn.Module.load_state_dict).
+        assign_loaded_tensors: Load into a meta-device model by assigning the
+            checkpoint tensors instead of copying them into existing storage.
     """
 
     state_dict = dist_checkpointing.load_common_state_dict(checkpoint_path)
@@ -2365,6 +2374,9 @@ def _load_model_weights_from_checkpoint(
     pg_collection = get_pg_collection(model)
     sharded_state_dict = _generate_model_state_dict(model, model_sd_kwargs, pg_collection=pg_collection)
 
+    if assign_loaded_tensors:
+        sharded_state_dict = _strip_sharded_tensor_data(sharded_state_dict)
+
     load_strategy = TorchDistLoadShardedStrategy()
     if fully_parallel_load:
         pg_collection = get_pg_collection(model)
@@ -2378,8 +2390,9 @@ def _load_model_weights_from_checkpoint(
     if return_state_dict:
         return state_dict
 
+    load_kwargs = {"assign": True} if assign_loaded_tensors else {}
     if len(model) == 1:
-        _load_model_state_dict(model[0], state_dict["model"], strict)
+        _load_model_state_dict(model[0], state_dict["model"], strict, **load_kwargs)
     else:
         for i in range(len(model)):
             # If there is no corresponding model in the state_dict, it will be ignored.
@@ -2387,7 +2400,7 @@ def _load_model_weights_from_checkpoint(
             model_key = "model%d" % i
             if model_key not in state_dict:
                 continue
-            _load_model_state_dict(model[i], state_dict[model_key], strict)
+            _load_model_state_dict(model[i], state_dict[model_key], strict, **load_kwargs)
 
     # The loaded state dict can own checkpoint staging tensors distinct from
     # the model parameters. Release both state-dict structures before the
@@ -2724,7 +2737,35 @@ def _process_state_dict_for_model_glu_interleaving(
     return model_state_dict
 
 
-def _load_model_state_dict(module: torch.nn.Module, state_dict: dict[str, Any], strict: bool):
+def _strip_sharded_tensor_data(sharded_state_dict: ShardedStateDict) -> ShardedStateDict:
+    """Remove meta tensor data so distributed checkpoint load allocates CPU tensors."""
+
+    def strip_data(value: Any) -> Any:
+        if isinstance(value, ShardedTensor):
+            return value.without_data()
+        if isinstance(value, ShardedTensorFactory):
+            original_build_fn = value.build_fn
+
+            def build_without_data(key: str, data: torch.Tensor, replica_id: Any, flattened_range: Any) -> Any:
+                result = original_build_fn(key, data, replica_id, flattened_range)
+                return dict_list_map_inplace(strip_data, result)
+
+            factory_data = value.data
+            if factory_data is not None and not factory_data.is_meta:
+                factory_data = torch.empty_like(factory_data, device="meta")
+            return replace(value, data=factory_data, build_fn=build_without_data)
+        return value
+
+    return dict_list_map_inplace(strip_data, sharded_state_dict)
+
+
+def _load_model_state_dict(
+    module: torch.nn.Module,
+    state_dict: dict[str, Any],
+    strict: bool,
+    *,
+    assign: bool = False,
+) -> None:
     """Helper function to load state dict with fallback for missing extra states."""
     if HAVE_MEGATRON_FSDP and isinstance(module, MegatronFSDP):
         # Because the state dictionary was generated from the nested module of Megatron-FSDP,
@@ -2732,12 +2773,13 @@ def _load_model_state_dict(module: torch.nn.Module, state_dict: dict[str, Any], 
         # In Megatron-LM, handled via adapter: FullyShardedDataParallel.load_state_dict().
         for key in list(state_dict.keys()):
             state_dict[f"module.{key}"] = state_dict.pop(key)
+    load_kwargs = {"assign": True} if assign else {}
     try:
-        module.load_state_dict(state_dict, strict=strict)
+        module.load_state_dict(state_dict, strict=strict, **load_kwargs)
     except Exception as e:
         if strict:
             # Fallback support for backward compatibility breaking changes in TransformerEngine
-            load_return = module.load_state_dict(state_dict, strict=False)
+            load_return = module.load_state_dict(state_dict, strict=False, **load_kwargs)
             missing = load_return.missing_keys
             unexpected = load_return.unexpected_keys
             non_extra = [k for k in missing + unexpected if not k.endswith("._extra_state")]

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -17,6 +17,7 @@ import logging
 import os
 import socket
 from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Generator, Literal, Optional, Union
 
@@ -41,12 +42,24 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 
 logger = logging.getLogger(__name__)
 
+_LOW_MEMORY_MODEL_LOAD = ContextVar("_LOW_MEMORY_MODEL_LOAD", default=False)
+
 HF_BASED_TOKENIZERS = [
     "BertWordPieceLowerCase",
     "BertWordPieceCase",
     "GPT2BPETokenizer",
     "HuggingFaceTokenizer",
 ]
+
+
+@contextmanager
+def low_memory_model_load_context() -> Generator[None, None, None]:
+    """Build CPU-loaded models on meta and assign checkpoint tensors directly."""
+    token = _LOW_MEMORY_MODEL_LOAD.set(True)
+    try:
+        yield
+    finally:
+        _LOW_MEMORY_MODEL_LOAD.reset(token)
 
 
 def _uses_hybrid_rng_tracker(model_cfg: Any) -> bool:
@@ -107,6 +120,17 @@ def megatron_cpu_init_context(config: Any) -> Generator[None, None, None]:
     original_use_cpu_initialization = config.use_cpu_initialization
     config.use_cpu_initialization = True
 
+    try:
+        yield
+    finally:
+        config.use_cpu_initialization = original_use_cpu_initialization
+
+
+@contextmanager
+def megatron_meta_init_context(config: Any) -> Generator[None, None, None]:
+    """Disable CPU master-weight initialization while constructing on meta."""
+    original_use_cpu_initialization = config.use_cpu_initialization
+    config.use_cpu_initialization = False
     try:
         yield
     finally:
@@ -347,10 +371,14 @@ def build_and_load_model(
 
     def _call_model_provider(model_cfg):
         """Handles provider call for both MBridge and MLM providers."""
+        use_meta_init = getattr(model_cfg, "init_model_with_meta_device", False) is True
         if isinstance(model_cfg, ModelProviderMixin):
             if hasattr(model_cfg, "finalize"):
                 model_cfg.finalize()
-            return model_cfg.provide_distributed_model(wrap_with_ddp=False, use_cpu_initialization=use_cpu_init)
+            return model_cfg.provide_distributed_model(
+                wrap_with_ddp=False,
+                use_cpu_initialization=use_cpu_init and not use_meta_init,
+            )
         elif isinstance(model_cfg, ModelConfig):
             if hasattr(model_cfg, "finalize"):
                 model_cfg.finalize()
@@ -396,7 +424,12 @@ def build_and_load_model(
             model_cfg.params_dtype = target_dtype
 
         if use_cpu_init:
-            with megatron_cpu_init_context(model_cfg):
+            init_context = (
+                megatron_meta_init_context(model_cfg)
+                if getattr(model_cfg, "init_model_with_meta_device", False) is True
+                else megatron_cpu_init_context(model_cfg)
+            )
+            with init_context:
                 model = _call_model_provider(model_cfg)
         else:
             model = _call_model_provider(model_cfg)
@@ -408,9 +441,10 @@ def build_and_load_model(
 
             load_modelopt_state(model, checkpoint_path)
 
-        maybe_state_dict = _load_model_weights_from_checkpoint(
-            checkpoint_path, model, return_state_dict=return_state_dict
-        )
+        load_kwargs = {"return_state_dict": return_state_dict}
+        if getattr(model_cfg, "init_model_with_meta_device", False) is True:
+            load_kwargs["assign_loaded_tensors"] = True
+        maybe_state_dict = _load_model_weights_from_checkpoint(checkpoint_path, model, **load_kwargs)
 
         if return_state_dict:
             del model
@@ -478,6 +512,8 @@ def load_megatron_model(
     if use_cpu_init:
         model_cfg.fp8 = None
         model_cfg.fp8_param = False
+        if _LOW_MEMORY_MODEL_LOAD.get():
+            model_cfg.init_model_with_meta_device = True
 
     # Apply model-parallel overrides if provided
     if mp_overrides:

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -19,6 +19,7 @@ import socket
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, Generator, Literal, Optional, Union
 
 import torch
@@ -31,7 +32,7 @@ from megatron.core.utils import get_model_config
 from megatron.training.models.base import ModelConfig
 
 from megatron.bridge.models.model_provider import ModelParallelKwargs, ModelProviderMixin
-from megatron.bridge.training.checkpointing import save_checkpoint
+from megatron.bridge.training.checkpointing import _FileBackedTensorAllocator, save_checkpoint
 from megatron.bridge.training.config import CheckpointConfig, ConfigContainer, LoggerConfig
 from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer, build_tokenizer
@@ -42,7 +43,9 @@ from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 
 logger = logging.getLogger(__name__)
 
-_LOW_MEMORY_MODEL_LOAD = ContextVar("_LOW_MEMORY_MODEL_LOAD", default=False)
+_LOW_MEMORY_MODEL_LOAD: ContextVar[_FileBackedTensorAllocator | None] = ContextVar(
+    "_LOW_MEMORY_MODEL_LOAD", default=None
+)
 
 HF_BASED_TOKENIZERS = [
     "BertWordPieceLowerCase",
@@ -53,13 +56,15 @@ HF_BASED_TOKENIZERS = [
 
 
 @contextmanager
-def low_memory_model_load_context() -> Generator[None, None, None]:
-    """Build CPU-loaded models on meta and assign checkpoint tensors directly."""
-    token = _LOW_MEMORY_MODEL_LOAD.set(True)
-    try:
-        yield
-    finally:
-        _LOW_MEMORY_MODEL_LOAD.reset(token)
+def low_memory_model_load_context(*, mmap_directory: Path | None = None) -> Generator[None, None, None]:
+    """Build CPU models on meta and make oversized checkpoint storage file-backed."""
+    with TemporaryDirectory(prefix=".mbridge-checkpoint-mmap-", dir=mmap_directory) as temporary_directory:
+        allocator = _FileBackedTensorAllocator(Path(temporary_directory))
+        token = _LOW_MEMORY_MODEL_LOAD.set(allocator)
+        try:
+            yield
+        finally:
+            _LOW_MEMORY_MODEL_LOAD.reset(token)
 
 
 def _uses_hybrid_rng_tracker(model_cfg: Any) -> bool:
@@ -444,6 +449,7 @@ def build_and_load_model(
         load_kwargs = {"return_state_dict": return_state_dict}
         if getattr(model_cfg, "init_model_with_meta_device", False) is True:
             load_kwargs["assign_loaded_tensors"] = True
+            load_kwargs["file_backed_allocator"] = _LOW_MEMORY_MODEL_LOAD.get()
         maybe_state_dict = _load_model_weights_from_checkpoint(checkpoint_path, model, **load_kwargs)
 
         if return_state_dict:
@@ -512,7 +518,7 @@ def load_megatron_model(
     if use_cpu_init:
         model_cfg.fp8 = None
         model_cfg.fp8_param = False
-        if _LOW_MEMORY_MODEL_LOAD.get():
+        if _LOW_MEMORY_MODEL_LOAD.get() is not None:
             model_cfg.init_model_with_meta_device = True
 
     # Apply model-parallel overrides if provided

--- a/src/megatron/bridge/training/model_load_save.py
+++ b/src/megatron/bridge/training/model_load_save.py
@@ -490,12 +490,15 @@ def load_megatron_model(
     if model_cfg.pipeline_model_parallel_size == 1 and model_cfg.virtual_pipeline_model_parallel_size is None:
         model_cfg.pipeline_model_parallel_layout = None
 
-    # Flex dispatcher requires TPxEP > 1; fall back to allgather for single-rank export
+    # Flex dispatcher requires TPxEP > 1; fall back to allgather for single-rank export.
+    # Shared-expert overlap is only valid with alltoall/flex and must follow that fallback.
     if getattr(model_cfg, "moe_token_dispatcher_type", None) == "flex":
         tp = getattr(model_cfg, "tensor_model_parallel_size", 1)
         ep = getattr(model_cfg, "expert_model_parallel_size", 1)
         if tp * ep == 1:
             model_cfg.moe_token_dispatcher_type = "allgather"
+            if getattr(model_cfg, "moe_shared_expert_overlap", False):
+                model_cfg.moe_shared_expert_overlap = False
 
     return build_and_load_model(
         checkpoint_path, model_cfg, model_type, mlm_args, return_state_dict, use_cpu_init, skip_temp_dist_context

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -168,6 +168,7 @@ def test_export_honors_file_backed_staging_directory(tmp_path, monkeypatch):
 
     module.export_checkpoint(
         hf_model="hf/model",
+        hf_revision=None,
         megatron_path=str(checkpoint),
         hf_path=str(tmp_path / "hf-export"),
         show_progress=False,

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -155,3 +155,25 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
         ),
         ("low_memory_model_load", "exit"),
     ]
+
+
+def test_export_honors_file_backed_staging_directory(tmp_path, monkeypatch):
+    module, calls = _load_cpu_backend()
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "run_config.yaml").touch()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    monkeypatch.setenv("MEGATRON_BRIDGE_CPU_EXPORT_MMAP_DIRECTORY", str(staging))
+
+    module.export_checkpoint(
+        hf_model="hf/model",
+        megatron_path=str(checkpoint),
+        hf_path=str(tmp_path / "hf-export"),
+        show_progress=False,
+        strict=True,
+        trust_remote_code=False,
+        overwrite=False,
+    )
+
+    assert ("low_memory_model_load", "enter", {"mmap_directory": staging}) in calls

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -5,6 +5,7 @@
 import importlib.util
 import sys
 import types
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -37,16 +38,27 @@ def _load_cpu_backend():
             calls.append(("from_auto_config", args, kwargs))
             return types.SimpleNamespace(hf_pretrained="checkpoint-config")
 
+    @contextmanager
+    def low_memory_model_load_context():
+        calls.append(("low_memory_model_load", "enter"))
+        try:
+            yield
+        finally:
+            calls.append(("low_memory_model_load", "exit"))
+
     modules = {
         "megatron": types.ModuleType("megatron"),
         "megatron.bridge": types.ModuleType("megatron.bridge"),
         "megatron.bridge.models": types.ModuleType("megatron.bridge.models"),
         "megatron.bridge.models.hf_pretrained": types.ModuleType("megatron.bridge.models.hf_pretrained"),
         "megatron.bridge.models.hf_pretrained.utils": types.ModuleType("megatron.bridge.models.hf_pretrained.utils"),
+        "megatron.bridge.training": types.ModuleType("megatron.bridge.training"),
+        "megatron.bridge.training.model_load_save": types.ModuleType("megatron.bridge.training.model_load_save"),
         "utils": types.ModuleType("utils"),
     }
     modules["megatron.bridge"].AutoBridge = AutoBridge
     modules["megatron.bridge.models.hf_pretrained.utils"].is_safe_repo = lambda **kwargs: kwargs["trust_remote_code"]
+    modules["megatron.bridge.training.model_load_save"].low_memory_model_load_context = low_memory_model_load_context
     modules["utils"].parse_dtype = lambda value: f"dtype:{value}"
     modules["utils"].prepare_output_directory = lambda *args, **kwargs: calls.append(
         ("prepare_output_directory", args, kwargs)
@@ -130,6 +142,7 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
             (str(checkpoint), "hf/model@0123456789abcdef"),  # pragma: allowlist secret
             {"trust_remote_code": False},
         ),
+        ("low_memory_model_load", "enter"),
         (
             "export_ckpt",
             "checkpoint-config",
@@ -140,4 +153,5 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
                 "strict": True,
             },
         ),
+        ("low_memory_model_load", "exit"),
     ]

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -39,8 +39,8 @@ def _load_cpu_backend():
             return types.SimpleNamespace(hf_pretrained="checkpoint-config")
 
     @contextmanager
-    def low_memory_model_load_context():
-        calls.append(("low_memory_model_load", "enter"))
+    def low_memory_model_load_context(**kwargs):
+        calls.append(("low_memory_model_load", "enter", kwargs))
         try:
             yield
         finally:
@@ -142,7 +142,7 @@ def test_export_preserves_reference_state_layout_with_checkpoint_config(tmp_path
             (str(checkpoint), "hf/model@0123456789abcdef"),  # pragma: allowlist secret
             {"trust_remote_code": False},
         ),
-        ("low_memory_model_load", "enter"),
+        ("low_memory_model_load", "enter", {"mmap_directory": Path("/")}),
         (
             "export_ckpt",
             "checkpoint-config",

--- a/tests/unit_tests/conversion/launcher/test_cpu_backend.py
+++ b/tests/unit_tests/conversion/launcher/test_cpu_backend.py
@@ -178,3 +178,25 @@ def test_export_honors_file_backed_staging_directory(tmp_path, monkeypatch):
     )
 
     assert ("low_memory_model_load", "enter", {"mmap_directory": staging}) in calls
+
+
+def test_export_creates_default_staging_directory(tmp_path):
+    module, calls = _load_cpu_backend()
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "run_config.yaml").touch()
+    staging = tmp_path / "nested"
+
+    module.export_checkpoint(
+        hf_model="hf/model",
+        hf_revision=None,
+        megatron_path=str(checkpoint),
+        hf_path=str(staging / "hf-export"),
+        show_progress=False,
+        strict=True,
+        trust_remote_code=False,
+        overwrite=False,
+    )
+
+    assert staging.is_dir()
+    assert ("low_memory_model_load", "enter", {"mmap_directory": staging}) in calls

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -23,6 +23,7 @@ from unittest.mock import Mock, mock_open, patch
 import numpy as np
 import pytest
 import torch
+from megatron.core.dist_checkpointing.mapping import ShardedTensor, ShardedTensorFactory
 from megatron.core.msc_utils import MultiStorageClientFeature
 
 from megatron.bridge.training.checkpointing import (
@@ -47,6 +48,7 @@ from megatron.bridge.training.checkpointing import (
     _record_dataloader_state_dir,
     _save_hf_adapter_weights,
     _save_hf_weights,
+    _strip_sharded_tensor_data,
     checkpoint_exists,
     cleanup_old_non_persistent_checkpoint,
     create_checkpoint_manager,
@@ -3394,6 +3396,48 @@ class TestLoadModelStateDictHelper:
 
         with pytest.raises(Exception):
             _load_model_state_dict(module, {"w": 1}, strict=False)
+
+    def test_load_model_state_dict_assigns_into_meta_module(self):
+        """Assignment materializes a meta module without copying checkpoint storage."""
+        module = torch.nn.Linear(3, 2, device="meta")
+        state_dict = {
+            "weight": torch.randn(2, 3),
+            "bias": torch.randn(2),
+        }
+
+        _load_model_state_dict(module, state_dict, strict=True, assign=True)
+
+        assert module.weight.device.type == "cpu"
+        assert module.bias.device.type == "cpu"
+        assert module.weight.data_ptr() == state_dict["weight"].data_ptr()
+        assert module.bias.data_ptr() == state_dict["bias"].data_ptr()
+
+
+class TestStripShardedTensorData:
+    """Tests for low-memory distributed checkpoint load metadata."""
+
+    def test_strips_direct_sharded_tensor_data(self):
+        tensor = ShardedTensor.from_rank_offsets("weight", torch.empty(2, 3, device="meta"))
+
+        result = _strip_sharded_tensor_data({"model": {"weight": tensor}})
+
+        assert result["model"]["weight"].data is None
+
+    def test_factory_builds_sharded_tensors_without_data(self):
+        data = torch.empty(2, 3, device="meta")
+        factory = ShardedTensorFactory(
+            key="weight",
+            data=data,
+            build_fn=lambda key, tensor, replica_id, flattened_range: ShardedTensor.from_rank_offsets(key, tensor),
+            merge_fn=lambda value: value,
+        )
+
+        result = _strip_sharded_tensor_data({"model": {"weight": factory}})
+        stripped_factory = result["model"]["weight"]
+        built = stripped_factory.build()
+
+        assert stripped_factory.data.is_meta
+        assert built.data is None
 
 
 class TestMegatronLMCompatibility:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -37,6 +37,7 @@ from megatron.bridge.training.checkpointing import (
     _build_auto_bridge_for_save,
     _clear_auto_bridge_cache,
     _extract_megatron_lm_args_from_state_dict,
+    _FileBackedTensorAllocator,
     _get_checkpoint_format,
     _get_non_persistent_iteration,
     _has_global_non_persistent_checkpoint,
@@ -46,6 +47,8 @@ from megatron.bridge.training.checkpointing import (
     _load_model_state_dict,
     _load_non_persistent_base_checkpoint,
     _record_dataloader_state_dir,
+    _replace_sharded_tensor_data_with_file_backed,
+    _requires_file_backed_checkpoint_load,
     _save_hf_adapter_weights,
     _save_hf_weights,
     _strip_sharded_tensor_data,
@@ -3438,6 +3441,56 @@ class TestStripShardedTensorData:
 
         assert stripped_factory.data.is_meta
         assert built.data is None
+
+
+class TestFileBackedCheckpointTensors:
+    """Tests for oversized CPU checkpoint storage backed by sparse files."""
+
+    def test_allocator_reuses_sparse_storage_block(self, tmp_path):
+        allocator = _FileBackedTensorAllocator(tmp_path, block_bytes=4096)
+
+        first = allocator.allocate_like(torch.empty(2, 3, dtype=torch.float32, device="meta"))
+        second = allocator.allocate_like(torch.empty(4, dtype=torch.bfloat16, device="meta"))
+        first.copy_(torch.arange(6, dtype=torch.float32).view(2, 3))
+        second.fill_(2)
+
+        assert first.device.type == "cpu"
+        assert second.device.type == "cpu"
+        assert len(allocator.blocks) == 1
+        assert (tmp_path / "block-00000.bin").stat().st_size == 4096
+        assert first.tolist() == [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+        assert second.tolist() == [2.0, 2.0, 2.0, 2.0]
+
+    def test_factory_build_and_merge_results_are_file_backed(self, tmp_path):
+        allocator = _FileBackedTensorAllocator(tmp_path, block_bytes=4096)
+        data = torch.empty(2, 3, device="meta")
+        factory = ShardedTensorFactory(
+            key="weight",
+            data=data,
+            build_fn=lambda key, tensor, replica_id, flattened_range: ShardedTensor.from_rank_offsets(key, tensor),
+            merge_fn=lambda value: value,
+        )
+
+        result = _replace_sharded_tensor_data_with_file_backed({"model": {"weight": factory}}, allocator)
+        mapped_factory = result["model"]["weight"]
+        built = mapped_factory.build()
+        merged = mapped_factory.merge_fn(torch.full((2, 3), 7.0))
+
+        assert mapped_factory.data.is_meta
+        assert built.data.device.type == "cpu"
+        assert merged.device.type == "cpu"
+        assert merged.tolist() == [[7.0, 7.0, 7.0], [7.0, 7.0, 7.0]]
+        assert len(allocator.blocks) == 1
+
+    def test_large_model_selects_file_backed_load(self, monkeypatch):
+        model = [torch.nn.Linear(4, 4, device="meta")]
+        model_bytes = sum(tensor.numel() * tensor.element_size() for tensor in model[0].parameters())
+        monkeypatch.setattr(
+            "megatron.bridge.training.checkpointing._available_memory_bytes",
+            lambda: model_bytes,
+        )
+
+        assert _requires_file_backed_checkpoint_load(model)
 
 
 class TestMegatronLMCompatibility:

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -750,6 +750,32 @@ class TestLoadMegatronModel:
 
     @patch("megatron.bridge.training.model_load_save.build_and_load_model")
     @patch("megatron.bridge.training.model_load_save.load_model_config")
+    def test_load_megatron_model_disables_shared_expert_overlap_on_flex_fallback(
+        self, mock_load_model_config, mock_build_and_load
+    ):
+        """Verify single-rank flex fallback also disables its incompatible overlap."""
+        cfg = SimpleNamespace(
+            tensor_model_parallel_size=8,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=8,
+            expert_tensor_parallel_size=1,
+            sequence_parallel=True,
+            virtual_pipeline_model_parallel_size=None,
+            hierarchical_context_parallel_sizes=None,
+            moe_token_dispatcher_type="flex",
+            moe_shared_expert_overlap=True,
+        )
+        mock_load_model_config.return_value = (cfg, None)
+        mock_build_and_load.return_value = Mock()
+
+        load_megatron_model("/ckpt")
+
+        assert cfg.moe_token_dispatcher_type == "allgather"
+        assert cfg.moe_shared_expert_overlap is False
+
+    @patch("megatron.bridge.training.model_load_save.build_and_load_model")
+    @patch("megatron.bridge.training.model_load_save.load_model_config")
     def test_load_megatron_model_disables_cuda_graphs_for_hybrid_configs(
         self, mock_load_model_config, mock_build_and_load
     ):

--- a/tests/unit_tests/training/test_model_load_save.py
+++ b/tests/unit_tests/training/test_model_load_save.py
@@ -33,7 +33,9 @@ from megatron.bridge.training.model_load_save import (
     load_megatron_model,
     load_model_config,
     load_tokenizer,
+    low_memory_model_load_context,
     megatron_cpu_init_context,
+    megatron_meta_init_context,
     save_megatron_model,
     temporary_distributed_context,
     torch_dtype_from_mcore_config,
@@ -152,6 +154,15 @@ class TestMegatronCpuInitContext:
             assert config.use_cpu_initialization is True
 
         assert config.use_cpu_initialization is False
+
+    def test_meta_context_disables_cpu_master_weight_initialization(self):
+        """Meta construction must not allocate or copy temporary CPU master weights."""
+        config = SimpleNamespace(use_cpu_initialization=True)
+
+        with megatron_meta_init_context(config):
+            assert config.use_cpu_initialization is False
+
+        assert config.use_cpu_initialization is True
 
     def test_megatron_cpu_init_context_with_already_true(self):
         """Test context manager when use_cpu_initialization is already True."""
@@ -773,6 +784,31 @@ class TestLoadMegatronModel:
 
         assert cfg.moe_token_dispatcher_type == "allgather"
         assert cfg.moe_shared_expert_overlap is False
+
+    @patch("megatron.bridge.training.model_load_save.build_and_load_model")
+    @patch("megatron.bridge.training.model_load_save.load_model_config")
+    def test_low_memory_context_enables_meta_device_for_cpu_load(self, mock_load_model_config, mock_build_and_load):
+        """Verify the CPU-export context builds checkpoint models on meta."""
+        cfg = SimpleNamespace(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+            sequence_parallel=False,
+            virtual_pipeline_model_parallel_size=None,
+            hierarchical_context_parallel_sizes=None,
+            init_model_with_meta_device=False,
+            fp8=None,
+            fp8_param=False,
+        )
+        mock_load_model_config.return_value = (cfg, None)
+        mock_build_and_load.return_value = Mock()
+
+        with low_memory_model_load_context():
+            load_megatron_model("/ckpt", use_cpu_init=True)
+
+        assert cfg.init_model_with_meta_device is True
 
     @patch("megatron.bridge.training.model_load_save.build_and_load_model")
     @patch("megatron.bridge.training.model_load_save.load_model_config")


### PR DESCRIPTION
## Summary

- initialize single-process CPU export models on the meta device
- materialize checkpoint tensors through bounded file-backed storage
- disable invalid single-rank MoE overlap settings
- support and document a configurable local staging directory
- create the selected staging directory before allocating temporary blocks

This is intentionally separate from the model verification PRs: their verified commands use distributed CPU export and do not exercise this single-process low-memory path.

## Tests

- 4 focused CPU backend tests passed
- staging and allocator coverage remains in the branch
- uv run pre-commit run --all-files passed

The training checkpoint tests require the project Linux environment and will run in CI.

Depends on #5830.