### PR TITLE
[inference] fix: Preserve checkout Python path in Slurm containers

### DIFF
--- a/scripts/inference/setup_inference.py
+++ b/scripts/inference/setup_inference.py
@@ -192,6 +192,9 @@ def _validate_task_args(task_name: str, inference_args: list[str]) -> None:
 def _build_executor(args: argparse.Namespace, env_names: list[str], mounts: list[str]) -> object:
     """Build the srun-native NeMo-Run Slurm executor."""
     gpu_kwargs = {} if args.no_gpu_resource_request else {"gpus_per_node": args.gpus_per_node}
+    container_env = [*env_names]
+    if "PYTHONPATH" not in container_env:
+        container_env.append("PYTHONPATH")
     # Slurm's --export=NIL removes the site PATH used to find scontrol and srun
     # on clusters where they are not installed in /usr/bin. Always inherit PATH
     # for the generated batch script, but expose it to the container only when
@@ -211,7 +214,7 @@ def _build_executor(args: argparse.Namespace, env_names: list[str], mounts: list
         packager=run.Packager(),
         container_image=args.container_image,
         container_mounts=mounts,
-        container_env=env_names,
+        container_env=container_env,
         additional_parameters={"export": ",".join(batch_env_names)},
         srun_args=args.srun_args,
         **gpu_kwargs,

--- a/tests/unit_tests/scripts/inference/test_setup_inference.py
+++ b/tests/unit_tests/scripts/inference/test_setup_inference.py
@@ -268,7 +268,7 @@ def test_slurm_executor_uses_srun_native_tasks_and_keeps_secrets_out(tmp_path, m
     assert executor.kwargs["exclusive"] is None
     assert "launcher" not in executor.kwargs
     assert executor.kwargs["tunnel"].job_dir == str(tmp_path / "experiments")
-    assert executor.kwargs["container_env"] == ["HF_TOKEN"]
+    assert executor.kwargs["container_env"] == ["HF_TOKEN", "PYTHONPATH"]
     assert executor.kwargs["additional_parameters"] == {"export": "PATH,HF_TOKEN"}
     assert executor.kwargs["container_mounts"] == ["/host:/container"]
     assert executor.kwargs["srun_args"] == ["--mpi=pmix", "--container-writable"]


### PR DESCRIPTION
## What does this PR do?

The supported Slurm inference launcher sets a checkout-first `PYTHONPATH` on its NeMo Run task, but did not include `PYTHONPATH` in the Pyxis container environment allowlist. For container images that define their own `PYTHONPATH`, Pyxis therefore retained the image value and the mounted inference script could import stale image-installed Bridge or Megatron packages.

This adds only the task-owned `PYTHONPATH` name to the inference executor's container allowlist, with deduplication when a user already forwards it. Slurm's batch export list and secret-value handling remain unchanged.

## Root cause

`_build_task()` supplied the correct checkout-first value through `run.Script.env`, while `_build_executor()` passed only explicit `--env` names to `SlurmExecutor.container_env`. NeMo Run exports the task value in the batch shell, but Pyxis requires the name in `--container-env` for that value to override image metadata.

## Validation

Fail-before on unmodified `main`:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/scripts/inference/test_setup_inference.py::test_slurm_executor_uses_srun_native_tasks_and_keeps_secrets_out -q
# 1 failed: expected PYTHONPATH in container_env, received only HF_TOKEN
```

Pass-after and adjacent coverage:

```text
uv run --active --no-sync python -m pytest tests/unit_tests/scripts/inference/test_setup_inference.py -q
# 32 passed

git diff --check
# passed

uv run pre-commit run --all-files
# passed
```

A real Pyxis control also confirmed that an image-defined variable wins when omitted from `--container-env`, while the host task value wins when the name is explicitly allowlisted.

## Scope

This changes only Slurm-backed Bridge inference task environment propagation. It does not alter user-provided environment values, batch-shell `PATH`, local inference, model behavior, or public APIs.
