### PR TITLE
fix(ckpt): terminate custom checkpoint managers once

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -787,10 +787,10 @@ def train(
     if pre_hook_enabled:
         disable_forward_pre_hook(model, optimizer=optimizer)
 
-    # This will finalize all unfinalized async request and terminate
-    # a persistent async worker if persistent ckpt worker is enabled
+    # Finalize pending saves here, but leave manager termination to the outer
+    # lifecycle on normal completion or the exit branch below.
     fault_tolerance.on_checkpointing_start(global_state)
-    checkpoint_manager.finalize_async_saves(state=global_state, blocking=True, terminate=True)
+    checkpoint_manager.finalize_async_saves(state=global_state, blocking=True, terminate=False)
     fault_tolerance.on_checkpointing_end(global_state=global_state, is_async_finalization=True)
 
     # Shutdown NVRx straggler detection if enabled

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -37,12 +37,103 @@ from megatron.bridge.training.train import (
     maybe_synchronize_training_step,
     save_checkpoint_and_time,
     should_disable_forward_pre_hook,
+    train,
     train_step,
 )
 from megatron.bridge.training.utils.train_utils import maybe_inject_state
 
 
 pytestmark = pytest.mark.unit
+
+
+class TestCheckpointManagerLifecycle:
+    """Tests for checkpoint manager ownership across the training lifecycle."""
+
+    def test_natural_completion_terminates_checkpoint_manager_once(self):
+        """The outer lifecycle should own the only terminal manager finalization."""
+
+        class OneShotCheckpointManager:
+            def __init__(self):
+                self.finalize_calls = []
+                self.terminated = False
+
+            def finalize_async_saves(self, state, blocking=False, terminate=False):
+                if self.terminated:
+                    raise RuntimeError("checkpoint manager was used after termination")
+                self.finalize_calls.append((blocking, terminate))
+                self.terminated = terminate
+
+        model_config = SimpleNamespace(cuda_graph_impl=None, fp8_recipe=None, param_sync_func=None)
+        config = SimpleNamespace(
+            train=SimpleNamespace(
+                train_iters=1,
+                manual_gc=False,
+                check_weight_hash_across_dp_replicas_interval=None,
+            ),
+            validation=SimpleNamespace(),
+            checkpoint=SimpleNamespace(save=None),
+            logger=SimpleNamespace(log_throughput_to_tensorboard=False),
+            model=SimpleNamespace(
+                virtual_pipeline_model_parallel_size=None,
+                cuda_graph_warmup_steps=0,
+                cuda_graph_use_single_mempool=False,
+                moe_expert_rank_capacity_factor=None,
+            ),
+            optimizer=SimpleNamespace(
+                use_distributed_optimizer=False,
+                optimizer_cuda_graph=False,
+                reuse_grad_buf_for_mxfp8_param_ag=False,
+            ),
+            ddp=SimpleNamespace(use_megatron_fsdp=False, overlap_param_gather=False),
+            straggler=None,
+            profiling=None,
+            tensor_inspect=None,
+        )
+        state = SimpleNamespace(
+            cfg=config,
+            train_state=SimpleNamespace(step=1, floating_point_operations_so_far=0.0),
+            timers=Mock(return_value=Mock()),
+            straggler_timer=Mock(),
+            energy_monitor=None,
+            nvrx_straggler_manager=None,
+            tensorboard_logger=None,
+            wandb_logger=None,
+            _comet_logger=None,
+        )
+        pg_collection = SimpleNamespace(
+            pp=SimpleNamespace(size=Mock(return_value=1)),
+            dp=SimpleNamespace(size=Mock(return_value=1)),
+        )
+        checkpoint_manager = OneShotCheckpointManager()
+
+        with (
+            patch("megatron.bridge.training.train.get_model_config", return_value=model_config),
+            patch(
+                "megatron.bridge.training.train.get_rerun_state_machine",
+                return_value=SimpleNamespace(current_iteration=1),
+            ),
+            patch("megatron.bridge.training.train.get_num_microbatches", return_value=1),
+            patch("megatron.bridge.training.train.get_forward_backward_func", return_value=Mock()),
+            patch("megatron.bridge.training.train.P2PCommunicator", return_value=Mock()),
+            patch("megatron.bridge.training.train._delete_cuda_graphs"),
+            patch("megatron.bridge.training.train.safe_shutdown_nvrx_straggler_manager"),
+            patch("megatron.bridge.training.train.destroy_global_state"),
+            patch("megatron.bridge.training.train.fault_tolerance"),
+        ):
+            train(
+                Mock(),
+                [Mock()],
+                Mock(),
+                Mock(),
+                None,
+                None,
+                state,
+                checkpoint_manager,
+                pg_collection,
+            )
+            _finish_train(state, checkpoint_manager)
+
+        assert checkpoint_manager.finalize_calls == [(True, False), (True, True)]
 
 
 class TestTrainStepAttentionLogitMonitoring:


### PR DESCRIPTION
## What changed

Keep the blocking async-checkpoint flush at the end of `train()`, but leave checkpoint-manager termination to the lifecycle boundary that actually exits training.

## Problem

`CheckpointConfig.custom_manager_class` accepts structurally conforming checkpoint managers. During a normal supported `pretrain()` run, `train()` called `finalize_async_saves(..., terminate=True)` and then `_finish_train()` called the same terminal operation again. A conforming manager backed by a one-shot worker or session therefore failed after otherwise successful training because Bridge reused it after termination. Planned exits had the same double-termination pattern between common cleanup and the `SystemExit` branch.

The default manager happened to tolerate repeated closure, so existing tests did not expose the contract violation.

## Fix

The common `train()` cleanup still uses `blocking=True`, ensuring pending saves complete, but now uses `terminate=False`:

- natural completion terminates once in `_finish_train()`;
- planned exits terminate once in the existing exit branch;
- skip-training and MegatronMIMO lifecycle ownership are unchanged.

## Validation

The focused regression test uses a conforming one-shot manager and composes the real natural `train()` cleanup with `_finish_train()`.

- Before the fix, it failed with `RuntimeError: checkpoint manager was used after termination`.
- After the fix:
  - `uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestCheckpointManagerLifecycle::test_natural_completion_terminates_checkpoint_manager_once -q` — 1 passed
  - `uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py tests/unit_tests/training/test_pretrain.py -q` — 72 passed
  - `uv run --no-sync pre-commit run --all-files` — passed
  - `git diff --check` — passed

## Scope

This does not change checkpoint save timing, checkpoint formats, public APIs, default-manager behavior, or failure-abort cleanup. It only assigns terminal ownership once while preserving the existing blocking flush.
