### PR TITLE
feat(data): allow custom Energon task encoder targets

### DIFF
--- a/src/megatron/bridge/data/builders/energon.py
+++ b/src/megatron/bridge/data/builders/energon.py
@@ -23,6 +23,7 @@ from transformers import AutoProcessor, AutoTokenizer, Qwen3VLProcessor
 
 from megatron.bridge.data.base import DataloaderConfig, DatasetBuildContext, validate_declarative_mapping
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
+from megatron.bridge.utils.instantiate_utils import _resolve_target
 
 
 def _validate_hf_path(path: str, *, field_name: str) -> None:
@@ -138,6 +139,18 @@ EnergonTaskEncoderConfig = (
 
 
 @dataclass(kw_only=True)
+class EnergonTaskEncoderFactoryConfig:
+    """Declarative factory for task encoders not implemented by Bridge."""
+
+    target: str
+    """Fully qualified factory callable invoked with the dataset config."""
+
+    def validate(self) -> None:
+        """Validate the task-encoder factory target."""
+        _validate_hf_path(self.target, field_name="task_encoder_factory.target")
+
+
+@dataclass(kw_only=True)
 class EnergonDatasetConfig(DataloaderConfig):
     """Serializable configuration for an Energon-backed multimodal dataset."""
 
@@ -153,6 +166,7 @@ class EnergonDatasetConfig(DataloaderConfig):
     max_samples_per_sequence: int | None = None
     packing_buffer_size: int | None = None
     dataset_kwargs: dict[str, Any] = field(default_factory=dict)
+    task_encoder_factory: EnergonTaskEncoderFactoryConfig | None = None
     enable_in_batch_packing: bool = False
     defer_in_batch_packing_to_step: bool = False
     pad_to_max_length: bool = False
@@ -203,6 +217,10 @@ class EnergonDatasetConfig(DataloaderConfig):
         if self.packing_buffer_size is not None and not isinstance(self.task_encoder, QwenVLEnergonTaskEncoderConfig):
             raise ValueError("Energon native sequence packing currently supports only QwenVLEnergonTaskEncoderConfig.")
         validate_declarative_mapping(self.dataset_kwargs, field_name="dataset_kwargs")
+        if self.task_encoder_factory is not None:
+            if not isinstance(self.task_encoder_factory, EnergonTaskEncoderFactoryConfig):
+                raise TypeError("task_encoder_factory must be an EnergonTaskEncoderFactoryConfig when set.")
+            self.task_encoder_factory.validate()
         reserved_dataset_kwargs = {
             "batch_size",
             "max_samples_per_sequence",
@@ -229,6 +247,10 @@ def build_energon_task_encoder(config: EnergonDatasetConfig) -> Any:
     """Construct the configured Energon task encoder at runtime."""
     task_config = config.task_encoder
     task_config.validate()
+    if config.task_encoder_factory is not None:
+        factory = _resolve_target(config.task_encoder_factory.target, "task_encoder_factory.target")
+        return factory(config)
+
     effective_packing = config.enable_in_batch_packing and not config.defer_in_batch_packing_to_step
     enable_energon_packing = config.packing_buffer_size is not None
 

--- a/tests/unit_tests/data/builders/test_energon_builder.py
+++ b/tests/unit_tests/data/builders/test_energon_builder.py
@@ -23,6 +23,7 @@ from megatron.bridge.data import DatasetBuildContext
 from megatron.bridge.data.builders.energon import (
     EnergonDatasetBuilder,
     EnergonDatasetConfig,
+    EnergonTaskEncoderFactoryConfig,
     HFEnergonTaskEncoderConfig,
     NemotronOmniEnergonTaskEncoderConfig,
     QwenVLEnergonTaskEncoderConfig,
@@ -45,8 +46,17 @@ def _qwen_config(**overrides) -> EnergonDatasetConfig:
     return EnergonDatasetConfig(**values)
 
 
+def build_test_task_encoder(dataset_config: EnergonDatasetConfig) -> EnergonDatasetConfig:
+    """Return the supplied config to exercise the declarative factory contract."""
+    return dataset_config
+
+
 def test_config_round_trip_is_declarative_and_cli_overridable():
-    config = _qwen_config(dataset_kwargs={"handler": "warn_and_continue"})
+    factory_target = f"{__name__}.build_test_task_encoder"
+    config = _qwen_config(
+        dataset_kwargs={"handler": "warn_and_continue"},
+        task_encoder_factory=EnergonTaskEncoderFactoryConfig(target=factory_target),
+    )
 
     serialized = ConfigContainer._convert_value_to_dict(config)
     restored = instantiate(serialized)
@@ -54,6 +64,7 @@ def test_config_round_trip_is_declarative_and_cli_overridable():
     assert isinstance(restored, EnergonDatasetConfig)
     assert isinstance(restored.task_encoder, QwenVLEnergonTaskEncoderConfig)
     assert restored.dataset_kwargs == {"handler": "warn_and_continue"}
+    assert restored.task_encoder_factory == EnergonTaskEncoderFactoryConfig(target=factory_target)
     assert "processor" not in serialized
     assert "tokenizer" not in serialized
 
@@ -182,6 +193,32 @@ def test_qwen_factory_enables_native_energon_packing_from_buffer_size(monkeypatc
     assert encoder_cls.call_args.kwargs["enable_energon_packing"] is True
     assert encoder_cls.call_args.kwargs["enable_in_batch_packing"] is False
     assert encoder_cls.call_args.kwargs["in_batch_packing_pad_to_multiple_of"] == 8
+
+
+def test_task_encoder_factory_builds_a_custom_runtime_encoder():
+    config = _qwen_config(
+        micro_batch_size=1,
+        packing_buffer_size=32,
+        task_encoder_factory=EnergonTaskEncoderFactoryConfig(target=f"{__name__}.build_test_task_encoder"),
+    )
+
+    config.validate()
+    assert build_energon_task_encoder(config) is config
+
+
+@pytest.mark.parametrize("target", ["", "   "])
+def test_task_encoder_factory_requires_a_target(target: str):
+    config = _qwen_config(task_encoder_factory=EnergonTaskEncoderFactoryConfig(target=target))
+
+    with pytest.raises(ValueError, match="task_encoder_factory.target"):
+        config.validate()
+
+
+def test_task_encoder_factory_rejects_a_non_factory_config():
+    config = _qwen_config(task_encoder_factory={"target": "tests.factory"})
+
+    with pytest.raises(TypeError, match="EnergonTaskEncoderFactoryConfig"):
+        config.validate()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do ?

Add a declarative extension point for task encoders used by user-defined multimodal models, while preserving the canonical Energon Config + Builder data path.

# User problem

Bridge supports adding custom multimodal models under `models/`, but a model-specific `TaskEncoder` cannot be selected through the declarative dataset configuration. Reusing the built-in Qwen-VL task encoder is only possible when the custom model follows the same tokenizer, processor, image-token, and batching contract. Model-forward extensibility alone is not sufficient for general custom VLM integrations.

# Proposed solution

- Add a single `task_encoder_target` to `EnergonDatasetConfig` for selecting a custom TaskEncoder class.
- Resolve the target with Bridge's existing allowlisted `instantiate()` mechanism. Custom targets must be in an allowlisted package, such as a model under `megatron.bridge.models`.
- Construct the encoder from the override-merged dataset configuration and standard runtime objects inside the existing Energon builder.
- Preserve the built-in Qwen-VL, generic Hugging Face, and Nemotron Omni paths when no custom target is configured.

Illustrative usage:

```python
EnergonDatasetConfig(
    task_encoder=QwenVLEnergonTaskEncoderConfig(...),
    task_encoder_target="megatron.bridge.models.my_vlm.MyTaskEncoder",
)
```

This extension is limited to task-encoder construction inside the existing Config + Builder path. It does not add an alternate dataset provider or dataloader API.

# Related issue

- #4343

# Validation

- `uvx ruff check src/megatron/bridge/data/builders/energon.py tests/unit_tests/data/builders/test_energon_builder.py`
- `uvx ruff format --check src/megatron/bridge/data/builders/energon.py tests/unit_tests/data/builders/test_energon_builder.py`
- `python3 -m compileall -q src/megatron/bridge/data/builders/energon.py tests/unit_tests/data/builders/test_energon_builder.py`
- `uv run --frozen pytest -q tests/unit_tests/data/builders/test_energon_builder.py` could not run locally because `nvidia-resiliency-ext==0.6.0` has no macOS arm64 distribution.
