### PR TITLE
[training] fix: persist checkpoints on planned exit

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -1474,7 +1474,7 @@ def checkpoint_and_decide_exit(
             callback_manager=callback_manager,
             module_name=module_name,
         )
-        saved_checkpoint = True
+        saved_checkpoint = state.cfg.checkpoint.non_persistent_ckpt_type == "global"
 
     # Exit based on duration.
     if state.cfg.train.exit_duration_in_mins:

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -1238,6 +1238,31 @@ class TestCheckpointAndDecideExit:
     @patch("megatron.bridge.training.train.save_checkpoint_and_time")
     @patch("megatron.bridge.training.train.barrier_and_log")
     @patch("megatron.bridge.training.train.check_nvrx_straggler_detection")
+    def test_local_checkpoint_does_not_suppress_persistent_exit_checkpoint(
+        self, mock_check_nvrx, mock_barrier_log, mock_save_checkpoint
+    ):
+        """A planned exit must persist state even when a local save is also due."""
+        mock_check_nvrx.return_value = False
+
+        state = self._create_mock_state(
+            checkpoint_save=True,
+            checkpoint_save_interval=100,
+            exit_interval=10,
+            step=10,
+        )
+        state.cfg.checkpoint.non_persistent_save_interval = 10
+        state.cfg.checkpoint.non_persistent_ckpt_type = "local"
+
+        result = checkpoint_and_decide_exit(state, **self._create_mock_args())
+
+        assert result is True
+        assert mock_save_checkpoint.call_count == 2
+        assert mock_save_checkpoint.call_args_list[0].kwargs["non_persistent_ckpt"] is True
+        assert mock_save_checkpoint.call_args_list[1].kwargs.get("non_persistent_ckpt", False) is False
+
+    @patch("megatron.bridge.training.train.save_checkpoint_and_time")
+    @patch("megatron.bridge.training.train.barrier_and_log")
+    @patch("megatron.bridge.training.train.check_nvrx_straggler_detection")
     def test_no_checkpoint_when_disabled(self, mock_check_nvrx, mock_barrier_log, mock_save_checkpoint):
         """Test that no checkpoint is saved when checkpointing is disabled."""
         mock_check_nvrx.return_value = False


### PR DESCRIPTION
## What does this PR do?

When a local non-persistent checkpoint interval coincides with a planned duration, iteration, or NVRx exit, Bridge currently treats the local save as satisfying the exit checkpoint requirement. The process then exits without persisting that completed step to shared/global storage.

This is reachable with supported configurations that combine frequent local checkpoints with lower-cadence global checkpoints, for example a local interval of 10, global interval of 100, and `train.exit_interval=10`. After allocation teardown or loss of local storage, resume falls back to the older global checkpoint.

## Root cause and fix

`checkpoint_and_decide_exit()` uses one `saved_checkpoint` guard for both global and local non-persistent saves. A local save sets the guard, so the later planned-exit branch skips its normal persistent save; the training loop also skips its normal-completion final-save fallback on an exit.

The fix retains the existing single-save behavior for global non-persistent checkpoints, but leaves the guard unset for local checkpoints so the existing persistent exit save runs. No API, format, lifecycle, or dependency changes are introduced.

## Validation

Fail-before on `fc96d33606002a910a400829c78a3b96335be8d7` with the added regression test only:

```text
uv run --no-project python -m pytest tests/unit_tests/training/test_train.py::TestCheckpointAndDecideExit::test_local_checkpoint_does_not_suppress_persistent_exit_checkpoint -q
1 failed: expected 2 save calls, observed 1
```

Pass-after with this change:

```text
uv run --no-project python -m pytest tests/unit_tests/training/test_train.py::TestCheckpointAndDecideExit::test_local_checkpoint_does_not_suppress_persistent_exit_checkpoint -q
1 passed

uv run --no-project python -m pytest tests/unit_tests/training/test_train.py::TestCheckpointAndDecideExit -q
19 passed

uv run --no-sync pre-commit run --all-files
Passed

git diff --check
Passed
```

## Scope

- Covers local non-persistent checkpoints coinciding with duration, iteration, or NVRx planned exits.
- Signal exits are unchanged because they save before interval checkpointing.
- Global non-persistent checkpoint behavior remains unchanged.
- This is a call-level checkpoint decision fix; no GPU, distributed I/O, convergence, or performance validation is claimed.
