### PR TITLE
[training] fix: Run train-end callbacks on planned exit

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -802,20 +802,7 @@ def train(
         print_rank_0(f"Total training energy (GPU): {total_energy / 1e6} MJ")
         energy_monitor.shutdown()
 
-    # If any exit conditions (signal handler, duration, iterations) have been reached, exit.
-    if should_exit:
-        # Close NVIDIA DLFw Inspect if enabled
-        tensor_inspect_end_if_enabled(config.tensor_inspect)
-        checkpoint_manager.finalize_async_saves(state=global_state, blocking=True, terminate=True)
-        wandb_writer = global_state.wandb_logger
-        if wandb_writer:
-            wandb_writer.finish()
-        if global_state._comet_logger:
-            global_state._comet_logger.end()
-        fault_tolerance.shutdown(global_state)
-        sys.exit(exit_code)
-
-    # Close NVIDIA DLFw Inspect at clean finish
+    # Close NVIDIA DLFw Inspect at the end of the training loop.
     tensor_inspect_end_if_enabled(config.tensor_inspect)
 
     if should_fire(callback_manager, "on_train_end"):
@@ -829,6 +816,17 @@ def train(
                 scheduler=scheduler,
             ),
         )
+
+    # If any exit conditions (signal handler, duration, iterations) have been reached, exit.
+    if should_exit:
+        checkpoint_manager.finalize_async_saves(state=global_state, blocking=True, terminate=True)
+        wandb_writer = global_state.wandb_logger
+        if wandb_writer:
+            wandb_writer.finish()
+        if global_state._comet_logger:
+            global_state._comet_logger.end()
+        fault_tolerance.shutdown(global_state)
+        sys.exit(exit_code)
 
 
 @nvtx_decorator()


### PR DESCRIPTION
## Summary

Configured graceful exits such as `exit_interval=1` currently terminate
`train()` before its sole `on_train_end` callback site. Integrations using the
documented callback lifecycle therefore miss terminal state and cleanup even
though the training loop completed normally and the process exits with status
zero.

The exit decision is made after a completed iteration, then `train()` performs
checkpoint finalization and reaches `sys.exit(exit_code)` before the callback
block. This change moves the existing common tensor-inspector finalization and
unchanged `on_train_end` block ahead of exit-only logger/fault-tolerance cleanup
and `SystemExit`.

## Reproduction and validation

A deterministic lifecycle harness imports the actual Bridge `train()` and
`CallbackManager` at the base revision, stubbing only accelerator work and
unrelated external integrations. It registers paired start/end callbacks and
runs `train_iters=2` with `exit_interval=1`:

```shell
PYTHONPATH=src:3rdparty/Megatron-LM uv run python /tmp/repro_train_end_exit.py
```

- Before: exit 1 from the contract assertion;
  `planned_exit_events=['start']`.
- After: exit 0; `planned_exit_events=['start', 'end']`.
- Unaffected natural-completion control: exit 0;
  `natural_exit_events=['start', 'end']`.
- `git diff --check`: passed.
- `uv run pre-commit run --all-files`: passed all hooks.

## Scope

This does not change exit conditions, exit codes, callback arguments,
checkpoint decisions, or cleanup calls. Arbitrary exception behavior is
unchanged, and no public API, dependency, workflow, or submodule is modified.
