### PR TITLE
[recipe] fix: correct Qwen3.5-VL 35B FP8 pipeline layout

### DIFF
--- a/src/megatron/bridge/perf_recipes/qwen_vl/h100/qwen35_vl.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/h100/qwen35_vl.py
@@ -65,7 +65,7 @@ def qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_config() -> ConfigContainer:
 
 
 def qwen35_vl_35b_a3b_pretrain_16gpu_h100_fp8cs_config() -> ConfigContainer:
-    """Qwen3.5-VL 35B-A3B pretrain: 16× H100, FP8 current-scaling, PP=2 VP=12."""
+    """Qwen3.5-VL 35B-A3B pretrain: 16× H100, FP8 current-scaling, PP=2 VP=10."""
     cfg = qwen35_vl_35b_a3b_pretrain_mock_config()
     cfg.mixed_precision = _perf_precision("fp8_cs")
     _qwen35_vl_common(cfg)
@@ -73,7 +73,7 @@ def qwen35_vl_35b_a3b_pretrain_16gpu_h100_fp8cs_config() -> ConfigContainer:
     cfg.model.tensor_model_parallel_size = 1
     cfg.model.pipeline_model_parallel_size = 2
     cfg.model.context_parallel_size = 1
-    cfg.model.virtual_pipeline_model_parallel_size = 12
+    cfg.model.virtual_pipeline_model_parallel_size = 10
     cfg.model.expert_model_parallel_size = 8
     cfg.model.expert_tensor_parallel_size = 1
     cfg.model.sequence_parallel = False

--- a/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
+++ b/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
@@ -17,9 +17,11 @@
 import sys
 from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
+from megatron.core.transformer.transformer_block import get_num_layers_to_build
 
 from megatron.bridge.perf_recipes.qwen_vl.gb200.qwen35_vl import (
     qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config,
@@ -28,6 +30,7 @@ from megatron.bridge.perf_recipes.qwen_vl.gb200.qwen35_vl import (
 )
 from megatron.bridge.perf_recipes.qwen_vl.h100.qwen35_vl import (
     qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_config,
+    qwen35_vl_35b_a3b_pretrain_16gpu_h100_fp8cs_config,
     qwen35_vl_122b_a10b_pretrain_128gpu_h100_bf16_config,
     qwen35_vl_122b_a10b_pretrain_128gpu_h100_fp8cs_config,
 )
@@ -72,6 +75,33 @@ def test_qwen35_vl_122b_h100_pipeline_layout(
     assert (num_layers // pp_size) % vp_size == 0
     assert pp_size == expected_pp_size
     assert vp_size == expected_vp_size
+
+
+def test_qwen35_vl_35b_h100_fp8cs_pipeline_layout_builds_all_layers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 35B FP8-CS benchmark topology should allocate all 40 language layers."""
+    patch_recipe_construction_dependencies(monkeypatch)
+    config = qwen35_vl_35b_a3b_pretrain_16gpu_h100_fp8cs_config()
+    model = config.model
+    allocation_config = SimpleNamespace(
+        pipeline_model_parallel_layout=getattr(model, "pipeline_model_parallel_layout", None),
+        num_layers_in_first_pipeline_stage=getattr(model, "num_layers_in_first_pipeline_stage", None),
+        num_layers_in_last_pipeline_stage=getattr(model, "num_layers_in_last_pipeline_stage", None),
+        account_for_embedding_in_pipeline_split=False,
+        account_for_loss_in_pipeline_split=False,
+        num_layers=40,
+        pipeline_model_parallel_size=model.pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=model.virtual_pipeline_model_parallel_size,
+    )
+
+    allocated_layers = sum(
+        get_num_layers_to_build(allocation_config, vp_stage=vp_stage, pp_rank=pp_rank)
+        for pp_rank in range(model.pipeline_model_parallel_size)
+        for vp_stage in range(model.virtual_pipeline_model_parallel_size)
+    )
+
+    assert allocated_layers == 40
 
 
 def test_qwen35_vl_35b_h100_measured_performance_defaults(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

The exported Qwen3.5/Qwen3.6-VL 35B H100 FP8 current-scaling recipe configured 40 language layers with pipeline parallel size 2 and virtual pipeline size 12. Pinned Megatron-Core therefore aborted model construction before iteration 0 because each physical stage's 20 layers cannot be divided across 12 virtual chunks.

This changes VP from 12 to 10, preserving two language layers per virtual chunk, and adds a focused contract test that runs the actual pinned layer allocator across every PP/VP coordinate.

## Supported trigger and impact

Launching `qwen35_vl_35b_a3b_pretrain_16gpu_h100_fp8cs_config` resolves the advertised 16-H100 benchmark topology and reaches `get_num_layers_to_build()`, which previously raised:

`AssertionError: num_layers_per_pipeline_rank 20 should be divisible by vp_size 12`

The benchmark could not construct the model or begin an iteration. The 16-rank TP/PP/EP topology itself is valid; only the virtual-layer partition was invalid.

## Root cause and fix

The recipe retained VP=12, which matches a 48-layer sibling but not this 40-layer model. With PP=2, VP=10 gives `40 / 2 / 10 = 2` layers per virtual chunk. No provider, runner, public API, dependency, or MCore change is needed.

Related PR #5884 covers the same allocator invariant for separate 397B recipes and topology-override cleanup; it does not change or test this 35B FP8-CS factory.

## Validation

- Fail before: `uv run python -m pytest tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py::test_qwen35_vl_35b_h100_fp8cs_pipeline_layout_builds_all_layers -q --tb=short` — 1 failed with the exact `20` versus `VP=12` assertion.
- Pass after: the same command — 1 passed.
- Adjacent Qwen3.5-VL performance tests: `uv run python -m pytest tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py -q --tb=short` — 7 passed.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed.

## Scope

This changes only the 35B H100 FP8-CS benchmark's VP degree and focused regression coverage. It does not change BF16, other model sizes, other hardware recipes, runtime override behavior, dependencies, workflows, public APIs, or the MCore submodule. Validation establishes configuration/model-construction correctness; it does not claim GPU throughput, convergence, or model-quality validation.
