### PR TITLE
[ckpt] fix: Reset NVRx results after async abort

### DIFF
--- a/src/megatron/bridge/training/inprocess_restart.py
+++ b/src/megatron/bridge/training/inprocess_restart.py
@@ -109,13 +109,17 @@ def inprocess_restart(train_fn: Callable, config: InProcessRestartConfig, global
                     async_calls_queue.close(abort=True)
                     global_state._async_calls_queue = None
 
-                from megatron.core.dist_checkpointing.strategies import filesystem_async
+                from megatron.core.dist_checkpointing.strategies import filesystem_async as mcore_filesystem_async
+                from nvidia_resiliency_ext.checkpointing.async_ckpt import (
+                    filesystem_async as nvrx_filesystem_async,
+                )
 
-                if filesystem_async._results_queue is not None:
-                    try:
-                        filesystem_async._results_queue._manager.shutdown()
-                    finally:
-                        filesystem_async._results_queue = None
+                for filesystem_async in (mcore_filesystem_async, nvrx_filesystem_async):
+                    if filesystem_async._results_queue is not None:
+                        try:
+                            filesystem_async._results_queue._manager.shutdown()
+                        finally:
+                            filesystem_async._results_queue = None
 
             except Exception:
                 pass

--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -225,13 +225,15 @@ def _abort_async_checkpoint_worker(state: GlobalState) -> None:
     finally:
         state._async_calls_queue = None
 
-        from megatron.core.dist_checkpointing.strategies import filesystem_async
+        from megatron.core.dist_checkpointing.strategies import filesystem_async as mcore_filesystem_async
+        from nvidia_resiliency_ext.checkpointing.async_ckpt import filesystem_async as nvrx_filesystem_async
 
-        if filesystem_async._results_queue is not None:
-            try:
-                filesystem_async._results_queue._manager.shutdown()
-            finally:
-                filesystem_async._results_queue = None
+        for filesystem_async in (mcore_filesystem_async, nvrx_filesystem_async):
+            if filesystem_async._results_queue is not None:
+                try:
+                    filesystem_async._results_queue._manager.shutdown()
+                finally:
+                    filesystem_async._results_queue = None
 
 
 def _safe_distributed_rank() -> str:

--- a/tests/unit_tests/training/test_inprocess_restart.py
+++ b/tests/unit_tests/training/test_inprocess_restart.py
@@ -436,9 +436,10 @@ class TestInProcessRestart:
 class TestAbortCheckpoint:
     """Test cases for the AbortCheckpoint class functionality."""
 
-    def test_abort_checkpoint_resets_mcore_results_queue(self):
-        """Test AbortCheckpoint resets MCore's queue owner for a retry."""
-        from megatron.core.dist_checkpointing.strategies import filesystem_async
+    def test_abort_checkpoint_resets_async_results_queues(self):
+        """Test AbortCheckpoint resets async result queue owners for a retry."""
+        from megatron.core.dist_checkpointing.strategies import filesystem_async as mcore_filesystem_async
+        from nvidia_resiliency_ext.checkpointing.async_ckpt import filesystem_async as nvrx_filesystem_async
 
         mock_config = MagicMock(spec=InProcessRestartConfig)
         mock_config.active_world_size = 1
@@ -458,8 +459,10 @@ class TestAbortCheckpoint:
         mock_config.termination_grace_time = 1.0
         mock_global_state = MagicMock(spec=GlobalState)
         mock_global_state.async_calls_queue = None
-        mock_results_queue = MagicMock()
-        filesystem_async._results_queue = mock_results_queue
+        mock_mcore_results_queue = MagicMock()
+        mock_nvrx_results_queue = MagicMock()
+        mcore_filesystem_async._results_queue = mock_mcore_results_queue
+        nvrx_filesystem_async._results_queue = mock_nvrx_results_queue
 
         try:
             with (
@@ -477,10 +480,13 @@ class TestAbortCheckpoint:
                 frozen_state = MagicMock()
                 assert abort_checkpoint(frozen_state) is frozen_state
 
-            mock_results_queue._manager.shutdown.assert_called_once_with()
-            assert filesystem_async._results_queue is None
+            mock_mcore_results_queue._manager.shutdown.assert_called_once_with()
+            mock_nvrx_results_queue._manager.shutdown.assert_called_once_with()
+            assert mcore_filesystem_async._results_queue is None
+            assert nvrx_filesystem_async._results_queue is None
         finally:
-            filesystem_async._results_queue = None
+            mcore_filesystem_async._results_queue = None
+            nvrx_filesystem_async._results_queue = None
 
     def test_abort_checkpoint_with_async_calls_queue(self):
         """Test AbortCheckpoint when async_calls_queue exists."""


### PR DESCRIPTION
## Problem

With `checkpoint.async_save=True`, the default `async_strategy="nvrx"`, and an in-process restart after the old writer reports a result but before finalization, Bridge can retain the abandoned NVRx result queue. The next checkpoint writer can consume that stale result, causing a checkpoint failure or finalizing metadata from the wrong save.

The abort paths closed the async queue but reset only the Megatron-Core filesystem result owner. NVRx maintains a separate module-global FIFO result queue.

## Fix

Reset both supported result-queue owners after abort in the in-process-restart and ordinary training-failure cleanup paths. The regression test seeds both queues and verifies that both managers are shut down and both globals are cleared.

## Validation

- `uv run --no-sync python repro_stale_nvrx_results.py` on the unmodified base: failed with `queue_reused=True` and the expected stale-queue assertion.
- The same deterministic reproducer after the fix: passed with `queue_reused=False`.
- `uv run python -m pytest tests/unit_tests/training/test_inprocess_restart.py -q`: 20 passed.
- `git diff --check`: passed.
- `uv run pre-commit run --all-files`: passed.

## Scope

This does not change checkpoint formats, retention behavior, public APIs, dependencies, CI configuration, or upstream Megatron-Core code.