### PR TITLE
docs(perf): note DeepSeek V4 dev branch

### DIFF
--- a/docs/performance-summary.md
+++ b/docs/performance-summary.md
@@ -47,6 +47,8 @@ The performance data includes:
 
 #### Model: DeepSeekV4 Flash
 
+> **Note:** DeepSeek V4 requires checking out the Megatron-Core `dev` branch. See the [DeepSeek V4 reference directory](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/r0.6.0/examples/models/deepseek_v4) for setup instructions.
+
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
 | DGX-GB300 | 128 | MXFP8 | 2048 | 1 | 4096 | 1 | 1 | 1 | n/a | 64 | 8224 | 748 |

--- a/examples/model_verification_cards/deepseek-v4-flash/card.yaml
+++ b/examples/model_verification_cards/deepseek-v4-flash/card.yaml
@@ -8,6 +8,11 @@ summary: >
   Timing and throughput metrics from functional training items are sanity
   checks rather than optimized performance results.
 
+  The Megatron-backed DeepSeek V4 workflows in this card require the
+  Megatron-Core dev branch; the default MCore submodule revision in Megatron
+  Bridge r0.6.0 is insufficient. Follow the public setup instructions in
+  examples/models/deepseek_v4/README.md.
+
   DeepSeek-V4-Flash support verification covers GPU conversion, training, and
   checkpoint resume on GB200. CPU conversion remains unverified because full
   BF16 materialization requires a high-memory CPU node. Optimized Megatron

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -49,6 +49,8 @@ git switch <branch>
 ```
 Example: If using 26.04 container, then execute- `git switch r0.4.0`
 
+> **DeepSeek V4:** The 26.08 DeepSeek V4 recipes are an exception to this release-branch guidance: they require the Megatron-Core `dev` branch, and the default MCore submodule revision in `r0.6.0` is insufficient. Follow the [DeepSeek V4 setup instructions](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/r0.6.0/examples/models/deepseek_v4).
+
 ### Step 2. Run instructions
 
 #### <ins>Examples</ins>

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -59,6 +59,8 @@ the Slurm partition must provide the requested hardware:
 `benchmark` is the unified runner's user-facing term. The existing `perf_recipes` package and `scripts/performance/`
 compatibility paths retain their legacy names.
 
+> **DeepSeek V4:** The 26.08 DeepSeek V4 benchmark recipes require the Megatron-Core `dev` branch, and the default MCore submodule revision in `r0.6.0` is insufficient. Follow the [DeepSeek V4 setup instructions](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/r0.6.0/examples/models/deepseek_v4).
+
 ```bash
 ./scripts/training/train.sh \
     --nodes 2 --gpus-per-node 8 \


### PR DESCRIPTION
# What does this PR do ?

Clarifies the Megatron-Core branch required to reproduce the 26.08 DeepSeek V4 performance results across the performance summary and direct benchmark-launch entrypoints.

# Changelog

- Note that DeepSeek V4 requires the Megatron-Core `dev` branch and that the default MCore submodule revision in `r0.6.0` is insufficient.
- Add the prerequisite to the performance launcher, unified benchmark launcher, and DeepSeek V4 Flash verification card.
- Link to the r0.6.0 DeepSeek V4 reference directory for setup instructions.

# GitHub Actions CI

Documentation-only validation:

- `uv run --no-project --with pyyaml python skills/create-model-verification-card/scripts/validate_card.py examples/model_verification_cards/deepseek-v4-flash/card.yaml`
- `uv run --no-sync pre-commit run --all-files`
- `git diff --check`
- Verified that the linked r0.6.0 reference directory resolves successfully.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Tests are not required for this documentation-only change.
- [x] Updated the necessary documentation.
- [x] No optional-install components are affected.

# Additional Information

No related issue.
