### PR TITLE
fix(tokenizer): honor HF_HUB_OFFLINE in tokenizer revision resolution

### DIFF
--- a/src/megatron/bridge/training/tokenizers/tokenizer.py
+++ b/src/megatron/bridge/training/tokenizers/tokenizer.py
@@ -101,12 +101,22 @@ def _resolve_hf_tokenizer_revision(config: TokenizerConfig) -> TokenizerConfig:
         return config
 
     from huggingface_hub import snapshot_download
+    from huggingface_hub.constants import HF_HUB_OFFLINE
 
+    # `snapshot_download` needs the repo tree listing to expand `allow_patterns` /
+    # `ignore_patterns`, and only caches that listing itself. A cache populated via
+    # per-file downloads (e.g. `transformers.AutoTokenizer.from_pretrained`, which
+    # uses `hf_hub_download`) has the snapshot files but no cached tree listing, so
+    # without `local_files_only` this call falls through to a network request for
+    # the tree and raises `OfflineModeIsEnabled` even though every requested file is
+    # already on disk. Pass `local_files_only` explicitly so offline mode is honored
+    # consistently with `hf_hub_download`.
     snapshot_path = snapshot_download(
         repo_id=tokenizer_model,
         revision=revision,
         allow_patterns=list(_HF_TOKENIZER_SNAPSHOT_ALLOW_PATTERNS),
         ignore_patterns=list(_HF_MODEL_WEIGHT_IGNORE_PATTERNS),
+        local_files_only=HF_HUB_OFFLINE,
     )
 
     resolved_config = copy(config)

--- a/tests/unit_tests/training/test_tokenizer.py
+++ b/tests/unit_tests/training/test_tokenizer.py
@@ -128,6 +128,38 @@ class TestTokenizers:
 
     @patch("megatron.bridge.training.tokenizers.tokenizer.build_mcore_tokenizer")
     @patch("huggingface_hub.snapshot_download")
+    def test_build_hf_tokenizer_revision_resolution_honors_offline_mode(
+        self, mock_snapshot_download, mock_build_mcore_tokenizer, monkeypatch
+    ):
+        """`snapshot_download` only caches the repo *tree* listing it fetches itself, so a
+        cache pre-populated via per-file downloads (e.g. `transformers.AutoTokenizer.from_pretrained`,
+        which uses `hf_hub_download`) has the requested files on disk but no cached tree listing.
+        Without `local_files_only`, `snapshot_download` then falls through to a network call for
+        that listing and raises under `HF_HUB_OFFLINE=1`, even though every requested file is
+        already cached. `_resolve_hf_tokenizer_revision` must pass `local_files_only` explicitly
+        so it honors offline mode the same way `hf_hub_download` already does.
+        See https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/5807.
+        """
+        import huggingface_hub
+
+        mock_build_mcore_tokenizer.return_value = sentinel.tokenizer
+        mock_snapshot_download.return_value = "/cache/models--resolved/snapshots/abc123"
+        config = TokenizerConfig(
+            tokenizer_type="HuggingFaceTokenizer",
+            tokenizer_model="Qwen/Qwen3-8B",
+            hf_tokenizer_kwargs={"revision": "abc123"},
+        )
+
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_OFFLINE", True)
+        build_tokenizer(config)
+        assert mock_snapshot_download.call_args.kwargs["local_files_only"] is True
+
+        monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_OFFLINE", False)
+        build_tokenizer(config)
+        assert mock_snapshot_download.call_args.kwargs["local_files_only"] is False
+
+    @patch("megatron.bridge.training.tokenizers.tokenizer.build_mcore_tokenizer")
+    @patch("huggingface_hub.snapshot_download")
     def test_build_tokenizer_skips_snapshot_resolution_without_remote_hf_revision(
         self, mock_snapshot_download, mock_build_mcore_tokenizer, tmp_path
     ):


### PR DESCRIPTION
# What does this PR do ?

Makes `_resolve_hf_tokenizer_revision` honor `HF_HUB_OFFLINE`, so a revision-pinned HF tokenizer resolves against a cache that `transformers` populated.

# Changelog

- `src/megatron/bridge/training/tokenizers/tokenizer.py`: pass `local_files_only=HF_HUB_OFFLINE` to `snapshot_download`.
- `tests/unit_tests/training/test_tokenizer.py`: add `test_build_hf_tokenizer_revision_resolution_honors_offline_mode`.

### Why

`snapshot_download` needs the repo tree listing to expand `allow_patterns` / `ignore_patterns`, and it only caches that listing when it fetches it itself. A cache populated by per-file `hf_hub_download`, which is what `transformers.AutoTokenizer.from_pretrained` uses underneath, has every requested file on disk but no cached tree listing. Without `local_files_only`, the call then falls through to a network request for that listing and raises `OfflineModeIsEnabled`, even though nothing actually needs downloading.

### Evidence

Measured against `huggingface_hub` 1.29.0 (the version `uv.lock` pins here), same repo id, same allow/ignore patterns and same pinned-SHA revision shape the function uses, cache pre-populated via per-file `hf_hub_download`, `HF_HUB_OFFLINE=1`:

| call | result |
| --- | --- |
| `snapshot_download(...)` without `local_files_only` (current) | `OfflineModeIsEnabled: Cannot reach .../tree/<sha>?recursive=true...`, exit 1 |
| `hf_hub_download(..., revision=...)` | succeeds, exit 0 |
| `snapshot_download(..., local_files_only=True)` | succeeds, exit 0 |

Running the real function before and after the change against that cache: before, it raises `OfflineModeIsEnabled`; after, it returns the snapshot path with all four tokenizer files present.

Regression checks on the fix itself: offline against a genuinely empty cache still fails cleanly with `LocalEntryNotFoundError`, and with `HF_HUB_OFFLINE` unset it still downloads from the network as before. The paths that already worked are unchanged.

### What I could not verify

**I could not run this repo's test suite, so the new test has not been through pytest's collector.** `uv sync` fails at `megatron-core @ editable+3rdparty/Megatron-LM` (the submodule is not checked out), and the pinned build dependencies (`transformer-engine` built from git, `flashinfer-cubin`, `mamba-ssm`, `causal-conv1d`) require CUDA and `nvcc`, which this machine does not have. Please treat CI as the first real run of the test.

What I did run: `ruff check` and `ruff format --check` on both touched files (pass), and the before/after harness above against real `huggingface_hub` rather than a mock of the failure.

I reproduced with `hf-internal-testing/llama-tokenizer` rather than the `Qwen3-8B` from the issue, for speed. The code path and call shape are identical, and I confirmed it with both a pinned-SHA and a branch revision.

# Additional Information

- Related to #5807
