### PR TITLE
[misc] fix: Provision NeMo Run in active inference environments

### DIFF
--- a/scripts/inference/infer.sh
+++ b/scripts/inference/infer.sh
@@ -21,6 +21,6 @@ cd "${REPO_ROOT}"
 
 UV_ARGS=(--no-project --with nemo-run==0.10.0)
 if [[ -n "${VIRTUAL_ENV:-}" ]]; then
-    UV_ARGS=(--active --no-sync)
+    UV_ARGS=(--active --no-sync --with nemo-run==0.10.0)
 fi
 exec uv run "${UV_ARGS[@]}" python "${SCRIPT_DIR}/setup_inference.py" "$@"

--- a/tests/unit_tests/scripts/inference/test_setup_inference.py
+++ b/tests/unit_tests/scripts/inference/test_setup_inference.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import importlib.util
+import os
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -72,6 +74,38 @@ def _launcher_args(*extra_options: str) -> list[str]:
         "--container-image",
         "image.sqsh",
         *extra_options,
+    ]
+
+
+def test_shell_launcher_provisions_nemo_run_in_active_environment(tmp_path):
+    fake_uv = tmp_path / "uv"
+    uv_args = tmp_path / "uv-args.txt"
+    fake_uv.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$UV_ARGS_FILE"\n', encoding="utf-8")
+    fake_uv.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "UV_ARGS_FILE": str(uv_args),
+            "VIRTUAL_ENV": str(tmp_path / "active-environment"),
+        }
+    )
+
+    subprocess.run(
+        [str(REPO_ROOT / "scripts" / "inference" / "infer.sh"), "--help"],
+        check=True,
+        env=env,
+    )
+
+    assert uv_args.read_text(encoding="utf-8").splitlines() == [
+        "run",
+        "--active",
+        "--no-sync",
+        "--with",
+        "nemo-run==0.10.0",
+        "python",
+        str(REPO_ROOT / "scripts" / "inference" / "setup_inference.py"),
+        "--help",
     ]
 
 


### PR DESCRIPTION
## Summary

- provision the pinned NeMo Run launcher dependency even when `VIRTUAL_ENV` is set
- preserve the existing active-environment and no-sync behavior
- cover the shell wrapper argv contract with a focused regression test

## User impact and root cause

`scripts/inference/infer.sh` is the documented login-node launcher. When any virtual environment was active, it replaced the pinned `nemo-run==0.10.0` overlay with `--active --no-sync`. A normal project environment does not install the optional launcher package, so the wrapper failed at the top-level `nemo_run` import before it could parse `--help`, render a dry run, or submit inference.

The fix keeps the prepared active environment but layers the exact launcher version with uv. No model-loading, Slurm, distributed, or GPU behavior changes.

## Regression evidence

Fail-before on `main`:

- `VIRTUAL_ENV="$PWD/.venv" PATH="$PWD/.venv/bin:$PATH" ./scripts/inference/infer.sh --help`
- exited 1 with `ModuleNotFoundError: No module named nemo_run` before argument parsing
- the focused shell test captured `uv run --active --no-sync python ...` without the required overlay

Pass-after:

- focused regression: 1 passed
- `uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts/inference tests/unit_tests/scripts/inference/test_setup_inference.py -q`: 33 passed
- activated-environment `./scripts/inference/infer.sh --help`: exited 0 and printed complete help
- `bash -n scripts/inference/infer.sh`: passed
- `git diff --check`: passed
- `uv run --no-sync pre-commit run --all-files`: passed

## Scope

This change only corrects dependency provisioning for the inference login-node wrapper. It does not change launcher arguments, public APIs, job resources, model support, or distributed execution.