### PR TITLE
[training] fix: preserve hook bootstrap after skipped iteration

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -429,6 +429,8 @@ def train(
 
         # Completely skip iteration if needed.
         if _should_skip_and_handle_iteration(global_state, train_data_iterator, pg_collection):
+            if global_state.train_state.step == start_iteration + 1:
+                start_iteration = global_state.train_state.step
             nvtx_range_pop(suffix=f"training_step_{nvtx_step}")
             handle_profiling_stop(
                 config.profiling,

--- a/tests/unit_tests/training/test_pg_collection_wiring.py
+++ b/tests/unit_tests/training/test_pg_collection_wiring.py
@@ -190,3 +190,154 @@ def test_train_stops_nsys_profiler_when_skipped_iteration_reaches_profile_end(mo
 
     start_nsys_profiler.assert_called_once_with(profiling)
     stop_nsys_profiler.assert_called_once()
+
+
+def test_first_skipped_iteration_preserves_cuda_graph_hook_bootstrap(monkeypatch):
+    """A dummy first iteration must not strand parameter-gather hook initialization."""
+    from megatron.bridge.training import train as train_module
+
+    config = SimpleNamespace(
+        train=SimpleNamespace(
+            manual_gc=False,
+            manual_gc_interval=0,
+            check_weight_hash_across_dp_replicas_interval=None,
+            train_sync_interval=None,
+            train_iters=3,
+            micro_batch_size=1,
+            iterations_to_skip={1},
+            decrease_batch_size_if_needed=False,
+        ),
+        validation=SimpleNamespace(eval_interval=0, start_eval_at_iter=None),
+        profiling=None,
+        straggler=None,
+        dist=SimpleNamespace(distributed_timeout_seconds_after_init=None),
+        ddp=SimpleNamespace(use_megatron_fsdp=False, overlap_param_gather=True),
+        optimizer=SimpleNamespace(
+            use_distributed_optimizer=True,
+            optimizer_cuda_graph=False,
+        ),
+        model=SimpleNamespace(
+            seq_length=8,
+            virtual_pipeline_model_parallel_size=None,
+            cuda_graph_warmup_steps=1,
+            cuda_graph_use_single_mempool=False,
+            moe_expert_rank_capacity_factor=None,
+        ),
+        logger=SimpleNamespace(
+            log_throughput_to_tensorboard=False,
+            skip_train_metrics_log=True,
+            log_interval=1,
+        ),
+        checkpoint=SimpleNamespace(save=None, save_interval=None),
+        tensor_inspect=None,
+    )
+    state = SimpleNamespace(
+        cfg=config,
+        train_state=SimpleNamespace(
+            step=0,
+            consumed_train_samples=0,
+            skipped_train_samples=0,
+            floating_point_operations_so_far=0,
+            do_valid=False,
+        ),
+        timers=Mock(),
+        straggler_timer=Mock(),
+        energy_monitor=None,
+        nvrx_straggler_manager=None,
+        tensorboard_logger=None,
+        wandb_logger=None,
+        _comet_logger=None,
+        start_time=0.0,
+    )
+    original_param_sync_func = Mock()
+    model_config = SimpleNamespace(
+        cuda_graph_impl="transformer_engine",
+        cuda_graph_warmup_steps=1,
+        param_sync_func=original_param_sync_func,
+    )
+    rerun_state_machine = SimpleNamespace(current_iteration=0)
+    data_distribution_group = SimpleNamespace(size=lambda: 1)
+    pg_collection = SimpleNamespace(
+        dp=data_distribution_group,
+        pp=SimpleNamespace(size=lambda: 1),
+    )
+    hook_state = {"enabled": True}
+    graph_state = {"created": False}
+    helper = SimpleNamespace(
+        graphs_created=lambda: graph_state["created"],
+        create_cudagraphs=lambda: graph_state.__setitem__("created", True),
+        cuda_graph_set_manual_hooks=Mock(),
+    )
+
+    def disable_forward_pre_hook(*args, **kwargs):
+        assert hook_state["enabled"], "parameter-gather forward pre-hooks were disabled twice"
+        hook_state["enabled"] = False
+
+    def enable_forward_pre_hook(*args, **kwargs):
+        assert not hook_state["enabled"]
+        hook_state["enabled"] = True
+
+    flops_stats = SimpleNamespace(
+        seqlen_sum=0,
+        seqlen_squared_sum=0,
+        num_vision_patches=0,
+        cross_seqlen_sum=0,
+        cross_seqlen_product_sum=0,
+        has_exact_vision_stats=False,
+    )
+    monkeypatch.setattr(train_module, "get_model_config", lambda _model: model_config)
+    monkeypatch.setattr(train_module, "get_rerun_state_machine", lambda: rerun_state_machine)
+    monkeypatch.setattr(train_module, "get_num_microbatches", lambda: 1)
+    monkeypatch.setattr(train_module, "update_num_microbatches", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "get_current_global_batch_size", lambda: 1)
+    monkeypatch.setattr(train_module, "get_current_running_global_batch_size", lambda: 1)
+    monkeypatch.setattr(train_module, "get_data_distribution_group", lambda *args, **kwargs: data_distribution_group)
+    monkeypatch.setattr(train_module, "should_disable_forward_pre_hook", lambda *args: True)
+    monkeypatch.setattr(train_module, "disable_forward_pre_hook", disable_forward_pre_hook)
+    monkeypatch.setattr(train_module, "enable_forward_pre_hook", enable_forward_pre_hook)
+    monkeypatch.setattr(train_module, "TECudaGraphHelper", lambda **kwargs: helper)
+    monkeypatch.setattr(train_module, "prepare_forward_step_func", lambda *args: Mock())
+    monkeypatch.setattr(train_module, "get_forward_backward_func", lambda **kwargs: Mock())
+    monkeypatch.setattr(train_module, "is_full_iteration_cuda_graph", lambda _config: False)
+    monkeypatch.setattr(train_module, "P2PCommunicator", lambda **kwargs: Mock())
+    monkeypatch.setattr(train_module, "train_step", lambda *args: ({}, 0, False, False, 0, None, None, None))
+    monkeypatch.setattr(train_module, "_dummy_train_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "_delete_cuda_graphs", lambda _helper: None)
+    monkeypatch.setattr(train_module, "safe_shutdown_nvrx_straggler_manager", lambda _manager: None)
+    monkeypatch.setattr(train_module, "tensor_inspect_step_if_enabled", lambda _config: None)
+    monkeypatch.setattr(train_module, "tensor_inspect_end_if_enabled", lambda _config: None)
+    monkeypatch.setattr(train_module, "should_fire", lambda *args: False)
+    monkeypatch.setattr(train_module, "nvtx_range_push", lambda **kwargs: None)
+    monkeypatch.setattr(train_module, "nvtx_range_pop", lambda **kwargs: None)
+    monkeypatch.setattr(train_module, "handle_profiling_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "handle_profiling_stop", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "maybe_synchronize_training_step", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "maybe_report_stragglers", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr(train_module, "maybe_check_weight_hash_across_dp_replicas", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "maybe_run_manual_gc", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_module, "checkpoint_and_decide_exit", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        train_module.flop_utils, "resolve_global_flops_runtime_stats", lambda *args, **kwargs: flops_stats
+    )
+    monkeypatch.setattr(train_module.flop_utils, "num_floating_point_operations", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(train_module.torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(train_module.fault_tolerance, "on_checkpointing_start", lambda _state: None)
+    monkeypatch.setattr(train_module.fault_tolerance, "on_checkpointing_end", lambda **kwargs: None)
+    monkeypatch.setattr(train_module.fault_tolerance, "on_training_step_start", lambda _state: None)
+    monkeypatch.setattr(train_module.fault_tolerance, "on_training_step_end", lambda _state: None)
+
+    train_module.train(
+        forward_step_func=Mock(),
+        model=[Mock()],
+        optimizer=Mock(),
+        scheduler=Mock(),
+        train_data_iterator=None,
+        valid_data_iterator=None,
+        global_state=state,
+        checkpoint_manager=Mock(),
+        pg_collection=pg_collection,
+    )
+
+    assert state.train_state.step == 3
+    assert graph_state["created"] is True
+    helper.cuda_graph_set_manual_hooks.assert_called_once()


### PR DESCRIPTION
## Problem

When the first configured training iteration is skipped, the dummy step advances the training step before the loop restores the parameter-gather forward hooks disabled for CUDA-graph warmup. With the distributed optimizer, `overlap_param_gather=True`, and Transformer Engine CUDA graphs enabled, the warmup boundary later disables those hooks a second time and MCore raises a `KeyError` from its already-empty hook-handle map.

This is reachable through supported training configuration and aborts the job before CUDA-graph capture completes.

## Root cause and fix

`train()` records `start_iteration` before entering the loop. A skipped first iteration increments `train_state.step` and continues before the `step == start_iteration` bootstrap block, so that equality can never be reached.

Rebase the loop-local `start_iteration` when the first dummy step advances it. This preserves the existing first-real-step bootstrap invariant and matches the corresponding behavior in the pinned MCore training loop. No configuration or API surface changes.

## Regression coverage

The unit regression drives the full Bridge loop contract through first-iteration skip, hook restoration, CUDA-graph capture, and manual-hook installation.

Fail-before/pass-after was also confirmed with a temporary two-rank Llama reproducer using a two-layer model, mock data, `iterations_to_skip={1}`, TE-scoped CUDA graphs with one warmup step, the distributed optimizer, and parameter-gather overlap:

```text
uv run python -m torch.distributed.run --nproc_per_node=2 --nnodes=1 \
  -m pytest -v -s -x --tb=short \
  tests/functional_tests/test_groups/recipes/test_first_skip_cuda_graph_eos.py
```

- Before: failed in `train.py:450` when MCore's second `disable_forward_pre_hook()` lookup raised `KeyError`.
- After: passed on both ranks, completed 10 iterations, and captured TE CUDA graphs.

Additional validation:

```text
uv run python -m pytest tests/unit_tests/training/test_pg_collection_wiring.py -q
# 4 passed

git diff --check
# passed

uv run pre-commit run --all-files
# passed
```

## Scope

This change only preserves bootstrap state across leading configured dummy iterations. It does not change non-leading skip behavior, CUDA-graph configuration, distributed optimizer semantics, or supported model scope.
