### PR TITLE
cp: `docs(perf): note DeepSeek V4 dev branch (#5876)` into `r0.6.0`

### DIFF
--- a/docs/performance-summary.md
+++ b/docs/performance-summary.md
@@ -47,6 +47,8 @@ The performance data includes:
 
 #### Model: DeepSeekV4 Flash
 
+> **Note:** DeepSeek V4 requires checking out the Megatron-Core `dev` branch. See the [DeepSeek V4 reference directory](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/r0.6.0/examples/models/deepseek_v4) for setup instructions.
+
 | System | #-GPUs | Precision | GBS | MBS | Sequence Length | TP | PP | CP | VP | EP | Tokens / sec / GPU | Model TFLOP / sec / GPU |
 |--------|--------|-----------|-----|-----|-----------------|----|----|----|----|----|-----------------------|-------------------------|
 | DGX-GB300 | 128 | MXFP8 | 2048 | 1 | 4096 | 1 | 1 | 1 | n/a | 64 | 8224 | 748 |

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -49,6 +49,8 @@ git switch <branch>
 ```
 Example: If using 26.04 container, then execute- `git switch r0.4.0`
 
+> **DeepSeek V4:** The 26.08 DeepSeek V4 recipes are an exception to this release-branch guidance: they require the Megatron-Core `dev` branch, and the default MCore submodule revision in `r0.6.0` is insufficient. Follow the [DeepSeek V4 setup instructions](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/r0.6.0/examples/models/deepseek_v4).
+
 ### Step 2. Run instructions
 
 #### <ins>Examples</ins>

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -59,6 +59,8 @@ the Slurm partition must provide the requested hardware:
 `benchmark` is the unified runner's user-facing term. The existing `perf_recipes` package and `scripts/performance/`
 compatibility paths retain their legacy names.
 
+> **DeepSeek V4:** The 26.08 DeepSeek V4 benchmark recipes require the Megatron-Core `dev` branch, and the default MCore submodule revision in `r0.6.0` is insufficient. Follow the [DeepSeek V4 setup instructions](https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/r0.6.0/examples/models/deepseek_v4).
+
 ```bash
 ./scripts/training/train.sh \
     --nodes 2 --gpus-per-node 8 \


### PR DESCRIPTION
# What does this PR do ?

Cherry-picks #5876 onto `r0.6.0` so 26.08 performance customers see the Megatron-Core `dev` prerequisite from the performance summary and both benchmark-launch entrypoints.

# Changelog

- Note that DeepSeek V4 requires the Megatron-Core `dev` branch in the 26.08 performance summary.
- Call out that the default MCore submodule revision in `r0.6.0` is insufficient in the performance launcher and unified benchmark launcher documentation.
- Link both customer-facing launch paths to the `r0.6.0` DeepSeek V4 setup instructions.

The source PR also updated a DeepSeek V4 verification card that exists only on `main`. That modify/delete conflict was resolved by preserving the card's absence on `r0.6.0`; no release-branch content was removed.

# Blast radius

Documentation only: three existing Markdown files and six added lines. No source code, recipes, runtime configuration, generated documentation snapshots, or tests are changed.

# GitHub Actions CI

- `uv run --no-sync pre-commit run --all-files`
- `git diff --check upstream/r0.6.0...HEAD`
- Verified that the linked `r0.6.0` reference directory resolves with HTTP 200.

# Source

- Source PR: #5876
- Source squash commit: `b11414c71b15e54d333eb49346ed199f20fa9021`
- Backport commit: `e4c41173c2ddd59fd6b0cabbc5ebf7805a3e6bce`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor and release cherry-pick guidance.
- [x] Tests are not required for this documentation-only backport.
- [x] Assessed and documented the blast radius.
- [x] Updated only the release-applicable documentation.

# Additional Information

No related issue.
