### PR TITLE
[peft] fix: Support partial canonical LoRA runtime

### DIFF
--- a/src/megatron/bridge/peft/canonical_lora.py
+++ b/src/megatron/bridge/peft/canonical_lora.py
@@ -74,6 +74,8 @@ class ModuleDict(nn.ModuleDict):
         """
         sharded_state_dict = {}
         for key, layer in self.items():
+            if layer is None:
+                continue
             sharded_state_dict.update(layer.sharded_state_dict(f"{prefix}{key}.", sharded_offsets, metadata))
         return sharded_state_dict
 
@@ -147,9 +149,33 @@ class LoRALinearSplitQKV(AdapterWrapper):
         linear_output, bias, layernorm_output = self.base_linear_forward(x, *args, **kwargs)
         if not self._adapter_enabled:
             return linear_output, bias
-        query = self.adapter_forward(self.adapter.adapter_q, layernorm_output, *args, **kwargs)
-        key = self.adapter_forward(self.adapter.adapter_k, layernorm_output, *args, **kwargs)
-        value = self.adapter_forward(self.adapter.adapter_v, layernorm_output, *args, **kwargs)
+        query = (
+            self.adapter_forward(self.adapter.adapter_q, layernorm_output, *args, **kwargs)
+            if self.adapter.adapter_q is not None
+            else None
+        )
+        key = (
+            self.adapter_forward(self.adapter.adapter_k, layernorm_output, *args, **kwargs)
+            if self.adapter.adapter_k is not None
+            else None
+        )
+        value = (
+            self.adapter_forward(self.adapter.adapter_v, layernorm_output, *args, **kwargs)
+            if self.adapter.adapter_v is not None
+            else None
+        )
+
+        if key is None and value is None:
+            kv_size = (linear_output.size(-1) - query.size(-1)) // 2
+            key = value = layernorm_output.new_zeros(*layernorm_output.shape[:-1], kv_size)
+        elif key is None:
+            key = torch.zeros_like(value)
+        elif value is None:
+            value = torch.zeros_like(key)
+
+        if query is None:
+            query_size = linear_output.size(-1) - 2 * key.size(-1)
+            query = layernorm_output.new_zeros(*layernorm_output.shape[:-1], query_size)
 
         adapter_output = self._interleave_qkv(query, key, value)
 
@@ -170,8 +196,20 @@ class LoRALinearSplitFC1UpGate(AdapterWrapper):
         linear_output, bias, layernorm_output = self.base_linear_forward(x, *args, **kwargs)
         if not self._adapter_enabled:
             return linear_output, bias
-        adapter_output_gate = self.adapter_forward(self.adapter.adapter_gate, layernorm_output, *args, **kwargs)
-        adapter_output_up = self.adapter_forward(self.adapter.adapter_up, layernorm_output, *args, **kwargs)
+        adapter_output_gate = (
+            self.adapter_forward(self.adapter.adapter_gate, layernorm_output, *args, **kwargs)
+            if self.adapter.adapter_gate is not None
+            else None
+        )
+        adapter_output_up = (
+            self.adapter_forward(self.adapter.adapter_up, layernorm_output, *args, **kwargs)
+            if self.adapter.adapter_up is not None
+            else None
+        )
+        if adapter_output_gate is None:
+            adapter_output_gate = torch.zeros_like(adapter_output_up)
+        if adapter_output_up is None:
+            adapter_output_up = torch.zeros_like(adapter_output_gate)
         adapter_output = torch.cat([adapter_output_gate, adapter_output_up], dim=-1)
         return linear_output + adapter_output, bias
 

--- a/tests/unit_tests/peft/test_canonical_lora.py
+++ b/tests/unit_tests/peft/test_canonical_lora.py
@@ -895,6 +895,54 @@ class TestCanonicalLoRAMegatronLayers:
 class TestCanonicalLoRAHelperClasses:
     """Test helper classes for CanonicalLoRA."""
 
+    def test_partial_canonical_qkv_forward_and_sharded_state(self):
+        """A selected Q adapter should leave omitted K/V slices unchanged and unsaved."""
+
+        class ShardedLinear(nn.Linear):
+            def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+                return {f"{prefix}weight": self.weight}
+
+        base_layer = nn.Linear(4, 8, bias=False)
+        nn.init.zeros_(base_layer.weight)
+        base_layer.config = SimpleNamespace(kv_channels=2, num_attention_heads=2, num_query_groups=1)
+        adapter_q = ShardedLinear(4, 4, bias=False)
+        nn.init.eye_(adapter_q.weight)
+        wrapper = LoRALinearSplitQKV(
+            base_layer,
+            ModuleDict({"adapter_q": adapter_q, "adapter_k": None, "adapter_v": None}),
+        )
+
+        x = torch.arange(4, dtype=torch.float32).reshape(1, 1, 4)
+        output, bias = wrapper(x)
+
+        assert bias is None
+        torch.testing.assert_close(
+            output,
+            torch.cat([x, torch.zeros(1, 1, 4)], dim=-1),
+        )
+        assert set(wrapper.adapter.sharded_state_dict(prefix="adapter.")) == {"adapter.adapter_q.weight"}
+
+    def test_partial_canonical_fc1_forward(self):
+        """A selected up adapter should leave the omitted gate slice unchanged."""
+
+        base_layer = nn.Linear(4, 8, bias=False)
+        nn.init.zeros_(base_layer.weight)
+        adapter_up = nn.Linear(4, 4, bias=False)
+        nn.init.eye_(adapter_up.weight)
+        wrapper = LoRALinearSplitFC1UpGate(
+            base_layer,
+            ModuleDict({"adapter_up": adapter_up, "adapter_gate": None}),
+        )
+
+        x = torch.arange(4, dtype=torch.float32).reshape(1, 1, 4)
+        output, bias = wrapper(x)
+
+        assert bias is None
+        torch.testing.assert_close(
+            output,
+            torch.cat([torch.zeros(1, 1, 4), x], dim=-1),
+        )
+
     def test_module_dict_sharded_state_dict(self):
         """Test ModuleDict's sharded_state_dict method."""
 


### PR DESCRIPTION
## Problem

`CanonicalLoRA` supports selecting only part of a fused QKV or FC1 projection, such as `linear_q` without K/V or `linear_fc1_up` without gate. The transform records omitted siblings as `None`, but the fused runtime wrappers call every sibling unconditionally. The first forward therefore raises `TypeError: 'NoneType' object is not callable`. Native sharded checkpoint construction similarly calls `sharded_state_dict()` on omitted siblings and raises `AttributeError`.

This affects supported partial CanonicalLoRA training/inference and torch-dist checkpoint save/resume. Partial HF adapter export support was established in #5874; this PR addresses the separate runtime and sharded-state consumers.

## Fix

- Treat each omitted fused projection as an exact zero adapter delta before interleaving/concatenation.
- Skip omitted entries when building the adapter sharded state.
- Add focused Q-only QKV and up-only FC1 regression tests, including selected-only checkpoint keys.

The patch does not add targets, change public APIs, or alter fully populated adapters.

## Validation

Fail-before deterministic CPU reproducer against unmodified `main`:

```text
uv run --no-project python reproduce_partial_canonical_lora.py
exit 1
partial QKV forward: TypeError: 'NoneType' object is not callable
partial QKV sharded state: AttributeError: 'NoneType' object has no attribute 'sharded_state_dict'
partial FC1 forward: TypeError: 'NoneType' object is not callable
```

The unchanged reproducer passes after the fix, including K-only QKV and gate-only FC1 controls:

```text
uv run --no-project python reproduce_partial_canonical_lora.py
exit 0
partial CanonicalLoRA forward and sharded-state contracts passed
```

Additional checks:

```text
git diff --check
Passed

uv run --no-project pre-commit run --all-files
Passed
```

The focused repository pytest could not collect on the validation workstation because its platform cannot install the pinned `nvidia-resiliency-ext==0.6.0` wheel; no pytest pass is claimed. The focused regression tests are included for CI.
