### PR TITLE
[misc] fix: Honor async generation sequence limit

### DIFF
--- a/scripts/inference/async_text_generation.py
+++ b/scripts/inference/async_text_generation.py
@@ -51,6 +51,7 @@ from megatron.bridge.inference.text_generation import (
     load_bridge_model,
     load_prompts,
     resolve_hf_model_path,
+    validate_sequence_length,
 )
 from megatron.bridge.utils.activation_map import str_to_dtype
 from megatron.bridge.utils.common_utils import maybe_initialize_distributed, print_rank_0
@@ -91,11 +92,14 @@ async def _generate(
     sampling_params: SamplingParams,
 ) -> None:
     longest_prompt = max(len(tokenizer.tokenize(prompt)) for prompt in prompts)
-    # Async path grows the configured window to fit the longest request rather than raising.
-    max_sequence_length = max(args.max_seq_length, longest_prompt + args.max_new_tokens)
+    validate_sequence_length(
+        longest_prompt_tokens=longest_prompt,
+        num_new_tokens=args.max_new_tokens,
+        max_seq_length=args.max_seq_length,
+    )
     inference_config = build_inference_config(
         model=model,
-        max_sequence_length=max_sequence_length,
+        max_sequence_length=args.max_seq_length,
         max_batch_size=args.max_batch_size,
         num_prompts=len(prompts),
         tp=args.tp,

--- a/tests/unit_tests/scripts/test_async_text_generation_entrypoint.py
+++ b/tests/unit_tests/scripts/test_async_text_generation_entrypoint.py
@@ -41,6 +41,14 @@ def _add_no_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     return parser
 
 
+def _validate_sequence_length(*, longest_prompt_tokens: int, num_new_tokens: int, max_seq_length: int) -> None:
+    required = longest_prompt_tokens + num_new_tokens
+    if required > max_seq_length:
+        raise ValueError(
+            f"Longest prompt plus generation needs {required} tokens, but --max_seq_length is {max_seq_length}."
+        )
+
+
 class _AsyncLLM:
     is_primary_rank = True
 
@@ -80,6 +88,7 @@ def async_text_generation_entrypoint(monkeypatch: pytest.MonkeyPatch):
         "load_bridge_model": lambda **kwargs: kwargs,
         "load_prompts": lambda *args: list(args),
         "resolve_hf_model_path": lambda *args: args[0],
+        "validate_sequence_length": _validate_sequence_length,
     }
     stubs = {
         "megatron.core.inference.apis": _module(
@@ -113,6 +122,37 @@ def async_text_generation_entrypoint(monkeypatch: pytest.MonkeyPatch):
         yield module
     finally:
         sys.modules.pop(spec.name, None)
+
+
+@pytest.mark.unit
+def test_generate_rejects_request_exceeding_max_sequence_length(
+    async_text_generation_entrypoint: types.ModuleType,
+) -> None:
+    args = types.SimpleNamespace(
+        max_seq_length=4,
+        max_new_tokens=3,
+        max_batch_size=None,
+        tp=1,
+        block_size_tokens=8,
+        kv_cache_buffer_size_gb=1.0,
+        max_tokens=None,
+        return_log_probs=False,
+        enable_chunked_prefill=False,
+        coordinator_host=None,
+        coordinator_port=None,
+    )
+    tokenizer = types.SimpleNamespace(tokenize=lambda prompt: [1, 2, 3])
+
+    with pytest.raises(ValueError, match=r"needs 6 tokens.*--max_seq_length is 4"):
+        asyncio.run(
+            async_text_generation_entrypoint._generate(
+                args,
+                model=object(),
+                tokenizer=tokenizer,
+                prompts=["prompt"],
+                sampling_params=object(),
+            )
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The documented concurrent async generation entrypoint accepted a prompt whose token count plus `--max_new_tokens` exceeded `--max_seq_length`. The shared CLI defines that value as the prompt-plus-generation limit, and the synchronous entrypoint rejects the same request.

For a supported RoPE model, the async path silently enlarged the engine window to the request size, so generation could proceed beyond the user-selected limit and consume KV capacity above that configured per-request boundary.

## Root cause

`async_text_generation._generate()` replaced the configured limit with `max(max_seq_length, prompt_tokens + max_new_tokens)` before constructing MCore's `InferenceConfig`. MCore therefore admitted the request against the already-enlarged window and could not enforce the original Bridge CLI value.

## Fix

Reuse the existing shared `validate_sequence_length()` contract before constructing the async engine, then pass the unchanged configured limit into `build_inference_config()`. This keeps async behavior aligned with both synchronous generation paths without changing MCore or public APIs.

## Regression evidence

Before the production fix, the focused regression failed for the claimed reason:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_async_text_generation_entrypoint.py::test_generate_rejects_request_exceeding_max_sequence_length -q --tb=short
1 failed: DID NOT RAISE <class 'ValueError'>
```

With the unchanged regression after the fix:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_async_text_generation_entrypoint.py::test_generate_rejects_request_exceeding_max_sequence_length -q --tb=short
1 passed
```

Focused adjacent async/shared/synchronous checks:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/test_async_text_generation_entrypoint.py tests/unit_tests/scripts/test_text_generation.py::test_validate_sequence_length tests/unit_tests/scripts/test_text_generation_entrypoint.py -q --tb=short
9 passed
```

Additional checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This is limited to enforcing the existing async text-generation CLI sequence limit. It does not change public signatures, MCore, model support, dependencies, CI configuration, or server request semantics. No GPU or convergence validation was required for this argument-to-config contract.
