### PR TITLE
[2/2] refactor(recipe): unify Qwen3 235B performance and convergence configs

### DIFF
--- a/docs/_static/model-verification/catalog-v1.json
+++ b/docs/_static/model-verification/catalog-v1.json
@@ -6538,10 +6538,10 @@
     {
       "architecture": "Qwen3MoeForCausalLM",
       "base_container": "nvcr.io/nvidia/nemo:26.08",
-      "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+      "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
       "entries": [
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6558,7 +6558,7 @@
           "workflow": "hf_to_megatron_cpu"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6575,7 +6575,7 @@
           "workflow": "hf_to_megatron_gpu"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6592,7 +6592,7 @@
           "workflow": "megatron_to_hf_cpu"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6609,7 +6609,7 @@
           "workflow": "megatron_to_hf_gpu"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6626,7 +6626,7 @@
           "workflow": "manual_forward_pass"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6643,7 +6643,7 @@
           "workflow": "inference"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6666,7 +6666,49 @@
           "workflow": "pretrain"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
+          "command_topologies": [
+            {
+              "gpus_per_node": "4",
+              "nodes": "64",
+              "recipe": "qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config",
+              "sequence_length": "4096",
+              "total_gpus": 256
+            }
+          ],
+          "commands": [
+            "./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4 --recipe qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config --mode pretrain --dataset megatron-indexed --seq_length 4096 --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40 'dataset.blend=[[\"work/data/rp2/head_01\"],null]' dataset.path_to_cache=work/cache/qwen3-235b-a22b/rp2 tokenizer.tokenizer_type=SentencePieceTokenizer tokenizer.tokenizer_model=work/data/rp2/tokenizer.model scheduler.lr_decay_iters=100 model.moe_router_force_load_balancing=false ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true rerun_state_machine.check_for_nan_in_loss=true checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234 dist.distributed_timeout_minutes=30 --save_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-checkpoints --save_interval 50 logger.log_interval=1 logger.log_throughput=true logger.tensorboard_dir=null logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-config.yaml"
+          ],
+          "dimensions": {},
+          "enabled_features": {
+            "cuda_graph": {
+              "implementation": "transformer_engine",
+              "scopes": [
+                "moe_router",
+                "moe_preprocess"
+              ]
+            },
+            "moe_dispatcher": "deepep"
+          },
+          "entry_id": "qwen3-235b-a22b-pretrain-gb200",
+          "expected_result": "On exactly 256 GB200s, this support-verification workload completes exactly 100 bounded RP2 optimizer steps with TP1/PP16/CP1/EP16/ETP1, DP1, SP off, GBS/MBS 8192/1, and sequence length 4096. MXFP8 compute, natural routing, DeepEP, and Transformer Engine CUDA graphs for moe_router and moe_preprocess remain active. Loss is finite from 11.176840 to 6.856652 with no skipped or NaN iterations, all five metrics are recorded, the post-setup configuration persists, and complete iter_0000050 and iter_0000100 checkpoints are saved. GBS8192 makes this support verification rather than cross-model convergence evidence for the GBS1024 cohort.\n",
+          "hardware": "GB200",
+          "last_verified": "2026-08-28",
+          "metrics": {
+            "final_loss": 6.856652,
+            "initial_loss": 11.17684,
+            "last_10_steps_model_tflops_per_gpu_avg": 262.34,
+            "last_10_steps_step_time_ms_avg": 72553.93,
+            "last_10_steps_tokens_per_second_per_gpu_avg": 1806.546
+          },
+          "precision": "fp8_mx",
+          "source_pointer": "items.pretrain.GB200",
+          "status": "verified",
+          "variant": null,
+          "workflow": "pretrain"
+        },
+        {
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6689,7 +6731,7 @@
           "workflow": "sft"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6706,7 +6748,7 @@
           "workflow": "sft_export_inference"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6729,7 +6771,7 @@
           "workflow": "sft_long_context"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6752,7 +6794,7 @@
           "workflow": "peft"
         },
         {
-          "bridge_commit": "bc09410353986ac7255ffd31fb2b720fb9007107",
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
           "command_topologies": [],
           "commands": [],
           "dimensions": {},
@@ -6771,6 +6813,39 @@
           "precision": "bf16",
           "source_pointer": "items.checkpoint_resume.H100",
           "status": "unverified",
+          "variant": null,
+          "workflow": "checkpoint_resume"
+        },
+        {
+          "bridge_commit": "135f8d67684b625f8ec3f1bd1a81f4ed69c1719f",
+          "command_topologies": [
+            {
+              "gpus_per_node": "4",
+              "nodes": "64",
+              "recipe": "qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config",
+              "sequence_length": "4096",
+              "total_gpus": 256
+            }
+          ],
+          "commands": [
+            "./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4 --recipe qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config --mode pretrain --dataset megatron-indexed --seq_length 4096 --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40 'dataset.blend=[[\"work/data/rp2/head_01\"],null]' dataset.path_to_cache=work/cache/qwen3-235b-a22b/rp2 tokenizer.tokenizer_type=SentencePieceTokenizer tokenizer.tokenizer_model=work/data/rp2/tokenizer.model scheduler.lr_decay_iters=100 model.moe_router_force_load_balancing=false ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true rerun_state_machine.check_for_nan_in_loss=true validation.eval_iters=0 validation.eval_interval=0 dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234 dist.distributed_timeout_minutes=30 --load_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-checkpoints --save_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-resumed-checkpoints --save_interval 50 checkpoint.ckpt_step=50 model.cuda_graph_impl=none logger.log_interval=1 logger.log_throughput=true logger.tensorboard_dir=null logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-resume-config.yaml"
+          ],
+          "dimensions": {},
+          "enabled_features": {},
+          "entry_id": "qwen3-235b-a22b-checkpoint-resume-gb200",
+          "expected_result": "The command restores optimizer, scheduler, data-order, and RNG state directly from iter_0000050, begins at step 51, and finishes at step 100 in a distinct output root. Scoped CUDA graph capture is disabled only for the continuation to avoid a resume-time communication deadlock; routing, precision, batches, data, optimizer, and schedule remain unchanged. All 50 resumed LM-loss values match the uninterrupted reference exactly; auxiliary losses differ by at most 1e-6, including exact step-51 values 7.353207/4.872377 and step-100 values 6.856652/1.976203. Both sentinels match, no iteration is skipped or NaN, all five metrics are recorded, the post-setup configuration persists, and a complete iter_0000100 checkpoint is saved.\n",
+          "hardware": "GB200",
+          "last_verified": "2026-08-28",
+          "metrics": {
+            "final_loss": 6.856652,
+            "initial_loss": 7.353207,
+            "last_10_steps_model_tflops_per_gpu_avg": 235.76,
+            "last_10_steps_step_time_ms_avg": 80779.18,
+            "last_10_steps_tokens_per_second_per_gpu_avg": 1622.596
+          },
+          "precision": "fp8_mx",
+          "source_pointer": "items.checkpoint_resume.GB200",
+          "status": "verified",
           "variant": null,
           "workflow": "checkpoint_resume"
         },
@@ -6846,7 +6921,7 @@
       "min_transformers_version": "5.8.1",
       "slug": "qwen3-235b-a22b",
       "source_card": "examples/model_verification_cards/qwen3-235b-a22b/card.yaml",
-      "summary": "Performance scope: pretrain_performance.GB200 and pretrain_performance.GB300 are verified with their tuned canonical 256-GPU MXFP8 recipes. Model-level and functional training workflows remain unverified in this card.\n",
+      "summary": "Performance scope: pretrain_performance.GB200 and pretrain_performance.GB300 are verified with their tuned canonical 256-GPU MXFP8 recipes. Functional pretraining and checkpoint resume are verified on GB200 as bounded support checks; model-level and the remaining functional workflows are unverified.\n",
       "title": "qwen3_235b_a22b"
     },
     {

--- a/docs/fern/versions/nightly/pages/models/README.mdx
+++ b/docs/fern/versions/nightly/pages/models/README.mdx
@@ -4,7 +4,7 @@
 
 Choose a model to open its interactive import/export and training configurations. Every option comes directly from an authoritative YAML verification card; independent fields are never combined into synthetic commands.
 
-Current inventory: **24 model cards** and **345 concrete configurations**.
+Current inventory: **24 model cards** and **347 concrete configurations**.
 
 Each model page lets you select import/export, pretraining, benchmarking, SFT, LoRA, or long-context SFT and immediately see the exact command and expected result for the recorded precision and GPU.
 

--- a/docs/fern/versions/nightly/pages/models/qwen/qwen3-235b-a22b.mdx
+++ b/docs/fern/versions/nightly/pages/models/qwen/qwen3-235b-a22b.mdx
@@ -79,6 +79,13 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       </span>
       <span class="verification-combination-meta">BF16</span>
     </button>
+    <button type="button" class="verification-combination" data-capability="pretrain" data-precision="fp8_mx" data-hardware="GB200" data-status="verified" data-entry="qwen3-235b-a22b-pretrain-gb200" aria-controls="qwen3-235b-a22b-pretrain-gb200" aria-pressed="false">
+      <span class="verification-combination-heading">
+        <strong>Pretrain · GB200</strong>
+        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
+      </span>
+      <span class="verification-combination-meta">FP8 MX</span>
+    </button>
     <button type="button" class="verification-combination" data-capability="sft" data-precision="bf16" data-hardware="H100" data-status="unverified" data-entry="qwen3-235b-a22b-sft-h100" aria-controls="qwen3-235b-a22b-sft-h100" aria-pressed="false">
       <span class="verification-combination-heading">
         <strong>SFT · H100</strong>
@@ -238,6 +245,57 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       <section class="verification-expected-result">
         <h5>Expected result</h5>
         <p>This workflow remains unverified and requires a bounded public run with the model&#x27;s pinned revision and all applicable verification gates.
+</p>
+      </section>
+    </article>
+    <article id="qwen3-235b-a22b-pretrain-gb200" class="verification-model-detail" data-entry-detail="qwen3-235b-a22b-pretrain-gb200" tabindex="-1">
+      <header class="verification-model-detail-heading">
+        <h4>Pretrain · GB200</h4>
+        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
+      </header>
+      <dl class="verification-model-detail-meta">
+        <div><dt>Hardware</dt><dd>GB200</dd></div>
+        <div><dt>Precision</dt><dd>FP8 MX</dd></div>
+        <div><dt>Last verified</dt><dd>2026-08-28</dd></div>
+      </dl>
+      <section class="verification-recorded-metrics">
+        <h5>Recorded metrics</h5>
+        <dl class="verification-metric-list">
+          <div>
+            <dt>Initial loss</dt>
+            <dd>11.17684</dd>
+          </div>
+          <div>
+            <dt>Final loss</dt>
+            <dd>6.856652</dd>
+          </div>
+          <div>
+            <dt>Step time · last 10 avg</dt>
+            <dd>72,553.930 ms</dd>
+          </div>
+          <div>
+            <dt>Model throughput · last 10 avg</dt>
+            <dd>262.340 TFLOP/s/GPU</dd>
+          </div>
+          <div>
+            <dt>Token throughput · last 10 avg</dt>
+            <dd>1,806.546 tokens/s/GPU</dd>
+          </div>
+        </dl>
+      </section>
+      <section class="verification-command-section">
+        <h5>Exact command</h5>
+        <div class="verification-command">
+          <div class="verification-command-heading">
+            <span>Command</span>
+            <button type="button" class="verification-copy-command">Copy</button>
+          </div>
+          <pre><code class="language-bash">./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4 --recipe qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config --mode pretrain --dataset megatron-indexed --seq_length 4096 --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40 &#x27;dataset.blend=[[&quot;work/data/rp2/head_01&quot;],null]&#x27; dataset.path_to_cache=work/cache/qwen3-235b-a22b/rp2 tokenizer.tokenizer_type=SentencePieceTokenizer tokenizer.tokenizer_model=work/data/rp2/tokenizer.model scheduler.lr_decay_iters=100 model.moe_router_force_load_balancing=false ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true rerun_state_machine.check_for_nan_in_loss=true checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234 dist.distributed_timeout_minutes=30 --save_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-checkpoints --save_interval 50 logger.log_interval=1 logger.log_throughput=true logger.tensorboard_dir=null logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-config.yaml</code></pre>
+        </div>
+      </section>
+      <section class="verification-expected-result">
+        <h5>Expected result</h5>
+        <p>On exactly 256 GB200s, this support-verification workload completes exactly 100 bounded RP2 optimizer steps with TP1/PP16/CP1/EP16/ETP1, DP1, SP off, GBS/MBS 8192/1, and sequence length 4096. MXFP8 compute, natural routing, DeepEP, and Transformer Engine CUDA graphs for moe_router and moe_preprocess remain active. Loss is finite from 11.176840 to 6.856652 with no skipped or NaN iterations, all five metrics are recorded, the post-setup configuration persists, and complete iter_0000050 and iter_0000100 checkpoints are saved. GBS8192 makes this support verification rather than cross-model convergence evidence for the GBS1024 cohort.
 </p>
       </section>
     </article>

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -4,7 +4,7 @@
 
 Choose a model to open its interactive import/export and training configurations. Every option comes directly from an authoritative YAML verification card; independent fields are never combined into synthetic commands.
 
-Current inventory: **24 model cards** and **345 concrete configurations**.
+Current inventory: **24 model cards** and **347 concrete configurations**.
 
 Each model page lets you select import/export, pretraining, benchmarking, SFT, LoRA, or long-context SFT and immediately see the exact command and expected result for the recorded precision and GPU.
 

--- a/docs/models/qwen/qwen3-235b-a22b.md
+++ b/docs/models/qwen/qwen3-235b-a22b.md
@@ -79,6 +79,13 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       </span>
       <span class="verification-combination-meta">BF16</span>
     </button>
+    <button type="button" class="verification-combination" data-capability="pretrain" data-precision="fp8_mx" data-hardware="GB200" data-status="verified" data-entry="qwen3-235b-a22b-pretrain-gb200" aria-controls="qwen3-235b-a22b-pretrain-gb200" aria-pressed="false">
+      <span class="verification-combination-heading">
+        <strong>Pretrain · GB200</strong>
+        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
+      </span>
+      <span class="verification-combination-meta">FP8 MX</span>
+    </button>
     <button type="button" class="verification-combination" data-capability="sft" data-precision="bf16" data-hardware="H100" data-status="unverified" data-entry="qwen3-235b-a22b-sft-h100" aria-controls="qwen3-235b-a22b-sft-h100" aria-pressed="false">
       <span class="verification-combination-heading">
         <strong>SFT · H100</strong>
@@ -238,6 +245,57 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       <section class="verification-expected-result">
         <h5>Expected result</h5>
         <p>This workflow remains unverified and requires a bounded public run with the model&#x27;s pinned revision and all applicable verification gates.
+</p>
+      </section>
+    </article>
+    <article id="qwen3-235b-a22b-pretrain-gb200" class="verification-model-detail" data-entry-detail="qwen3-235b-a22b-pretrain-gb200" tabindex="-1">
+      <header class="verification-model-detail-heading">
+        <h4>Pretrain · GB200</h4>
+        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
+      </header>
+      <dl class="verification-model-detail-meta">
+        <div><dt>Hardware</dt><dd>GB200</dd></div>
+        <div><dt>Precision</dt><dd>FP8 MX</dd></div>
+        <div><dt>Last verified</dt><dd>2026-08-28</dd></div>
+      </dl>
+      <section class="verification-recorded-metrics">
+        <h5>Recorded metrics</h5>
+        <dl class="verification-metric-list">
+          <div>
+            <dt>Initial loss</dt>
+            <dd>11.17684</dd>
+          </div>
+          <div>
+            <dt>Final loss</dt>
+            <dd>6.856652</dd>
+          </div>
+          <div>
+            <dt>Step time · last 10 avg</dt>
+            <dd>72,553.930 ms</dd>
+          </div>
+          <div>
+            <dt>Model throughput · last 10 avg</dt>
+            <dd>262.340 TFLOP/s/GPU</dd>
+          </div>
+          <div>
+            <dt>Token throughput · last 10 avg</dt>
+            <dd>1,806.546 tokens/s/GPU</dd>
+          </div>
+        </dl>
+      </section>
+      <section class="verification-command-section">
+        <h5>Exact command</h5>
+        <div class="verification-command">
+          <div class="verification-command-heading">
+            <span>Command</span>
+            <button type="button" class="verification-copy-command">Copy</button>
+          </div>
+          <pre><code class="language-bash">./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4 --recipe qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config --mode pretrain --dataset megatron-indexed --seq_length 4096 --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40 &#x27;dataset.blend=[[&quot;work/data/rp2/head_01&quot;],null]&#x27; dataset.path_to_cache=work/cache/qwen3-235b-a22b/rp2 tokenizer.tokenizer_type=SentencePieceTokenizer tokenizer.tokenizer_model=work/data/rp2/tokenizer.model scheduler.lr_decay_iters=100 model.moe_router_force_load_balancing=false ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true rerun_state_machine.check_for_nan_in_loss=true checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234 dist.distributed_timeout_minutes=30 --save_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-checkpoints --save_interval 50 logger.log_interval=1 logger.log_throughput=true logger.tensorboard_dir=null logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-config.yaml</code></pre>
+        </div>
+      </section>
+      <section class="verification-expected-result">
+        <h5>Expected result</h5>
+        <p>On exactly 256 GB200s, this support-verification workload completes exactly 100 bounded RP2 optimizer steps with TP1/PP16/CP1/EP16/ETP1, DP1, SP off, GBS/MBS 8192/1, and sequence length 4096. MXFP8 compute, natural routing, DeepEP, and Transformer Engine CUDA graphs for moe_router and moe_preprocess remain active. Loss is finite from 11.176840 to 6.856652 with no skipped or NaN iterations, all five metrics are recorded, the post-setup configuration persists, and complete iter_0000050 and iter_0000100 checkpoints are saved. GBS8192 makes this support verification rather than cross-model convergence evidence for the GBS1024 cohort.
 </p>
       </section>
     </article>

--- a/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
+++ b/examples/model_verification_cards/qwen3-235b-a22b/card.yaml
@@ -4,8 +4,9 @@
 title: qwen3_235b_a22b
 summary: >
   Performance scope: pretrain_performance.GB200 and pretrain_performance.GB300
-  are verified with their tuned canonical 256-GPU MXFP8 recipes. Model-level
-  and functional training workflows remain unverified in this card.
+  are verified with their tuned canonical 256-GPU MXFP8 recipes. Functional
+  pretraining and checkpoint resume are verified on GB200 as bounded support
+  checks; model-level and the remaining functional workflows are unverified.
 verification_index:
   model_level:
     unverified:
@@ -18,6 +19,9 @@ verification_index:
   training:
     H100:
       unverified: [pretrain, sft, sft_export_inference, sft_long_context, peft, checkpoint_resume]
+    GB200:
+      verified: [pretrain, checkpoint_resume]
+      unverified: [sft, sft_export_inference, sft_long_context, peft]
   performance:
     GB300: verified
     GB200: verified
@@ -28,7 +32,7 @@ model:
   min_transformers_version: "5.8.1"
 verification_environment:
   base_container: nvcr.io/nvidia/nemo:26.08
-  bridge_commit: bc09410353986ac7255ffd31fb2b720fb9007107  # pragma: allowlist secret
+  bridge_commit: 135f8d67684b625f8ec3f1bd1a81f4ed69c1719f  # pragma: allowlist secret
 
 items:
   hf_to_megatron_cpu:
@@ -101,6 +105,53 @@ items:
       expected_result: >
         This workflow remains unverified and requires a bounded public run with
         the model's pinned revision and all applicable verification gates.
+
+    GB200:
+      status: verified
+      precision: fp8_mx
+      enabled_features:
+        cuda_graph:
+          implementation: transformer_engine
+          scopes: [moe_router, moe_preprocess]
+        moe_dispatcher: deepep
+      command: >
+        ./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4
+        --recipe qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config
+        --mode pretrain --dataset megatron-indexed --seq_length 4096
+        --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40
+        'dataset.blend=[["work/data/rp2/head_01"],null]'
+        dataset.path_to_cache=work/cache/qwen3-235b-a22b/rp2
+        tokenizer.tokenizer_type=SentencePieceTokenizer
+        tokenizer.tokenizer_model=work/data/rp2/tokenizer.model
+        scheduler.lr_decay_iters=100
+        model.moe_router_force_load_balancing=false
+        ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true
+        rerun_state_machine.check_for_nan_in_loss=true checkpoint.load=null
+        validation.eval_iters=0 validation.eval_interval=0
+        dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234
+        dist.distributed_timeout_minutes=30
+        --save_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-checkpoints
+        --save_interval 50 logger.log_interval=1 logger.log_throughput=true
+        logger.tensorboard_dir=null
+        logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-config.yaml
+      last_verified: 2026-08-28
+      metrics:
+        initial_loss: 11.176840
+        final_loss: 6.856652
+        last_10_steps_step_time_ms_avg: 72553.930
+        last_10_steps_model_tflops_per_gpu_avg: 262.340
+        last_10_steps_tokens_per_second_per_gpu_avg: 1806.546
+      expected_result: >
+        On exactly 256 GB200s, this support-verification workload completes
+        exactly 100 bounded RP2 optimizer steps with TP1/PP16/CP1/EP16/ETP1,
+        DP1, SP off, GBS/MBS 8192/1, and sequence length 4096. MXFP8 compute,
+        natural routing, DeepEP, and Transformer Engine CUDA graphs for
+        moe_router and moe_preprocess remain active. Loss is finite from
+        11.176840 to 6.856652 with no skipped or NaN iterations, all five
+        metrics are recorded, the post-setup configuration persists, and
+        complete iter_0000050 and iter_0000100 checkpoints are saved. GBS8192
+        makes this support verification rather than cross-model convergence
+        evidence for the GBS1024 cohort.
 
   sft:
     H100:
@@ -186,6 +237,60 @@ items:
       expected_result: >
         This workflow remains unverified and requires a bounded public run with
         the model's pinned revision and all applicable verification gates.
+
+    GB200:
+      status: verified
+      precision: fp8_mx
+      depends_on: pretrain
+      command: >
+        ./scripts/training/train.sh --wait --nodes 64 --gpus-per-node 4
+        --recipe qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config
+        --mode pretrain --dataset megatron-indexed --seq_length 4096
+        --max_steps 100 --lr 3e-4 --min_lr 3e-5 --warmup_iters 40
+        'dataset.blend=[["work/data/rp2/head_01"],null]'
+        dataset.path_to_cache=work/cache/qwen3-235b-a22b/rp2
+        tokenizer.tokenizer_type=SentencePieceTokenizer
+        tokenizer.tokenizer_model=work/data/rp2/tokenizer.model
+        scheduler.lr_decay_iters=100
+        model.moe_router_force_load_balancing=false
+        ddp.check_for_nan_in_grad=true ddp.check_for_large_grads=true
+        rerun_state_machine.check_for_nan_in_loss=true
+        validation.eval_iters=0 validation.eval_interval=0
+        dataset.random_seed=1234 dataset.num_workers=8 rng.seed=1234
+        dist.distributed_timeout_minutes=30
+        --load_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-reference-checkpoints
+        --save_dir work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-resumed-checkpoints
+        --save_interval 50 checkpoint.ckpt_step=50
+        model.cuda_graph_impl=none
+        logger.log_interval=1 logger.log_throughput=true
+        logger.tensorboard_dir=null
+        logger.save_config_filepath=work/model-verification/qwen3-235b-a22b/pretrain-mxfp8-gb200-resume-config.yaml
+      last_verified: 2026-08-28
+      metrics:
+        initial_loss: 7.353207
+        final_loss: 6.856652
+        last_10_steps_step_time_ms_avg: 80779.180
+        last_10_steps_model_tflops_per_gpu_avg: 235.760
+        last_10_steps_tokens_per_second_per_gpu_avg: 1622.596
+      resume_comparison:
+        reference_item: pretrain
+        sentinel_steps: [51, 100]
+        loss_relative_tolerance: 1.0e-2
+        loss_absolute_tolerance: 1.0e-6
+        sentinels_match: true
+        execution_only_overrides: [model.cuda_graph_impl]
+      expected_result: >
+        The command restores optimizer, scheduler, data-order, and RNG state
+        directly from iter_0000050, begins at step 51, and finishes at step 100
+        in a distinct output root. Scoped CUDA graph capture is disabled only
+        for the continuation to avoid a resume-time communication deadlock;
+        routing, precision, batches, data, optimizer, and schedule remain
+        unchanged. All 50 resumed LM-loss values match the uninterrupted
+        reference exactly; auxiliary losses differ by at most 1e-6, including
+        exact step-51 values 7.353207/4.872377 and step-100 values
+        6.856652/1.976203. Both sentinels match, no iteration is skipped or NaN,
+        all five metrics are recorded, the post-setup configuration persists,
+        and a complete iter_0000100 checkpoint is saved.
 
   pretrain_performance:
     GB300:

--- a/skills/create-model-verification-card/SKILL.md
+++ b/skills/create-model-verification-card/SKILL.md
@@ -701,7 +701,13 @@ result. Private executor configuration stays outside the card.
   from `--pretrained_checkpoint`, omit that fallback from the resume command;
   the middle checkpoint already contains the initialized model state. Persist
   each run's post-setup config to its own path so the resume does not overwrite
-  the reference evidence.
+  the reference evidence. If a demonstrated resume defect requires changing an
+  allowlisted execution-only field, record its exact name under
+  `resume_comparison.execution_only_overrides` and explain the deviation in
+  `expected_result`. Currently only `model.cuda_graph_impl` is allowlisted.
+  The resumed command must otherwise match the reference, and every resumed
+  step must pass the same loss gate; a sentinel-only comparison is insufficient
+  for this exception.
 - **Performance (when present):** Use the exact canonical public performance
   recipe. Keep its bounded mock-data run separate from the real-data functional
   run and state public hardware plus thresholds.

--- a/skills/create-model-verification-card/scripts/validate_card.py
+++ b/skills/create-model-verification-card/scripts/validate_card.py
@@ -156,8 +156,11 @@ RESUME_KEYS = frozenset(
         "loss_relative_tolerance",
         "loss_absolute_tolerance",
         "sentinels_match",
+        "execution_only_overrides",
     }
 )
+RESUME_REQUIRED_KEYS = RESUME_KEYS - {"execution_only_overrides"}
+RESUME_EXECUTION_ONLY_OVERRIDE_ALLOWLIST = frozenset({"model.cuda_graph_impl"})
 FORBIDDEN_KEY_FRAGMENTS = (
     "account",
     "cluster",
@@ -959,7 +962,7 @@ def _validate_resume(
     _check_keys(
         comparison,
         allowed=RESUME_KEYS,
-        required=RESUME_KEYS,
+        required=RESUME_REQUIRED_KEYS,
         path=comparison_path,
         errors=errors,
     )
@@ -974,6 +977,27 @@ def _validate_resume(
     relative_tolerance = comparison.get("loss_relative_tolerance")
     if _is_finite_number(relative_tolerance) and float(relative_tolerance) > 1.0e-2:
         errors.append(f"{_pointer(*comparison_path, 'loss_relative_tolerance')}: must not exceed 1%")
+
+    execution_only_overrides = comparison.get("execution_only_overrides")
+    if execution_only_overrides is not None:
+        execution_override_path = (*comparison_path, "execution_only_overrides")
+        if (
+            not isinstance(execution_only_overrides, list)
+            or not execution_only_overrides
+            or not all(isinstance(field, str) and field for field in execution_only_overrides)
+        ):
+            errors.append(f"{_pointer(*execution_override_path)}: expected a non-empty list of field names")
+        else:
+            duplicates = sorted(
+                {field for field in execution_only_overrides if execution_only_overrides.count(field) > 1}
+            )
+            if duplicates:
+                errors.append(f"{_pointer(*execution_override_path)}: field names must be unique")
+            unsupported = sorted(set(execution_only_overrides) - RESUME_EXECUTION_ONLY_OVERRIDE_ALLOWLIST)
+            if unsupported:
+                errors.append(
+                    f"{_pointer(*execution_override_path)}: unsupported execution-only fields: {', '.join(unsupported)}"
+                )
 
     if status != "verified":
         return
@@ -1127,9 +1151,36 @@ def _validate_resume_against_pretrain(
         for setting in {*reference_settings, *resume_settings}
         if reference_settings.count(setting) != resume_settings.count(setting)
     ]
+    differing_names = {"<positional>" if kind == "positional" else name for kind, name, _ in differing_settings}
+    comparison = item.get("resume_comparison")
+    declared_overrides = comparison.get("execution_only_overrides") if isinstance(comparison, Mapping) else None
+    valid_declared_overrides = (
+        set(declared_overrides)
+        if isinstance(declared_overrides, list)
+        and declared_overrides
+        and all(isinstance(field, str) for field in declared_overrides)
+        and set(declared_overrides) <= RESUME_EXECUTION_ONLY_OVERRIDE_ALLOWLIST
+        else set()
+    )
+    if differing_names == valid_declared_overrides:
+        return
+    stale_overrides = sorted(valid_declared_overrides - differing_names)
+    if stale_overrides:
+        errors.append(
+            f"{_pointer(*resume_path, 'resume_comparison', 'execution_only_overrides')}: "
+            f"declared fields do not differ from the reference: {', '.join(stale_overrides)}"
+        )
+    undeclared_differences = differing_names - valid_declared_overrides
+    if not undeclared_differences:
+        return
+    undeclared_settings = [
+        setting
+        for setting in differing_settings
+        if ("<positional>" if setting[0] == "positional" else setting[1]) in undeclared_differences
+    ]
     errors.append(
         f"{_pointer(*resume_command_path)}: reference and resume launch settings must match; "
-        f"differences found in {_resume_setting_names(differing_settings)}"
+        f"differences found in {_resume_setting_names(undeclared_settings)}"
     )
 
 

--- a/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
@@ -32,6 +32,9 @@ from megatron.bridge.perf_recipes.qwen.gb300.qwen3_moe import (
 from megatron.bridge.recipes.qwen.gb200.qwen3_moe import (
     qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config as _qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config,
 )
+from megatron.bridge.recipes.qwen.gb200.qwen3_moe import (
+    qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config as _qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config,
+)
 
 
 def qwen3_235b_a22b_pretrain_64gpu_gb200_bf16_config() -> ConfigContainer:
@@ -444,31 +447,16 @@ def qwen3_235b_a22b_pretrain_256gpu_gb200_fp8cs_config() -> ConfigContainer:
 
 
 def qwen3_235b_a22b_pretrain_256gpu_gb200_fp8mx_config() -> ConfigContainer:
-    """Qwen3 235B-A22B pretrain: 256× GB200, MXFP8, PP=8 EP=32."""
-    cfg = qwen3_235b_a22b_pretrain_config()
-    cfg.mixed_precision = _perf_precision("fp8_mx")
-    cfg.model.bias_activation_fusion = True
-    cfg.model.recompute_granularity = None
-    cfg.model.recompute_method = None
-    cfg.model.recompute_num_layers = None
-    cfg.model.moe_router_fusion = True
-    cfg.model.seq_length = 4096
-    cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    """Qwen3 235B-A22B benchmark: 256-GPU GB200 MXFP8 recipe plus benchmark overrides."""
+    cfg = _qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config()
 
-    cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 8
-    cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = 3
     cfg.model.expert_model_parallel_size = 32
-    cfg.model.sequence_parallel = False
-    cfg.train.global_batch_size = 8192
-    cfg.train.micro_batch_size = 1
-
-    cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_token_dispatcher_type = "flex"
-
-    _benchmark_common(cfg)
+    _benchmark_common(cfg, force_moe_load_balancing=True)
+    cfg.checkpoint.save_interval = 500
+    cfg.validation.eval_iters = 32
+    cfg.validation.eval_interval = 500
     _enable_hybridep_full_iteration_mxfp8(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {

--- a/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
@@ -453,7 +453,7 @@ def qwen3_235b_a22b_pretrain_256gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.virtual_pipeline_model_parallel_size = 3
     cfg.model.expert_model_parallel_size = 32
-    _benchmark_common(cfg, force_moe_load_balancing=True)
+    _benchmark_common(cfg)
     cfg.checkpoint.save_interval = 500
     cfg.validation.eval_iters = 32
     cfg.validation.eval_interval = 500

--- a/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
@@ -467,7 +467,7 @@ def qwen3_235b_a22b_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 4
     cfg.model.virtual_pipeline_model_parallel_size = 12
     cfg.model.expert_model_parallel_size = 32
-    _benchmark_common(cfg, force_moe_load_balancing=True)
+    _benchmark_common(cfg)
     cfg.checkpoint.save_interval = 500
     cfg.validation.eval_iters = 32
     cfg.validation.eval_interval = 500

--- a/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
@@ -27,6 +27,9 @@ from megatron.bridge.perf_recipes.qwen.common import (
     qwen3_235b_a22b_pretrain_config,
     qwen3_next_80b_a3b_pretrain_config,
 )
+from megatron.bridge.recipes.qwen.gb300.qwen3_moe import (
+    qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config as _qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config,
+)
 
 
 def qwen3_235b_a22b_pretrain_64gpu_gb300_bf16_config() -> ConfigContainer:
@@ -458,31 +461,16 @@ def qwen3_235b_a22b_pretrain_256gpu_gb300_fp8cs_config() -> ConfigContainer:
 
 
 def qwen3_235b_a22b_pretrain_256gpu_gb300_fp8mx_config() -> ConfigContainer:
-    """Qwen3 235B-A22B pretrain: 256× GB300, MXFP8, PP=4 EP=32."""
-    cfg = qwen3_235b_a22b_pretrain_config()
-    cfg.mixed_precision = _perf_precision("fp8_mx")
-    cfg.model.bias_activation_fusion = True
-    cfg.model.recompute_granularity = None
-    cfg.model.recompute_method = None
-    cfg.model.recompute_num_layers = None
-    cfg.model.moe_router_fusion = True
-    cfg.model.seq_length = 4096
-    cfg.dataset.seq_length = 4096
-    cfg.model.moe_router_force_load_balancing = True
+    """Qwen3 235B-A22B benchmark: 256-GPU GB300 MXFP8 recipe plus benchmark overrides."""
+    cfg = _qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config()
 
-    cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 4
-    cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = 12
     cfg.model.expert_model_parallel_size = 32
-    cfg.model.sequence_parallel = False
-    cfg.train.global_batch_size = 8192
-    cfg.train.micro_batch_size = 2
-
-    cfg.model.moe_flex_dispatcher_backend = "hybridep"
-    cfg.model.moe_token_dispatcher_type = "flex"
-
-    _benchmark_common(cfg)
+    _benchmark_common(cfg, force_moe_load_balancing=True)
+    cfg.checkpoint.save_interval = 500
+    cfg.validation.eval_iters = 32
+    cfg.validation.eval_interval = 500
     _enable_hybridep_full_iteration_mxfp8(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {

--- a/src/megatron/bridge/recipes/qwen/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/__init__.py
@@ -15,6 +15,7 @@
 # Qwen3 GB200 models
 from .gb200.qwen3_moe import (
     qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config,
+    qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config,
 )
 
 # Qwen3.5 GB200 models
@@ -22,6 +23,9 @@ from .gb200.qwen35 import (
     qwen35_text_9b_pretrain_8gpu_gb200_bf16_config,
     qwen35_text_35b_a3b_pretrain_8gpu_gb200_bf16_config,
 )
+
+# Qwen3 GB300 models
+from .gb300.qwen3_moe import qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config
 
 # Qwen2 models
 from .qwen2 import (
@@ -164,6 +168,8 @@ __all__ = [
     "qwen3_30b_a3b_sft_config",
     "qwen3_30b_a3b_peft_config",
     "qwen3_235b_a22b_pretrain_config",
+    "qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config",
+    "qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config",
     "qwen3_235b_a22b_sft_config",
     "qwen3_235b_a22b_peft_config",
     # Qwen3-Next models

--- a/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/gb200/qwen3_moe.py
@@ -19,10 +19,92 @@ from __future__ import annotations
 from megatron.bridge.recipes.qwen.h100.qwen3_moe import (
     qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config,
 )
+from megatron.bridge.recipes.qwen.qwen3_moe import qwen3_235b_a22b_pretrain_config
 from megatron.bridge.recipes.utils.environment_utils import COMMON_RECIPE_ENV_VARS
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
 from megatron.bridge.training.mixed_precision import bf16_with_mxfp8_mixed
+
+
+def qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config() -> ConfigContainer:
+    """Return the natural-routing Qwen3-235B MXFP8 pretraining recipe for 256 GB200 GPUs."""
+    cfg = qwen3_235b_a22b_pretrain_config()
+
+    cfg.mixed_precision = bf16_with_mxfp8_mixed()
+    cfg.mixed_precision.grad_reduce_in_fp32 = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.model.bias_activation_fusion = True
+    cfg.model.apply_rope_fusion = True
+    cfg.model.moe_router_fusion = True
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.recompute_modules = ["moe_act"]
+    cfg.model.seq_length = 4096
+    cfg.dataset.seq_length = 4096
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 16
+    cfg.model.context_parallel_size = 1
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.expert_model_parallel_size = 16
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.train.train_iters = 100
+    cfg.train.global_batch_size = 8192
+    cfg.train.micro_batch_size = 1
+    cfg.scheduler.lr_warmup_iters = 40
+    cfg.scheduler.lr_decay_iters = 100
+    cfg.checkpoint.save_interval = 100
+
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_flex_dispatcher_backend = "deepep"
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_hybridep_num_sms = 32
+    # Keep dynamic expert work outside the graph so convergence safety checks
+    # remain available with natural routing.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
+    cfg.rng.te_rng_tracker = True
+    cfg.model.use_te_rng_tracker = True
+    cfg.model.offload_modules = []
+    cfg.model.moe_pad_experts_for_cuda_graph_inference = True
+    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
+    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 1.0
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.high_priority_a2a_comm_stream = True
+    cfg.model.use_transformer_engine_op_fuser = False
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.mixed_precision.fp8_dot_product_attention = True
+    cfg.comm_overlap = CommOverlapConfig(
+        tp_comm_overlap=True,
+        overlap_moe_expert_parallel_comm=False,
+        delay_wgrad_compute=False,
+    )
+
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.check_for_large_grads = True
+    cfg.rerun_state_machine.check_for_nan_in_loss = True
+    cfg.validation.eval_iters = 0
+    cfg.validation.eval_interval = 0
+    cfg.logger.log_interval = 1
+    cfg.logger.tensorboard_dir = None
+
+    cfg.env_vars = {
+        **COMMON_RECIPE_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+    }
+    return cfg
 
 
 def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
@@ -109,4 +191,7 @@ def qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config() -> ConfigContainer:
     return cfg
 
 
-__all__ = ["qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config"]
+__all__ = [
+    "qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config",
+    "qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config",
+]

--- a/src/megatron/bridge/recipes/qwen/gb300/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/gb300/__init__.py
@@ -12,19 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from megatron.bridge.recipes.qwen.gb200.qwen3_moe import (
-    qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config,
-    qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config,
-)
-from megatron.bridge.recipes.qwen.gb200.qwen35 import (
-    qwen35_text_9b_pretrain_8gpu_gb200_bf16_config,
-    qwen35_text_35b_a3b_pretrain_8gpu_gb200_bf16_config,
+from megatron.bridge.recipes.qwen.gb300.qwen3_moe import (
+    qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config,
 )
 
 
-__all__ = [
-    "qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config",
-    "qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config",
-    "qwen35_text_9b_pretrain_8gpu_gb200_bf16_config",
-    "qwen35_text_35b_a3b_pretrain_8gpu_gb200_bf16_config",
-]
+__all__ = ["qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config"]

--- a/src/megatron/bridge/recipes/qwen/gb300/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/gb300/qwen3_moe.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GB300 recipes for Qwen3 MoE models."""
+
+from megatron.bridge.recipes.qwen.qwen3_moe import qwen3_235b_a22b_pretrain_config
+from megatron.bridge.recipes.utils.environment_utils import COMMON_RECIPE_ENV_VARS
+from megatron.bridge.training.comm_overlap import CommOverlapConfig
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.mixed_precision import bf16_with_mxfp8_mixed
+
+
+def qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config() -> ConfigContainer:
+    """Return the natural-routing Qwen3-235B MXFP8 pretraining recipe for 256 GB300 GPUs."""
+    cfg = qwen3_235b_a22b_pretrain_config()
+
+    cfg.mixed_precision = bf16_with_mxfp8_mixed()
+    cfg.mixed_precision.grad_reduce_in_fp32 = False
+    cfg.ddp.grad_reduce_in_fp32 = False
+    cfg.model.bias_activation_fusion = True
+    cfg.model.apply_rope_fusion = True
+    cfg.model.moe_router_fusion = True
+    cfg.model.recompute_granularity = "selective"
+    cfg.model.recompute_method = None
+    cfg.model.recompute_num_layers = None
+    cfg.model.recompute_modules = ["moe_act"]
+    cfg.model.seq_length = 4096
+    cfg.dataset.seq_length = 4096
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 8
+    cfg.model.context_parallel_size = 1
+    cfg.model.virtual_pipeline_model_parallel_size = 3
+    cfg.model.expert_model_parallel_size = 16
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.train.train_iters = 100
+    cfg.train.global_batch_size = 8192
+    cfg.train.micro_batch_size = 2
+    cfg.scheduler.lr_warmup_iters = 40
+    cfg.scheduler.lr_decay_iters = 100
+    cfg.checkpoint.save_interval = 100
+
+    cfg.model.moe_router_force_load_balancing = False
+    cfg.model.moe_flex_dispatcher_backend = "deepep"
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_hybridep_num_sms = 32
+    # Keep dynamic expert work outside the graph so convergence safety checks
+    # remain available with natural routing.
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["moe_router", "moe_preprocess"]
+    cfg.rng.te_rng_tracker = True
+    cfg.model.use_te_rng_tracker = True
+    cfg.model.offload_modules = []
+    cfg.model.moe_pad_experts_for_cuda_graph_inference = True
+    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
+    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 1.0
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.high_priority_a2a_comm_stream = True
+    cfg.model.use_transformer_engine_op_fuser = False
+    cfg.model.moe_mlp_glu_interleave_size = 32
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.mixed_precision.fp8_dot_product_attention = True
+    cfg.comm_overlap = CommOverlapConfig(
+        tp_comm_overlap=True,
+        overlap_moe_expert_parallel_comm=True,
+        delay_wgrad_compute=True,
+    )
+
+    cfg.ddp.check_for_nan_in_grad = True
+    cfg.ddp.check_for_large_grads = True
+    cfg.rerun_state_machine.check_for_nan_in_loss = True
+    cfg.validation.eval_iters = 0
+    cfg.validation.eval_interval = 0
+    cfg.logger.log_interval = 1
+    cfg.logger.tensorboard_dir = None
+
+    cfg.env_vars = {
+        **COMMON_RECIPE_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+    }
+    return cfg
+
+
+__all__ = ["qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config"]

--- a/tests/unit_tests/recipes/test_qwen_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_recipes.py
@@ -841,6 +841,135 @@ def test_qwen3_30b_a3b_gb200_fp8mx_perf_recipe_uses_main_recipe(
     assert perf_cfg.model.cuda_graph_scope == []
 
 
+@pytest.mark.parametrize(
+    ("main_recipe_name", "perf_module_name", "perf_recipe_name"),
+    [
+        (
+            "qwen3_235b_a22b_256gpu_gb200_fp8mx_pretrain_config",
+            "megatron.bridge.perf_recipes.qwen.gb200.qwen3_moe",
+            "qwen3_235b_a22b_pretrain_256gpu_gb200_fp8mx_config",
+        ),
+        (
+            "qwen3_235b_a22b_256gpu_gb300_fp8mx_pretrain_config",
+            "megatron.bridge.perf_recipes.qwen.gb300.qwen3_moe",
+            "qwen3_235b_a22b_pretrain_256gpu_gb300_fp8mx_config",
+        ),
+    ],
+)
+def test_qwen3_235b_blackwell_main_recipes_match_measured_perf_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    main_recipe_name: str,
+    perf_module_name: str,
+    perf_recipe_name: str,
+):
+    """Natural-routing candidates preserve measured knobs except convergence-safe scheduling."""
+    mod = importlib.import_module("megatron.bridge.recipes.qwen.qwen3_moe")
+    patch_recipe_module_global(monkeypatch, mod, "AutoBridge", _FakeMoeBridge)
+
+    main_recipe = getattr(_qwen_module, main_recipe_name)
+    perf_recipe = getattr(importlib.import_module(perf_module_name), perf_recipe_name)
+    main_cfg = main_recipe()
+    perf_cfg = perf_recipe()
+
+    assert main_cfg.mixed_precision == perf_cfg.mixed_precision
+    if "gb200" in main_recipe_name:
+        assert main_cfg.comm_overlap.tp_comm_overlap is True
+        assert main_cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+        assert main_cfg.comm_overlap.delay_wgrad_compute is False
+        assert perf_cfg.comm_overlap.tp_comm_overlap is True
+        assert perf_cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+        assert perf_cfg.comm_overlap.delay_wgrad_compute is True
+    else:
+        assert main_cfg.comm_overlap == perf_cfg.comm_overlap
+    hybridep_domain_key = "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"
+    assert {k: v for k, v in main_cfg.env_vars.items() if k != hybridep_domain_key} == {
+        k: v for k, v in perf_cfg.env_vars.items() if k != hybridep_domain_key
+    }
+    assert hybridep_domain_key not in main_cfg.env_vars
+    assert perf_cfg.env_vars[hybridep_domain_key] == 32
+    assert main_cfg.logger.tensorboard_dir == perf_cfg.logger.tensorboard_dir is None
+    assert main_cfg.train.global_batch_size == perf_cfg.train.global_batch_size
+    assert main_cfg.train.micro_batch_size == perf_cfg.train.micro_batch_size
+
+    equivalent_model_fields = (
+        "tensor_model_parallel_size",
+        "context_parallel_size",
+        "expert_tensor_parallel_size",
+        "sequence_parallel",
+        "moe_hybridep_num_sms",
+        "offload_modules",
+        "bias_activation_fusion",
+        "apply_rope_fusion",
+        "moe_router_fusion",
+    )
+    for field_name in equivalent_model_fields:
+        assert getattr(main_cfg.model, field_name) == getattr(perf_cfg.model, field_name)
+
+    assert main_cfg.model.moe_flex_dispatcher_backend == "deepep"
+    assert main_cfg.model.moe_token_dispatcher_type == "alltoall"
+    assert perf_cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert perf_cfg.model.moe_token_dispatcher_type == "flex"
+
+    if "gb200" in main_recipe_name:
+        assert main_cfg.model.pipeline_model_parallel_size == 16
+        assert main_cfg.model.virtual_pipeline_model_parallel_size is None
+        assert perf_cfg.model.pipeline_model_parallel_size == 8
+        assert perf_cfg.model.virtual_pipeline_model_parallel_size == 3
+    else:
+        assert main_cfg.model.pipeline_model_parallel_size == 8
+        assert main_cfg.model.virtual_pipeline_model_parallel_size == 3
+        assert perf_cfg.model.pipeline_model_parallel_size == 4
+        assert perf_cfg.model.virtual_pipeline_model_parallel_size == 12
+    assert main_cfg.model.expert_model_parallel_size == 16
+    assert perf_cfg.model.expert_model_parallel_size == 32
+
+    # Full-iteration graphs conflict with the main recipe's loss-NaN check and
+    # therefore remain benchmark-only.
+    assert main_cfg.model.cuda_graph_impl == "transformer_engine"
+    assert main_cfg.model.cuda_graph_scope == ["moe_router", "moe_preprocess"]
+    assert perf_cfg.model.cuda_graph_impl == "full_iteration"
+    assert perf_cfg.model.cuda_graph_scope == []
+
+    # Only the benchmark owns synthetic routing and the short-run policy.
+    assert main_cfg.model.moe_router_force_load_balancing is False
+    assert perf_cfg.model.moe_router_force_load_balancing is True
+    assert main_cfg.tokenizer.use_tokenizer_vocab_size is True
+    assert perf_cfg.tokenizer.use_tokenizer_vocab_size is False
+    assert main_cfg.checkpoint.save is not None
+    assert perf_cfg.checkpoint.save is None
+    assert main_cfg.ddp.check_for_nan_in_grad is True
+    assert perf_cfg.ddp.check_for_nan_in_grad is False
+    assert main_cfg.rerun_state_machine.check_for_nan_in_loss is True
+    assert perf_cfg.rerun_state_machine.check_for_nan_in_loss is False
+    assert main_cfg.model.use_transformer_engine_op_fuser is False
+    assert perf_cfg.model.use_transformer_engine_op_fuser is True
+    assert main_cfg.model.moe_pad_experts_for_cuda_graph_inference is True
+    assert perf_cfg.model.moe_pad_experts_for_cuda_graph_inference is True
+    assert getattr(main_cfg.model, "moe_paged_stash", False) is False
+    assert perf_cfg.model.moe_paged_stash is True
+    assert getattr(main_cfg.model, "moe_expert_rank_capacity_factor", None) is None
+    assert perf_cfg.model.moe_expert_rank_capacity_factor == 1.5
+    assert main_cfg.model.moe_paged_stash_buffer_size_factor_cuda == 1.2
+    assert perf_cfg.model.moe_paged_stash_buffer_size_factor_cuda == 1.2
+    assert main_cfg.model.moe_paged_stash_buffer_size_factor_cpu == 1.0
+    assert perf_cfg.model.moe_paged_stash_buffer_size_factor_cpu == 1.0
+    assert main_cfg.model.recompute_granularity == "selective"
+    assert main_cfg.model.recompute_modules == ["moe_act"]
+    assert perf_cfg.model.recompute_granularity is None
+    assert perf_cfg.model.recompute_modules is None
+    assert main_cfg.train.train_iters == 100
+    assert perf_cfg.train.train_iters == 50
+    assert main_cfg.train.global_batch_size == 8192
+    assert main_cfg.train.micro_batch_size == (1 if "gb200" in main_recipe_name else 2)
+    assert main_cfg.scheduler.lr_warmup_iters == 40
+    assert main_cfg.scheduler.lr_decay_iters == 100
+    assert main_cfg.checkpoint.save_interval == 100
+    assert perf_cfg.checkpoint.save_interval == 500
+    assert main_cfg.validation.eval_iters == main_cfg.validation.eval_interval == 0
+    assert perf_cfg.validation.eval_iters == 32
+    assert perf_cfg.validation.eval_interval == 500
+
+
 def test_qwen3_235b_a22b_lora_defaults(monkeypatch: pytest.MonkeyPatch):
     """Test that 235B-A22B LoRA has correct default parallelism."""
     from megatron.bridge.recipes.qwen import qwen3_235b_a22b_peft_config

--- a/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
+++ b/tests/unit_tests/skills/create_model_verification_card/test_validate_card.py
@@ -102,6 +102,8 @@ TRAINING_THROUGHPUT_INPUTS = {
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 32): (4096, 2048, 32),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 128): (4096, 8192, 128),
     ("qwen3-30b-a3b", "pretrain_weak_scaling", "GB300", 256): (4096, 16384, 256),
+    ("qwen3-235b-a22b", "pretrain", "GB200"): (4096, 8192, 256),
+    ("qwen3-235b-a22b", "checkpoint_resume", "GB200"): (4096, 8192, 256),
     ("qwen3-235b-a22b", "pretrain_performance", "GB300"): (4096, 8192, 256),
     ("qwen3-235b-a22b", "pretrain_performance", "GB200"): (4096, 8192, 256),
     ("qwen3-8b", "pretrain", "H100"): (4096, 1024, 16),
@@ -729,3 +731,105 @@ def test_resume_reference_only_warm_start(resume_initialization, expected_errors
     )
 
     assert errors == expected_errors
+
+
+def test_resume_accepts_declared_allowlisted_execution_only_override():
+    validator = _load_validator()
+    errors = []
+    common_command = (
+        "./scripts/training/train.sh --nodes 1 --gpus-per-node 8 "
+        "--recipe example_pretrain --mode pretrain --max_steps 100"
+    )
+
+    validator._validate_resume_against_pretrain(
+        {
+            "status": "verified",
+            "bridge_commit": "commit",
+            "command": (
+                f"{common_command} --load_dir work/reference --save_dir work/resume "
+                "checkpoint.ckpt_step=50 model.cuda_graph_impl=none "
+                "logger.save_config_filepath=work/resume.yaml"
+            ),
+            "resume_comparison": {"execution_only_overrides": ["model.cuda_graph_impl"]},
+        },
+        {
+            "status": "verified",
+            "bridge_commit": "commit",
+            "command": (
+                f"{common_command} --save_dir work/reference checkpoint.load=null "
+                "logger.save_config_filepath=work/reference.yaml"
+            ),
+        },
+        resume_path=("items", "checkpoint_resume", "GB200"),
+        pretrain_path=("items", "pretrain", "GB200"),
+        default_bridge_commit=None,
+        errors=errors,
+    )
+
+    assert errors == []
+
+
+def test_resume_rejects_undeclared_execution_only_override():
+    validator = _load_validator()
+    errors = []
+    common_command = (
+        "./scripts/training/train.sh --nodes 1 --gpus-per-node 8 "
+        "--recipe example_pretrain --mode pretrain --max_steps 100"
+    )
+
+    validator._validate_resume_against_pretrain(
+        {
+            "status": "verified",
+            "bridge_commit": "commit",
+            "command": (
+                f"{common_command} --load_dir work/reference --save_dir work/resume "
+                "checkpoint.ckpt_step=50 model.cuda_graph_impl=none"
+            ),
+        },
+        {
+            "status": "verified",
+            "bridge_commit": "commit",
+            "command": f"{common_command} --save_dir work/reference checkpoint.load=null",
+        },
+        resume_path=("items", "checkpoint_resume", "GB200"),
+        pretrain_path=("items", "pretrain", "GB200"),
+        default_bridge_commit=None,
+        errors=errors,
+    )
+
+    assert errors == [
+        "/items/checkpoint_resume/GB200/command: reference and resume launch settings must match; "
+        "differences found in model.cuda_graph_impl"
+    ]
+
+
+def test_resume_rejects_unallowlisted_execution_only_override():
+    validator = _load_validator()
+    errors = []
+
+    validator._validate_resume(
+        {
+            "depends_on": "pretrain",
+            "command": (
+                "./scripts/training/train.sh --nodes 1 --gpus-per-node 8 "
+                "--recipe example_pretrain --mode pretrain --max_steps 100 "
+                "--load_dir work/reference --save_dir work/resume checkpoint.ckpt_step=50"
+            ),
+            "resume_comparison": {
+                "reference_item": "pretrain",
+                "sentinel_steps": [51, 100],
+                "loss_relative_tolerance": 1.0e-2,
+                "loss_absolute_tolerance": 1.0e-6,
+                "sentinels_match": True,
+                "execution_only_overrides": ["model.moe_router_force_load_balancing"],
+            },
+        },
+        item_path=("items", "checkpoint_resume", "GB200"),
+        status="verified",
+        errors=errors,
+    )
+
+    assert errors == [
+        "/items/checkpoint_resume/GB200/resume_comparison/execution_only_overrides: "
+        "unsupported execution-only fields: model.moe_router_force_load_balancing"
+    ]


### PR DESCRIPTION
# What does this PR do ?

This is **2/2** of the Qwen performance-recipe unification stack and depends on #5771. It adds only Qwen3-235B GB200/GB300 main recipes and migrates the corresponding performance recipes to build from them.

The new main recipes are fully flattened and hardware-specific. They do not introduce a shared Qwen main-recipe builder or a `functional` layer. Performance recipes remain the only place that may compose a main recipe with common benchmark-only overrides.

# Changelog

- Add flat 256-GPU Qwen3-235B MXFP8 main recipes for GB200 and GB300 with natural routing and safety checks.
- Keep main-recipe iteration counts and global/micro batch sizes unchanged from their convergence contracts.
- Base the matching 235B GB200 and GB300 performance factories on the main factories plus benchmark overrides.
- Keep forced routing, short benchmark schedules, disabled checkpoint/eval and safety checks, full-iteration graphs, fixed expert capacity, active paged stash, and benchmark-only recomputation changes out of the main recipes.
- Add focused tests for 235B topology, precision, dispatcher, overlap, graph, batch, environment, and benchmark-only differences.

## Performance verification

Existing canonical performance results remain at or near the README values:

| Platform | Measured TFLOPS/GPU | README TFLOPS/GPU | Delta | Measured tokens/s/GPU | README tokens/s/GPU | Delta |
|---|---:|---:|---:|---:|---:|---:|
| GB200 | 1083.660 | 1077 | +0.618% | 7320.274 | 7280 | +0.553% |
| GB300 | 1300.440 | 1306 | -0.426% | 8784.492 | 8816 | -0.357% |

Additional checks:

- The combined 1/2 + 2/2 source tree exactly matches the pre-split implementation.
- All nine Qwen MXFP8 performance configurations are byte-for-byte identical to their pre-unification resolved YAML.
- Focused recipe tests: 136 passed. One unrelated metadata assertion also fails on the base because an existing Nemotron cross-package collision is not registered.
- `pre-commit run --all-files` passed.

## Draft validation gate

The remaining gate is exact 256-GPU natural-routing verification:

- GB200: 100-step pretrain plus direct step-50-to-100 checkpoint resume.
- GB300: 100-step pretrain plus direct step-50-to-100 checkpoint resume.
- The Qwen3-235B verification card will be updated only after completed runs have finite losses, zero skipped/NaN iterations, complete checkpoints, and matching resume sentinels.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) for how to trigger CI.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added necessary tests.
- [ ] Add the Qwen3-235B GB200/GB300 pretrain and checkpoint-resume evidence after validation completes.
- [x] This PR does not affect optional-install components.

