### PR TITLE
[recipe] fix: Disable unsupported Qwen-VL EP overlap

### DIFF
--- a/src/megatron/bridge/perf_recipes/qwen_vl/common.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/common.py
@@ -79,6 +79,9 @@ def _qwen35_vl_post(cfg: ConfigContainer) -> None:
     cfg.model.cuda_graph_impl = "none"
     clear_cuda_graph_modules(cfg.model)
     cfg.optimizer.overlap_param_gather = False
+    # Combined-1F1B requires a root schedule plan that preserves visual inputs.
+    cfg.comm_overlap.overlap_moe_expert_parallel_comm = False
+    cfg.comm_overlap.delay_wgrad_compute = False
 
 
 def _qwen35_vl_post_clear_scope(cfg: ConfigContainer) -> None:

--- a/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
+++ b/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
@@ -23,6 +23,12 @@ import pytest
 import torch
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
 
+from megatron.bridge.models.qwen_vl.modelling_qwen3_vl.model import Qwen3VLModel
+from megatron.bridge.perf_recipes.qwen_vl.b200.qwen35_vl import (
+    qwen35_vl_122b_a10b_pretrain_32gpu_b200_bf16_config,
+    qwen35_vl_122b_a10b_pretrain_32gpu_b200_fp8cs_config,
+    qwen35_vl_122b_a10b_pretrain_32gpu_b200_fp8mx_config,
+)
 from megatron.bridge.perf_recipes.qwen_vl.gb200.qwen35_vl import (
     qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config,
     qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8cs_config,
@@ -75,6 +81,25 @@ def test_qwen35_vl_122b_h100_pipeline_layout(
     assert (num_layers // pp_size) % vp_size == 0
     assert pp_size == expected_pp_size
     assert vp_size == expected_vp_size
+
+
+@pytest.mark.parametrize(
+    "recipe_fn",
+    [
+        qwen35_vl_122b_a10b_pretrain_32gpu_b200_bf16_config,
+        qwen35_vl_122b_a10b_pretrain_32gpu_b200_fp8cs_config,
+        qwen35_vl_122b_a10b_pretrain_32gpu_b200_fp8mx_config,
+    ],
+)
+def test_qwen35_vl_122b_b200_ep_overlap_has_schedule_plan(
+    recipe_fn: Callable,
+) -> None:
+    """B200 VLM recipes must not select combined-1F1B without a schedule plan."""
+    config = recipe_fn()
+
+    assert config.comm_overlap.overlap_moe_expert_parallel_comm is not True or hasattr(
+        Qwen3VLModel, "build_schedule_plan"
+    ), "EP overlap selects combined-1F1B, but Qwen3VLModel has no build_schedule_plan"
 
 
 def test_qwen35_vl_35b_h100_fp8cs_pipeline_layout_builds_all_layers(


### PR DESCRIPTION
## Summary

Qwen3.5-VL 122B B200 performance recipes configure PP=4, VP=4, EP=8 and enable MoE expert-parallel overlap. That supported launch selects the combined-1F1B schedule, which requests `build_schedule_plan` from the wrapped root model before the first forward step.

`Qwen3VLModel` has no root schedule-plan method, and MCore wrapper lookup does not descend into its nested language model. The recipes therefore fail before training with a missing `build_schedule_plan` contract. The same VLM path also cannot yet preserve visual inputs through a language-model-only plan.

The fix clears EP overlap and its dependent delayed-wgrad option in the existing Qwen3.5-VL post-override hook. These recipes retain conventional interleaved 1F1B; no model, public API, launcher, or non-Qwen-VL behavior changes.

## Regression evidence

Focused contract:

`uv run python -m pytest tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py::test_qwen35_vl_122b_b200_ep_overlap_has_schedule_plan -q`

- Before: 3 failed for BF16, FP8 current-scaling, and MXFP8 because overlap was `True` and `Qwen3VLModel` lacked `build_schedule_plan`.
- After: 3 passed with the assertion unchanged.

Focused plus adjacent H100 pipeline-layout controls:

`uv run python -m pytest tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py -k "qwen35_vl_122b_h100_pipeline_layout or qwen35_vl_122b_b200_ep_overlap_has_schedule_plan" -q`

Result: 5 passed, 5 deselected.

`git diff --check` and `uv run pre-commit run --all-files` also passed.

## Scope

This change intentionally disables the unsupported overlap optimization. It does not implement a VLM schedule plan, alter visual tensor handling, or claim throughput or convergence validation.