### PR TITLE
[training] fix: Stop profiler on skipped end iteration

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -428,6 +428,13 @@ def train(
         # Completely skip iteration if needed.
         if _should_skip_and_handle_iteration(global_state, train_data_iterator, pg_collection):
             nvtx_range_pop(suffix=f"training_step_{nvtx_step}")
+            handle_profiling_stop(
+                config.profiling,
+                global_state.train_state.step,
+                torch.distributed.get_rank(),
+                prof,
+                nsys_nvtx_context,
+            )
             continue
 
         # Capture CUDA Graphs after warmup.

--- a/tests/unit_tests/training/test_pg_collection_wiring.py
+++ b/tests/unit_tests/training/test_pg_collection_wiring.py
@@ -15,6 +15,7 @@
 import inspect
 import signal
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 
 def test_train_step_accepts_pg_collection_argument():
@@ -77,3 +78,109 @@ def test_should_skip_iteration_uses_passed_pg_collection(monkeypatch):
     expected_batch = 3 * 4 * 2
     assert state.train_state.consumed_train_samples == expected_batch
     assert state.train_state.skipped_train_samples == expected_batch
+
+
+def test_train_stops_nsys_profiler_when_skipped_iteration_reaches_profile_end(monkeypatch):
+    """Skipping the stop iteration must still close an active Nsys capture."""
+    from megatron.bridge.training import profiling as profiling_module
+    from megatron.bridge.training import train as train_module
+
+    profiling = SimpleNamespace(
+        use_pytorch_profiler=False,
+        use_nsys_profiler=True,
+        profile_step_start=0,
+        profile_step_end=1,
+        profile_ranks=[0],
+        record_shapes=False,
+    )
+    config = SimpleNamespace(
+        train=SimpleNamespace(
+            manual_gc=False,
+            check_weight_hash_across_dp_replicas_interval=None,
+            train_iters=1,
+            micro_batch_size=1,
+            iterations_to_skip={1},
+        ),
+        validation=SimpleNamespace(eval_interval=0, start_eval_at_iter=None),
+        profiling=profiling,
+        straggler=None,
+        ddp=SimpleNamespace(use_megatron_fsdp=False, overlap_param_gather=False),
+        optimizer=SimpleNamespace(
+            use_distributed_optimizer=False,
+            optimizer_cuda_graph=False,
+        ),
+        model=SimpleNamespace(
+            virtual_pipeline_model_parallel_size=None,
+            cuda_graph_warmup_steps=0,
+            cuda_graph_use_single_mempool=False,
+            moe_expert_rank_capacity_factor=None,
+        ),
+        logger=SimpleNamespace(log_throughput_to_tensorboard=False),
+        checkpoint=SimpleNamespace(save=None, save_interval=None),
+        tensor_inspect=None,
+    )
+    state = SimpleNamespace(
+        cfg=config,
+        train_state=SimpleNamespace(
+            step=0,
+            consumed_train_samples=0,
+            skipped_train_samples=0,
+            floating_point_operations_so_far=0,
+        ),
+        timers=Mock(),
+        straggler_timer=Mock(),
+        energy_monitor=None,
+        nvrx_straggler_manager=None,
+        tensorboard_logger=None,
+        wandb_logger=None,
+        _comet_logger=None,
+    )
+    model_config = SimpleNamespace(cuda_graph_impl=None)
+    rerun_state_machine = SimpleNamespace(current_iteration=0)
+    pg_collection = SimpleNamespace(
+        dp=SimpleNamespace(size=lambda: 1),
+        pp=SimpleNamespace(size=lambda: 1),
+    )
+    checkpoint_manager = Mock()
+    start_nsys_profiler = Mock(return_value=Mock())
+    stop_nsys_profiler = Mock()
+
+    monkeypatch.setattr(train_module, "get_model_config", lambda _model: model_config)
+    monkeypatch.setattr(train_module, "get_rerun_state_machine", lambda: rerun_state_machine)
+    monkeypatch.setattr(train_module, "get_num_microbatches", lambda: 1)
+    monkeypatch.setattr(train_module, "update_num_microbatches", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "should_disable_forward_pre_hook", lambda *args: False)
+    monkeypatch.setattr(train_module, "get_forward_backward_func", lambda **kwargs: Mock())
+    monkeypatch.setattr(train_module, "is_full_iteration_cuda_graph", lambda _config: False)
+    monkeypatch.setattr(train_module, "P2PCommunicator", lambda **kwargs: Mock())
+    monkeypatch.setattr(train_module, "_dummy_train_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "_delete_cuda_graphs", lambda _helper: None)
+    monkeypatch.setattr(train_module, "safe_shutdown_nvrx_straggler_manager", lambda _manager: None)
+    monkeypatch.setattr(train_module, "tensor_inspect_end_if_enabled", lambda _config: None)
+    monkeypatch.setattr(train_module, "should_fire", lambda *args: False)
+    monkeypatch.setattr(train_module, "nvtx_range_push", lambda **kwargs: None)
+    monkeypatch.setattr(train_module, "nvtx_range_pop", lambda **kwargs: None)
+    monkeypatch.setattr(train_module.torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(profiling_module, "start_nsys_profiler", start_nsys_profiler)
+    monkeypatch.setattr(profiling_module, "stop_nsys_profiler", stop_nsys_profiler)
+    monkeypatch.setattr(train_module.fault_tolerance, "on_checkpointing_start", lambda _state: None)
+    monkeypatch.setattr(
+        train_module.fault_tolerance,
+        "on_checkpointing_end",
+        lambda **kwargs: None,
+    )
+
+    train_module.train(
+        forward_step_func=Mock(),
+        model=[Mock()],
+        optimizer=Mock(),
+        scheduler=Mock(),
+        train_data_iterator=None,
+        valid_data_iterator=None,
+        global_state=state,
+        checkpoint_manager=checkpoint_manager,
+        pg_collection=pg_collection,
+    )
+
+    start_nsys_profiler.assert_called_once_with(profiling)
+    stop_nsys_profiler.assert_called_once()


### PR DESCRIPTION
## What changed

When `train.iterations_to_skip` advances a skipped iteration exactly to the configured Nsys `profile_step_end`, the training loop now invokes the existing profiling-stop helper before continuing.

## User impact

A supported configuration such as Nsys profiling over steps 0 through 1 with iteration 1 skipped starts capture normally, advances the training state to the stop boundary, and then bypasses the common profiling cleanup. CUDA profiling and its NVTX context can therefore remain active beyond the requested range and affect subsequent work.

The execution path is:

1. `handle_profiling_start` starts Nsys capture at the configured start step.
2. `_should_skip_and_handle_iteration` advances the global step for the skipped iteration.
3. The skip branch immediately continues before the loop's common `handle_profiling_stop` call.

The fix calls that existing helper at the skipped-iteration boundary. Other profiling behavior and non-skipped iterations are unchanged.

## Validation

Fail-before, on unmodified `main`:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_pg_collection_wiring.py::test_train_stops_nsys_profiler_when_skipped_iteration_reaches_profile_end -q
1 failed (expected one stop call, observed zero)
```

Pass-after:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_pg_collection_wiring.py::test_train_stops_nsys_profiler_when_skipped_iteration_reaches_profile_end -q
1 passed
```

Adjacent tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_pg_collection_wiring.py tests/unit_tests/training/test_profiling.py -q
36 passed
```

Additional checks:

```text
git diff --check
passed

UV_PROJECT_ENVIRONMENT=/opt/venv uv run --no-sync pre-commit run --all-files
passed
```

## Scope

This patch is limited to the standard training loop's supported skip path and the Nsys stop-boundary regression. It does not generalize other early-exit paths, change MIMO behavior, or claim model-quality, convergence, or performance validation.
