### PR TITLE
test: conversion-only stack gate (-m conversion) for NeMo-RL / MCore bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,6 +287,7 @@ markers = [
     "gpu: marks tests requiring GPU hardware",
     "skipduringci: marks tests that are skipped ci as they are addressed by Jenkins jobs but should be run to test user setups",
     "pleasefixme: marks tests that are broken and need fixing",
+    "conversion: marks the conversion-only stack (HF<->Megatron mapping/provider/roundtrip) that MCore bumps must not break; NeMo-RL depends on this subset (select with '-m conversion')",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Root test configuration.
+
+Defines the *conversion-only stack*: the subset of tests that exercise
+HuggingFace <-> Megatron weight mapping, model providers, and roundtrip
+conversion, with no dependency on the Megatron-Bridge training loop.
+
+Membership is a path rule, applied automatically at collection time, so a
+newly added ``*_bridge.py`` / ``*_provider.py`` / ``*_conversion.py`` test is
+included in ``-m conversion`` without anyone having to remember to tag it.
+This is the contract NeMo-RL relies on: RL depends on MCore directly and only
+needs this conversion subset of Megatron-Bridge to keep working across MCore
+bumps. Run it with ``pytest -m conversion``.
+
+To change what counts as "conversion", edit ``_is_conversion_test`` below --
+that is the single source of truth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# Explicit core files under tests/unit_tests/models/ that belong to the
+# conversion stack but are not covered by the *_bridge / *_provider suffixes.
+_UNIT_MODEL_CORE_FILES = frozenset(
+    {
+        "test_param_mapping.py",
+        "test_mapping_registry.py",
+        "test_conversion_utils.py",
+        "test_conversion_unwrap_utils.py",
+        "test_gpt_provider.py",
+        "test_model_provider_mixin.py",
+    }
+)
+
+
+def _is_conversion_test(path: Path) -> bool:
+    """Return True if a collected test file is part of the conversion-only stack."""
+    posix = path.as_posix()
+    name = path.name
+
+    # CPU unit tier: per-family bridge/provider mapping + core mapping helpers.
+    if "/tests/unit_tests/models/" in posix:
+        if name.endswith("_bridge.py") or name.endswith("_provider.py"):
+            return True
+        if name in _UNIT_MODEL_CORE_FILES:
+            return True
+
+    # GPU functional tier: generic converter + per-family HF<->Megatron roundtrip.
+    if "/tests/functional_tests/test_groups/converter/" in posix:
+        return True
+    if "/tests/functional_tests/test_groups/models/" in posix and name.endswith("_conversion.py"):
+        return True
+
+    return False
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-apply the ``conversion`` marker to every conversion-stack test."""
+    marker = pytest.mark.conversion
+    for item in items:
+        try:
+            path = Path(item.path)
+        except (AttributeError, TypeError):
+            path = Path(str(item.fspath))
+        if _is_conversion_test(path):
+            item.add_marker(marker)


### PR DESCRIPTION
## What

Adds a **conversion-only test stack** that Megatron-Bridge exposes as a stable, self-maintaining subset — the tests that exercise HF↔Megatron **mapping / provider / roundtrip** conversion, with no dependency on the Bridge training loop.

- **`tests/conftest.py`** — a `pytest_collection_modifyitems` hook that auto-applies a new `conversion` marker by **path rule** (`_is_conversion_test` is the single source of truth):
  - CPU: `tests/unit_tests/models/**/*_bridge.py`, `*_provider.py`, plus core mapping helpers (`test_param_mapping`, `test_mapping_registry`, `test_conversion_utils`, `test_conversion_unwrap_utils`, `test_gpt_provider`, `test_model_provider_mixin`)
  - GPU: `test_groups/converter/**` and `test_groups/models/**/*_conversion.py`
  - New `*_bridge.py` / `*_conversion.py` tests are included automatically — no manual tagging, cannot silently rot.
- **`pyproject.toml`** — registers the `conversion` marker (required; `--strict-markers` is on).
- **`tests/functional_tests/launch_scripts/h100/rl/L0_conversion_stack.sh`** — runs `pytest -m conversion` scoped to the families NeMo-RL uses (**Qwen3, Llama**): CPU mapping units fail-fast, then GPU roundtrip.

## Why

NeMo-RL is moving to depend on **MCore directly**, not on Megatron-Bridge (removing the RL → MB → MC diamond). Conversion is still inherently a Bridge function, so this gate lets an **MCore bump catch conversion breakage early** — it's the contract RL cares about, decoupled from the training stack.

## No CI duplication

The script lives in `launch_scripts/h100/rl/` — **not** `active/` or `flaky/`. The functional sweep in `cicd-main.yml` only globs `active/${tier}_*.sh` and `flaky/L*.sh`, so it never picks this up and there's no overlap with `L0_Launch_converter.sh`.

## Follow-up (why this is a draft)

Trigger wiring is intentionally not included. Intended home: fold into the `cicd-mbridge-testing` job that MCore CI already triggers, or a standalone `workflow_dispatch` + `paths: 3rdparty/Megatron-LM` job, reusing the `test-template` action with `script_dir: h100/rl`.

## Verify

```bash
uv run pytest -m conversion --collect-only -q        # see the selected set
bash tests/functional_tests/launch_scripts/h100/rl/L0_conversion_stack.sh   # 2-GPU node
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)