### PR TITLE
fix(peft): support hybrid-stack activation recompute

### DIFF
--- a/src/megatron/bridge/peft/recompute.py
+++ b/src/megatron/bridge/peft/recompute.py
@@ -41,7 +41,7 @@ def _iter_unwrapped_models(model) -> Iterable[torch.nn.Module]:
 
 
 def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] | None = None) -> Set[int]:
-    """Enable grad on TransformerBlock inputs when only adapters are trainable.
+    """Enable grad on recompute-block inputs when only adapters are trainable.
 
     Root cause analysis:
 
@@ -53,15 +53,19 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
       This means CheckpointFunction.backward() is never called, and LoRA gradients
       inside the checkpoint are never computed.
 
-    Solution: Hook TransformerBlock.forward to ensure hidden_states.requires_grad=True
-    before it enters checkpointed computation. This doesn't unfreeze any parameters;
-    it just ensures the autograd machinery calls checkpoint's backward.
+    Solution: Hook TransformerBlock.forward and HybridStack.forward to ensure
+    hidden_states.requires_grad=True before it enters checkpointed computation.
+    This doesn't unfreeze any parameters; it just ensures the autograd machinery
+    calls checkpoint's backward.
 
     Borrowed (with modifications) from
     https://github.com/HollowMan6/verl/blob/4285f0601028aee7ddcb9ec5a15198ebfc69bba3/verl/utils/megatron_peft_utils.py
     """
 
+    from megatron.core.models.hybrid.hybrid_block import HybridStack
     from megatron.core.transformer.transformer_block import TransformerBlock
+
+    recompute_block_types = (TransformerBlock, HybridStack)
 
     patched_registry = peft_recompute_patched or PEFT_RECOMPUTE_PATCHED
 
@@ -83,8 +87,8 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
             if not (trainable_adapter and not trainable_base):
                 continue  # Not adapter-only training, no fix needed
 
-            def _patch_transformer_block(module: torch.nn.Module) -> bool:
-                if isinstance(module, TransformerBlock):
+            def _patch_recompute_block(module: torch.nn.Module) -> bool:
+                if isinstance(module, recompute_block_types):
                     original_forward = module.forward
 
                     @wraps(original_forward)
@@ -104,18 +108,18 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
 
             patched = False
             for module in unwrapped_model.modules():
-                if _patch_transformer_block(module):
+                if _patch_recompute_block(module):
                     patched = True
             if patched:
                 patched_registry.add(id(unwrapped_model))
                 print_rank_0(
-                    "[PEFT+Recompute] Patched TransformerBlock.forward to enable grad on "
+                    "[PEFT+Recompute] Patched recompute-block forward to enable grad on "
                     "hidden_states input. This ensures checkpoint backward is called when "
                     "only adapters are trainable (PP=1 with frozen base model).",
                 )
     except Exception as exc:  # pragma: no cover - best effort logging
         # Log but don't fail - user will see grad_norm=0 and can debug
-        print_rank_0(f"[PEFT+Recompute] Warning: Failed to patch TransformerBlock: {exc}")
+        print_rank_0(f"[PEFT+Recompute] Warning: Failed to patch recompute block: {exc}")
 
     return patched_registry
 

--- a/tests/unit_tests/peft/test_recompute.py
+++ b/tests/unit_tests/peft/test_recompute.py
@@ -16,6 +16,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from megatron.bridge.peft import recompute as recompute_mod
@@ -28,7 +29,7 @@ class DummyAdapter(torch.nn.Module):
         self.weight = torch.nn.Parameter(torch.ones(1))
 
 
-class DummyTransformerBlock(torch.nn.Module):
+class DummyRecomputeBlock(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.last_input_requires_grad = None
@@ -38,11 +39,19 @@ class DummyTransformerBlock(torch.nn.Module):
         return hidden_states
 
 
+class DummyTransformerBlock(DummyRecomputeBlock):
+    pass
+
+
+class DummyHybridStack(DummyRecomputeBlock):
+    pass
+
+
 class DummyModel(torch.nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, block_cls=DummyTransformerBlock) -> None:
         super().__init__()
         self.config = SimpleNamespace(recompute_method="uniform")
-        self.block = DummyTransformerBlock()
+        self.block = block_cls()
 
         # Frozen base parameter (not trainable)
         self.base = torch.nn.Linear(1, 1, bias=False)
@@ -59,9 +68,11 @@ class DummyModel(torch.nn.Module):
             yield module
 
 
-def _patch_transformer_block(monkeypatch):
+def _patch_recompute_blocks(monkeypatch):
+    import megatron.core.models.hybrid.hybrid_block as hybrid_block
     import megatron.core.transformer.transformer_block as transformer_block
 
+    monkeypatch.setattr(hybrid_block, "HybridStack", DummyHybridStack, raising=False)
     monkeypatch.setattr(
         transformer_block,
         "TransformerBlock",
@@ -70,11 +81,12 @@ def _patch_transformer_block(monkeypatch):
     )
 
 
-def test_maybe_enable_recompute_inputs_grad_patches_block(monkeypatch):
-    _patch_transformer_block(monkeypatch)
+@pytest.mark.parametrize("block_cls", [DummyTransformerBlock, DummyHybridStack])
+def test_maybe_enable_recompute_inputs_grad_patches_block(monkeypatch, block_cls):
+    _patch_recompute_blocks(monkeypatch)
     recompute_mod.PEFT_RECOMPUTE_PATCHED.clear()
 
-    model = DummyModel()
+    model = DummyModel(block_cls)
     patched_registry = maybe_enable_recompute_inputs_grad(model, set())
 
     assert id(model) in patched_registry


### PR DESCRIPTION
Mirrors #5586 onto a Chen-owned branch so trusted CI can run.

## Summary

- Preserve Charles Tang's HybridStack PEFT activation-recompute fix.
- Mark frozen-model HybridStack inputs differentiable before full activation recompute.
- Preserve the existing TransformerBlock behavior.
- Strengthen the parameterized unit test so the TransformerBlock and HybridStack doubles are independent sibling types.

## Validation

- `uv run --no-sync pre-commit run --all-files` passed.
- `git diff --check` passed.
- The source PR records passing focused tests and live Nemotron 3.5 Lightning validation.
- Local focused pytest could not run in this clean worktree because the workstation environment did not contain pytest; trusted CI is requested here.
- Independent final diff review found no actionable findings.

Original implementation and runtime evidence: #5586.