### PR TITLE
fix(peft): reduce long-context LoRA peak memory

### DIFF
--- a/src/megatron/bridge/peft/lora_layers.py
+++ b/src/megatron/bridge/peft/lora_layers.py
@@ -80,12 +80,15 @@ class LoRALinear(AdapterWrapper):
         linear_output, bias, layernorm_output = self.base_linear_forward(x, *args, **kwargs)
         if not self._adapter_enabled:
             return linear_output if not self._base_returns_tuple else (linear_output, bias)
+        # Serialize full-width branch buffers to keep long-context peak at two outputs.
+        combined_output = linear_output.clone()
+        del linear_output
         adapter_output = self.adapter_forward(self.adapter, layernorm_output.contiguous(), *args, **kwargs)
-        adapter_output = adapter_output.reshape(linear_output.shape)
-        combined = linear_output + adapter_output
+        adapter_output = adapter_output.reshape(combined_output.shape)
+        combined_output.add_(adapter_output)
         if not self._base_returns_tuple:
-            return combined
-        return combined, bias
+            return combined_output
+        return combined_output, bias
 
 
 class LoRATopKRouter(AdapterWrapper):

--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -1289,6 +1289,7 @@ class ParallelLinearAdapter(nn.Module):
             x, _ = self.linear_in(x)
 
         x = self.activation(x)
+        x = x * (self.alpha / self.dim)
 
         if self.config.cpu_offloading and self.config.cpu_offloading_activations:
             x.activation_offloading = True
@@ -1308,8 +1309,6 @@ class ParallelLinearAdapter(nn.Module):
         # Add dropout if available
         if self.dropout_position == "post":
             x = self.dropout(x)
-
-        x = x * (self.alpha / self.dim)
 
         if pad_len > 0:
             # Remove MoE padding.

--- a/tests/unit_tests/peft/test_adapter_wrapper.py
+++ b/tests/unit_tests/peft/test_adapter_wrapper.py
@@ -20,6 +20,7 @@ modules with adapters in Parameter-Efficient Fine-Tuning scenarios.
 """
 
 import os
+import weakref
 from unittest.mock import Mock, patch
 
 import pytest
@@ -392,6 +393,77 @@ class TestAdapterWrapper:
                 raise RuntimeError("boom")
 
         assert torch.allclose(model(x), enabled_output, atol=1e-6)
+
+    def test_lora_linear_combines_outputs_without_modifying_branch_storage(self, mock_linear_simple, simple_adapter):
+        """Combining the LoRA branches must not modify either branch output."""
+        wrapper = LoRALinear(mock_linear_simple, simple_adapter)
+        base_outputs = []
+        adapter_outputs = []
+        mock_linear_simple.register_forward_hook(lambda _module, _inputs, output: base_outputs.append(output[0]))
+        simple_adapter.register_forward_hook(lambda _module, _inputs, output: adapter_outputs.append(output))
+        x = torch.randn(5, 10, requires_grad=True)
+
+        output, _ = wrapper(x)
+        output.square().sum().backward()
+
+        assert output.data_ptr() != base_outputs[0].data_ptr()
+        assert output.data_ptr() != adapter_outputs[0].data_ptr()
+        assert x.grad is not None
+        assert torch.isfinite(x.grad).all()
+        assert mock_linear_simple.weight.grad is not None
+        assert simple_adapter.weight.grad is not None
+
+    def test_lora_linear_does_not_modify_custom_autograd_views(self):
+        """Both linear branches can return views that forbid in-place updates."""
+
+        base_output_refs = []
+        base_storage_refs = []
+
+        class ViewOutput(torch.autograd.Function):
+            """Return a custom-autograd view like grouped linear."""
+
+            @staticmethod
+            def forward(ctx, tensor):
+                """Return a view of the custom function input."""
+                return tensor.view_as(tensor)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                """Propagate the view gradient."""
+                return grad_output
+
+        class ViewLinear(MockLinear):
+            """Mock grouped linear whose custom autograd function returns a view."""
+
+            def forward(self, x, *args, **kwargs):
+                """Return a Megatron-style tuple containing a custom-autograd view."""
+                output, bias = super().forward(x, *args, **kwargs)
+                output = ViewOutput.apply(output)
+                base_output_refs.append(weakref.ref(output))
+                base_storage_refs.append(weakref.ref(output.untyped_storage()))
+                return output, bias
+
+        class ViewAdapter(nn.Linear):
+            """Mock adapter whose output projection returns a custom-autograd view."""
+
+            def forward(self, x):
+                """Return a custom-autograd view of the adapter output."""
+                assert base_output_refs[-1]() is None
+                assert base_storage_refs[-1]() is None
+                return ViewOutput.apply(super().forward(x))
+
+        base = ViewLinear("simple")
+        adapter = ViewAdapter(10, 10)
+        wrapper = LoRALinear(base, adapter)
+        x = torch.randn(5, 10, requires_grad=True)
+
+        output, _ = wrapper(x)
+        output.square().sum().backward()
+
+        assert x.grad is not None
+        assert torch.isfinite(x.grad).all()
+        assert base.weight.grad is not None
+        assert adapter.weight.grad is not None
 
     def test_peft_enable_disable_adapter_layers_manual(self, mock_linear_simple, simple_adapter):
         """Test manual adapter enable/disable via PEFT helpers."""

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -660,6 +660,36 @@ class TestParallelLinearAdapter:
         expected_scale = adapter.alpha / adapter.dim
         assert expected_scale > 0
 
+    @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
+    @patch("megatron.bridge.peft.utils.RowParallelLinear")
+    def test_parallel_linear_adapter_scales_bottleneck_before_output_projection(
+        self, mock_row_linear, mock_col_linear, mock_config
+    ):
+        """LoRA scaling should not allocate an expanded output-sized temporary."""
+        mock_linear_in = Mock()
+        mock_linear_in.side_effect = lambda x: (x[..., :2], None)
+        mock_linear_out = Mock()
+        mock_linear_out.side_effect = lambda x: (torch.cat((x, x, x, x), dim=-1), None)
+        mock_col_linear.side_effect = [mock_linear_in, mock_linear_out]
+        adapter = ParallelLinearAdapter(
+            in_features=4,
+            out_features=8,
+            dim=2,
+            base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+            activation="identity",
+            alpha=1,
+            is_expert=True,
+            model_parallel_config=mock_config,
+        )
+        x = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+
+        output = adapter(x)
+
+        bottleneck = x[..., :2]
+        scale = adapter.alpha / adapter.dim
+        torch.testing.assert_close(mock_linear_out.call_args.args[0], bottleneck * scale)
+        torch.testing.assert_close(output, torch.cat((bottleneck, bottleneck, bottleneck, bottleneck), dim=-1) * scale)
+
     @patch("megatron.bridge.peft.utils.gather_from_sequence_parallel_region")
     @patch("megatron.bridge.peft.utils.ColumnParallelLinear")
     @patch("megatron.bridge.peft.utils.RowParallelLinear")


### PR DESCRIPTION
## Summary

- Reduce LoRA peak memory from three full-width outputs to two by reusing owned output storage.
- Apply LoRA scaling to the rank-sized bottleneck before the bias-free output projection.
- Restack directly on Bridge main; this PR no longer contains or depends on the GLM FP8 import change in #5851.

## Testing

```bash
uv run --active --no-sync ruff check src/megatron/bridge/peft/lora_layers.py src/megatron/bridge/peft/utils.py tests/unit_tests/peft/test_adapter_wrapper.py tests/unit_tests/peft/test_utils.py
uv run --active --no-sync python -m compileall -q src/megatron/bridge/peft/lora_layers.py src/megatron/bridge/peft/utils.py tests/unit_tests/peft/test_adapter_wrapper.py tests/unit_tests/peft/test_utils.py
```

Both pass on commit 19ef437a. The focused tests cover custom-autograd views, storage release, finite backward gradients, and pre-projection scaling. Full NVIDIA CI is rerunning after the restack.

Live evidence: TCLI XID 1049298 exercised the same LoRA memory change and completed rank-32 exact-262,144 sampling, forward/backward, optimizer, and checkpoint on three B300 nodes without OOM.