### PR TITLE
[data] fix: preserve sparse MIMO modality DP ownership

### DIFF
--- a/src/megatron/bridge/data/megatron_mimo/collate.py
+++ b/src/megatron/bridge/data/megatron_mimo/collate.py
@@ -9,6 +9,9 @@ from typing import Any, Dict, List
 import torch
 
 
+_MIMO_SAMPLE_INDICES_KEY = "_mimo_sample_indices"
+
+
 def megatron_mimo_collate_fn(
     batch: List[Dict[str, Any]],
     modality_names: List[str],
@@ -65,6 +68,7 @@ def megatron_mimo_collate_fn(
 
     # Collate modality inputs
     modality_inputs: Dict[str, Dict[str, Any]] = {}
+    modality_sample_indices: Dict[str, torch.Tensor] = {}
 
     for modality_name in modality_names:
         # Collect all tensors for this modality across the batch
@@ -81,6 +85,9 @@ def megatron_mimo_collate_fn(
             continue
 
         modality_inputs[modality_name] = {}
+        present_sample_indices = [sample_idx for sample_idx, item in enumerate(modality_batch_items) if item]
+        if len(present_sample_indices) != len(batch):
+            modality_sample_indices[modality_name] = torch.tensor(present_sample_indices, dtype=torch.long)
 
         for key in first_non_empty.keys():
             values = []
@@ -110,7 +117,7 @@ def megatron_mimo_collate_fn(
                 # Keep non-tensor values as list
                 modality_inputs[modality_name][key] = values
 
-    return {
+    collated = {
         "input_ids": input_ids,
         "labels": labels,
         "loss_mask": loss_mask,
@@ -118,3 +125,6 @@ def megatron_mimo_collate_fn(
         "position_ids": position_ids,
         "modality_inputs": modality_inputs,
     }
+    if modality_sample_indices:
+        collated[_MIMO_SAMPLE_INDICES_KEY] = modality_sample_indices
+    return collated

--- a/src/megatron/bridge/data/megatron_mimo/dp_utils.py
+++ b/src/megatron/bridge/data/megatron_mimo/dp_utils.py
@@ -10,6 +10,8 @@ import torch
 import torch.distributed as dist
 from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 
+from megatron.bridge.data.megatron_mimo.collate import _MIMO_SAMPLE_INDICES_KEY
+
 
 if TYPE_CHECKING:
     from megatron.core.hyper_comm_grid import HyperCommGrid
@@ -71,7 +73,6 @@ def _slice_patch_packed_visual_dict(value: Dict[str, Any], dp_rank: int, dp_size
     slices remain sample-aligned instead of only image-aligned.
     """
     g = value["grid_thw"]  # [num_images, 3]
-    hs = value["hidden_states"]  # [sum(patches), feat]
     n_images = int(g.size(0))
     if n_images % dp_size != 0:
         raise ValueError(
@@ -82,6 +83,19 @@ def _slice_patch_packed_visual_dict(value: Dict[str, Any], dp_rank: int, dp_size
     imgs_per_shard = n_images // dp_size
     img_lo = dp_rank * imgs_per_shard
     img_hi = img_lo + imgs_per_shard
+
+    return _slice_patch_packed_visual_dict_by_image_range(value, img_lo, img_hi)
+
+
+def _slice_patch_packed_visual_dict_by_image_range(
+    value: Dict[str, Any],
+    img_lo: int,
+    img_hi: int,
+) -> Dict[str, Any]:
+    """Slice patch-packed inputs over a contiguous range of image rows."""
+    g = value["grid_thw"]
+    hs = value["hidden_states"]
+    n_images = int(g.size(0))
 
     patches_per_image = g.prod(dim=-1).to(torch.long)  # [num_images]
     total_patches = int(patches_per_image.sum().item())
@@ -107,6 +121,47 @@ def _slice_patch_packed_visual_dict(value: Dict[str, Any], dp_rank: int, dp_size
             # outer slicer's "non-divisible list" branch.
             out[key] = sub_value
     return out
+
+
+def _slice_sparse_modality_value(
+    value: Any,
+    selected: torch.Tensor,
+    *,
+    modality_name: str,
+) -> Any:
+    """Select compacted modality rows owned by one sample DP shard."""
+    num_present_samples = int(selected.numel())
+    if _is_patch_packed_visual_dict(value):
+        num_images = int(value["grid_thw"].size(0))
+        if num_images != num_present_samples:
+            raise ValueError(
+                f"Sparse modality '{modality_name}' has {num_present_samples} present samples "
+                f"but {num_images} patch-packed images. Per-sample image counts are required "
+                "to preserve DP ownership for multi-image sparse batches."
+            )
+        selected_images = selected.nonzero(as_tuple=True)[0]
+        if selected_images.numel() == 0:
+            return _slice_patch_packed_visual_dict_by_image_range(value, 0, 0)
+        img_lo = int(selected_images[0].item())
+        img_hi = int(selected_images[-1].item()) + 1
+        if selected_images.numel() != img_hi - img_lo:
+            raise ValueError(f"Sparse modality '{modality_name}' must have contiguous sample ownership per DP shard.")
+        return _slice_patch_packed_visual_dict_by_image_range(value, img_lo, img_hi)
+    if isinstance(value, torch.Tensor):
+        if value.dim() == 0 or value.size(0) != num_present_samples:
+            raise ValueError(
+                f"Sparse modality '{modality_name}' tensor has leading size "
+                f"{value.size(0) if value.dim() > 0 else 'scalar'}, expected {num_present_samples}."
+            )
+        return value[selected]
+    if isinstance(value, dict):
+        return {
+            key: _slice_sparse_modality_value(sub_value, selected, modality_name=modality_name)
+            for key, sub_value in value.items()
+        }
+    if isinstance(value, list) and len(value) == num_present_samples:
+        return [item for item, keep in zip(value, selected.tolist()) if keep]
+    return value
 
 
 def _find_rank_module(
@@ -234,11 +289,35 @@ def slice_batch_for_megatron_mimo(
         >>> local_batch = slice_batch_for_megatron_mimo(global_batch, dp_rank=1, dp_size=3)
         >>> local_batch['tokens'].shape  # torch.Size([4, 2048])
     """
-    if dp_size == 1:
+    modality_sample_indices = batch.get(_MIMO_SAMPLE_INDICES_KEY)
+    if dp_size == 1 and modality_sample_indices is None:
         return batch
 
-    sliced = {}
+    global_batch_size: int | None = None
+    for key in ("input_ids", "labels", "loss_mask"):
+        value = batch.get(key)
+        if isinstance(value, torch.Tensor):
+            global_batch_size = value.size(_batch_dim_for_tensor(key, value))
+            break
+    if modality_sample_indices is not None and global_batch_size is None:
+        raise ValueError("Sparse MegatronMIMO modality inputs require a sample-batched tensor.")
+
+    sample_start = 0
+    sample_end = global_batch_size if global_batch_size is not None else 0
+    if global_batch_size is not None and dp_size > 1:
+        if global_batch_size % dp_size != 0:
+            raise ValueError(
+                f"Batch size {global_batch_size} is not divisible by DP size {dp_size}. "
+                "Ensure micro_batch_size is divisible by every module's data_parallel_size."
+            )
+        local_batch_size = global_batch_size // dp_size
+        sample_start = dp_rank * local_batch_size
+        sample_end = sample_start + local_batch_size
+
+    sliced: Dict[str, Any] = {}
     for key, value in batch.items():
+        if key == _MIMO_SAMPLE_INDICES_KEY:
+            continue
         if isinstance(value, torch.Tensor):
             batch_dim = _batch_dim_for_tensor(key, value)
             batch_size = value.size(batch_dim)
@@ -255,10 +334,36 @@ def slice_batch_for_megatron_mimo(
             index[batch_dim] = builtins.slice(start_idx, end_idx)
             sliced[key] = value[tuple(index)]
         elif isinstance(value, dict):
+            if key == "modality_inputs" and isinstance(modality_sample_indices, dict):
+                local_modalities = {}
+                for modality_name, modality_value in value.items():
+                    sample_indices = modality_sample_indices.get(modality_name)
+                    if not isinstance(sample_indices, torch.Tensor):
+                        if _is_patch_packed_visual_dict(modality_value):
+                            local_modalities[modality_name] = _slice_patch_packed_visual_dict(
+                                modality_value,
+                                dp_rank,
+                                dp_size,
+                            )
+                        else:
+                            local_modalities[modality_name] = slice_batch_for_megatron_mimo(
+                                modality_value,
+                                dp_rank,
+                                dp_size,
+                            )
+                        continue
+                    selected = (sample_indices >= sample_start) & (sample_indices < sample_end)
+                    if selected.any():
+                        local_modalities[modality_name] = _slice_sparse_modality_value(
+                            modality_value,
+                            selected,
+                            modality_name=modality_name,
+                        )
+                sliced[key] = local_modalities
             # Patch-packed visual encoder inputs use dim 0 for different units
             # across fields (patches for hidden_states, images for grid_thw), so
             # they need joint slicing instead of normal recursive tensor slicing.
-            if _is_patch_packed_visual_dict(value):
+            elif _is_patch_packed_visual_dict(value):
                 sliced[key] = _slice_patch_packed_visual_dict(value, dp_rank, dp_size)
             else:
                 # Recurse into nested dicts (e.g. modality_inputs)

--- a/tests/unit_tests/data/megatron_mimo/test_dp_utils.py
+++ b/tests/unit_tests/data/megatron_mimo/test_dp_utils.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
+from megatron.bridge.data.megatron_mimo.collate import megatron_mimo_collate_fn
 from megatron.bridge.data.megatron_mimo.dp_utils import (
     get_megatron_mimo_dp_info,
     get_megatron_mimo_sampling_info,
@@ -230,6 +231,94 @@ class TestSliceBatchForMegatronMIMO:
         assert sliced["tokens"].shape[0] == 2
         assert sliced["modality_inputs"]["vision"]["pixel_values"].shape[0] == 2
 
+    def test_sparse_modality_rows_follow_their_sample_dp_shard(self):
+        """Compacted modality rows must retain their owning language sample."""
+
+        def make_sample(owner: int, *, has_vision: bool) -> dict:
+            modality_inputs = {}
+            if has_vision:
+                modality_inputs["vision"] = {"pixel_values": torch.tensor([owner])}
+            return {
+                "input_ids": torch.tensor([owner, owner]),
+                "labels": torch.tensor([owner, owner]),
+                "loss_mask": torch.ones(2),
+                "attention_mask": torch.ones(2),
+                "position_ids": torch.arange(2),
+                "modality_inputs": modality_inputs,
+            }
+
+        batch = megatron_mimo_collate_fn(
+            [
+                make_sample(0, has_vision=False),
+                make_sample(1, has_vision=False),
+                make_sample(2, has_vision=True),
+                make_sample(3, has_vision=True),
+            ],
+            modality_names=["vision"],
+        )
+
+        shard_0 = slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+        shard_1 = slice_batch_for_megatron_mimo(batch, dp_rank=1, dp_size=2)
+
+        assert shard_0["input_ids"][:, 0].tolist() == [0, 1]
+        assert "vision" not in shard_0["modality_inputs"]
+        assert shard_1["input_ids"][:, 0].tolist() == [2, 3]
+        assert shard_1["modality_inputs"]["vision"]["pixel_values"].flatten().tolist() == [2, 3]
+
+    def test_sparse_metadata_keeps_dense_patch_packed_slicing(self):
+        grids = torch.tensor([(1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5)])
+        patches_per_image = grids.prod(dim=-1)
+        hidden_states = torch.cat(
+            [torch.full((int(num_patches), 1), image_idx) for image_idx, num_patches in enumerate(patches_per_image)]
+        )
+        batch = {
+            "input_ids": torch.arange(8).reshape(4, 2),
+            "labels": torch.arange(8).reshape(4, 2),
+            "loss_mask": torch.ones(4, 2),
+            "modality_inputs": {
+                "images": {"hidden_states": hidden_states, "grid_thw": grids},
+                "audio": {"x": torch.tensor([[1], [3]])},
+            },
+            "_mimo_sample_indices": {"audio": torch.tensor([1, 3])},
+        }
+
+        shard_1 = slice_batch_for_megatron_mimo(batch, dp_rank=1, dp_size=2)
+
+        images = shard_1["modality_inputs"]["images"]
+        assert images["hidden_states"].shape == (41, 1)
+        assert set(images["hidden_states"].unique().tolist()) == {2, 3}
+        torch.testing.assert_close(images["grid_thw"], grids[2:])
+        torch.testing.assert_close(shard_1["modality_inputs"]["audio"]["x"], torch.tensor([[3]]))
+
+    def test_sparse_ownership_after_encoder_adapter_nesting(self):
+        batch = {
+            "input_ids": torch.arange(8).reshape(4, 2),
+            "labels": torch.arange(8).reshape(4, 2),
+            "loss_mask": torch.ones(4, 2),
+            "modality_inputs": {"vision": {"clip": {"x": torch.tensor([[1], [3]])}}},
+            "_mimo_sample_indices": {"vision": torch.tensor([1, 3])},
+        }
+
+        shard_0 = slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+        shard_1 = slice_batch_for_megatron_mimo(batch, dp_rank=1, dp_size=2)
+
+        torch.testing.assert_close(shard_0["modality_inputs"]["vision"]["clip"]["x"], torch.tensor([[1]]))
+        torch.testing.assert_close(shard_1["modality_inputs"]["vision"]["clip"]["x"], torch.tensor([[3]]))
+
+    def test_dp_size_one_removes_sparse_ownership_metadata(self):
+        batch = {
+            "input_ids": torch.arange(4).reshape(2, 2),
+            "labels": torch.arange(4).reshape(2, 2),
+            "loss_mask": torch.ones(2, 2),
+            "modality_inputs": {"vision": {"pixel_values": torch.tensor([[1]])}},
+            "_mimo_sample_indices": {"vision": torch.tensor([1])},
+        }
+
+        sliced = slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=1)
+
+        assert "_mimo_sample_indices" not in sliced
+        torch.testing.assert_close(sliced["modality_inputs"]["vision"]["pixel_values"], torch.tensor([[1]]))
+
     def test_preserves_non_tensor_values(self):
         batch = {
             "tokens": torch.randn(4, 10),
@@ -345,6 +434,27 @@ class TestPatchPackedVisualSlice:
         # And each rank's patch rows correspond to its assigned images.
         assert set(e0["hidden_states"].unique().tolist()) == {0.0, 1.0}
         assert set(e1["hidden_states"].unique().tolist()) == {2.0, 3.0}
+
+    def test_sparse_patch_packed_inputs_follow_sample_ownership(self):
+        batch = self._make_batch([(1, 2, 2), (1, 3, 3)])
+        batch.update(
+            {
+                "input_ids": torch.arange(8).reshape(4, 2),
+                "labels": torch.arange(8).reshape(4, 2),
+                "loss_mask": torch.ones(4, 2),
+                "_mimo_sample_indices": {"images": torch.tensor([1, 3])},
+            }
+        )
+
+        shard_0 = slice_batch_for_megatron_mimo(batch, dp_rank=0, dp_size=2)
+        shard_1 = slice_batch_for_megatron_mimo(batch, dp_rank=1, dp_size=2)
+
+        encoder_0 = shard_0["modality_inputs"]["images"]["vision_encoder"]
+        encoder_1 = shard_1["modality_inputs"]["images"]["vision_encoder"]
+        torch.testing.assert_close(encoder_0["grid_thw"], torch.tensor([[1, 2, 2]]))
+        torch.testing.assert_close(encoder_1["grid_thw"], torch.tensor([[1, 3, 3]]))
+        assert encoder_0["hidden_states"].unique().tolist() == [0.0]
+        assert encoder_1["hidden_states"].unique().tolist() == [1.0]
 
     def test_dp4_with_variable_grids(self):
         """4-way joint slice across 4 variable-size images."""


### PR DESCRIPTION
## Problem

MegatronMIMO supports batches where a modality is absent from some samples. The collator compacts modality inputs by dropping absent rows, but the default full-batch module-local DP slicer partitions the compacted tensor independently from the full sample batch.

With a microbatch of four samples, module DP 2, and vision presence `[false, false, true, true]`, shard 0 owns text-only samples 0–1 but receives the compacted vision row owned by sample 2. This can produce a modality-token/embedding-count failure or cross-sample encoder ownership in supported heterogeneous MIMO training.

The same root cause was proposed previously in #4949, #4986, and #5905; those attempts are closed and unmerged. Current `main` at `5fbb10dfdc94a1f12e2d94506a0409548d9ecd9b` was revalidated independently before this submission.

## Fix

The collator records private per-modality sample indices only for sparse modalities. Module-local DP slicing uses those indices to select modality rows that belong to its contiguous language-sample shard, then removes the private metadata before model forward.

Dense batches retain the existing fast path. Patch-packed visual inputs continue to be sliced jointly on whole-image/patch boundaries; unsupported sparse multi-image layouts fail explicitly instead of silently crossing sample ownership.

## Validation

An unchanged deterministic CPU reproducer using the real collator and slicer was run against the exact base and patch:

```text
uv run --no-sync python <reproducer> --repo <clean-base>
exit 1: text-only shard received vision inputs owned by another sample: [2]

uv run --no-sync python <reproducer> --repo <patched-tree>
exit 0, including the dense all-present control
```

The workstation CPU environment required a focused import shim because the global test conftest imports GPU-only packages. The production collator, slicer, Torch tensors, and checked-in tests were real.

```text
PYTHONPATH=<focused-import-shim> VBH_BRIDGE_SOURCE="$PWD/src/megatron/bridge" \
UV_PROJECT_ENVIRONMENT=<project-env> uv run --no-sync python -m pytest \
  --confcutdir=tests/unit_tests/data/megatron_mimo \
  tests/unit_tests/data/megatron_mimo/test_dp_utils.py::TestSliceBatchForMegatronMIMO::test_sparse_modality_rows_follow_their_sample_dp_shard -q --tb=short
# 1 passed

PYTHONPATH=<focused-import-shim> VBH_BRIDGE_SOURCE="$PWD/src/megatron/bridge" \
UV_PROJECT_ENVIRONMENT=<project-env> uv run --no-sync python -m pytest \
  --confcutdir=tests/unit_tests/data/megatron_mimo \
  tests/unit_tests/data/megatron_mimo/test_collate.py \
  tests/unit_tests/data/megatron_mimo/test_dp_utils.py -q --tb=short
# 34 passed

PRE_COMMIT_HOME=<cache> uv run --no-project --with pre-commit==3.7.1 pre-commit run --all-files
# all hooks passed

git diff --check
# passed
```

## Scope

This change is limited to generic MegatronMIMO collation and default module-local DP slicing. It does not change public APIs, dependencies, configuration defaults, scalable-DP behavior, or model conversion. No full-suite, GPU end-to-end, convergence, quality, or performance claim is made.
