### PR TITLE
docs(model-card): reconcile k-exaone-2 source payload total

### DIFF
--- a/examples/model_verification_cards/k-exaone-2/card.yaml
+++ b/examples/model_verification_cards/k-exaone-2/card.yaml
@@ -99,7 +99,7 @@ items:
     expected_result: >
       A complete distributed export produced 59,396 indexed keys in 17
       safetensors shards. Every exported tensor matches the pinned source
-      bitwise across 1,498,715,008,512 payload bytes, and the corrected
+      bitwise across 1,498,715,010,176 payload bytes, and the corrected
       config/tokenizer reload successfully. The run exposed and fixed
       preservation of one physical repeated MTP layer across four speculative
       steps. The config fix is committed; this item remains unverified until

--- a/tests/unit_tests/doc_consistency/test_model_verification_card_payload_totals.py
+++ b/tests/unit_tests/doc_consistency/test_model_verification_card_payload_totals.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Consistency checks for examples/model_verification_cards/*/card.yaml.
+
+The four conversion leaves of a card all convert the one revision-pinned source
+checkpoint named by model.hf_id/model.hf_revision, so a payload-byte total is a
+property of that source rather than of any single run. Every conversion leaf that
+publishes such a total must therefore publish the same one. Leaves outside the
+conversion set are excluded: an SFT-export leaf legitimately describes a different
+checkpoint.
+
+Deliberately free of torch/megatron imports so it runs without a GPU.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CARDS_ROOT = REPO_ROOT / "examples" / "model_verification_cards"
+
+CONVERSION_ITEMS = (
+    "hf_to_megatron_cpu",
+    "hf_to_megatron_gpu",
+    "megatron_to_hf_cpu",
+    "megatron_to_hf_gpu",
+)
+
+# "1,498,715,010,176 payload bytes", also "... tensor-payload bytes".
+PAYLOAD_BYTES = re.compile(r"([0-9][0-9,]{6,})\s+(?:[\w-]+[- ])?payload bytes")
+
+
+def _card_paths() -> list[Path]:
+    paths = sorted(CARDS_ROOT.glob("*/card.yaml"))
+    assert paths, f"no model verification cards found under {CARDS_ROOT}"
+    return paths
+
+
+def _conversion_payload_totals(card_path: Path) -> dict[str, set[str]]:
+    """Map each conversion leaf to the payload-byte totals its result publishes."""
+    card = yaml.safe_load(card_path.read_text(encoding="utf-8"))
+    items = card.get("items") or {}
+    totals: dict[str, set[str]] = {}
+    for name in CONVERSION_ITEMS:
+        leaf = items.get(name)
+        if not isinstance(leaf, dict):
+            continue
+        result = leaf.get("expected_result")
+        if not isinstance(result, str):
+            continue
+        found = {match.group(1) for match in PAYLOAD_BYTES.finditer(result)}
+        if found:
+            totals[name] = found
+    return totals
+
+
+def test_conversion_leaves_publish_one_payload_total_per_card():
+    """Conversion leaves of a card agree on the pinned source's payload-byte total."""
+    for card_path in _card_paths():
+        totals = _conversion_payload_totals(card_path)
+        distinct = set().union(*totals.values()) if totals else set()
+        assert len(distinct) <= 1, (
+            f"{card_path.relative_to(REPO_ROOT)} publishes {len(distinct)} different payload-byte "
+            f"totals for one immutable source checkpoint: "
+            f"{ {leaf: sorted(values) for leaf, values in sorted(totals.items())} }"
+        )
+
+
+def test_k_exaone_2_conversion_leaves_agree():
+    """k-exaone-2 import and export leaves publish the same corrected total."""
+    totals = _conversion_payload_totals(CARDS_ROOT / "k-exaone-2" / "card.yaml")
+    assert set(totals) == {"hf_to_megatron_gpu", "megatron_to_hf_gpu"}, (
+        f"expected both k-exaone-2 GPU conversion leaves to publish a payload total, got {sorted(totals)}"
+    )
+    assert set().union(*totals.values()) == {"1,498,715,010,176"}, (
+        f"k-exaone-2 conversion leaves disagree on the source payload total: {totals}"
+    )
+
+
+if __name__ == "__main__":
+    # Allow standalone RED-GREEN without pytest:  python3 test_model_verification_card_payload_totals.py
+    import traceback
+
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e}")
+            traceback.print_exc()
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
# What does this PR do ?

Fixes the k-exaone-2 verification card publishing two different payload-byte totals for one revision-pinned source checkpoint, by reconciling the export leaf to the total PR #5779 corrected on the import leaf.

# Changelog

- `examples/model_verification_cards/k-exaone-2/card.yaml`: export leaf's superseded total `1,498,715,008,512` reconciled to `1,498,715,010,176`.
- `tests/unit_tests/doc_consistency/test_model_verification_card_payload_totals.py`: 2 tests asserting the four conversion leaves of every shipped card agree on any payload-byte total.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

# Additional Information

- **Root cause:** `bb1322d6` added both conversion leaves carrying one figure, `1,498,715,008,512`. #5779 corrected it to `1,498,715,010,176` on the import leaf only, stating it "left GPU export ... unchanged".
- **Blast radius:** card-only. Both leaves claim a bitwise match of the same 59,396 tensors against the same pinned source, so the totals cannot legitimately differ by 1,664 bytes.
- **Precedent:** `glm5` publishes its total on both conversion leaves and they agree; k-exaone-2 is the only card of 24 where they disagree.
- **Regression?** No — introduced by #5779 (`6b8409c8`, 2026-08-25), which corrected one of two occurrences.
- **Verification:** red-green — RED 0/2 with the fix reverted, GREEN 2/2 with it; `validate_card.py` exit 0; ruff 0.9.9 clean.
- **Not covered:** which figure is arithmetically correct. This reconciles the card to the value #5779 declared correct; re-measuring needs the ~1.4 TB checkpoint on 48 H100s. Reviewer `yaoyu-33` please confirm.
