### PR TITLE
[recipe] fix: Clear GB200 uneven pipeline layout

### DIFF
--- a/src/megatron/bridge/recipes/qwen_vl/gb200/qwen35_vl.py
+++ b/src/megatron/bridge/recipes/qwen_vl/gb200/qwen35_vl.py
@@ -118,6 +118,8 @@ def _apply_qwen35_vl_35b_a3b_gb200_functional_defaults(cfg: ConfigContainer) -> 
     cfg.model.pipeline_model_parallel_size = 1
     cfg.model.pipeline_dtype = None
     cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.num_layers_in_first_pipeline_stage = None
+    cfg.model.num_layers_in_last_pipeline_stage = None
     cfg.model.context_parallel_size = 1
     cfg.model.expert_model_parallel_size = 8
     cfg.model.expert_tensor_parallel_size = 1

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py
@@ -119,6 +119,8 @@ class _FakeModelCfg:
         self.pipeline_model_parallel_size = 1
         self.pipeline_dtype = None
         self.virtual_pipeline_model_parallel_size = None
+        self.num_layers_in_first_pipeline_stage = None
+        self.num_layers_in_last_pipeline_stage = None
         self.context_parallel_size = 1
         self.expert_model_parallel_size = 1
         self.expert_tensor_parallel_size = 1
@@ -727,6 +729,8 @@ def test_qwen35_vl_35b_a3b_gb200_functional_defaults(
     assert cfg.model.pipeline_model_parallel_size == 1
     assert cfg.model.pipeline_dtype is None
     assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.num_layers_in_first_pipeline_stage is None
+    assert cfg.model.num_layers_in_last_pipeline_stage is None
     assert cfg.model.context_parallel_size == 1
     assert cfg.model.expert_model_parallel_size == 8
     assert cfg.model.expert_tensor_parallel_size == 1


### PR DESCRIPTION
## Problem

The public `qwen35_vl_35b_a3b_sft_8gpu_gb200_bf16_functional_config` recipe changes its H100 parent from pipeline parallelism 2 to 1 but retains the parent's explicit first/last-stage layer counts (17/23).

During normal provider finalization, Megatron-Core therefore sees zero middle layers but negative-one middle pipeline stages and rejects the documented GB200 SFT configuration before model construction.

## Fix

Clear both uneven-pipeline edge counts at the same GB200 helper that changes PP to 1. This restores ordinary single-stage ownership without changing the recipe's supported topology or adding a new configuration surface.

The focused recipe test now initializes the fake provider with the real fields and asserts that both SFT and its unaffected PEFT sibling leave them unset after applying GB200 defaults.

## Validation

Fail-before on the audited base:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py::test_qwen35_vl_35b_a3b_gb200_functional_defaults -q --tb=short
1 failed, 1 passed
```

Pass-after:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py::test_qwen35_vl_35b_a3b_gb200_functional_defaults -q --tb=short
2 passed

uv run python -m pytest --confcutdir=tests/unit_tests/recipes tests/unit_tests/recipes/qwen_vl/test_qwen35_vl_recipes.py -q --tb=short
117 passed

uv run pre-commit run --all-files
Passed
```

## Scope

This only resets stale uneven-stage fields when the existing GB200 functional helper selects PP1. It does not change model mappings, public APIs, dependencies, CI, or other hardware recipes.
