### PR TITLE
[PEFT] fix: preserve partial canonical LoRA exports

### DIFF
--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -1178,9 +1178,7 @@ class MegatronPeftBridge:
             # Nothing to merge on this rank (e.g., non-owning PP rank or filtered mapping).
             return converted_weights_dict
 
-        if len(adapter_weights) > 1 and all(
-            w.adapter_key in ADAPTER_NAME_MAP.values() for w in adapter_weights if w.adapter_key
-        ):
+        if all(w.adapter_key in ADAPTER_NAME_MAP.values() for w in adapter_weights):
             return self._merge_canonical_adapter_from_weights(megatron_model, converted_weights_dict, adapter_weights)
 
         assert len(adapter_weights) == 1, "Expected a single adapter weight for standard LoRA merging"
@@ -1425,8 +1423,10 @@ class MegatronPeftBridge:
                     target_adapter_key = adapter_key
                     break
 
-            if target_adapter is None:
+            if target_adapter_key is None:
                 raise ValueError(f"Adapter name mapping not found for {hf_name}")
+            if target_adapter is None:
+                continue
 
             linear_in_weight = target_adapter.linear_in_weight.weight
             linear_out_weight = target_adapter.linear_out_weight.weight

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -583,6 +583,66 @@ def test_merge_canonical_adapter_from_weights(monkeypatch):
     torch.testing.assert_close(updated["decoder.layers.0.self_attn.v_proj.weight"], 3 * torch.ones(1, 2))
 
 
+def test_merge_partial_canonical_adapter_preserves_unselected_projection():
+    bridge = DummyBridge()
+    converted = {
+        "model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2),
+        "model.layers.0.self_attn.k_proj.weight": torch.zeros(1, 2),
+        "model.layers.0.self_attn.v_proj.weight": torch.full((1, 2), 9.0),
+    }
+    adapter_q = AdapterWeight(
+        global_base_prefix="decoder.layers.0.self_attention.linear_qkv",
+        adapter_key="adapter_q",
+        alpha=1,
+        dim=1,
+        linear_in_weight=MegatronWeightTuple("in_q", torch.tensor([[1.0, 2.0]]), vp_stage=0),
+        linear_out_weight=MegatronWeightTuple("out_q", torch.ones(2, 1), vp_stage=0),
+    )
+    adapter_k = AdapterWeight(
+        global_base_prefix="decoder.layers.0.self_attention.linear_qkv",
+        adapter_key="adapter_k",
+        alpha=1,
+        dim=1,
+        linear_in_weight=MegatronWeightTuple("in_k", torch.tensor([[1.0, 2.0]]), vp_stage=0),
+        linear_out_weight=MegatronWeightTuple("out_k", 2 * torch.ones(1, 1), vp_stage=0),
+    )
+
+    updated = bridge._merge_lora_adapter_weights(
+        [SimpleNamespace(config=SimpleNamespace(num_moe_experts=0))],
+        converted,
+        [adapter_q, adapter_k],
+    )
+
+    torch.testing.assert_close(updated["model.layers.0.self_attn.q_proj.weight"], torch.tensor([[1.0, 2.0]] * 2))
+    torch.testing.assert_close(updated["model.layers.0.self_attn.k_proj.weight"], torch.tensor([[2.0, 4.0]]))
+    torch.testing.assert_close(updated["model.layers.0.self_attn.v_proj.weight"], torch.full((1, 2), 9.0))
+
+
+def test_merge_single_canonical_adapter_preserves_unselected_projection():
+    bridge = DummyBridge()
+    converted = {
+        "model.layers.0.mlp.gate_proj.weight": torch.full((2, 2), 7.0),
+        "model.layers.0.mlp.up_proj.weight": torch.zeros(2, 2),
+    }
+    adapter_up = AdapterWeight(
+        global_base_prefix="decoder.layers.0.mlp.linear_fc1",
+        adapter_key="adapter_up",
+        alpha=1,
+        dim=1,
+        linear_in_weight=MegatronWeightTuple("in_up", torch.tensor([[1.0, 2.0]]), vp_stage=0),
+        linear_out_weight=MegatronWeightTuple("out_up", torch.ones(2, 1), vp_stage=0),
+    )
+
+    updated = bridge._merge_lora_adapter_weights(
+        [SimpleNamespace(config=SimpleNamespace(num_moe_experts=0))],
+        converted,
+        [adapter_up],
+    )
+
+    torch.testing.assert_close(updated["model.layers.0.mlp.gate_proj.weight"], torch.full((2, 2), 7.0))
+    torch.testing.assert_close(updated["model.layers.0.mlp.up_proj.weight"], torch.tensor([[1.0, 2.0]] * 2))
+
+
 def test_column_parallel_mapping_gathers_3d_expert_adapter_along_tp(monkeypatch):
     mapping = ColumnParallelMapping(
         "decoder.layers.0.mlp.experts.linear_fc1.adapter.linear_out.weight",


### PR DESCRIPTION
## What changed

Partial `CanonicalLoRA` targets are supported, but the default merged Hugging
Face export mishandled them in two ways:

- A partial QKV adapter such as Q+K raised when the converted V sibling had no
  selected adapter.
- A singleton canonical adapter such as FC1-up was dispatched through standard
  LoRA merging and applied its delta to the unselected gate sibling.

The merge dispatcher now recognizes canonical adapter keys even for singleton
groups. Canonical merging skips recognized HF siblings that were not selected,
while retaining the existing error for names that have no canonical mapping.

## User impact

Exporting a supported partial canonical adapter with the default
`merge_adapter_weights=True` could either fail or silently alter an unselected
projection. The fix merges only the selected canonical projections and preserves
the remaining base weights.

## Regression evidence

Both focused regressions failed on unmodified `main` for the claimed reasons:

```text
uv run python -m pytest tests/unit_tests/models/test_model_bridge_lora.py::test_merge_partial_canonical_adapter_preserves_unselected_projection -q
# FAILED: Adapter name mapping not found for ...v_proj.weight

uv run python -m pytest tests/unit_tests/models/test_model_bridge_lora.py::test_merge_single_canonical_adapter_preserves_unselected_projection -q
# FAILED: the unselected gate projection was modified
```

After the fix:

```text
uv run python -m pytest tests/unit_tests/models/test_model_bridge_lora.py -q
# 58 passed

git diff --check
# passed

uv run pre-commit run --all-files
# passed
```

## Scope

This change is limited to merged HF export. It does not broaden supported model
families, change standard LoRA behavior, or alter CanonicalLoRA forward and
checkpoint lifecycle handling.
