### PR TITLE
[data] fix: Finalize MegatronMIMO dataset configs

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -2067,7 +2067,7 @@ def megatron_mimo_runtime_config_update(cfg: ConfigContainer) -> None:
     Keeps (safe for MegatronMIMO):
     - Recipe environment variable defaults
     - ``data_parallel_size = 1`` (MegatronMIMO-specific hard-code)
-    - Sub-config finalization (optimizer, ddp, logger, train, scheduler, checkpoint)
+    - Sub-config finalization (dataset, optimizer, ddp, logger, train, scheduler, checkpoint)
     - Distributed optimizer sync validation
     - Deterministic mode validation
 
@@ -2089,6 +2089,8 @@ def megatron_mimo_runtime_config_update(cfg: ConfigContainer) -> None:
     # Finalize sub-configs that don't depend on model construction order.
     # NOTE: cfg.model.finalize() is NOT called here — it validates parallelism
     # config and is called inside setup_megatron_mimo() right before build_infra().
+    if hasattr(cfg.dataset, "finalize"):
+        cfg.dataset.finalize()
     if hasattr(cfg.optimizer, "finalize"):
         cfg.optimizer.finalize()
     if hasattr(cfg.ddp, "finalize"):

--- a/tests/unit_tests/data/megatron_mimo/test_loaders.py
+++ b/tests/unit_tests/data/megatron_mimo/test_loaders.py
@@ -1,12 +1,17 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Unit tests for build_megatron_mimo_data_loaders."""
 
+from dataclasses import dataclass
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from torch.utils.data import Dataset
 
+from megatron.bridge.data.base import DatasetBuildContext
+from megatron.bridge.data.megatron_mimo.base_provider import MegatronMIMODatasetProvider
 from megatron.bridge.data.megatron_mimo.loaders import build_megatron_mimo_data_loaders
+from megatron.bridge.training.config import megatron_mimo_runtime_config_update
 
 
 class FakeMegatronMIMOProvider:
@@ -216,6 +221,20 @@ class IndexDataset(Dataset):
         return idx
 
 
+@dataclass(kw_only=True)
+class RuntimeFinalizedIndexDatasetProvider(MegatronMIMODatasetProvider):
+    """Concrete provider that relies on the shared dataloader finalization contract."""
+
+    train_size: int = 8
+
+    def build_datasets(self, context: DatasetBuildContext):
+        del context
+        return IndexDataset(self.train_size), None, None
+
+    def get_collate_fn(self):
+        return lambda batch: batch
+
+
 class IndexDatasetProvider:
     """Provider that yields IndexDataset for train/valid/test.
 
@@ -268,6 +287,38 @@ def _make_real_loader_cfg(monkeypatch, *, micro_batch_size: int, sampler_dp_rank
         train=SimpleNamespace(micro_batch_size=micro_batch_size),
         validation=SimpleNamespace(eval_micro_batch_size=micro_batch_size),
     )
+
+
+def test_mimo_runtime_update_normalizes_zero_worker_provider_before_loader_construction(monkeypatch):
+    provider = RuntimeFinalizedIndexDatasetProvider(num_workers=0)
+    runtime_cfg = MagicMock()
+    runtime_cfg.env_vars = {}
+    runtime_cfg.dataset = provider
+    runtime_cfg.train.num_epochs = None
+    runtime_cfg.train.global_batch_size = 2
+    runtime_cfg.train.micro_batch_size = 2
+    runtime_cfg.validation.eval_global_batch_size = None
+    runtime_cfg.validation.eval_micro_batch_size = None
+    runtime_cfg.profiling = None
+    runtime_cfg.ddp.use_distributed_optimizer = False
+    runtime_cfg.optimizer.use_distributed_optimizer = False
+    runtime_cfg.ddp.overlap_param_gather = False
+    runtime_cfg.optimizer.overlap_param_gather = False
+
+    megatron_mimo_runtime_config_update(runtime_cfg)
+
+    loader_cfg = _make_real_loader_cfg(monkeypatch, micro_batch_size=2)
+    train_loader, _, _ = build_megatron_mimo_data_loaders(
+        loader_cfg,
+        train_state=SimpleNamespace(consumed_train_samples=0),
+        megatron_mimo_provider=provider,
+        train_samples=provider.train_size,
+        valid_samples=0,
+        test_samples=0,
+    )
+
+    assert provider.persistent_workers is False
+    assert next(iter(train_loader)) == [0, 1]
 
 
 def test_train_loader_starts_from_consumed_samples_end_to_end(monkeypatch):


### PR DESCRIPTION
## Problem\n\nA supported MegatronMIMO dataset provider can set num_workers=0 while inheriting persistent_workers=True. The specialized MegatronMIMO runtime update skipped dataset finalization, so these values reached the PyTorch DataLoader unchanged and raised ValueError: persistent_workers option needs num_workers > 0 during setup.\n\nThe affected path is the public MegatronMIMODatasetProvider configuration through megatron_mimo_runtime_config_update and build_megatron_mimo_data_loaders.\n\n## Root cause and fix\n\nDataloaderConfig.finalize owns the existing normalization invariant for zero workers, but the specialized MegatronMIMO runtime lifecycle did not invoke it. This change calls the provider finalizer at that lifecycle boundary, matching the standard configuration path without duplicating loader logic.\n\nThe regression test uses a concrete public MIMO provider, runs the specialized runtime update, constructs the real loader, and verifies both normalization and iteration.\n\n## Validation\n\nFail before:\n- Private deterministic CPU reproducer at the audited base: failed with ValueError: persistent_workers option needs num_workers > 0\n\nPass after:\n- The same reproducer: passed\n- uv run --no-sync python -m pytest tests/unit_tests/data/megatron_mimo/test_loaders.py::test_mimo_runtime_update_normalizes_zero_worker_provider_before_loader_construction -q --tb=short: 1 passed\n- uv run --no-sync python -m pytest tests/unit_tests/data/megatron_mimo/test_loaders.py tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_megatron_mimo_runtime_config_update_resolves_eval_batch_size_defaults -q --tb=short: 12 passed\n- git diff --check: passed\n- uv run --no-sync pre-commit run --all-files: passed\n\n## Scope\n\nThis does not change public APIs, dependencies, distributed ownership, samplers, model behavior, or third-party code. Full-suite, performance, convergence, and model-quality validation were not run.