### PR TITLE
fix(ckpt): derive checkpoint replica_id from the gtp_remat-inclusive DP group

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -1236,7 +1236,7 @@ def save_checkpoint(
 
     # Collect cfg, model, RNG.
     sharded_sd_metadata = _build_sharded_state_dict_metadata(cfg.optimizer.use_distributed_optimizer, ckpt_cfg)
-    sharded_sd_metadata["dp_cp_group"] = pg_collection.dp_cp
+    sharded_sd_metadata["dp_cp_group"] = _checkpoint_dp_cp_group(pg_collection)
     if cfg.optimizer.use_distributed_optimizer:
         print_rank_0(
             f"Storing distributed optimizer sharded state of type {sharded_sd_metadata['distrib_optim_sharding_type']}"
@@ -1376,7 +1376,7 @@ def save_checkpoint(
                 if ckpt_cfg.fully_parallel_save:
                     save_strategy = FullyParallelSaveStrategyWrapper(
                         save_strategy,
-                        pg_collection.dp_cp,
+                        _checkpoint_dp_cp_group(pg_collection),
                         ckpt_cfg.ckpt_assume_constant_structure,
                     )
             # MegatronMIMO + torch_dist can hit known access-pattern validation failures
@@ -2368,7 +2368,7 @@ def _load_model_weights_from_checkpoint(
     load_strategy = TorchDistLoadShardedStrategy()
     if fully_parallel_load:
         pg_collection = get_pg_collection(model)
-        load_strategy = FullyParallelLoadStrategyWrapper(load_strategy, pg_collection.dp_cp)
+        load_strategy = FullyParallelLoadStrategyWrapper(load_strategy, _checkpoint_dp_cp_group(pg_collection))
     state_dict = dist_checkpointing.load(
         sharded_state_dict, checkpoint_path, load_strategy, strict=dist_ckpt_strictness
     )
@@ -2990,7 +2990,7 @@ def _load_checkpoint_from_path(
 
         if sharded_sd_metadata is None:
             sharded_sd_metadata = {}
-        sharded_sd_metadata["dp_cp_group"] = pg_collection.dp_cp
+        sharded_sd_metadata["dp_cp_group"] = _checkpoint_dp_cp_group(pg_collection)
         optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
         model_sd_kwargs = dict(metadata=sharded_sd_metadata)
 
@@ -3642,7 +3642,7 @@ def _load_global_dist_base_checkpoint(
     )
     load_strategy = TorchDistLoadShardedStrategy()
     if ckpt_cfg.fully_parallel_load:
-        load_strategy = FullyParallelLoadStrategyWrapper(load_strategy, pg_collection.dp_cp)
+        load_strategy = FullyParallelLoadStrategyWrapper(load_strategy, _checkpoint_dp_cp_group(pg_collection))
     if checkpointing_context is not None:
         checkpointing_context["load_strategy"] = load_strategy
     validate_sharding_integrity = True
@@ -3973,6 +3973,30 @@ def _build_sharded_state_dict_metadata(use_distributed_optimizer: bool, cfg: Che
     metadata["singleton_local_shards"] = False
     metadata["chained_optim_avoid_prefix"] = True
     return metadata
+
+
+def _checkpoint_dp_cp_group(pg_collection: ProcessGroupCollection) -> torch.distributed.ProcessGroup:
+    """Return the DP x CP group that sharded-checkpoint ``replica_id`` must be derived from.
+
+    ``pg_collection.dp_cp`` deliberately EXCLUDES the GTP weight-rematerialization axis -- it is
+    the *replicate* group, used for gradient all-reduce and optimizer-state sharding. Checkpoint
+    ``replica_id`` needs the opposite: the gtp_remat-INCLUSIVE ``dp_cp_gtp_remat`` group. A tensor
+    that is not GTP-sharded (a norm weight, a bias, an ``_extra_state`` blob) is held identically
+    by every gtp_remat peer, and with the excluded group those peers all report the same DP rank,
+    so each of them claims to be the main replica of the same shard. Distributed checkpointing then
+    rejects the save/load with::
+
+        CheckpointingException: Invalid sharding pattern validation. Errors: Invalid access
+          pattern for ShardedTensor(key='decoder.final_layernorm.weight', ...)
+
+    Megatron-LM's own training loop applies exactly this override before building the sharded
+    state dict (see ``megatron/training/training.py``); Megatron-Bridge has its own checkpoint
+    entrypoints and needs it too.
+
+    ``dp_cp_gtp_remat`` is absent on older Megatron-Core revisions and is the same group as
+    ``dp_cp`` whenever GTP is inactive, so the fallback is a no-op in both cases.
+    """
+    return getattr(pg_collection, "dp_cp_gtp_remat", None) or pg_collection.dp_cp
 
 
 def _get_train_state_from_state_dict(state_dict: dict[str, Any]) -> TrainState:

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -3219,6 +3219,10 @@ class TestLoadModelWeightsFromCheckpoint:
         mock_pg_collection = Mock()
         mock_dp_cp_group = Mock()
         mock_pg_collection.dp_cp = mock_dp_cp_group
+        # The wrapper re-elects one writer per shard within the group it is given, so it must get
+        # the gtp_remat-INCLUSIVE group, not the gtp-excluded replicate group.
+        mock_dp_cp_gtp_remat_group = Mock()
+        mock_pg_collection.dp_cp_gtp_remat = mock_dp_cp_gtp_remat_group
         mock_get_pg_collection.return_value = mock_pg_collection
 
         # Call the function
@@ -3232,8 +3236,8 @@ class TestLoadModelWeightsFromCheckpoint:
             strict=True,
         )
 
-        # Verify fully parallel wrapper was used with pg_collection.dp_cp
-        mock_fully_parallel_wrapper.assert_called_once_with(mock_strategy, mock_dp_cp_group)
+        # Verify fully parallel wrapper was used with pg_collection.dp_cp_gtp_remat
+        mock_fully_parallel_wrapper.assert_called_once_with(mock_strategy, mock_dp_cp_gtp_remat_group)
 
     @patch("megatron.bridge.training.checkpointing.dist_checkpointing")
     @patch("megatron.bridge.training.checkpointing.unwrap_model")
@@ -5934,3 +5938,29 @@ class TestMaybeSaveDataloaderState:
             {"dataloader_state_dict": {"dummy_energon_state": "xyz"}}, expected_path
         )
         mock_torch_save.assert_not_called()
+
+
+class TestCheckpointDpCpGroup:
+    """`_checkpoint_dp_cp_group` picks the group sharded-checkpoint replica_id is derived from."""
+
+    def test_prefers_gtp_remat_inclusive_group(self):
+        """With GTP active, replica_id must come from the gtp_remat-INCLUSIVE group."""
+        from megatron.bridge.training.checkpointing import _checkpoint_dp_cp_group
+
+        pg_collection = Mock()
+        pg_collection.dp_cp = Mock(name="dp_cp_replicate")
+        pg_collection.dp_cp_gtp_remat = Mock(name="dp_cp_gtp_remat")
+
+        assert _checkpoint_dp_cp_group(pg_collection) is pg_collection.dp_cp_gtp_remat
+
+    @pytest.mark.parametrize("absent_value", [None, "missing"])
+    def test_falls_back_to_dp_cp(self, absent_value):
+        """Older Megatron-Core has no `dp_cp_gtp_remat`; the fallback must be a no-op."""
+        from megatron.bridge.training.checkpointing import _checkpoint_dp_cp_group
+
+        pg_collection = Mock(spec=["dp_cp"]) if absent_value == "missing" else Mock()
+        pg_collection.dp_cp = Mock(name="dp_cp_replicate")
+        if absent_value is None:
+            pg_collection.dp_cp_gtp_remat = None
+
+        assert _checkpoint_dp_cp_group(pg_collection) is pg_collection.dp_cp


### PR DESCRIPTION
Found while validating megatron-core's GTP weight rematerialization
(NVIDIA/Megatron-LM#6133) against NeMo-RL's Megatron functional suites.

## The bug

`pg_collection.dp_cp` is the GTP **replicate** group: it deliberately *excludes*
the `gtp_remat` axis, because that is what gradient all-reduce and
optimizer-state sharding need. Sharded checkpointing needs the opposite group.

A tensor that is not GTP-sharded — a norm weight, a bias, an `_extra_state` blob
— is held identically by every `gtp_remat` peer. With the gtp-excluded group,
all of those peers report the same DP rank, so all of them get `replica_id 0`
and each claims to be the main replica of the same shard. Distributed
checkpointing rejects it:

```
CheckpointingException: Invalid sharding pattern validation. Errors: Invalid
  access pattern for ShardedTensor(key='decoder.final_layernorm.weight', ...)
```

The `FullyParallel` save/load wrappers have the same requirement for a second,
independent reason: they re-elect one writer per shard *within* the group they
are handed, so a gtp-excluded group elects one writer per `gtp_remat` peer set
instead of one overall — reintroducing the duplicate even after the metadata is
corrected.

Megatron-LM's own training loop already applies exactly this override before
building the sharded state dict (see `megatron/training/training.py`).
Megatron-Bridge has its own checkpoint entrypoints, which NeMo-RL and other
downstreams use, so it needs the same.

## The fix

One helper, `_checkpoint_dp_cp_group(pg_collection)`, used at the five sites
that feed a group into checkpoint metadata or a `FullyParallel*` wrapper. It
returns `dp_cp_gtp_remat` when megatron-core exposes it, and `dp_cp` otherwise.

`dp_cp_gtp_remat` is absent on older megatron-core revisions and is the same
group as `dp_cp` whenever GTP is inactive, so this is a **no-op** in both cases —
it only changes behaviour when GTP weight rematerialization is actually on.

The PEFT adapter load path (`peft/utils.py`) builds its own collection with
`required_pgs=["dp_cp"]` and is left unchanged; LoRA with GTP is untested.

## Validation

The production change was exercised on GB200 (aarch64, 4 GPUs) in a GRPO run
with `TP=1`, `gtp_remat_size=2` and colocated Megatron generation: without it,
the run aborts on the access-pattern validation above during checkpoint save;
with it, checkpointing completes and the run finishes two full training steps.
That validation also needed four megatron-core fixes, raised separately as
NVIDIA/Megatron-LM#6940.

Unit tests are added for both branches of the helper (preferred group present,
and the two ways it can be absent) and the existing `FullyParallelLoad`
assertion is updated to expect the gtp_remat-inclusive group. They are pure
`Mock`, no GPU needed.

---

Raised by an automated agent. Draft — needs a human review before merge.