### PR TITLE
[recipe] fix: allocate Qwen3.5-VL 397B pipeline layers

### DIFF
--- a/scripts/training/recipe_runner.py
+++ b/scripts/training/recipe_runner.py
@@ -404,14 +404,24 @@ def sync_model_pipeline_layout(
         middle_layer_count = model.num_layers - sum(
             stage_layers or 0 for stage_layers in (first_stage_layers, last_stage_layers)
         )
+        virtual_pipeline_size = model.virtual_pipeline_model_parallel_size or 1
+        middle_stage_layers = (
+            middle_layer_count // middle_stage_count
+            if middle_stage_count > 0 and middle_layer_count % middle_stage_count == 0
+            else None
+        )
         stages_are_compatible = (
             middle_stage_count >= 0
             and middle_layer_count >= 0
             and bool(middle_stage_count) == bool(middle_layer_count)
             and (middle_stage_count == 0 or middle_layer_count % middle_stage_count == 0)
+            and all(
+                stage_layers is None or stage_layers % virtual_pipeline_size == 0
+                for stage_layers in (first_stage_layers, middle_stage_layers, last_stage_layers)
+            )
         )
         if (
-            "model.pipeline_model_parallel_size" in override_fields
+            override_fields.intersection(topology_fields)
             and getattr(model, "pipeline_model_parallel_layout", None) is None
             and not stages_are_compatible
         ):

--- a/src/megatron/bridge/perf_recipes/qwen_vl/b200/qwen35_vl.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/b200/qwen35_vl.py
@@ -219,6 +219,8 @@ def qwen35_vl_397b_a17b_pretrain_64gpu_b200_bf16_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = 4
+    cfg.model.num_layers_in_first_pipeline_stage = 4
+    cfg.model.num_layers_in_last_pipeline_stage = 8
     cfg.model.expert_model_parallel_size = 8
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = False

--- a/src/megatron/bridge/perf_recipes/qwen_vl/gb200/qwen35_vl.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/gb200/qwen35_vl.py
@@ -264,6 +264,8 @@ def qwen35_vl_397b_a17b_pretrain_64gpu_gb200_bf16_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.num_layers_in_first_pipeline_stage = 4
+    cfg.model.num_layers_in_last_pipeline_stage = 8
     cfg.model.expert_model_parallel_size = 8
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = False

--- a/src/megatron/bridge/perf_recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/h100/qwen35_vl.py
@@ -188,6 +188,8 @@ def qwen35_vl_397b_a17b_pretrain_256gpu_h100_bf16_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = 4
+    cfg.model.num_layers_in_first_pipeline_stage = 4
+    cfg.model.num_layers_in_last_pipeline_stage = 8
     cfg.model.expert_model_parallel_size = 32
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = True

--- a/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
+++ b/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
@@ -17,19 +17,31 @@
 import sys
 from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
+from megatron.core.transformer.transformer_block import get_num_layers_to_build
 
+from megatron.bridge.perf_recipes.qwen_vl.b200.qwen35_vl import (
+    qwen35_vl_397b_a17b_pretrain_64gpu_b200_bf16_config,
+    qwen35_vl_397b_a17b_pretrain_64gpu_b200_fp8cs_config,
+    qwen35_vl_397b_a17b_pretrain_64gpu_b200_fp8mx_config,
+)
 from megatron.bridge.perf_recipes.qwen_vl.gb200.qwen35_vl import (
     qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config,
     qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8cs_config,
     qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8mx_config,
+    qwen35_vl_397b_a17b_pretrain_64gpu_gb200_bf16_config,
+    qwen35_vl_397b_a17b_pretrain_64gpu_gb200_fp8cs_config,
+    qwen35_vl_397b_a17b_pretrain_64gpu_gb200_fp8mx_config,
 )
 from megatron.bridge.perf_recipes.qwen_vl.h100.qwen35_vl import (
     qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_config,
     qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_config,
     qwen35_vl_122b_a10b_pretrain_128gpu_h100_fp8cs_config,
+    qwen35_vl_397b_a17b_pretrain_256gpu_h100_bf16_config,
+    qwen35_vl_397b_a17b_pretrain_256gpu_h100_fp8cs_config,
 )
 from megatron.bridge.utils.cuda_graph import cuda_graph_module_names
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_construction_dependencies
@@ -72,6 +84,52 @@ def test_qwen35_vl_122b_h100_pipeline_layout(
     assert (num_layers // pp_size) % vp_size == 0
     assert pp_size == expected_pp_size
     assert vp_size == expected_vp_size
+
+
+@pytest.mark.parametrize(
+    "recipe_fn",
+    [
+        qwen35_vl_397b_a17b_pretrain_256gpu_h100_bf16_config,
+        qwen35_vl_397b_a17b_pretrain_256gpu_h100_fp8cs_config,
+        qwen35_vl_397b_a17b_pretrain_64gpu_b200_bf16_config,
+        qwen35_vl_397b_a17b_pretrain_64gpu_b200_fp8cs_config,
+        qwen35_vl_397b_a17b_pretrain_64gpu_b200_fp8mx_config,
+        qwen35_vl_397b_a17b_pretrain_64gpu_gb200_bf16_config,
+        qwen35_vl_397b_a17b_pretrain_64gpu_gb200_fp8cs_config,
+        qwen35_vl_397b_a17b_pretrain_64gpu_gb200_fp8mx_config,
+    ],
+)
+def test_qwen35_vl_397b_pipeline_layout_builds_all_layers(
+    recipe_fn: Callable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 397B benchmark topology should allocate all 60 language layers."""
+    patch_recipe_construction_dependencies(monkeypatch)
+    config = recipe_fn()
+    model = config.model
+    allocation_config = SimpleNamespace(
+        pipeline_model_parallel_layout=getattr(model, "pipeline_model_parallel_layout", None),
+        num_layers_in_first_pipeline_stage=getattr(model, "num_layers_in_first_pipeline_stage", None),
+        num_layers_in_last_pipeline_stage=getattr(model, "num_layers_in_last_pipeline_stage", None),
+        account_for_embedding_in_pipeline_split=False,
+        account_for_loss_in_pipeline_split=False,
+        num_layers=60,
+        pipeline_model_parallel_size=model.pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=model.virtual_pipeline_model_parallel_size,
+    )
+    vp_stages = (
+        [None]
+        if model.virtual_pipeline_model_parallel_size is None
+        else range(model.virtual_pipeline_model_parallel_size)
+    )
+
+    allocated_layers = sum(
+        get_num_layers_to_build(allocation_config, vp_stage=vp_stage, pp_rank=pp_rank)
+        for pp_rank in range(model.pipeline_model_parallel_size)
+        for vp_stage in vp_stages
+    )
+
+    assert allocated_layers == 60
 
 
 def test_qwen35_vl_35b_h100_measured_performance_defaults(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/scripts/training/test_recipe_runner.py
+++ b/tests/unit_tests/scripts/training/test_recipe_runner.py
@@ -371,6 +371,33 @@ def test_sync_model_pipeline_layout_preserves_compatible_recipe_stages(recipe_ru
     ) == (11, 11)
 
 
+def test_sync_model_pipeline_layout_repartitions_layers_after_vp_override(recipe_runner: ModuleType) -> None:
+    """Topology overrides must not retain stage counts indivisible by VP."""
+    config = SimpleNamespace(
+        model=SimpleNamespace(
+            num_layers=60,
+            pipeline_model_parallel_size=4,
+            virtual_pipeline_model_parallel_size=3,
+            pipeline_model_parallel_layout=None,
+            num_layers_in_first_pipeline_stage=4,
+            num_layers_in_last_pipeline_stage=8,
+        )
+    )
+
+    recipe_runner.sync_model_pipeline_layout(
+        config,
+        cli_overrides=[
+            "model.pipeline_model_parallel_size=4",
+            "model.virtual_pipeline_model_parallel_size=3",
+        ],
+    )
+
+    assert (
+        config.model.num_layers_in_first_pipeline_stage,
+        config.model.num_layers_in_last_pipeline_stage,
+    ) == (None, None)
+
+
 @pytest.mark.parametrize(
     "dataset",
     [


### PR DESCRIPTION
## Summary

Eight exported Qwen3.5-VL 397B performance recipes configured 60 language layers with pipeline parallel size 8 and no uneven or custom layout. Pinned Megatron-Core therefore aborted model construction because 60 is not divisible by 8.

This change assigns 4 language layers to the vision-heavy first stage, 8 to the last stage, and 8 to each middle stage. H100 and B200 remain valid with VP=4, and precision variants inherit the corrected BF16 topology. The existing CLI topology synchronizer now also discards those recipe-owned uneven counts when a supported PP/VP override makes any physical-stage count indivisible by VP.

## Root cause and impact

The H100 BF16/FP8-CS, B200 BF16/FP8-CS/MXFP8, and GB200 BF16/FP8-CS/MXFP8 factories all override the canonical 397B provider to PP=8 without supplying uneven stage counts. Model construction reaches `get_num_layers_to_build()` and raises:

`AssertionError: num_layers=60 should be divisible by config.pipeline_model_parallel_size=8`

As a result, none of those eight advertised benchmark recipes could start a benchmark iteration. After adding the uneven default, the runner also needed to account for VP divisibility when users override the recipe topology; otherwise a valid PP=4/VP=3 override retained 4/8 stage counts that MCore rejects.

## Validation

- Fail before: `uv run --active --no-sync python -m pytest tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py::test_qwen35_vl_397b_pipeline_layout_builds_all_layers -q --tb=short` — 8 failed with the exact PP divisibility assertion.
- Pass after: the same command — 8 passed.
- Adjacent Qwen3.5 performance tests: `uv run --active --no-sync python -m pytest tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py -q --tb=short` — 14 passed.
- Focused performance-factory slice: `uv run --active --no-sync python -m pytest tests/unit_tests/recipes/test_all_perf_recipe_factories.py -k qwen35 -q --tb=short` — 51 passed, 383 deselected.
- Runner topology tests: `PYTHONPATH=<temporary-import-stub>:$PWD uv run --no-project --python 3.12 --with pytest python -m pytest --confcutdir=tests/unit_tests/scripts/training tests/unit_tests/scripts/training/test_recipe_runner.py -q` — 38 passed.
- `git diff --check` — passed.
- `pre-commit run --all-files` — passed.

## Scope

This changes only the three 397B BF16 topology roots, the existing runner behavior for incompatible recipe-owned uneven stages after PP/VP overrides, and focused regression coverage. It does not change model/provider APIs, dependencies, CI, other Qwen3.5 sizes, PP=1 hardware recipes, or explicitly supplied compatible stage counts.
