### PR TITLE
cp: `feat(perf): add NCCL EP support with focused examples (5468)` into `r0.6.0`

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -869,8 +869,8 @@ def parse_cli_args():
     performance_args.add_argument(
         "--moe_flex_dispatcher_backend",
         type=lambda x: None if x == "None" else x,
-        help="MoE flex dispatcher backend. Options- deepep, hybridep, None. If None, will use alltoall dispatcher.",
-        choices=["deepep", "hybridep", None],
+        help="MoE flex dispatcher backend. Options- deepep, hybridep, ncclep, None. If None, will use alltoall dispatcher.",
+        choices=["deepep", "hybridep", "ncclep", None],
         required=False,
         # -1 means the option was omitted and the recipe backend must be kept;
         # None means the user explicitly requested the alltoall dispatcher.

--- a/scripts/performance/utils/overrides.py
+++ b/scripts/performance/utils/overrides.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 
 from omegaconf import OmegaConf
 
+from megatron.bridge.perf_recipes.environment import HYBRID_EP_ENV_NAMES
 from megatron.bridge.recipes.deepseek.deepseek_v3 import set_deepseek_v3_pipeline_model_parallel_layout
 from megatron.bridge.recipes.kimi.kimi_k2 import _get_kimi_k2_pipeline_layout
 from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides
@@ -244,6 +245,13 @@ def _apply_flat_cli_environment_compatibility(
     cp_size = getattr(model, "context_parallel_size", 1) or 1
     ep_size = getattr(model, "expert_model_parallel_size", 1) or 1
     gpu = args.gpu.lower()
+    effective_dispatcher_backend = getattr(model, "moe_flex_dispatcher_backend", base_dispatcher_backend)
+
+    # Only NCCL EP drops these. DeepEP and the alltoall dispatcher keep whatever the recipe set,
+    # so switching to NCCL EP never changes the environment of an unrelated benchmark.
+    if effective_dispatcher_backend == "ncclep":
+        for name in sorted(HYBRID_EP_ENV_NAMES):
+            _remove_recipe_env(recipe, name, protected)
 
     connection_override = any(
         value is not None
@@ -255,14 +263,14 @@ def _apply_flat_cli_environment_compatibility(
     )
     if connection_override:
         moe_a2a_overlap = args.moe_a2a_overlap if args.moe_a2a_overlap is not None else base_moe_a2a_overlap
-        max_connections = 32 if base_dispatcher_backend in {"deepep", "hybridep"} else 8
+        max_connections = 32 if effective_dispatcher_backend in {"deepep", "hybridep", "ncclep"} else 8
         if gpu in {"b200", "b300", "gb200", "gb300", "vr200"}:
             max_connections = 32
         elif (tp_size > 1 or cp_size > 1) and not moe_a2a_overlap:
             max_connections = 1
         _set_recipe_env(recipe, "CUDA_DEVICE_MAX_CONNECTIONS", max_connections, protected)
 
-    if args.expert_model_parallel_size is not None and base_dispatcher_backend == "hybridep":
+    if args.expert_model_parallel_size is not None and effective_dispatcher_backend == "hybridep":
         if ep_size <= 0:
             raise ValueError("HybridEP expert parallel size must be positive.")
         if gpu in {"h100", "b200", "b300"}:

--- a/scripts/performance/utils/utils.py
+++ b/scripts/performance/utils/utils.py
@@ -294,14 +294,21 @@ def apply_target_topology_environment(
     model-specific environment stays explicit in the recipe. Explicit
     ``env_vars`` overrides remain final.
     """
+    from megatron.bridge.perf_recipes.environment import HYBRID_EP_ENV_NAMES
+
     topology_names = {
         "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN",
         "NVLINK_DOMAIN_SIZE",
         "USE_MNNVL",
     }
     protected = protected_env_names or set()
-    if getattr(config.model, "moe_flex_dispatcher_backend", None) != "hybridep":
-        for name in topology_names - protected:
+    dispatcher_backend = getattr(config.model, "moe_flex_dispatcher_backend", None)
+    if dispatcher_backend != "hybridep":
+        # NCCL EP also drops the HybridEP tuning this function never derives, so an NCCL EP launch
+        # carries no stale HybridEP settings at all. DeepEP and alltoall keep whatever the recipe
+        # set, exactly as before.
+        stale_names = HYBRID_EP_ENV_NAMES if dispatcher_backend == "ncclep" else topology_names
+        for name in stale_names - protected:
             config.env_vars.pop(name, None)
         return
 
@@ -387,9 +394,9 @@ def apply_argparse_overrides(config: Any, args: Any) -> Any:
 
     dispatcher_backend = getattr(args, "moe_flex_dispatcher_backend", -1)
     num_moe_experts = getattr(config.model, "num_moe_experts", None)
-    if dispatcher_backend in {"deepep", "hybridep"} and num_moe_experts not in {None, 0}:
+    if dispatcher_backend in {"deepep", "hybridep", "ncclep"} and num_moe_experts not in {None, 0}:
         config.model.moe_flex_dispatcher_backend = dispatcher_backend
-    elif dispatcher_backend in {"deepep", "hybridep"}:
+    elif dispatcher_backend in {"deepep", "hybridep", "ncclep"}:
         logger.warning("Ignoring flex dispatcher override for a model without MoE experts.")
     elif dispatcher_backend is None:
         config.model.moe_flex_dispatcher_backend = None
@@ -413,7 +420,7 @@ def finalize_config_overrides(config: Any) -> Any:
 
     dispatcher_backend = getattr(config.model, "moe_flex_dispatcher_backend", None)
     num_moe_experts = getattr(config.model, "num_moe_experts", None)
-    if dispatcher_backend in {"deepep", "hybridep"} and num_moe_experts not in {None, 0}:
+    if dispatcher_backend in {"deepep", "hybridep", "ncclep"} and num_moe_experts not in {None, 0}:
         config.model.moe_token_dispatcher_type = "flex"
         config.model.moe_shared_expert_overlap = False
     elif dispatcher_backend is None and getattr(config.model, "moe_token_dispatcher_type", None) == "flex":

--- a/src/megatron/bridge/perf_recipes/environment.py
+++ b/src/megatron/bridge/perf_recipes/environment.py
@@ -24,3 +24,16 @@ COMMON_PERF_ENV_VARS: dict[str, str | int | float | bool] = {
     # Run NCCL work on its high-priority stream for every measured workload.
     "TORCH_NCCL_HIGH_PRIORITY": 1,
 }
+
+# HybridEP tuning, read by DeepEP's HybridEPBuffer. Megatron Core only builds that buffer when
+# moe_flex_dispatcher_backend is "hybridep", so these names are inert on any other backend. NCCL EP
+# recipes still drop them so the launched environment, which is dumped with the run, does not
+# advertise HybridEP tuning that nothing reads.
+HYBRID_EP_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN",
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API",
+        "NVLINK_DOMAIN_SIZE",
+        "USE_MNNVL",
+    }
+)

--- a/src/megatron/bridge/perf_recipes/gpt_oss/__init__.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/__init__.py
@@ -15,6 +15,7 @@ from megatron.bridge.perf_recipes.gpt_oss.gb200.gpt_oss import (
     gpt_oss_20b_pretrain_72gpu_gb200_nvfp4_config,
     gpt_oss_20b_pretrain_512gpu_gb200_fp8mx_config,
     gpt_oss_120b_pretrain_64gpu_gb200_bf16_config,
+    gpt_oss_120b_pretrain_64gpu_gb200_bf16_ncclep_config,
     gpt_oss_120b_pretrain_64gpu_gb200_fp8mx_config,
 )
 from megatron.bridge.perf_recipes.gpt_oss.gb300.gpt_oss import (

--- a/src/megatron/bridge/perf_recipes/gpt_oss/common.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/common.py
@@ -20,6 +20,36 @@ from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import ConfigContainer
 
 
+def _enable_ncclep_bf16(cfg: ConfigContainer) -> None:
+    """Swap the recipe's flex dispatcher for eager NCCL EP on BF16.
+
+    Only the dispatch stack changes. Parallelism, batch sizes, precision, recompute and the CUDA
+    graph mode are left exactly as the parent recipe set them. The calling recipe builder still
+    declares its own ``cfg.env_vars`` mapping inline, so the launched environment stays readable
+    next to the recipe instead of being derived here.
+    """
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "ncclep"
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.high_priority_a2a_comm_stream = True
+    cfg.model.moe_hybridep_num_sms = None
+    cfg.model.moe_flex_dispatcher_num_sms = None
+    cfg.model.moe_ncclep_zero_copy = False
+
+    if cfg.comm_overlap is None:
+        cfg.comm_overlap = CommOverlapConfig(tp_comm_overlap=False)
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
+    cfg.comm_overlap.delay_wgrad_compute = False
+
+    cfg.model.offload_modules = []
+
+    # GPT-OSS's clamped quick-GeLU does not have a BF16 op-fuser kernel. Eager NCCL EP sizes the
+    # receive buffer per step, so it needs neither the op fuser nor a static capacity factor.
+    cfg.model.use_transformer_engine_op_fuser = False
+    cfg.model.moe_expert_rank_capacity_factor = None
+    cfg.model.moe_paged_stash = False
+
+
 def _apply_gpt_oss_120b_full_iter_fp8mx_configs(cfg: ConfigContainer) -> None:
     """Apply legacy GPT-OSS 120B FP8-MX full-iteration CUDA graph settings."""
     cfg.model.cuda_graph_impl = "full_iteration"

--- a/src/megatron/bridge/perf_recipes/gpt_oss/gb200/gpt_oss.py
+++ b/src/megatron/bridge/perf_recipes/gpt_oss/gb200/gpt_oss.py
@@ -22,6 +22,7 @@ from megatron.bridge.perf_recipes.gpt_oss.common import (
     _apply_gpt_oss_20b_transformer_engine_graph_configs,
     _apply_gpt_oss_120b_full_iter_fp8mx_configs,
     _benchmark_common,
+    _enable_ncclep_bf16,
     _gpt_oss_20b_fp8mx_precision,
     _gpt_oss_20b_nvfp4_precision,
     _perf_precision,
@@ -259,6 +260,34 @@ def gpt_oss_120b_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
         "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+    }
+    return cfg
+
+
+def gpt_oss_120b_pretrain_64gpu_gb200_bf16_ncclep_config() -> ConfigContainer:
+    """GPT-OSS 120B pretrain: 64× GB200, BF16, NCCL EP=64.
+
+    Note:
+        This recipe is temporary, added only for experimentation with NCCL EP.
+        It will be removed in the near future.
+    """
+    cfg = gpt_oss_120b_pretrain_64gpu_gb200_bf16_config()
+    _enable_ncclep_bf16(cfg)
+    # Keep process settings next to the recipe so users can see the exact benchmark environment.
+    # Eager NCCL EP reads no HybridEP topology, so no HybridEP names are declared here.
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        # CUDA stream scheduling for this model and parallel layout.
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        # CUDA graph and allocator behavior for this recipe.
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        # NCCL user-buffer and launch settings.
+        "NCCL_NVLS_ENABLE": 0,
+        # Transformer Engine overlap settings for this model.
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
     }
     return cfg

--- a/src/megatron/bridge/perf_recipes/nemotronh/__init__.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/__init__.py
@@ -39,6 +39,7 @@ from megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh import (
     nemotron_3_5_lightning_pretrain_8gpu_gb300_nvfp4_config,
     nemotron_3_nano_pretrain_8gpu_gb300_bf16_config,
     nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config,
+    nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_ncclep_config,
     nemotron_3_nano_pretrain_8gpu_gb300_nvfp4_config,
     nemotron_3_super_pretrain_64gpu_gb300_bf16_config,
     nemotron_3_super_pretrain_64gpu_gb300_fp8mx_config,

--- a/src/megatron/bridge/perf_recipes/nemotronh/common.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/common.py
@@ -62,6 +62,36 @@ def _with_global_batch_size(cfg: ConfigContainer, global_batch_size: int) -> Con
     return cfg
 
 
+def _enable_ncclep_mxfp8(cfg: ConfigContainer) -> None:
+    """Enable static-shape NCCL EP for an MXFP8 recipe.
+
+    The calling recipe builder still declares its own ``cfg.env_vars`` mapping inline, so the
+    launched environment stays readable next to the recipe instead of being derived here.
+    """
+    cfg.model.moe_token_dispatcher_type = "flex"
+    cfg.model.moe_flex_dispatcher_backend = "ncclep"
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.high_priority_a2a_comm_stream = True
+    cfg.model.moe_hybridep_num_sms = None
+    cfg.model.moe_flex_dispatcher_num_sms = None
+    cfg.model.moe_ncclep_zero_copy = False
+
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.use_transformer_engine_op_fuser = True
+    cfg.model.moe_mlp_glu_interleave_size = 32
+
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+    cfg.comm_overlap.delay_wgrad_compute = False
+
+    cfg.model.offload_modules = []
+    cfg.model.moe_expert_rank_capacity_factor = 1.05
+    cfg.model.moe_paged_stash = True
+    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.2
+    cfg.model.moe_paged_stash_buffer_size_factor_cpu = 1.0
+
+    cfg.model.moe_router_padding_for_quantization = True
+
+
 def _nemotron_3_super_nvfp4_precision() -> MixedPrecisionConfig:
     """Return the NVFP4 precision config used by Nemotron 3 Super perf recipes."""
     cfg = nemotron_3_super_bf16_with_nvfp4_mixed()

--- a/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/gb300/nemotronh.py
@@ -22,6 +22,7 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
     _apply_nemotron_3_ultra_fsdp_hsdp,
     _apply_nemotron_3_ultra_perf_defaults,
     _benchmark_common,
+    _enable_ncclep_mxfp8,
     _nemotron_3_super_nvfp4_precision,
     _perf_precision,
     _with_global_batch_size,
@@ -423,6 +424,39 @@ def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config() -> ConfigContainer:
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
+        # Transformer Engine overlap settings for this model.
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        # Use cuDNN LayerNorm for this measured baseline.
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+    }
+    return cfg
+
+
+def nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_ncclep_config() -> ConfigContainer:
+    """Nemotron 3 Nano pretrain: 8× GB300, MXFP8, NCCL EP=8.
+
+    Note:
+        This recipe is temporary, added only for experimentation with NCCL EP.
+        It will be removed in the near future.
+    """
+    cfg = nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_config()
+    _enable_ncclep_mxfp8(cfg)
+    # Keep process settings next to the recipe so users can see the exact benchmark environment.
+    # Static-shape NCCL EP reads no HybridEP topology, so no HybridEP names are declared here.
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        # CUDA stream scheduling for this model and parallel layout.
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        # CUDA graph and allocator behavior for this recipe.
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        # NCCL user-buffer and launch settings.
+        "NCCL_NVLS_ENABLE": 0,
         # Transformer Engine overlap settings for this model.
         "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1503,7 +1503,7 @@ class ConfigContainer(Container):
                     f"Sequence length in dataset config: {data_seq_length}"
                 )
 
-        # Validate DeepEP or HybridEP is supported for the current GPU architecture
+        # Validate the selected flex dispatcher backend for the current GPU architecture
         if isinstance(self.model, (GPTModelConfig, HybridModelConfig)):
             validate_flex_dispatcher_backend(self.model.transformer)
         else:

--- a/src/megatron/bridge/training/flex_dispatcher_backend.py
+++ b/src/megatron/bridge/training/flex_dispatcher_backend.py
@@ -34,19 +34,26 @@ def apply_flex_dispatcher_backend(
     model_config: TransformerConfig,
     moe_flex_dispatcher_backend: str | None = None,
 ) -> None:
-    """Apply DeepEP or HybridEP optimizations to the model config.
+    """Apply a supported flex dispatcher backend to the model config.
 
     DeepEP is applicable only for MoE models on Ampere, Hopper, B200 and B300 GPUs.
     HybridEP is applicable only for MoE models on GB200, GB300 with NVL72 and on Ampere, Hopper, B200 and B300 GPUs.
+    NCCL EP is applicable only for MoE models on Hopper and Blackwell GPUs.
     """
     num_moe_experts = getattr(model_config, "num_moe_experts", None)
     if num_moe_experts is None or num_moe_experts == 0:
         if get_rank_safe() == 0:
             logger.warning(
-                "DeepEP and HybridEP are only applicable to MoE models. "
+                "Flex dispatcher backends are only applicable to MoE models. "
                 "Model config does not use MoE (num_moe_experts is not set or is 0). "
-                "Skipping DeepEP configuration."
+                "Skipping flex dispatcher configuration."
             )
+        return
+
+    if not torch.cuda.is_available() and moe_flex_dispatcher_backend in ("deepep", "hybridep", "ncclep"):
+        model_config.moe_token_dispatcher_type = "flex"
+        model_config.moe_flex_dispatcher_backend = moe_flex_dispatcher_backend
+        model_config.moe_shared_expert_overlap = False
         return
 
     device_properties = torch.cuda.get_device_properties(0)
@@ -70,9 +77,21 @@ def apply_flex_dispatcher_backend(
                 )
             _fallback_to_alltoall(model_config)
             return
+    elif moe_flex_dispatcher_backend == "ncclep":
+        if device_properties.major not in [9, 10]:
+            if get_rank_safe() == 0:
+                logger.warning(
+                    f"NCCL EP is only applicable to Hopper and Blackwell GPUs. "
+                    f"Current GPU: {device_properties.name}. Falling back to alltoall."
+                )
+            _fallback_to_alltoall(model_config)
+            return
     else:
         if get_rank_safe() == 0:
-            logger.warning("Not a valid flex dispatcher backend. Skipping flex dispatcher backend configuration.")
+            logger.warning(
+                "Not a valid flex dispatcher backend. Expected one of deepep, hybridep, or ncclep. "
+                "Skipping flex dispatcher backend configuration."
+            )
         return
 
     model_config.moe_token_dispatcher_type = "flex"
@@ -81,7 +100,7 @@ def apply_flex_dispatcher_backend(
 
 
 def validate_flex_dispatcher_backend(model_config: TransformerConfig) -> None:
-    """Validate DeepEP or HybridEP is supported for the current GPU architecture."""
+    """Validate the selected flex dispatcher backend for the current GPU architecture."""
     if model_config.moe_token_dispatcher_type == "flex":
         device_properties = torch.cuda.get_device_properties(0)
         if model_config.moe_flex_dispatcher_backend == "deepep":
@@ -97,4 +116,10 @@ def validate_flex_dispatcher_backend(model_config: TransformerConfig) -> None:
             if not device_properties.major in [8, 9, 10]:
                 raise ValueError(
                     "HybridEP is supported for GB200, GB300 with NVL72 and for Ampere, Hopper, B200 and B300 GPUs"
+                )
+
+        if model_config.moe_flex_dispatcher_backend == "ncclep":
+            if device_properties.major not in [9, 10]:
+                raise ValueError(
+                    f"NCCL EP is supported for Hopper and Blackwell GPUs. Current GPU: {device_properties.name}"
                 )

--- a/tests/unit_tests/recipes/test_gpt_oss_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_gpt_oss_perf_recipes.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the GPT-OSS 120B GB200 BF16 NCCL EP performance recipe.
+
+The NCCL EP recipe derives from the corresponding parent recipe and changes only the MoE dispatch
+stack, so the parity test below pins parallelism, batch sizes, precision and recompute settings.
+"""
+
+import pytest
+
+from megatron.bridge.perf_recipes.gpt_oss import (
+    gpt_oss_120b_pretrain_64gpu_gb200_bf16_config,
+    gpt_oss_120b_pretrain_64gpu_gb200_bf16_ncclep_config,
+)
+
+
+pytestmark = pytest.mark.unit
+
+_HYBRID_EP_ENV_NAMES = {
+    "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN",
+    "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API",
+    "NVLINK_DOMAIN_SIZE",
+    "USE_MNNVL",
+}
+
+
+def test_gpt_oss_gb200_bf16_ncclep_dispatch_stack() -> None:
+    """The BF16 example selects eager NCCL EP without HybridEP environment settings."""
+    cfg = gpt_oss_120b_pretrain_64gpu_gb200_bf16_ncclep_config()
+
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "ncclep"
+    assert cfg.model.moe_shared_expert_overlap is False
+    assert cfg.model.high_priority_a2a_comm_stream is True
+    assert cfg.model.moe_hybridep_num_sms is None
+    assert cfg.model.moe_flex_dispatcher_num_sms is None
+    assert cfg.model.moe_ncclep_zero_copy is False
+
+    assert cfg.model.offload_modules == []
+    assert cfg.comm_overlap is not None
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is True
+    assert cfg.comm_overlap.delay_wgrad_compute is False
+    assert cfg.env_vars.keys().isdisjoint(_HYBRID_EP_ENV_NAMES)
+
+    assert cfg.model.use_transformer_engine_op_fuser is False
+    assert "NVTE_CUTEDSL_FUSED_GROUPED_MLP" not in cfg.env_vars
+    assert cfg.model.moe_expert_rank_capacity_factor is None
+    assert cfg.model.moe_paged_stash is False
+
+
+def test_gpt_oss_gb200_bf16_ncclep_matches_parent_outside_dispatch_stack() -> None:
+    """Everything the NCCL EP switch should not touch stays identical to the parent recipe."""
+    cfg = gpt_oss_120b_pretrain_64gpu_gb200_bf16_ncclep_config()
+    parent = gpt_oss_120b_pretrain_64gpu_gb200_bf16_config()
+
+    for field in (
+        "expert_model_parallel_size",
+        "tensor_model_parallel_size",
+        "pipeline_model_parallel_size",
+        "context_parallel_size",
+        "sequence_parallel",
+        "seq_length",
+        "num_moe_experts",
+        "moe_router_topk",
+        "moe_router_force_load_balancing",
+        "recompute_granularity",
+        "recompute_modules",
+        "cuda_graph_impl",
+    ):
+        assert getattr(cfg.model, field) == getattr(parent.model, field), field
+
+    assert cfg.train.micro_batch_size == parent.train.micro_batch_size
+    assert cfg.train.global_batch_size == parent.train.global_batch_size
+    assert type(cfg.mixed_precision) is type(parent.mixed_precision)

--- a/tests/unit_tests/recipes/test_nemotron_3_nano_ncclep_perf_recipe.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_nano_ncclep_perf_recipe.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Nemotron 3 Nano GB300 MXFP8 NCCL EP performance recipe."""
+
+import pytest
+
+from megatron.bridge.perf_recipes.nemotronh import nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_ncclep_config
+from megatron.bridge.utils.cuda_graph import cuda_graph_module_names
+
+
+pytestmark = pytest.mark.unit
+
+_HYBRID_EP_ENV_NAMES = {
+    "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN",
+    "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API",
+    "NVLINK_DOMAIN_SIZE",
+    "USE_MNNVL",
+}
+
+
+def test_nemotron_3_nano_gb300_mxfp8_ncclep_defaults() -> None:
+    """The MXFP8 example uses static fused NCCL EP and no HybridEP environment."""
+    cfg = nemotron_3_nano_pretrain_8gpu_gb300_fp8mx_ncclep_config()
+
+    assert cfg.model.moe_token_dispatcher_type == "flex"
+    assert cfg.model.moe_flex_dispatcher_backend == "ncclep"
+    assert cfg.model.moe_shared_expert_overlap is False
+    assert cfg.model.high_priority_a2a_comm_stream is True
+    assert cfg.model.moe_hybridep_num_sms is None
+    assert cfg.model.moe_flex_dispatcher_num_sms is None
+    assert cfg.model.moe_ncclep_zero_copy is False
+
+    assert cfg.model.moe_grouped_gemm is True
+    assert cfg.model.use_transformer_engine_op_fuser is True
+    assert cfg.model.moe_mlp_glu_interleave_size == 32
+
+    assert cfg.model.offload_modules == []
+    assert cfg.model.moe_expert_rank_capacity_factor == 1.05
+    assert cfg.model.moe_paged_stash is True
+    assert cfg.model.moe_paged_stash_buffer_size_factor_cuda == 1.2
+    assert cfg.model.moe_paged_stash_buffer_size_factor_cpu == 1.0
+
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cuda_graph_module_names(cfg.model) == ["attn", "mamba", "moe_router", "moe_preprocess"]
+    assert cfg.model.use_te_rng_tracker is True
+    assert cfg.rng.te_rng_tracker is True
+    assert cfg.env_vars.keys().isdisjoint(_HYBRID_EP_ENV_NAMES)
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
+
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+    assert cfg.comm_overlap.delay_wgrad_compute is False
+    # moe_router_padding_for_quantization requires model.fp8/fp4, which runtime setup copies over
+    # from cfg.mixed_precision before the model config is finalized, so this recipe is not
+    # finalized here.
+    assert cfg.model.moe_router_padding_for_quantization is True
+    assert cfg.mixed_precision.fp8 == "e4m3"
+    assert cfg.mixed_precision.fp8_recipe == "mxfp8"

--- a/tests/unit_tests/scripts/performance/test_recipe_environment.py
+++ b/tests/unit_tests/scripts/performance/test_recipe_environment.py
@@ -110,6 +110,41 @@ def test_target_topology_removes_disabled_hybridep_values():
     assert not config.env_vars
 
 
+@pytest.mark.parametrize("dispatcher_backend", [None, "deepep"])
+def test_target_topology_keeps_chunk_tuning_outside_ncclep(dispatcher_backend):
+    """Only the derived topology is target-dependent, so other tuning survives every backend."""
+    config = SimpleNamespace(
+        env_vars={
+            "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+            "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+            "NVLINK_DOMAIN_SIZE": 8,
+            "USE_MNNVL": 0,
+        },
+        model=SimpleNamespace(moe_flex_dispatcher_backend=dispatcher_backend, expert_model_parallel_size=8),
+    )
+
+    utils.apply_target_topology_environment(config, gpu="h100")
+
+    assert config.env_vars == {"NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128}
+
+
+def test_target_topology_removes_every_hybridep_value_for_ncclep():
+    config = SimpleNamespace(
+        env_vars={
+            "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+            "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+            "NVLINK_DOMAIN_SIZE": 8,
+            "USE_MNNVL": 0,
+            "MODEL_SPECIFIC": 1,
+        },
+        model=SimpleNamespace(moe_flex_dispatcher_backend="ncclep", expert_model_parallel_size=8),
+    )
+
+    utils.apply_target_topology_environment(config, gpu="h100")
+
+    assert config.env_vars == {"MODEL_SPECIFIC": 1}
+
+
 def test_target_topology_rejects_nonpositive_ep_size():
     config = SimpleNamespace(
         env_vars={},
@@ -673,6 +708,93 @@ def test_flat_default_args_leave_inline_recipe_environment_unchanged():
     assert recipe.env_vars == original_env
 
 
+def test_flat_ncclep_override_removes_hybridep_environment():
+    from utils.overrides import _apply_flat_cli_environment_compatibility
+
+    recipe = SimpleNamespace(
+        env_vars={
+            "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+            "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+            "NVLINK_DOMAIN_SIZE": 72,
+            "USE_MNNVL": 1,
+            "MODEL_SPECIFIC": 1,
+        },
+        model=SimpleNamespace(
+            moe_flex_dispatcher_backend="ncclep",
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=8,
+        ),
+    )
+    args = SimpleNamespace(
+        gpu="gb200",
+        moe_a2a_overlap=None,
+        tensor_model_parallel_size=None,
+        pipeline_model_parallel_size=None,
+        context_parallel_size=None,
+        expert_model_parallel_size=None,
+        nccl_ub=None,
+        model_family_name="nemotronh",
+        model_recipe_name="nemotron_3_nano",
+        task="pretrain",
+    )
+
+    _apply_flat_cli_environment_compatibility(
+        recipe,
+        args,
+        base_dispatcher_backend="hybridep",
+        base_moe_a2a_overlap=False,
+    )
+
+    assert recipe.env_vars == {"MODEL_SPECIFIC": 1}
+
+
+@pytest.mark.parametrize("dispatcher_backend", [None, "deepep"])
+def test_flat_non_ncclep_backends_keep_hybridep_environment(dispatcher_backend):
+    """Switching to NCCL EP must not change the environment of any other benchmark."""
+    from utils.overrides import _apply_flat_cli_environment_compatibility
+
+    original_env = {
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "MODEL_SPECIFIC": 1,
+    }
+    recipe = SimpleNamespace(
+        env_vars=dict(original_env),
+        model=SimpleNamespace(
+            moe_flex_dispatcher_backend=dispatcher_backend,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=8,
+        ),
+    )
+    args = SimpleNamespace(
+        gpu="gb200",
+        moe_a2a_overlap=None,
+        tensor_model_parallel_size=None,
+        pipeline_model_parallel_size=None,
+        context_parallel_size=None,
+        expert_model_parallel_size=None,
+        nccl_ub=None,
+        model_family_name="nemotronh",
+        model_recipe_name="nemotron_3_nano",
+        task="pretrain",
+    )
+
+    _apply_flat_cli_environment_compatibility(
+        recipe,
+        args,
+        base_dispatcher_backend=dispatcher_backend,
+        base_moe_a2a_overlap=False,
+    )
+
+    assert recipe.env_vars == original_env
+
+
 def test_vr200_argparse_overrides_keep_sm100_cuda_connection_count():
     from utils.overrides import _apply_flat_cli_environment_compatibility
 
@@ -883,6 +1005,68 @@ def test_runner_applies_env_relevant_argparse_overrides():
     assert effective_recipe.model.moe_token_dispatcher_type == "flex"
     assert effective_recipe.model.moe_flex_dispatcher_backend == "hybridep"
     assert effective_recipe.model.moe_shared_expert_overlap is False
+
+
+def test_runner_accepts_ncclep_dispatcher_override():
+    recipe = SimpleNamespace(
+        model=SimpleNamespace(
+            expert_model_parallel_size=8,
+            num_moe_experts=128,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_shared_expert_overlap=True,
+            moe_expert_rank_capacity_factor=1.5,
+        ),
+        ddp=SimpleNamespace(nccl_ub=False, fsdp_manual_registration=False),
+    )
+    args = SimpleNamespace(
+        expert_model_parallel_size=None,
+        nccl_ub=False,
+        moe_flex_dispatcher_backend="ncclep",
+    )
+
+    effective_recipe = run_recipe._apply_recipe_overrides(recipe, args, [], environment_only=True)
+    effective_recipe = utils.finalize_config_overrides(effective_recipe)
+
+    assert effective_recipe.model.moe_token_dispatcher_type == "flex"
+    assert effective_recipe.model.moe_flex_dispatcher_backend == "ncclep"
+    assert effective_recipe.model.moe_shared_expert_overlap is False
+
+
+def test_runner_accepts_ncclep_without_capacity_factor():
+    """An unset capacity factor selects NCCL EP eager mode and must not be rejected."""
+    recipe = SimpleNamespace(
+        model=SimpleNamespace(
+            expert_model_parallel_size=8,
+            num_moe_experts=128,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend="hybridep",
+            moe_shared_expert_overlap=True,
+            moe_expert_rank_capacity_factor=None,
+        ),
+        ddp=SimpleNamespace(nccl_ub=False, fsdp_manual_registration=False),
+    )
+    args = SimpleNamespace(
+        expert_model_parallel_size=None,
+        nccl_ub=False,
+        moe_flex_dispatcher_backend="ncclep",
+    )
+
+    effective_recipe = run_recipe._apply_recipe_overrides(recipe, args, [], environment_only=True)
+    effective_recipe = utils.finalize_config_overrides(effective_recipe)
+
+    assert effective_recipe.model.moe_token_dispatcher_type == "flex"
+    assert effective_recipe.model.moe_flex_dispatcher_backend == "ncclep"
+    assert effective_recipe.model.moe_expert_rank_capacity_factor is None
+
+
+def test_performance_parser_accepts_ncclep_dispatcher():
+    from argument_parser import parse_cli_args
+
+    parser = parse_cli_args()
+    action = next(action for action in parser._actions if action.dest == "moe_flex_dispatcher_backend")
+
+    assert "ncclep" in action.choices
 
 
 def test_runner_applies_determinism_before_environment_export():

--- a/tests/unit_tests/training/test_deepep.py
+++ b/tests/unit_tests/training/test_deepep.py
@@ -102,7 +102,7 @@ class TestApplyDeepEP:
 
         # Verify warning was logged
         mock_logger.warning.assert_called_once()
-        assert "DeepEP and HybridEP are only applicable to MoE models" in mock_logger.warning.call_args[0][0]
+        assert "Flex dispatcher backends are only applicable to MoE models" in mock_logger.warning.call_args[0][0]
 
         # Verify configs were NOT set
         assert config.moe_token_dispatcher_type != "flex"
@@ -120,7 +120,7 @@ class TestApplyDeepEP:
 
         # Verify warning was logged
         mock_logger.warning.assert_called_once()
-        assert "DeepEP and HybridEP are only applicable to MoE models" in mock_logger.warning.call_args[0][0]
+        assert "Flex dispatcher backends are only applicable to MoE models" in mock_logger.warning.call_args[0][0]
 
         # Verify configs were NOT set
         assert config.moe_token_dispatcher_type != "flex"
@@ -195,6 +195,7 @@ class TestFlexDispatcherFallback:
         [
             pytest.param("deepep", 10, "NVIDIA GB200", id="deepep-gb200"),
             pytest.param("hybridep", 11, "NVIDIA X200", id="hybridep-unsupported"),
+            pytest.param("ncclep", 8, "NVIDIA A100", id="ncclep-ampere"),
         ],
     )
     @patch("torch.cuda.get_device_properties")
@@ -406,3 +407,88 @@ class TestValidateHybridEP:
 
         # Verify get_device_properties was called
         mock_get_device_properties.assert_called_once_with(0)
+
+
+class TestNCCLEP:
+    """Test NCCL EP application and GPU validation."""
+
+    @pytest.mark.parametrize("major", [9, 10])
+    @patch("torch.cuda.get_device_properties")
+    def test_apply_and_validate_supported_gpu(self, mock_get_device_properties, major):
+        mock_properties = MagicMock()
+        mock_properties.major = major
+        mock_properties.name = "NVIDIA H100" if major == 9 else "NVIDIA GB200"
+        mock_get_device_properties.return_value = mock_properties
+        config = SimpleNamespace(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend=None,
+            moe_shared_expert_overlap=True,
+            moe_expert_rank_capacity_factor=1.5,
+        )
+
+        apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend="ncclep")
+        validate_flex_dispatcher_backend(config)
+
+        assert config.moe_token_dispatcher_type == "flex"
+        assert config.moe_flex_dispatcher_backend == "ncclep"
+        assert config.moe_shared_expert_overlap is False
+
+    @patch("torch.cuda.get_device_properties")
+    def test_apply_allows_eager_mode_without_capacity_factor(self, mock_get_device_properties):
+        mock_properties = MagicMock()
+        mock_properties.major = 10
+        mock_properties.name = "NVIDIA GB200"
+        mock_get_device_properties.return_value = mock_properties
+        config = SimpleNamespace(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend=None,
+            moe_shared_expert_overlap=True,
+            moe_expert_rank_capacity_factor=None,
+        )
+
+        apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend="ncclep")
+
+        assert config.moe_token_dispatcher_type == "flex"
+        assert config.moe_flex_dispatcher_backend == "ncclep"
+        assert config.moe_shared_expert_overlap is False
+
+    @patch("torch.cuda.get_device_properties")
+    def test_validate_unsupported_gpu_raises_error(self, mock_get_device_properties):
+        mock_properties = MagicMock()
+        mock_properties.major = 8
+        mock_properties.name = "NVIDIA A100"
+        mock_get_device_properties.return_value = mock_properties
+        config = SimpleNamespace(
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="ncclep",
+        )
+
+        with pytest.raises(ValueError, match="NCCL EP is supported for Hopper and Blackwell GPUs"):
+            validate_flex_dispatcher_backend(config)
+
+        # Verify get_device_properties was called
+        mock_get_device_properties.assert_called_once_with(0)
+
+    def test_apply_without_cuda_builds_flex_config(self, monkeypatch: pytest.MonkeyPatch):
+        """NCCL EP config construction must not probe CUDA devices on GPU-less hosts."""
+        monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+
+        def fail_hardware_probe(*args, **kwargs):
+            del args, kwargs
+            pytest.fail("apply_flex_dispatcher_backend probed CUDA device properties without CUDA")
+
+        monkeypatch.setattr("torch.cuda.get_device_properties", fail_hardware_probe)
+        config = SimpleNamespace(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="alltoall",
+            moe_flex_dispatcher_backend=None,
+            moe_shared_expert_overlap=True,
+        )
+
+        apply_flex_dispatcher_backend(config, moe_flex_dispatcher_backend="ncclep")
+
+        assert config.moe_token_dispatcher_type == "flex"
+        assert config.moe_flex_dispatcher_backend == "ncclep"
+        assert config.moe_shared_expert_overlap is False


### PR DESCRIPTION
# What does this PR do?

Cherry-picks #5468 (merge commit `cb515a946207a299f2a91321073e7f8032bc0e5c`) into `r0.6.0`.

Adds NCCL EP support to the Megatron-Bridge performance harness with two focused recipe examples:

- Nemotron 3 Nano, 8× GB300, MXFP8: static-shape NCCL EP with the Transformer Engine op fuser and CuTe DSL fused grouped MLP.
- GPT-OSS 120B, 64× GB200, BF16: eager NCCL EP without a static expert-rank capacity factor.

# Conflict resolution

One conflict in `src/megatron/bridge/training/flex_dispatcher_backend.py`: `r0.6.0` lacks the no-CUDA construction guard in `apply_flex_dispatcher_backend` that exists on `main`. The incoming block (guard covering `deepep`, `hybridep`, and `ncclep`) was kept, which makes `apply_flex_dispatcher_backend` identical to `main`. The guard is required for the new CPU unit tests added by this PR.

Note: `validate_flex_dispatcher_backend` on `r0.6.0` still lacks the `moe_flex_dispatcher_backend is None` early-return present on `main` — that change comes from a different `main` commit and is intentionally not included here.

# Validation

- `uv run --no-sync pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)