### PR TITLE
fix(model): handle singleton packed Qwen3-VL batches

### DIFF
--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -613,8 +613,14 @@ class Qwen3VLModel(MegatronModule):
 
         cp_rank = self.pg_collection.cp.rank()
         cp_size = self.pg_collection.cp.size()
+        # A singleton BSHD row is shape-identical to THD. The legacy Qwen step
+        # supplies a keep mask and lets this model construct MRoPE, while THD
+        # producers supply explicit 3D MRoPE positions.
         legacy_packed_bshd = (
-            packed_seq_params is not None and input_ids is not None and input_ids.dim() == 2 and input_ids.size(0) > 1
+            packed_seq_params is not None
+            and input_ids is not None
+            and input_ids.dim() == 2
+            and (input_ids.size(0) > 1 or (attention_mask is not None and position_ids is None))
         )
         packed_input_pre_sharded = _is_packed_input_pre_sharded(
             input_ids,

--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
@@ -614,7 +614,8 @@ class Qwen3VLModel(MegatronModule):
         cp_rank = self.pg_collection.cp.rank()
         cp_size = self.pg_collection.cp.size()
         legacy_packed_bshd = (
-            packed_seq_params is not None and input_ids is not None and input_ids.dim() == 2 and input_ids.size(0) > 1
+            packed_seq_params is not None and input_ids is not None and input_ids.dim() == 2 and (input_ids.size(0) > 1 or (attention_mask is not None and position_ids is None)
+    )
         )
         packed_input_pre_sharded = _is_packed_input_pre_sharded(
             input_ids,

--- a/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
+++ b/tests/unit_tests/models/qwen_vl/modelling_qwen3_vl/test_model.py
@@ -739,7 +739,20 @@ class TestQwen3VLModel:
         assert language_model.last_kwargs["visual_pos_masks"] is None
         assert language_model.last_kwargs["decoder_input"].shape == (2, 1, 4)
 
-    def test_forward_preserves_legacy_qwen_step_packed_bshd_behavior(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ("input_ids", "cu_seqlens"),
+        [
+            (torch.tensor([[11, 12, 21, 22]], dtype=torch.long), torch.tensor([0, 4], dtype=torch.int32)),
+            (torch.tensor([[11, 12], [21, 22]], dtype=torch.long), torch.tensor([0, 2, 4], dtype=torch.int32)),
+        ],
+        ids=("singleton", "multiple-samples"),
+    )
+    def test_forward_preserves_legacy_qwen_step_packed_bshd_behavior(
+        self,
+        monkeypatch,
+        input_ids,
+        cu_seqlens,
+    ):
         """Legacy Qwen step inputs are converted from BSHD to THD exactly once."""
         monkeypatch.setattr(
             "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.torch.cuda.nvtx.range_push",
@@ -748,6 +761,18 @@ class TestQwen3VLModel:
         monkeypatch.setattr(
             "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.torch.cuda.nvtx.range_pop",
             lambda *_args, **_kwargs: None,
+        )
+
+        preprocess_calls = []
+
+        def fake_preprocess_packed_seqs(value, mask, **_kwargs):
+            preprocess_calls.append(value)
+            trailing_shape = value.shape[2:]
+            return value[mask].reshape(1, -1, *trailing_shape), object()
+
+        monkeypatch.setattr(
+            "megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model.preprocess_packed_seqs",
+            fake_preprocess_packed_seqs,
         )
 
         class DummyLanguageModel:
@@ -774,19 +799,18 @@ class TestQwen3VLModel:
             vision_start_token_id=3,
             use_dist_train=False,
         )
-        input_ids = torch.tensor([[11, 12], [21, 22]], dtype=torch.long)
         labels = torch.tensor([[12, -100, 22, -100]], dtype=torch.long)
         loss_mask = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
         attention_mask = torch.ones_like(input_ids, dtype=torch.bool)
-        cu_seqlens = torch.tensor([0, 2, 4], dtype=torch.int32)
+        max_seqlen = int(cu_seqlens.diff().max().item())
         packed_seq_params = PackedSeqParams(
             qkv_format="thd",
             cu_seqlens_q=cu_seqlens,
             cu_seqlens_kv=cu_seqlens,
             cu_seqlens_q_padded=cu_seqlens,
             cu_seqlens_kv_padded=cu_seqlens,
-            max_seqlen_q=2,
-            max_seqlen_kv=2,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
         )
 
         output = Qwen3VLModel.forward(
@@ -807,6 +831,7 @@ class TestQwen3VLModel:
         assert language_model.last_kwargs["loss_mask"] is loss_mask
         assert language_model.last_kwargs["packed_seq_params"] is packed_seq_params
         assert language_model.last_kwargs["padding_mask"] is None
+        assert len(preprocess_calls) == 2
 
     def test_forward_preserves_collate_packed_layout_for_sequence_parallel(self, monkeypatch):
         """Packed SP forwards the collator's THD tensors and metadata unchanged."""


### PR DESCRIPTION
# What does this PR do ?

Fix singleton legacy packed-BSHD detection for Qwen3-VL.

A packed input with shape `[1, T]` is ambiguous: it can be either a singleton
legacy BSHD batch or an already packed THD input.

The legacy Qwen step supplies an attention mask and lets the model construct
MRoPE position IDs, while the existing THD path supplies explicit 3D MRoPE
position IDs. This change uses that distinction to convert singleton legacy
BSHD inputs to THD exactly once without repacking valid THD inputs.

# Changelog

- Handle `B=1` packed BSHD inputs when an attention mask is present and explicit
  MRoPE position IDs are absent.
- Preserve the existing packed THD path with explicit 3D MRoPE position IDs.
- Extend the regression test to cover singleton and multi-sample legacy packed
  BSHD inputs.
- Verify that legacy preprocessing is invoked for both input IDs and generated
  MRoPE position IDs.

# Testing

Passed:

- `pre-commit run --all-files`
- `python3 -m py_compile` for the modified model and test files
- `git diff --check`

The targeted pytest was not run locally because the pinned Megatron-LM
submodule was unavailable. The PR is therefore initially submitted as a draft.

# Duplicate-work check

No open PR was found for the `legacy_packed_bshd` or singleton packed-BSHD
fix at the time this change was prepared.

# Additional Information

AI assistance was used to analyze and prepare this change. The submitter has
reviewed the resulting diff.