### PR TITLE
[model] fix: Exclude runtime groups from Nemotron VL configs

### DIFF
--- a/src/megatron/bridge/models/nemotron_vl/nemotron_vl_provider.py
+++ b/src/megatron/bridge/models/nemotron_vl/nemotron_vl_provider.py
@@ -98,7 +98,7 @@ class NemotronVLModelProvider(HybridModelProvider):
     def provide(self, pre_process=None, post_process=None, vp_stage=None):  # noqa: D401
         """Assemble a full :class:`~megatron.core.models.multimodal.llava_model.LLaVAModel`."""
 
-        language_cfg = copy.deepcopy(self)
+        language_cfg = self._copy_config_without_runtime_process_groups(deep=True)
 
         vision_cfg = copy.deepcopy(language_cfg)
         vision_cfg.sequence_parallel = False

--- a/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
+++ b/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest.mock import Mock, patch
 
 from megatron.core.transformer.attention_layer_config import AttentionLayerConfig

--- a/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
+++ b/tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock, patch
+
+from megatron.core.transformer.attention_layer_config import AttentionLayerConfig
+
+from megatron.bridge.models.nemotron_vl.nemotron_vl_provider import NemotronVLModelProvider
+
+
+def test_provider_keeps_runtime_process_groups_out_of_nested_configs():
+    class UncopyableProcessGroupCollection:
+        def __deepcopy__(self, memo):
+            raise TypeError("runtime process groups cannot be copied")
+
+    provider = NemotronVLModelProvider(num_layers=2, vocab_size=1000)
+    pg_collection = UncopyableProcessGroupCollection()
+    provider._pg_collection = pg_collection
+
+    def create_model(**kwargs):
+        copied_config = AttentionLayerConfig.from_config(kwargs["language_transformer_config"])
+        assert copied_config._pg_collection is None
+        return Mock()
+
+    with (
+        patch(
+            "megatron.bridge.models.nemotron_vl.nemotron_vl_provider.get_vit_layer_with_transformer_engine_spec",
+            return_value=Mock(),
+        ),
+        patch(
+            "megatron.bridge.models.nemotron_vl.nemotron_vl_provider.get_language_mlp_submodules",
+            return_value=Mock(),
+        ),
+        patch(
+            "megatron.bridge.models.nemotron_vl.nemotron_vl_provider.LLaVAModel",
+            side_effect=create_model,
+        ),
+        patch("megatron.bridge.models.nemotron_vl.modeling_nemotron_vl.NemotronVLModel", return_value=Mock()),
+    ):
+        provider.provide(pre_process=True, post_process=True)
+
+    assert provider._pg_collection is pg_collection


### PR DESCRIPTION
## What

- Exclude the runtime-only process-group collection from the standalone Nemotron VL nested language configuration.
- Add a focused regression test that exercises MCore's real per-layer config copy.

## Supported trigger and impact

The exported Nemotron Nano V2 VL SFT/PEFT recipes and the registered `NemotronH_Nano_VL_V2` AutoBridge path select `NemotronVLModelProvider`. Distributed model construction attaches a live process-group collection to that provider before `provide()` constructs the nested language model.

After the MCore bump in #5882, hybrid layer allocation deep-copies the nested config dictionary. The standalone provider's raw deepcopy retained the runtime process groups, so model construction failed before loading weights or training with an uncopyable `ProcessGroup` error.

## Root cause and minimal fix

`NemotronVLModelProvider.provide()` used `copy.deepcopy(self)` for its nested language config. Bridge's config deepcopy intentionally preserves `_pg_collection` by identity, but MCore's later per-layer config copy deep-copies the config dictionary directly.

Use the helper introduced by #5882 to deep-copy the nested config with runtime process groups cleared. The original provider retains its collection, and no public API or supported configuration changes.

## Validation

Fail-before and pass-after command:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/models/nemotron_vl tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py -q
```

- Before: 1 failed at `AttentionLayerConfig.from_config()` with `TypeError: runtime process groups cannot be copied`.
- After: 1 passed.

Adjacent validation:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/nemotron_vl/test_nemotron_vl_provider.py tests/unit_tests/models/hybrid/test_hybrid_provider.py::TestHybridModelProvider::test_provide_preserves_runtime_config_identity_without_copying_process_groups tests/unit_tests/models/nemotron_omni/test_nemotron_omni_model.py::test_canonical_provider_keeps_runtime_process_groups_out_of_language_config tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py::test_dense_legacy_v2_checkpoint_keeps_nemotron_vl_path -q
```

- 4 passed.
- `uv run --no-sync pre-commit run --all-files`: passed.
- `git diff --check`: passed.

These were CPU contract checks; no GPU, full-suite, convergence, or performance validation is claimed.

## Scope

This patch only restores model construction for the existing standalone dense Nemotron V2 VL path. It does not extend the deprecated model family's support window or change direct Hybrid/Nemotron Omni behavior.
