### PR TITLE
[model] fix: Preserve legacy Omni frame counts

### DIFF
--- a/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni_llava.py
+++ b/src/megatron/bridge/models/nemotron_omni/modeling_nemotron_omni_llava.py
@@ -84,7 +84,6 @@ class NemotronOmniLlavaModel(NemotronVLModel):
                 raise NotImplementedError(
                     "NemotronOmniLlavaModel only supports image inputs; every num_frames value must be 1."
                 )
-            num_frames = 1
         elif num_frames not in (None, 1):
             raise NotImplementedError("NemotronOmniLlavaModel only supports image inputs; num_frames must be 1.")
 

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py
@@ -328,13 +328,17 @@ def test_llava_provider_uses_exact_replacement_counts_with_production_tile_limit
     assert llava_model.img_seq_len == 1
 
 
-def test_llava_forward_normalizes_all_one_frame_tensor_before_delegating():
+def test_llava_forward_preserves_all_one_frame_tensor_for_multiple_images():
     class _RecordingLlava:
         def __init__(self):
             self.kwargs = None
 
         def __call__(self, *args, **kwargs):
             self.kwargs = kwargs
+            num_frames = kwargs["num_frames"]
+            frame_counts = [num_frames] if isinstance(num_frames, int) else num_frames.tolist()
+            if sum(frame_counts) != len(kwargs["imgs_sizes"]):
+                raise ValueError("num_frames must partition imgs_sizes exactly")
             return args
 
     model = NemotronOmniLlavaModel.__new__(NemotronOmniLlavaModel)
@@ -344,7 +348,7 @@ def test_llava_forward_normalizes_all_one_frame_tensor_before_delegating():
     result = model.forward("input", num_frames=torch.ones(3, dtype=torch.int32), imgs_sizes=torch.ones(3, 2))
 
     assert result == ("input",)
-    assert model.llava_model.kwargs["num_frames"] == 1
+    assert torch.equal(model.llava_model.kwargs["num_frames"], torch.ones(3, dtype=torch.int32))
     assert model.llava_model.kwargs["imgs_sizes"].shape == (3, 2)
 
 


### PR DESCRIPTION
## What

Preserve per-image `num_frames` cardinality in the deprecated but supported Nemotron Omni LLaVA compatibility path.

A legacy multi-image batch emits one `imgs_sizes` row and one frame count per image. The wrapper validated that every frame count was one, then replaced the whole tensor with scalar `1`. Pinned MCore converts that scalar to `[1]` and requires the frame-count sum to equal the number of image-size rows, so any batch with two or more images failed before vision preprocessing.

This boundary became observable while reviewing the MCore update in #5865.

## Root cause and fix

`NemotronOmniLlavaModel.forward()` discarded the cardinality of a valid all-one frame-count tensor. The fix removes only that scalar conversion and forwards the already validated tensor unchanged. Invalid video frame counts remain rejected, and the canonical Nemotron Omni path is unchanged.

## Regression evidence

Fail-before on unmodified `main` (`8bc33cd2ca1cd044e1520130f4c5e1f5e0181434`):

```text
uv run --active --no-sync python -m pytest tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py::test_llava_forward_preserves_all_one_frame_tensor_for_multiple_images -q --tb=short
1 failed: ValueError: num_frames must partition imgs_sizes exactly
```

Pass-after with the unchanged regression:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py::test_llava_forward_preserves_all_one_frame_tensor_for_multiple_images -q --tb=short
1 passed
```

Adjacent provider and frame-validation coverage:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py -k "llava_provider_uses_exact_replacement_counts_with_production_tile_limit or llava_forward_preserves_all_one_frame_tensor_for_multiple_images or llava_forward_rejects_video_frame_counts" -q --tb=short
4 passed, 43 deselected
```

Additional validation:

```text
git diff --check
Passed

uv run --active --no-sync pre-commit run --all-files
Passed all hooks
```

## Scope

- No public API or configuration changes.
- No video-input support added.
- No canonical Nemotron Omni behavior changed.
- No dependency, lockfile, CI, or upstream MCore changes.
- Focused contract and adjacent unit validation only; no full-suite, convergence, or performance claim.
