### PR TITLE
fix(recipe): restore Qwen3.5-VL large MoE batch sizes

### DIFF
--- a/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
@@ -1449,7 +1449,7 @@ def qwen35_vl_397b_a17b_sft_128gpu_h100_bf16_config() -> ConfigContainer:
     # Training config
     cfg.train.train_iters = 300000
     cfg.train.global_batch_size = 32
-    cfg.train.micro_batch_size = 4
+    cfg.train.micro_batch_size = 1
     cfg.train.manual_gc = True
     cfg.train.manual_gc_interval = 100
     cfg.train.manual_gc_eval = 100
@@ -2221,7 +2221,7 @@ def qwen35_vl_122b_a10b_peft_8gpu_h100_bf16_config(
     # Training config
     cfg.train.train_iters = 300000
     cfg.train.global_batch_size = 36
-    cfg.train.micro_batch_size = 4
+    cfg.train.micro_batch_size = 1
     cfg.train.manual_gc = True
     cfg.train.manual_gc_interval = 100
     cfg.train.manual_gc_eval = 100
@@ -2336,7 +2336,7 @@ def qwen35_vl_397b_a17b_peft_32gpu_h100_bf16_config(
     # Training config
     cfg.train.train_iters = 300000
     cfg.train.global_batch_size = 32
-    cfg.train.micro_batch_size = 4
+    cfg.train.micro_batch_size = 1
     cfg.train.manual_gc = True
     cfg.train.manual_gc_interval = 100
     cfg.train.manual_gc_eval = 100

--- a/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/h100/qwen35_vl.py
@@ -1337,7 +1337,7 @@ def qwen35_vl_122b_a10b_sft_48gpu_h100_bf16_config() -> ConfigContainer:
     # Training config
     cfg.train.train_iters = 300000
     cfg.train.global_batch_size = 36
-    cfg.train.micro_batch_size = 4
+    cfg.train.micro_batch_size = 1
     cfg.train.manual_gc = True
     cfg.train.manual_gc_interval = 100
     cfg.train.manual_gc_eval = 100

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -794,7 +794,7 @@ def test_qwen35_vl_35b_a3b_gb200_functional_defaults(
 
 
 def test_qwen35_vl_122b_a10b_sft_defaults(monkeypatch: pytest.MonkeyPatch):
-    """122B-A10B SFT should have correct default parallelism and learning rate."""
+    """122B-A10B SFT should have correct parallelism, batch size, and learning rate."""
     patch_recipe_module_global(monkeypatch, _qwen35_vl_module, "AutoBridge", _FakeAutoBridge)
 
     cfg = _qwen35_vl_module.qwen35_vl_122b_a10b_sft_config()
@@ -810,6 +810,13 @@ def test_qwen35_vl_122b_a10b_sft_defaults(monkeypatch: pytest.MonkeyPatch):
         * cfg.model.expert_tensor_parallel_size
         == 48
     )
+    data_parallel_size = cfg.get_data_parallel_size(48)
+    samples_per_micro_step = cfg.train.micro_batch_size * data_parallel_size
+    assert data_parallel_size == 4
+    assert cfg.train.global_batch_size == 36
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size % samples_per_micro_step == 0
+    assert cfg.train.global_batch_size // samples_per_micro_step == 9
     assert cfg.model.pipeline_dtype == torch.bfloat16
     assert cfg.peft is None
     assert cfg.optimizer.lr == 2e-5

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -824,7 +824,7 @@ def test_qwen35_vl_122b_a10b_sft_defaults(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_qwen35_vl_122b_a10b_peft_defaults(monkeypatch: pytest.MonkeyPatch):
-    """122B-A10B PEFT should have correct default parallelism and learning rate."""
+    """122B-A10B PEFT should have correct parallelism, batch size, and learning rate."""
     patch_recipe_module_global(monkeypatch, _qwen35_vl_module, "AutoBridge", _FakeAutoBridge)
 
     cfg = _qwen35_vl_module.qwen35_vl_122b_a10b_peft_config()
@@ -833,6 +833,13 @@ def test_qwen35_vl_122b_a10b_peft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.tensor_model_parallel_size == 2
     assert cfg.model.pipeline_model_parallel_size == 1
     assert cfg.model.expert_model_parallel_size == 8
+    data_parallel_size = cfg.get_data_parallel_size(8)
+    samples_per_micro_step = cfg.train.micro_batch_size * data_parallel_size
+    assert data_parallel_size == 4
+    assert cfg.train.global_batch_size == 36
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size % samples_per_micro_step == 0
+    assert cfg.train.global_batch_size // samples_per_micro_step == 9
     assert cfg.model.pipeline_dtype is None
     assert cfg.peft is not None
     assert cfg.optimizer.lr == 2e-4
@@ -844,7 +851,7 @@ def test_qwen35_vl_122b_a10b_peft_defaults(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_qwen35_vl_397b_a17b_sft_defaults(monkeypatch: pytest.MonkeyPatch):
-    """397B-A17B SFT should have correct default parallelism and learning rate."""
+    """397B-A17B SFT should have correct parallelism, batch size, and learning rate."""
     patch_recipe_module_global(monkeypatch, _qwen35_vl_module, "AutoBridge", _FakeAutoBridge)
 
     cfg = _qwen35_vl_module.qwen35_vl_397b_a17b_sft_config()
@@ -853,6 +860,13 @@ def test_qwen35_vl_397b_a17b_sft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.tensor_model_parallel_size == 2
     assert cfg.model.pipeline_model_parallel_size == 4
     assert cfg.model.expert_model_parallel_size == 32
+    data_parallel_size = cfg.get_data_parallel_size(128)
+    samples_per_micro_step = cfg.train.micro_batch_size * data_parallel_size
+    assert data_parallel_size == 16
+    assert cfg.train.global_batch_size == 32
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size % samples_per_micro_step == 0
+    assert cfg.train.global_batch_size // samples_per_micro_step == 2
     assert cfg.model.pipeline_dtype == torch.bfloat16
     assert cfg.peft is None
     assert cfg.optimizer.lr == 2e-5
@@ -860,7 +874,7 @@ def test_qwen35_vl_397b_a17b_sft_defaults(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_qwen35_vl_397b_a17b_peft_defaults(monkeypatch: pytest.MonkeyPatch):
-    """397B-A17B PEFT should have correct default parallelism and learning rate."""
+    """397B-A17B PEFT should have correct parallelism, batch size, and learning rate."""
     patch_recipe_module_global(monkeypatch, _qwen35_vl_module, "AutoBridge", _FakeAutoBridge)
 
     cfg = _qwen35_vl_module.qwen35_vl_397b_a17b_peft_config()
@@ -869,6 +883,13 @@ def test_qwen35_vl_397b_a17b_peft_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.tensor_model_parallel_size == 2
     assert cfg.model.pipeline_model_parallel_size == 1
     assert cfg.model.expert_model_parallel_size == 32
+    data_parallel_size = cfg.get_data_parallel_size(32)
+    samples_per_micro_step = cfg.train.micro_batch_size * data_parallel_size
+    assert data_parallel_size == 16
+    assert cfg.train.global_batch_size == 32
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.train.global_batch_size % samples_per_micro_step == 0
+    assert cfg.train.global_batch_size // samples_per_micro_step == 2
     assert cfg.peft is not None
     assert cfg.optimizer.lr == 2e-4
     assert cfg.model.pipeline_dtype is None


### PR DESCRIPTION
## Summary

- restore the pre-PR #2902 micro batch size of 1 for four Qwen3.5-VL large-MoE fine-tuning recipes: 122B SFT, 122B PEFT, 397B SFT, and 397B PEFT
- keep each recipe’s GPU topology and global batch unchanged, yielding integral gradient-accumulation counts of 9, 9, 2, and 2 respectively
- extend the existing model-specific recipe tests to validate encoded-world data parallelism and exact batch arithmetic

PR #2902 changed the shared Qwen3.5-VL helper from MBS1 to MBS4 based on 35B Blackwell testing. That unintentionally changed these larger recipes, and the later H100 namespace refactor flattened MBS4 into each explicit function. At their encoded GPU counts, MBS4 makes the global batch non-divisible; Bridge rejects the configurations before training.

## Testing

- `uv run python -m pytest tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py` in `nvcr.io/nvidian/nemo:26.08.rc9`: 117 passed
- constructed all 25 exported H100 recipes and validated dense/expert topology plus batch divisibility: passed
- `uv run pre-commit run --all-files` in `nvcr.io/nvidian/nemo:26.08.rc9`: passed
- `git diff --check`: passed