### PR TITLE
fix(peft): replicate adapters for duplicated linears

### DIFF
--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -594,7 +594,7 @@ class MegatronPeftBridge:
                     and hasattr(adapter, "base_linear_is_parallel")
                 ):
                     input_is_parallel = adapter.input_is_parallel
-                    base_linear_is_parallel = True
+                    base_linear_is_parallel = not getattr(adapter, "replicate_adapter", False)
                     requires_expert_splits = adapter.linear_in.weight.ndim > 2
                 elif isinstance(adapter, LinearAdapter):
                     # Adapter wrapping a plain nn.Linear: no parallelism layout

--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -371,6 +371,7 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
                     is_expert=is_expert,
                     disable_tensor_parallel_comm=attrs.disable_tensor_parallel_comm,
                     disable_sequence_parallel_comm=attrs.disable_sequence_parallel_comm,
+                    replicate_adapter=attrs.replicate_adapter,
                 )
 
             if name == "linear_fc1" and _should_treat_linear_fc1_as_unfused(full_name):

--- a/src/megatron/bridge/peft/dora.py
+++ b/src/megatron/bridge/peft/dora.py
@@ -108,6 +108,7 @@ class DoRA(PEFT, ModuleMatcher):
                 disable_tensor_parallel_comm=attrs.disable_tensor_parallel_comm,
                 disable_sequence_parallel_comm=attrs.disable_sequence_parallel_comm,
                 base_linear_is_parallel=attrs.base_linear_is_parallel,
+                replicate_adapter=attrs.replicate_adapter,
             )
             return DoRALinear(m, adapter)
         return m

--- a/src/megatron/bridge/peft/dora_layers.py
+++ b/src/megatron/bridge/peft/dora_layers.py
@@ -40,6 +40,10 @@ class ParallelLinearDoRAAdapter(ParallelLinearAdapter):
             value (torch.Tensor): Initial values for the weight magnitude parameter.
         """
         self.weight_magnitude = nn.Parameter(value, requires_grad=True)
+        if self.replicate_adapter:
+            self.weight_magnitude.allreduce = True
+            self.weight_magnitude.tensor_model_parallel = False
+            self.weight_magnitude.sequence_parallel = self.config.sequence_parallel
 
     def get_weight_magnitude(self) -> torch.Tensor:
         """
@@ -68,8 +72,8 @@ class ParallelLinearDoRAAdapter(ParallelLinearAdapter):
         sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
 
         magnitude_key = f"{prefix}weight_magnitude"
-        if self.input_is_parallel:
-            # RPL output is gathered, so weight_magnitude is not sharded for TP
+        if self.replicate_adapter or self.input_is_parallel:
+            # Row-parallel and duplicated outputs are full-width, so magnitude is replicated.
             magnitude_sharded_tensor = make_sharded_tensor_for_checkpoint(
                 self.weight_magnitude, magnitude_key, prepend_offsets=sharded_offsets
             )
@@ -119,7 +123,10 @@ class DoRALinear(AdapterWrapper):
         Returns:
             torch.Tensor: The L2 norm of the combined weight matrix.
         """
-        if self.adapter.input_is_parallel:
+        if self.adapter.replicate_adapter:
+            linear_out_weight = self.adapter.linear_out.weight
+            linear_in_weight = self.adapter.linear_in.weight
+        elif self.adapter.input_is_parallel:
             linear_out_weight = gather_from_tensor_model_parallel_region(self.adapter.linear_out.weight.T).T
             linear_in_weight = self.adapter.linear_in.weight
         else:

--- a/src/megatron/bridge/peft/lora.py
+++ b/src/megatron/bridge/peft/lora.py
@@ -251,6 +251,7 @@ class LoRA(PEFT, ModuleMatcher):
                     sequence_parallel_input_regather=self.sequence_parallel_input_regather,
                     disable_tensor_parallel_comm=attrs.disable_tensor_parallel_comm,
                     disable_sequence_parallel_comm=attrs.disable_sequence_parallel_comm,
+                    replicate_adapter=attrs.replicate_adapter,
                 )
             adapter = adapter_cls(attrs.in_features, attrs.out_features, dim, **adapter_kwargs)
             if isinstance(module, TopKRouter):

--- a/src/megatron/bridge/peft/multi_lora_layers.py
+++ b/src/megatron/bridge/peft/multi_lora_layers.py
@@ -169,12 +169,13 @@ class MultiLoRALinear(AdapterWrapper):
         # q/kv down-projections): their adapters are unsharded and need no TP
         # collectives between the two adapter projections.
         self.base_linear_is_parallel = attrs.base_linear_is_parallel
+        self.replicate_adapter = attrs.replicate_adapter
         self.use_a2a = a2a_experimental
-        # Mirrors ParallelLinearAdapter's lin_out_gather_output: row-parallel
-        # bases and replicated bases produce a full [tokens, out] tensor, so the
-        # column-sharded adapter output must be gathered before the residual
-        # add; a column-parallel base keeps the [tokens, out/tp] shard.
-        self._gather_output = attrs.input_is_parallel or not attrs.base_linear_is_parallel
+        # Row-parallel adapters gather their output to full width; column-parallel
+        # adapters keep an output shard; replicated adapters already produce full width.
+        self._gather_output = not self.replicate_adapter and (
+            attrs.input_is_parallel or not attrs.base_linear_is_parallel
+        )
 
         # ModuleList of ParallelLinearAdapters gives per-adapter optimizer state
         # isolation, clean checkpoint serialization, and bridge export compatibility.
@@ -195,6 +196,7 @@ class MultiLoRALinear(AdapterWrapper):
                     disable_tensor_parallel_comm=attrs.disable_tensor_parallel_comm,
                     disable_sequence_parallel_comm=attrs.disable_sequence_parallel_comm,
                     base_linear_is_parallel=attrs.base_linear_is_parallel,
+                    replicate_adapter=attrs.replicate_adapter,
                     a2a_experimental=a2a_experimental,
                     dropout=dropout,
                     dropout_position=dropout_position,
@@ -241,7 +243,7 @@ class MultiLoRALinear(AdapterWrapper):
         # The shard is contiguous in the same sequence-major flattening the spans
         # address (same invariant as the MoE slot routing's SP narrow).
         total = self.tokens_per_adapter_total
-        if total is not None and x_flat.shape[0] != total:
+        if self.replicate_adapter and total is not None and x_flat.shape[0] != total:
             tp_size = parallel_state.get_tensor_model_parallel_world_size()
             if x_flat.shape[0] * tp_size != total:
                 raise RuntimeError(
@@ -261,15 +263,13 @@ class MultiLoRALinear(AdapterWrapper):
 
         mid = _dense_multi_lora_mm(x_flat, stacked_A, token_splits=token_splits, offsets=offsets)
 
-        # TP collective between A and B: row-parallel base needs an all-reduce
-        # of the partial sums; every other base (column-parallel and replicated
-        # alike — ParallelLinearAdapter shards A on the rank axis whenever
-        # input_is_parallel is False) needs an all-gather of the rank-sharded
-        # mid to a full [tokens, dim] for the second GEMM.
-        if self.input_is_parallel:
-            mid = reduce_from_tensor_model_parallel_region(mid)
-        else:
-            mid = gather_from_tensor_model_parallel_region(mid)
+        # TP collective between A and B: row-parallel A needs an all-reduce;
+        # column-parallel A needs an all-gather; replicated A is already complete.
+        if not self.replicate_adapter:
+            if self.input_is_parallel:
+                mid = reduce_from_tensor_model_parallel_region(mid)
+            else:
+                mid = gather_from_tensor_model_parallel_region(mid)
 
         out = _dense_multi_lora_mm(mid, stacked_B, token_splits=token_splits, offsets=offsets)
 
@@ -307,14 +307,22 @@ class MultiLoRALinear(AdapterWrapper):
         # advanced since model build. A bare nn.init here diverges replicas on
         # slot reuse (breaking the DP-equal invariant the weight checker relies
         # on). Mirror the construction-time init methods rather than hardcoding.
-        from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
+        from megatron.core.tensor_parallel.random import (
+            get_cuda_rng_tracker,
+            get_data_parallel_rng_tracker_name,
+        )
 
         from megatron.bridge.peft.utils import ParallelLinearAdapter
 
         adapter = self.adapters[idx]
         col_fn = ParallelLinearAdapter._get_init_fn(None, self._column_init_method)
         row_fn = ParallelLinearAdapter._get_init_fn(None, self._row_init_method)
-        with get_cuda_rng_tracker().fork():
+        rng_context = (
+            get_cuda_rng_tracker().fork(get_data_parallel_rng_tracker_name())
+            if self.replicate_adapter
+            else get_cuda_rng_tracker().fork()
+        )
+        with rng_context:
             col_fn(adapter.linear_in.weight.data)
             row_fn(adapter.linear_out.weight.data)
 

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -544,6 +544,7 @@ class AdapterAttributes:
     disable_tensor_parallel_comm: bool
     disable_sequence_parallel_comm: bool
     base_linear_is_parallel: bool
+    replicate_adapter: bool = False
 
 
 def get_adapter_attributes_from_linear(
@@ -580,6 +581,7 @@ def get_adapter_attributes_from_linear(
     """
     disable_sequence_parallel_comm = not m.config.sequence_parallel
     base_linear_is_parallel = True
+    replicate_adapter = False
 
     # In some modules (notably MoE shared_experts when moe_shared_expert_overlap is enabled),
     # Megatron disables TP-related communications on the base linear layer by
@@ -658,6 +660,7 @@ def get_adapter_attributes_from_linear(
         in_features = m.in_features
         out_features = m.out_features
         base_linear_is_parallel = False
+        replicate_adapter = True
     elif isinstance(m, ColumnParallelLinear):
         input_is_parallel = False
         in_features = m.input_size
@@ -676,6 +679,7 @@ def get_adapter_attributes_from_linear(
         disable_tensor_parallel_comm=disable_tensor_parallel_comm,
         disable_sequence_parallel_comm=disable_sequence_parallel_comm,
         base_linear_is_parallel=base_linear_is_parallel,
+        replicate_adapter=replicate_adapter,
     )
 
 
@@ -947,6 +951,7 @@ class ParallelLinearAdapter(nn.Module):
         is_expert: Whether this adapter is for expert layers in MoE (default: False).
         disable_sequence_parallel_comm: Whether to disable sequence parallel communication (default: True).
         base_linear_is_parallel: Whether the base linear layer uses parallelization (default: True).
+        replicate_adapter: Whether both low-rank matrices should be duplicated across TP ranks.
         sequence_parallel_input_regather: Whether eligible LoRA-A projections retain the sequence-local input and
             re-gather it in backward using MCore's sequence-parallel linear path (default: False).
     """
@@ -970,6 +975,7 @@ class ParallelLinearAdapter(nn.Module):
         disable_tensor_parallel_comm: bool = False,
         disable_sequence_parallel_comm: bool = True,
         base_linear_is_parallel: bool = True,
+        replicate_adapter: bool = False,
         pg_collection: ProcessGroupCollection | None = None,
         sequence_parallel_input_regather: bool = False,
     ) -> None:
@@ -992,6 +998,7 @@ class ParallelLinearAdapter(nn.Module):
             is_expert: Whether for expert layers in MoE.
             disable_tensor_parallel_comm: Disable tensor parallel communication.
             disable_sequence_parallel_comm: Disable sequence parallel communication.
+            replicate_adapter: Duplicate both low-rank matrices across TP ranks.
             sequence_parallel_input_regather: Re-gather eligible LoRA-A sequence-parallel inputs in backward.
         """
         super().__init__()
@@ -1004,6 +1011,7 @@ class ParallelLinearAdapter(nn.Module):
         self.use_a2a = a2a_experimental
         self.is_expert = is_expert
         self.base_linear_is_parallel = base_linear_is_parallel
+        self.replicate_adapter = replicate_adapter
         self.sequence_parallel_input_regather = sequence_parallel_input_regather
         self._sequence_parallel_input_regather_fallback_logged = False
         self.use_legacy_shared_expert_adapter_checkpoint = False
@@ -1023,14 +1031,43 @@ class ParallelLinearAdapter(nn.Module):
         self.ep_group = _get_process_group(self.pg_collection, "ep")
         self.expert_dp_group = _get_process_group(self.pg_collection, "expt_dp")
         _sequence_parallel = model_parallel_config.sequence_parallel
-        model_parallel_config.sequence_parallel = False  # SP is irrelevant for the lora linear layer
         self.config = model_parallel_config
 
         # Ensure adapter parameters are initialized when creating adapter layers.
         # In some flows (e.g., after import), perform_initialization may be False to skip heavy init.
         model_parallel_config.perform_initialization = True
 
-        if input_is_parallel:
+        if replicate_adapter:
+            if is_expert:
+                raise ValueError("Replicated adapters are only supported for non-expert linears")
+            if not HAVE_TE:
+                raise RuntimeError("Replicated adapters require Transformer Engine")
+            self.linear_in = TELinear(
+                in_features,
+                dim,
+                parallel_mode="duplicated",
+                config=model_parallel_config,
+                init_method=self._get_init_fn(column_init_method),
+                bias=False,
+                skip_bias_add=False,
+                skip_weight_param_allocation=False,
+                tp_group=None,
+            )
+            self.linear_out = TELinear(
+                dim,
+                out_features,
+                parallel_mode="duplicated",
+                config=model_parallel_config,
+                init_method=self._get_init_fn(row_init_method),
+                bias=False,
+                skip_bias_add=False,
+                skip_weight_param_allocation=False,
+                tp_group=None,
+            )
+        else:
+            model_parallel_config.sequence_parallel = False  # SP is irrelevant for TP-sharded LoRA linears
+
+        if not replicate_adapter and input_is_parallel:
             self.linear_in = RowParallelLinear(
                 in_features,
                 dim,
@@ -1042,7 +1079,7 @@ class ParallelLinearAdapter(nn.Module):
                 is_expert=is_expert,
                 tp_group=self.tp_group,
             )
-        else:
+        elif not replicate_adapter:
             self.linear_in = ColumnParallelLinear(
                 in_features,
                 dim,
@@ -1059,28 +1096,29 @@ class ParallelLinearAdapter(nn.Module):
         # a column parallel layer with two low-rank column parallel layers
         # if the original column parallel layer uses gather_output=False,
         # then we will use the self.liner_out layer defined below.
-        lin_out_gather_output = True if input_is_parallel else False
-        if (
-            self.use_a2a
-            and input_is_parallel
-            and _sequence_parallel
-            or (disable_tensor_parallel_comm and not input_is_parallel)
-        ):
-            lin_out_gather_output = False
+        if not replicate_adapter:
+            lin_out_gather_output = True if input_is_parallel else False
+            if (
+                self.use_a2a
+                and input_is_parallel
+                and _sequence_parallel
+                or (disable_tensor_parallel_comm and not input_is_parallel)
+            ):
+                lin_out_gather_output = False
 
-        if not base_linear_is_parallel:
-            lin_out_gather_output = True
+            if not base_linear_is_parallel:
+                lin_out_gather_output = True
 
-        self.linear_out = ColumnParallelLinear(
-            dim,
-            out_features,
-            config=model_parallel_config,
-            bias=False,
-            gather_output=lin_out_gather_output,
-            init_method=self._get_init_fn(row_init_method),
-            is_expert=is_expert,
-            tp_group=self.tp_group,
-        )
+            self.linear_out = ColumnParallelLinear(
+                dim,
+                out_features,
+                config=model_parallel_config,
+                bias=False,
+                gather_output=lin_out_gather_output,
+                init_method=self._get_init_fn(row_init_method),
+                is_expert=is_expert,
+                tp_group=self.tp_group,
+            )
 
         if dropout > 0.0:
             self.dropout = nn.Dropout(dropout)
@@ -1098,7 +1136,8 @@ class ParallelLinearAdapter(nn.Module):
             self._register_shared_expert_grad_sync_hooks()
 
         # revert config change in case it is read elsewhere
-        model_parallel_config.sequence_parallel = _sequence_parallel
+        if not replicate_adapter:
+            model_parallel_config.sequence_parallel = _sequence_parallel
         self.disable_sequence_parallel_comm = disable_sequence_parallel_comm
         if not _sequence_parallel:
             self.disable_sequence_parallel_comm = True
@@ -1227,7 +1266,7 @@ class ParallelLinearAdapter(nn.Module):
             x, pad_len = pad_seq_to_mult(x, self.config.expert_tensor_parallel_size)
 
         use_sequence_parallel_input_regather, fallback_reason = self._sequence_parallel_input_regather_eligibility(x)
-        if not self.input_is_parallel:
+        if not self.input_is_parallel and not self.replicate_adapter:
             # MCore's SP linear keeps the local input in ctx, launches the
             # backward all-gather asynchronously before dgrad, and waits only
             # before wgrad. The baseline path keeps communication external.

--- a/tests/functional_tests/launch_scripts/h100/active/L0_Launch_peft_replicated_adapters.sh
+++ b/tests/functional_tests/launch_scripts/h100/active/L0_Launch_peft_replicated_adapters.sh
@@ -17,5 +17,7 @@
 set -xeuo pipefail
 
 export CUDA_VISIBLE_DEVICES="0,1"
+# Keep TE and the dense mathematical oracle on the same strict-FP32 path.
+export NVIDIA_TF32_OVERRIDE=0
 uv run python -m torch.distributed.run --nproc_per_node=2 -m pytest -v -s -x --tb=short \
   tests/unit_tests/peft/test_replicated_peft_distributed.py

--- a/tests/functional_tests/launch_scripts/h100/active/L0_Launch_peft_replicated_adapters.sh
+++ b/tests/functional_tests/launch_scripts/h100/active/L0_Launch_peft_replicated_adapters.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CI_TIMEOUT=10
+set -xeuo pipefail
+
+export CUDA_VISIBLE_DEVICES="0,1"
+uv run python -m torch.distributed.run --nproc_per_node=2 -m pytest -v -s -x --tb=short \
+  tests/unit_tests/peft/test_replicated_peft_distributed.py

--- a/tests/unit_tests/peft/test_replicated_peft_distributed.py
+++ b/tests/unit_tests/peft/test_replicated_peft_distributed.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-rank correctness tests for PEFT on duplicated sequence-parallel linears.
+
+Run with:
+uv run python -m torch.distributed.run --nproc_per_node=2 -m pytest \
+    tests/unit_tests/peft/test_replicated_peft_distributed.py
+"""
+
+import os
+from collections.abc import Iterator
+
+import megatron.core.parallel_state as parallel_state
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from megatron.core.extensions.transformer_engine import TELinear
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+from megatron.bridge.peft.dora import DoRA
+from megatron.bridge.peft.dora_layers import DoRALinear
+from megatron.bridge.peft.lora import LoRA
+from megatron.bridge.peft.lora_layers import LoRALinear
+from megatron.bridge.peft.multi_lora import MultiLoRA
+from megatron.bridge.peft.multi_lora_layers import MultiLoRALinear, set_tokens_per_adapter_slot
+
+
+_TP_SIZE = 2
+_HIDDEN_SIZE = 8
+_OUTPUT_SIZE = 4
+_LORA_RANK = 2
+_LOCAL_TOKENS = 2
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_tp() -> Iterator[None]:
+    if int(os.environ.get("WORLD_SIZE", "1")) != _TP_SIZE:
+        pytest.skip("requires a two-rank torch.distributed launch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    owns_process_group = not dist.is_initialized()
+    owns_model_parallel = not parallel_state.model_parallel_is_initialized()
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", "0")))
+    if owns_process_group:
+        dist.init_process_group(backend="nccl")
+    if owns_model_parallel:
+        parallel_state.initialize_model_parallel(tensor_model_parallel_size=_TP_SIZE)
+    model_parallel_cuda_manual_seed(2026, force_reset_rng=True)
+
+    try:
+        yield
+    finally:
+        if owns_model_parallel and parallel_state.model_parallel_is_initialized():
+            parallel_state.destroy_model_parallel()
+        if owns_process_group and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _config() -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=_HIDDEN_SIZE,
+        num_attention_heads=2,
+        tensor_model_parallel_size=_TP_SIZE,
+        sequence_parallel=True,
+        params_dtype=torch.float32,
+        gradient_accumulation_fusion=False,
+    )
+
+
+def _base_linear() -> TELinear:
+    config = _config()
+    return TELinear(
+        _HIDDEN_SIZE,
+        _OUTPUT_SIZE,
+        parallel_mode="duplicated",
+        config=config,
+        init_method=config.init_method,
+        bias=False,
+        skip_bias_add=False,
+        skip_weight_param_allocation=False,
+        tp_group=None,
+        name="linear_q_down_proj",
+    )
+
+
+def _full_inputs() -> tuple[torch.Tensor, torch.Tensor]:
+    total_tokens = _TP_SIZE * _LOCAL_TOKENS
+    x = torch.arange(
+        1,
+        total_tokens * _HIDDEN_SIZE + 1,
+        device="cuda",
+        dtype=torch.float32,
+    ).reshape(total_tokens, 1, _HIDDEN_SIZE)
+    output_grad = torch.arange(
+        1,
+        total_tokens * _OUTPUT_SIZE + 1,
+        device="cuda",
+        dtype=torch.float32,
+    ).reshape(total_tokens, 1, _OUTPUT_SIZE)
+    return x / 10, output_grad / 100
+
+
+def _logical_weight(rows: int, columns: int, offset: int) -> torch.Tensor:
+    return (
+        torch.arange(
+            offset,
+            offset + rows * columns,
+            device="cuda",
+            dtype=torch.float32,
+        ).reshape(rows, columns)
+        / 100
+    )
+
+
+def _copy_logical_weight(parameter: torch.Tensor, logical_weight: torch.Tensor) -> None:
+    """Load either the pre-fix TP shard or the fixed replicated parameter."""
+    with torch.no_grad():
+        if parameter.shape == logical_weight.shape:
+            parameter.copy_(logical_weight)
+            return
+        shards = logical_weight.chunk(_TP_SIZE, dim=0)
+        assert parameter.shape == shards[dist.get_rank()].shape
+        parameter.copy_(shards[dist.get_rank()])
+
+
+def _assert_replicated_parameter(parameter: torch.Tensor, expected_shape: tuple[int, ...]) -> None:
+    assert parameter.shape == expected_shape
+    assert not getattr(parameter, "tensor_model_parallel", False)
+    assert getattr(parameter, "sequence_parallel", False)
+
+
+def _summed_grad(parameter: torch.Tensor) -> torch.Tensor:
+    assert parameter.grad is not None
+    grad = parameter.grad.detach().clone()
+    dist.all_reduce(grad)
+    return grad
+
+
+@pytest.mark.gpu
+def test_lora_replicated_base_matches_dense_forward_and_gradients() -> None:
+    wrapped = LoRA(
+        target_modules=["linear_q_down_proj"],
+        dim=_LORA_RANK,
+        alpha=_LORA_RANK,
+        lora_A_init_method="xavier",
+    ).transform(_base_linear(), name="linear_q_down_proj")
+    assert isinstance(wrapped, LoRALinear)
+    adapter = wrapped.adapter
+
+    full_a = _logical_weight(_LORA_RANK, _HIDDEN_SIZE, 1)
+    full_b = _logical_weight(_OUTPUT_SIZE, _LORA_RANK, 101)
+    _copy_logical_weight(adapter.linear_in.weight, full_a)
+    _copy_logical_weight(adapter.linear_out.weight, full_b)
+
+    x_full, grad_full = _full_inputs()
+    rank = dist.get_rank()
+    x_local = x_full.chunk(_TP_SIZE, dim=0)[rank]
+    grad_local = grad_full.chunk(_TP_SIZE, dim=0)[rank]
+    actual = adapter(x_local)
+    expected = F.linear(F.linear(x_local, full_a), full_b)
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+    actual.backward(grad_local)
+    actual_a_grad = _summed_grad(adapter.linear_in.weight)
+    actual_b_grad = _summed_grad(adapter.linear_out.weight)
+    a_reference = full_a.detach().clone().requires_grad_()
+    b_reference = full_b.detach().clone().requires_grad_()
+    reference = F.linear(F.linear(x_full, a_reference), b_reference)
+    reference_a_grad, reference_b_grad = torch.autograd.grad((reference * grad_full).sum(), (a_reference, b_reference))
+
+    _assert_replicated_parameter(adapter.linear_in.weight, full_a.shape)
+    _assert_replicated_parameter(adapter.linear_out.weight, full_b.shape)
+    torch.testing.assert_close(actual_a_grad, reference_a_grad, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(actual_b_grad, reference_b_grad, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.gpu
+def test_dora_replicated_base_matches_dense_forward_and_gradients() -> None:
+    base = _base_linear()
+    base_weight = _logical_weight(_OUTPUT_SIZE, _HIDDEN_SIZE, 201)
+    with torch.no_grad():
+        base.weight.copy_(base_weight)
+    wrapped = DoRA(
+        target_modules=["linear_q_down_proj"],
+        dim=_LORA_RANK,
+        alpha=_LORA_RANK,
+        lora_A_init_method="xavier",
+    ).transform(base, name="linear_q_down_proj")
+    assert isinstance(wrapped, DoRALinear)
+    adapter = wrapped.adapter
+
+    full_a = _logical_weight(_LORA_RANK, _HIDDEN_SIZE, 301)
+    full_b = _logical_weight(_OUTPUT_SIZE, _LORA_RANK, 401)
+    _copy_logical_weight(adapter.linear_in.weight, full_a)
+    _copy_logical_weight(adapter.linear_out.weight, full_b)
+    direction = base_weight + full_b @ full_a
+    magnitude = torch.linalg.norm(direction, dim=1) * torch.linspace(0.8, 1.1, _OUTPUT_SIZE, device="cuda")
+    with torch.no_grad():
+        adapter.weight_magnitude.copy_(magnitude)
+
+    x_full, grad_full = _full_inputs()
+    rank = dist.get_rank()
+    x_local = x_full.chunk(_TP_SIZE, dim=0)[rank]
+    grad_local = grad_full.chunk(_TP_SIZE, dim=0)[rank]
+    actual, _ = wrapped(x_local)
+    expected = F.linear(x_local, direction) * (magnitude / torch.linalg.norm(direction, dim=1)).view(1, 1, -1)
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+    actual.backward(grad_local)
+    actual_a_grad = _summed_grad(adapter.linear_in.weight)
+    actual_b_grad = _summed_grad(adapter.linear_out.weight)
+    actual_magnitude_grad = _summed_grad(adapter.weight_magnitude)
+    a_reference = full_a.detach().clone().requires_grad_()
+    b_reference = full_b.detach().clone().requires_grad_()
+    magnitude_reference = magnitude.detach().clone().requires_grad_()
+    direction_reference = base_weight + b_reference @ a_reference
+    norm_reference = torch.linalg.norm(direction_reference, dim=1).detach()
+    reference = F.linear(x_full, direction_reference) * (magnitude_reference / norm_reference).view(1, 1, -1)
+    reference_grads = torch.autograd.grad(
+        (reference * grad_full).sum(), (a_reference, b_reference, magnitude_reference)
+    )
+
+    _assert_replicated_parameter(adapter.linear_in.weight, full_a.shape)
+    _assert_replicated_parameter(adapter.linear_out.weight, full_b.shape)
+    _assert_replicated_parameter(adapter.weight_magnitude, magnitude.shape)
+    torch.testing.assert_close(actual_a_grad, reference_grads[0], rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(actual_b_grad, reference_grads[1], rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(actual_magnitude_grad, reference_grads[2], rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.gpu
+def test_multi_lora_replicated_base_matches_dense_forward_and_gradients() -> None:
+    base = _base_linear()
+    base_weight = _logical_weight(_OUTPUT_SIZE, _HIDDEN_SIZE, 501)
+    with torch.no_grad():
+        base.weight.copy_(base_weight)
+    wrapped = MultiLoRA(
+        target_modules=["linear_q_down_proj"],
+        n_adapters=2,
+        dim=_LORA_RANK,
+        alpha=_LORA_RANK,
+    ).transform(base, name="linear_q_down_proj")
+    assert isinstance(wrapped, MultiLoRALinear)
+
+    full_weights: list[tuple[torch.Tensor, torch.Tensor]] = []
+    for slot, adapter in enumerate(wrapped.adapters):
+        full_a = _logical_weight(_LORA_RANK, _HIDDEN_SIZE, 601 + slot * 200)
+        full_b = _logical_weight(_OUTPUT_SIZE, _LORA_RANK, 701 + slot * 200)
+        _copy_logical_weight(adapter.linear_in.weight, full_a)
+        _copy_logical_weight(adapter.linear_out.weight, full_b)
+        wrapped.init_adapter_slot(slot, rank=_LORA_RANK, alpha=_LORA_RANK)
+        full_weights.append((full_a, full_b))
+
+    x_full, grad_full = _full_inputs()
+    rank = dist.get_rank()
+    x_local = x_full.chunk(_TP_SIZE, dim=0)[rank]
+    grad_local = grad_full.chunk(_TP_SIZE, dim=0)[rank]
+    set_tokens_per_adapter_slot(
+        wrapped,
+        torch.tensor([_LOCAL_TOKENS, _LOCAL_TOKENS], device="cuda", dtype=torch.int32),
+    )
+    actual, _ = wrapped(x_local)
+    expected_adapter = torch.cat(
+        [
+            F.linear(F.linear(x_part, full_a), full_b)
+            for x_part, (full_a, full_b) in zip(
+                x_full.split([_LOCAL_TOKENS, _LOCAL_TOKENS], dim=0), full_weights, strict=True
+            )
+        ],
+        dim=0,
+    )
+    expected = F.linear(x_full, base_weight) + expected_adapter
+    torch.testing.assert_close(actual, expected.chunk(_TP_SIZE, dim=0)[rank], rtol=1e-6, atol=1e-6)
+
+    actual.backward(grad_local)
+    actual_grads: list[tuple[torch.Tensor, torch.Tensor]] = []
+    for adapter in wrapped.adapters:
+        actual_grads.append((_summed_grad(adapter.linear_in.weight), _summed_grad(adapter.linear_out.weight)))
+
+    a_references = [full_a.detach().clone().requires_grad_() for full_a, _ in full_weights]
+    b_references = [full_b.detach().clone().requires_grad_() for _, full_b in full_weights]
+    reference_adapter = torch.cat(
+        [
+            F.linear(F.linear(x_part, a_reference), b_reference)
+            for x_part, a_reference, b_reference in zip(
+                x_full.split([_LOCAL_TOKENS, _LOCAL_TOKENS], dim=0),
+                a_references,
+                b_references,
+                strict=True,
+            )
+        ],
+        dim=0,
+    )
+    reference_grads = torch.autograd.grad(
+        ((F.linear(x_full, base_weight) + reference_adapter) * grad_full).sum(),
+        (*a_references, *b_references),
+    )
+
+    for slot, adapter in enumerate(wrapped.adapters):
+        full_a, full_b = full_weights[slot]
+        _assert_replicated_parameter(adapter.linear_in.weight, full_a.shape)
+        _assert_replicated_parameter(adapter.linear_out.weight, full_b.shape)
+        torch.testing.assert_close(actual_grads[slot][0], reference_grads[slot], rtol=1e-6, atol=1e-6)
+        torch.testing.assert_close(
+            actual_grads[slot][1], reference_grads[len(wrapped.adapters) + slot], rtol=1e-6, atol=1e-6
+        )

--- a/tests/unit_tests/peft/test_replicated_peft_distributed.py
+++ b/tests/unit_tests/peft/test_replicated_peft_distributed.py
@@ -220,7 +220,7 @@ def test_dora_replicated_base_matches_dense_forward_and_gradients() -> None:
     grad_local = grad_full.chunk(_TP_SIZE, dim=0)[rank]
     actual, _ = wrapped(x_local)
     expected = F.linear(x_local, direction) * (magnitude / torch.linalg.norm(direction, dim=1)).view(1, 1, -1)
-    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
 
     actual.backward(grad_local)
     actual_a_grad = _summed_grad(adapter.linear_in.weight)
@@ -239,9 +239,9 @@ def test_dora_replicated_base_matches_dense_forward_and_gradients() -> None:
     _assert_replicated_parameter(adapter.linear_in.weight, full_a.shape)
     _assert_replicated_parameter(adapter.linear_out.weight, full_b.shape)
     _assert_replicated_parameter(adapter.weight_magnitude, magnitude.shape)
-    torch.testing.assert_close(actual_a_grad, reference_grads[0], rtol=1e-6, atol=1e-6)
-    torch.testing.assert_close(actual_b_grad, reference_grads[1], rtol=1e-6, atol=1e-6)
-    torch.testing.assert_close(actual_magnitude_grad, reference_grads[2], rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(actual_a_grad, reference_grads[0], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(actual_b_grad, reference_grads[1], rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(actual_magnitude_grad, reference_grads[2], rtol=1e-5, atol=1e-5)
 
 
 @pytest.mark.gpu
@@ -286,7 +286,7 @@ def test_multi_lora_replicated_base_matches_dense_forward_and_gradients() -> Non
         dim=0,
     )
     expected = F.linear(x_full, base_weight) + expected_adapter
-    torch.testing.assert_close(actual, expected.chunk(_TP_SIZE, dim=0)[rank], rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(actual, expected.chunk(_TP_SIZE, dim=0)[rank], rtol=1e-5, atol=1e-5)
 
     actual.backward(grad_local)
     actual_grads: list[tuple[torch.Tensor, torch.Tensor]] = []
@@ -316,7 +316,7 @@ def test_multi_lora_replicated_base_matches_dense_forward_and_gradients() -> Non
         full_a, full_b = full_weights[slot]
         _assert_replicated_parameter(adapter.linear_in.weight, full_a.shape)
         _assert_replicated_parameter(adapter.linear_out.weight, full_b.shape)
-        torch.testing.assert_close(actual_grads[slot][0], reference_grads[slot], rtol=1e-6, atol=1e-6)
+        torch.testing.assert_close(actual_grads[slot][0], reference_grads[slot], rtol=1e-5, atol=1e-5)
         torch.testing.assert_close(
-            actual_grads[slot][1], reference_grads[len(wrapped.adapters) + slot], rtol=1e-6, atol=1e-6
+            actual_grads[slot][1], reference_grads[len(wrapped.adapters) + slot], rtol=1e-5, atol=1e-5
         )

--- a/tests/unit_tests/peft/test_replicated_peft_distributed.py
+++ b/tests/unit_tests/peft/test_replicated_peft_distributed.py
@@ -218,8 +218,10 @@ def test_dora_replicated_base_matches_dense_forward_and_gradients() -> None:
     rank = dist.get_rank()
     x_local = x_full.chunk(_TP_SIZE, dim=0)[rank]
     grad_local = grad_full.chunk(_TP_SIZE, dim=0)[rank]
+    base_output_local, _ = base(x_local)
     actual, _ = wrapped(x_local)
-    expected = F.linear(x_local, direction) * (magnitude / torch.linalg.norm(direction, dim=1)).view(1, 1, -1)
+    magnitude_scale = (magnitude / torch.linalg.norm(direction, dim=1)).view(1, 1, -1)
+    expected = (base_output_local.detach() + F.linear(F.linear(x_local, full_a), full_b)) * magnitude_scale
     torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
 
     actual.backward(grad_local)
@@ -231,7 +233,12 @@ def test_dora_replicated_base_matches_dense_forward_and_gradients() -> None:
     magnitude_reference = magnitude.detach().clone().requires_grad_()
     direction_reference = base_weight + b_reference @ a_reference
     norm_reference = torch.linalg.norm(direction_reference, dim=1).detach()
-    reference = F.linear(x_full, direction_reference) * (magnitude_reference / norm_reference).view(1, 1, -1)
+    base_output_parts = [torch.empty_like(base_output_local) for _ in range(_TP_SIZE)]
+    dist.all_gather(base_output_parts, base_output_local.detach())
+    base_output_full = torch.cat(base_output_parts, dim=0)
+    reference = (base_output_full + F.linear(F.linear(x_full, a_reference), b_reference)) * (
+        magnitude_reference / norm_reference
+    ).view(1, 1, -1)
     reference_grads = torch.autograd.grad(
         (reference * grad_full).sum(), (a_reference, b_reference, magnitude_reference)
     )
@@ -275,6 +282,7 @@ def test_multi_lora_replicated_base_matches_dense_forward_and_gradients() -> Non
         wrapped,
         torch.tensor([_LOCAL_TOKENS, _LOCAL_TOKENS], device="cuda", dtype=torch.int32),
     )
+    base_output_local, _ = base(x_local)
     actual, _ = wrapped(x_local)
     expected_adapter = torch.cat(
         [
@@ -285,8 +293,8 @@ def test_multi_lora_replicated_base_matches_dense_forward_and_gradients() -> Non
         ],
         dim=0,
     )
-    expected = F.linear(x_full, base_weight) + expected_adapter
-    torch.testing.assert_close(actual, expected.chunk(_TP_SIZE, dim=0)[rank], rtol=1e-5, atol=1e-5)
+    expected_local = base_output_local.detach() + expected_adapter.chunk(_TP_SIZE, dim=0)[rank]
+    torch.testing.assert_close(actual, expected_local, rtol=1e-5, atol=1e-5)
 
     actual.backward(grad_local)
     actual_grads: list[tuple[torch.Tensor, torch.Tensor]] = []
@@ -308,7 +316,7 @@ def test_multi_lora_replicated_base_matches_dense_forward_and_gradients() -> Non
         dim=0,
     )
     reference_grads = torch.autograd.grad(
-        ((F.linear(x_full, base_weight) + reference_adapter) * grad_full).sum(),
+        (reference_adapter * grad_full).sum(),
         (*a_references, *b_references),
     )
 


### PR DESCRIPTION
## What does this PR do?

Fixes LoRA, DoRA, and MultiLoRA on duplicated `TELinear` bases when tensor parallelism and sequence parallelism are enabled.

MLA q/kv down-projections are duplicated across TP ranks and consume different sequence-parallel token shards. Bridge nevertheless built TP-sharded adapter A/B factors. The feature gather therefore joined values computed from different tokens: shapes remained valid, but adapter outputs and gradients were wrong. DoRA failed even earlier while adding a sharded `B @ A` to the full duplicated base weight.

## Fix

- mark adapters wrapping duplicated `TELinear` bases with an explicit replicated-factor topology
- construct full duplicated `TELinear` A/B factors, preserving MCore initialization, gradient, and distributed-checkpoint metadata
- keep sequence-parallel inputs local and let MCore sum replicated parameter gradients across TP
- skip MultiLoRA's between-factor and output TP gathers for replicated factors
- make DoRA's magnitude and weight-norm paths replicated as well
- export replicated A/B factors through `ReplicatedMapping`; ordinary and ModelOpt adapters retain their existing TP mappings

CanonicalLoRA uses the same shared adapter construction and is wired to the replicated topology as well.

## Fail-first evidence

The first commit adds three real two-rank tests against upstream `main`:

| Adapter | Upstream result |
|---|---|
| LoRA | numeric mismatch, max absolute difference `1.728`, max relative difference `2.305` |
| DoRA | construction failure: duplicated base output `4` versus local adapter output `2` |
| MultiLoRA | numeric mismatch, max absolute difference `1369.486`, max relative difference `3.334` |

All failures occur under TP=2 with distinct SP token shards and deterministic full logical adapter weights.

## Validation

- production fix `a15e4fc3` with the original distributed tests on 2x B300, CUDA 13, Transformer Engine 2.16: **3 passed**
- current test code plus the launcher's strict-FP32 environment on 2x H100, CUDA 12.8, Transformer Engine 2.16: **3 passed in 2.15s**
- current head `1b8fa886` changes only the test oracle and launcher environment after the production fix
- each test checks local forward arithmetic and TP-summed A/B gradients against dense full-sequence autograd
- DoRA additionally checks its replicated magnitude gradient
- focused existing PEFT/model-bridge suites: **329 passed**; the same 12 integration tests fail both before and after because this devbox lacks Apex's fused weight-gradient extension
- `pre-commit run --all-files`: passed
- Python syntax compilation: passed

The functional regression uses two GPUs and has one H100 L0 launcher.

## Scope

This PR only fixes duplicated-base adapter topology. It does not change unrelated existing DoRA behavior such as row-parallel norm calculation, dropout semantics, or HF magnitude export.
