### PR TITLE
perf(deepseek): add DeepSeek V4 Flash Blackwell recipes

### DIFF
--- a/scripts/performance/dump_perf_configs.py
+++ b/scripts/performance/dump_perf_configs.py
@@ -188,6 +188,10 @@ COMBOS = [
     ("deepseek", "deepseek_v3", "pretrain", 1024, "h100", "bf16"),
     ("deepseek", "deepseek_v3", "pretrain", 1024, "h100", "fp8_cs"),
     ("deepseek", "deepseek_v3", "pretrain", 1024, "h100", "fp8_sc"),
+    ("deepseek", "deepseek_v4_flash", "pretrain", 128, "gb300", "fp8_mx"),
+    ("deepseek", "deepseek_v4_flash", "pretrain", 128, "gb200", "fp8_mx"),
+    ("deepseek", "deepseek_v4_flash", "pretrain", 128, "b300", "fp8_mx"),
+    ("deepseek", "deepseek_v4_flash", "pretrain", 128, "b200", "fp8_mx"),
     ("deepseek", "deepseek_v4_pro", "pretrain", 256, "gb300", "fp8_mx"),
     # Qwen3 MoE 30B-A3B
     ("qwen", "qwen3_30b_a3b", "pretrain", 8, "gb300", "bf16"),

--- a/src/megatron/bridge/perf_recipes/deepseek/__init__.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/__init__.py
@@ -5,12 +5,18 @@ from megatron.bridge.perf_recipes.deepseek.b200.deepseek_v3 import (
     deepseek_v3_pretrain_256gpu_b200_fp8mx_large_scale_config,
     deepseek_v3_pretrain_256gpu_b200_nvfp4_config,
 )
+from megatron.bridge.perf_recipes.deepseek.b200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_b200_fp8mx_config,
+)
 from megatron.bridge.perf_recipes.deepseek.b300.deepseek_v3 import (
     deepseek_v3_pretrain_256gpu_b300_bf16_config,
     deepseek_v3_pretrain_256gpu_b300_fp8cs_config,
     deepseek_v3_pretrain_256gpu_b300_fp8mx_config,
     deepseek_v3_pretrain_256gpu_b300_fp8mx_large_scale_config,
     deepseek_v3_pretrain_256gpu_b300_nvfp4_config,
+)
+from megatron.bridge.perf_recipes.deepseek.b300.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_b300_fp8mx_config,
 )
 from megatron.bridge.perf_recipes.deepseek.gb200.deepseek_v3 import (
     deepseek_v3_pretrain_256gpu_gb200_bf16_config,

--- a/src/megatron/bridge/perf_recipes/deepseek/b200/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/b200/deepseek_v4.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""B200 performance recipes for DeepSeek V4."""
+
+from megatron.bridge.models.deepseek.deepseek_v4_bridge import (
+    set_deepseek_v4_pipeline_model_parallel_layout,
+)
+from megatron.bridge.perf_recipes.deepseek.b300.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_b300_fp8mx_config,
+)
+from megatron.bridge.perf_recipes.environment import COMMON_PERF_ENV_VARS
+from megatron.bridge.training.config import ConfigContainer
+
+
+def _apply_deepseek_v4_b200_overrides(cfg: ConfigContainer) -> None:
+    """Apply the lower-memory B200 topology and communication settings."""
+    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.expert_model_parallel_size = 8
+    cfg.train.micro_batch_size = 1
+    set_deepseek_v4_pipeline_model_parallel_layout(cfg.model)
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["attn", "moe_router", "moe_preprocess"]
+    cfg.model.moe_pad_experts_for_cuda_graph_inference = False
+    cfg.model.moe_paged_stash = False
+
+    recompute_modules = list(cfg.model.recompute_modules or [])
+    if "mlp" not in recompute_modules:
+        recompute_modules.append("mlp")
+    cfg.model.recompute_modules = recompute_modules
+
+    cfg.comm_overlap.overlap_grad_reduce = True
+    # Hash-routed MoE layers do not currently support EP A2A overlap.
+    cfg.comm_overlap.delay_wgrad_compute = False
+    cfg.dist.distributed_timeout_minutes = 30
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+
+
+def deepseek_v4_flash_pretrain_128gpu_b200_fp8mx_config() -> ConfigContainer:
+    """DeepSeek V4 Flash pretrain: 128× B200, MXFP8."""
+    cfg = deepseek_v4_flash_pretrain_128gpu_b300_fp8mx_config()
+    _apply_deepseek_v4_b200_overrides(cfg)
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
+    }
+    return cfg

--- a/src/megatron/bridge/perf_recipes/deepseek/b300/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/b300/deepseek_v4.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""B300 performance recipes for DeepSeek V4."""
+
+from megatron.bridge.models.deepseek.deepseek_v4_bridge import (
+    set_deepseek_v4_pipeline_model_parallel_layout,
+)
+from megatron.bridge.perf_recipes.deepseek.gb300.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config,
+)
+from megatron.bridge.perf_recipes.environment import COMMON_PERF_ENV_VARS
+from megatron.bridge.training.config import ConfigContainer
+
+
+def _apply_deepseek_v4_b300_overrides(cfg: ConfigContainer) -> None:
+    """Apply a B300 topology scaled down from the larger DeepSeek V3 model."""
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.virtual_pipeline_model_parallel_size = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.train.micro_batch_size = 2
+    cfg.model.moe_hybridep_num_sms_preprocessing = 32
+    cfg.model.moe_paged_stash_buffer_size_factor_cuda = 1.5
+    set_deepseek_v4_pipeline_model_parallel_layout(cfg.model)
+
+
+def deepseek_v4_flash_pretrain_128gpu_b300_fp8mx_config() -> ConfigContainer:
+    """DeepSeek V4 Flash pretrain: 128× B300, MXFP8."""
+    cfg = deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config()
+    _apply_deepseek_v4_b300_overrides(cfg)
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
+        "NCCL_IGNORE_CPU_AFFINITY": 1,
+    }
+    return cfg

--- a/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
@@ -18,6 +18,8 @@ import pytest
 import torch
 
 from megatron.bridge.perf_recipes.deepseek import (
+    deepseek_v4_flash_pretrain_128gpu_b200_fp8mx_config,
+    deepseek_v4_flash_pretrain_128gpu_b300_fp8mx_config,
     deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config,
     deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config,
 )
@@ -127,3 +129,54 @@ def test_deepseek_v4_flash_128gpu_gb300_fp8mx_config() -> None:
     assert cfg.model.moe_hybridep_num_sms is None
     assert is_full_iteration_cuda_graph(cfg.model)
     assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 32
+
+
+def test_deepseek_v4_flash_128gpu_b300_fp8mx_config() -> None:
+    cfg = deepseek_v4_flash_pretrain_128gpu_b300_fp8mx_config()
+
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 4
+    assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_layout is not None
+    assert cfg.train.global_batch_size == 2048
+    assert cfg.train.micro_batch_size == 2
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.model.moe_paged_stash_buffer_size_factor_cuda == 1.5
+    assert is_full_iteration_cuda_graph(cfg.model)
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+    assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
+    assert cfg.env_vars["USE_MNNVL"] == 0
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1
+    assert cfg.env_vars["NCCL_IGNORE_CPU_AFFINITY"] == 1
+
+
+def test_deepseek_v4_flash_128gpu_b200_fp8mx_config() -> None:
+    cfg = deepseek_v4_flash_pretrain_128gpu_b200_fp8mx_config()
+
+    assert cfg.model.tensor_model_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_size == 4
+    assert cfg.model.virtual_pipeline_model_parallel_size is None
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.pipeline_model_parallel_layout is not None
+    assert cfg.train.global_batch_size == 2048
+    assert cfg.train.micro_batch_size == 1
+    assert cfg.model.moe_flex_dispatcher_backend == "hybridep"
+    assert cfg.model.moe_hybridep_num_sms_preprocessing == 32
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope == ["attn", "moe_router", "moe_preprocess"]
+    assert cfg.model.moe_pad_experts_for_cuda_graph_inference is False
+    assert cfg.model.moe_paged_stash is False
+    assert "mlp" in cfg.model.recompute_modules
+    assert cfg.comm_overlap.delay_wgrad_compute is False
+    assert cfg.comm_overlap.overlap_moe_expert_parallel_comm is False
+    assert cfg.dist.distributed_timeout_minutes == 30
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+    assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
+    assert cfg.env_vars["USE_MNNVL"] == 0
+    assert cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 1


### PR DESCRIPTION
Add tuned 128-GPU FP8MX configurations for B200 and B300, register all Blackwell variants for config generation, and cover the new platform-specific topology, recompute, CUDA graph, and environment settings with unit tests. Package the performance utilities so config-dumping imports resolve consistently.