### PR TITLE
[misc] fix: Preserve empty JSONL prompts

### DIFF
--- a/src/megatron/bridge/inference/text_generation.py
+++ b/src/megatron/bridge/inference/text_generation.py
@@ -108,7 +108,8 @@ def load_prompts(
                     continue
                 if prompt_file_num_truncate is not None and file_prompts_collected >= prompt_file_num_truncate:
                     break
-                collected.append(_get_prompt_from_json_line(raw_prompt) or raw_prompt)
+                json_prompt = _get_prompt_from_json_line(raw_prompt)
+                collected.append(raw_prompt if json_prompt is None else json_prompt)
                 file_prompts_collected += 1
     if not collected:
         collected = list(default_prompts)

--- a/tests/unit_tests/scripts/test_text_generation.py
+++ b/tests/unit_tests/scripts/test_text_generation.py
@@ -364,6 +364,16 @@ def test_load_prompts_from_file_with_jsonl_and_truncate(text_generation, tmp_pat
     assert text_generation.load_prompts(None, str(prompt_file), 2, ["d"]) == ["json prompt", "raw prompt"]
 
 
+def test_load_prompts_preserves_empty_jsonl_prompt(text_generation, tmp_path):
+    prompt_file = tmp_path / "prompts.jsonl"
+    prompt_file.write_text('{"prompt": ""}\n{"metadata": "raw fallback"}\n', encoding="utf-8")
+
+    assert text_generation.load_prompts(None, str(prompt_file), None, ["default"]) == [
+        "",
+        '{"metadata": "raw fallback"}',
+    ]
+
+
 def test_load_prompts_truncates_only_file_prompts(text_generation, tmp_path):
     prompt_file = tmp_path / "prompts.txt"
     prompt_file.write_text("file-1\nfile-2\nfile-3\n", encoding="utf-8")


### PR DESCRIPTION
## What does this PR do?

Preserves an empty string selected from a documented JSONL prompt record instead of replacing it with the literal JSON source line.

## Supported trigger and impact

Both offline text-generation entrypoints accept `--prompt-file`, and the inference documentation says JSONL records may supply prompt text through `text`, `prompt`, or `input`.

For a record such as `{"prompt": ""}`, the JSON parser correctly returned the empty string. The loader then used a truthiness fallback, so the model received the raw `{"prompt": ""}` record instead. This silently changed the user prompt, token count, and generated result.

## Root cause and minimal fix

`None` already represents an unrecognized or invalid JSON prompt that should fall back to raw text. The loader conflated that sentinel with the valid falsey empty string through `parsed_prompt or raw_prompt`.

The fix uses an explicit `is None` check at that ownership boundary. It does not change raw-line fallback, prompt truncation, batching, sampling, or runtime behavior for non-empty prompts.

## Regression evidence

The focused test writes a recognized empty prompt followed by an unrecognized JSON mapping. It verifies both the corrected empty-string behavior and the unchanged raw fallback control.

Fail-before:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation.py::test_load_prompts_preserves_empty_jsonl_prompt -q

FAILED: index 0 was '{"prompt": ""}' instead of ''
1 failed
```

Pass-after:

```text
same focused command
1 passed
```

Adjacent validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts \
  tests/unit_tests/scripts/test_text_generation.py \
  tests/unit_tests/scripts/test_text_generation_entrypoint.py \
  tests/unit_tests/scripts/test_async_text_generation_entrypoint.py -q

29 passed
```

Additional checks:

- `git diff --check`: passed
- `uv run --no-sync pre-commit run --all-files`: passed

## Scope

No dependency, lockfile, workflow, public API, MCore, GPU, or distributed changes. GPU validation is not applicable because the bug and fix are fully established in prompt parsing before model construction.
