### PR TITLE
[data] fix: Propagate MIMO dataset loading errors

### DIFF
--- a/src/megatron/bridge/data/megatron_mimo/hf_provider.py
+++ b/src/megatron/bridge/data/megatron_mimo/hf_provider.py
@@ -146,9 +146,11 @@ class HFMegatronMIMODatasetProvider(MegatronMIMODatasetProvider):
                 ),
             )
             return dataset
-        except ValueError:
-            # Split doesn't exist
-            return None
+        except ValueError as error:
+            message = str(error)
+            if message.startswith('Unknown split "') and ". Should be one of " in message:
+                return None
+            raise
 
     def _build_split_dataset(
         self,

--- a/tests/unit_tests/data/megatron_mimo/test_hf_provider.py
+++ b/tests/unit_tests/data/megatron_mimo/test_hf_provider.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass
 
+import pytest
 import torch
 
 from megatron.bridge.data.base import DatasetBuildContext
@@ -58,7 +59,7 @@ def test_build_datasets_happy_path(monkeypatch):
         del path, name, trust_remote_code, data_files
         calls.load_dataset += 1
         if split == "validation":
-            raise ValueError("missing split")
+            raise ValueError("Unknown split \"validation\". Should be one of ['train', 'test'].")
         return [{"text": "hello", "image": "image_0.jpg"}]
 
     class _AutoImageProcessor:
@@ -93,6 +94,21 @@ def test_build_datasets_happy_path(monkeypatch):
     assert calls.auto_tokenizer == 1
     assert calls.load_dataset == 3
     assert calls.is_safe_repo >= 3
+
+
+def test_build_datasets_propagates_non_split_value_error(monkeypatch):
+    def fake_load_dataset(path, name=None, split=None, trust_remote_code=None, data_files=None):
+        del path, name, split, trust_remote_code, data_files
+        raise ValueError("Empty 'data_files': '[]'. It should be either non-empty or None (default).")
+
+    provider = _make_provider()
+    monkeypatch.setattr(provider, "_load_processors", lambda: {})
+    monkeypatch.setattr(provider, "_load_tokenizer", lambda: DummyTokenizer())
+    monkeypatch.setattr("megatron.bridge.data.megatron_mimo.hf_provider.load_dataset", fake_load_dataset)
+
+    context = DatasetBuildContext(train_samples=1, valid_samples=0, test_samples=0)
+    with pytest.raises(ValueError, match="Empty 'data_files'"):
+        provider.build_datasets(context)
 
 
 def test_get_collate_fn_returns_partial():


### PR DESCRIPTION
## Problem

`HFMegatronMIMODatasetProvider` treats every `ValueError` raised by Hugging Face `load_dataset()` as an unavailable optional split. Public dataset configuration errors that use the same exception type can therefore become `None`, silently disabling requested training/evaluation or producing a later generic iterator failure.

A concrete trigger is a positive-count split loaded through the public provider with a non-split dataset error such as an empty `hf_data_files` list.

## Root cause and fix

`_load_hf_dataset()` caught the exception type around the complete loader call, even though the pinned `datasets` package uses `ValueError` for both unknown splits and unrelated configuration failures.

The fix keeps the existing optional-split behavior only for the dependency's specific `Unknown split ... Should be one of ...` condition and re-raises every other `ValueError` at the owning dataset boundary.

## Regression evidence

Fail before:
- Deterministic CPU reproducer on the audited base: exit 1; expected the non-split error to propagate, but the provider returned `None`.

Pass after:
- The unchanged reproducer: passed with the original non-split `ValueError`.
- `uv run --no-sync python -m pytest tests/unit_tests/data/megatron_mimo/test_hf_provider.py -q --tb=short`: 7 passed.
- `git diff --check`: passed.
- `uv run --no-sync pre-commit run --all-files`: passed.

## Scope

This does not change public APIs, dependencies, distributed behavior, supported split names, models, or third-party code. Full-suite, performance, convergence, and model-quality validation were not run.