### PR TITLE
fix(training): validate Gloo for memory-efficient checkpoints

### DIFF
--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -645,11 +645,6 @@ class CheckpointConfig(MTrainCheckpointConfig):
                     f"Please set checkpoint.load to the base checkpoint directory."
                 )
 
-        if self.dist_ckpt_optim_fully_reshardable:
-            assert not self.distrib_optim_fully_reshardable_mem_efficient, (
-                "distrib_optim_fully_reshardable_mem_efficient requires use_gloo_process_groups"
-            )
-
 
 @dataclass(kw_only=True)
 class LoggerConfig(MTrainLoggerConfig):
@@ -1597,6 +1592,14 @@ class ConfigContainer(Container):
                 assert self.checkpoint.ckpt_format in ["torch_dist", "fsdp_dtensor"], (
                     "Legacy checkpointing requires ckpt_format='torch_dist' or 'fsdp_dtensor'"
                 )
+
+        # Memory-efficient fully reshardable optimizer checkpointing uses Gloo
+        # for the DP state exchange. Validate this cross-config requirement here
+        # because CheckpointConfig.finalize() cannot inspect DistributedInitConfig.
+        if self.checkpoint.dist_ckpt_optim_fully_reshardable:
+            assert (
+                not self.checkpoint.distrib_optim_fully_reshardable_mem_efficient or self.dist.use_gloo_process_groups
+            ), "distrib_optim_fully_reshardable_mem_efficient requires dist.use_gloo_process_groups=True"
 
         # Cross-validation between training and scheduler configs
         self._validate_training_scheduler_compatibility()

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -1593,9 +1593,6 @@ class ConfigContainer(Container):
                     "Legacy checkpointing requires ckpt_format='torch_dist' or 'fsdp_dtensor'"
                 )
 
-        # Memory-efficient fully reshardable optimizer checkpointing uses Gloo
-        # for the DP state exchange. Validate this cross-config requirement here
-        # because CheckpointConfig.finalize() cannot inspect DistributedInitConfig.
         if self.checkpoint.dist_ckpt_optim_fully_reshardable:
             assert (
                 not self.checkpoint.distrib_optim_fully_reshardable_mem_efficient or self.dist.use_gloo_process_groups

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -677,6 +677,40 @@ class TestConfigContainerValidation:
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 
+    @pytest.mark.parametrize(
+        "use_gloo_process_groups, expect_assertion_error",
+        [(False, True), (True, False)],
+    )
+    def test_memory_efficient_fully_reshardable_checkpoint_requires_gloo(
+        self, monkeypatch, use_gloo_process_groups, expect_assertion_error
+    ):
+        """Require Gloo only when memory-efficient fully reshardable checkpoints are enabled."""
+        gpt_model_cfg = create_test_gpt_config()
+        dist_cfg = create_test_distributed_init_config(use_gloo_process_groups=use_gloo_process_groups)
+        opt_cfg = create_test_optimizer_config(use_distributed_optimizer=True)
+        chkpt_cfg = create_test_checkpoint_config(
+            dist_ckpt_optim_fully_reshardable=True,
+            distrib_optim_fully_reshardable_mem_efficient=True,
+        )
+        ddp_cfg = create_test_ddp_config(use_distributed_optimizer=True)
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=4,
+            model_config=gpt_model_cfg,
+            dist_config=dist_cfg,
+            optimizer_config=opt_cfg,
+            checkpoint_config=chkpt_cfg,
+            ddp_config=ddp_cfg,
+        )
+        try:
+            if expect_assertion_error:
+                with pytest.raises(AssertionError, match="requires dist.use_gloo_process_groups=True"):
+                    container.validate()
+            else:
+                container.validate()
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
     def test_scheduler_lr_decay_iters_default(self, monkeypatch):
         """Test `lr_decay_iters` defaults to `train_iters` and `lr_decay_steps` calculation."""
         gpt_model_cfg = create_test_gpt_config()


### PR DESCRIPTION
## Problem

`CheckpointConfig.finalize()` rejects every combination of `dist_ckpt_optim_fully_reshardable=True` and
`distrib_optim_fully_reshardable_mem_efficient=True`, even when Gloo process groups are enabled. 
The error message says that the memory-efficient option requires Gloo, but the current assertion does not inspect the Gloo setting.

## Root cause and fix

The check was introduced in [complex checkpoint deprecation (#1119)](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/1119).

Megatron Core's own argument validation rejects this combination when `use_gloo_process_groups` is disabled ([argument validation](https://github.com/NVIDIA/Megatron-LM/blob/d7288711ba278d160d2a5a22c099915c9fe1395c/megatron/training/arguments.py#L1380-L1389)).
The optimizer implementation documents and implements the memory-efficient path by selecting the Gloo DP group and returning the optimizer state only on DP rank 0 ([optimizer implementation](https://github.com/NVIDIA/Megatron-LM/blob/d7288711ba278d160d2a5a22c099915c9fe1395c/megatron/core/optimizer/distrib_optimizer.py#L1439-L1461)).
The same behavior is also stated in the Megatron Core configuration documentation ([configuration docstring](https://github.com/NVIDIA/Megatron-LM/blob/d7288711ba278d160d2a5a22c099915c9fe1395c/megatron/training/config/training_config.py#L509-L515)).

Move the cross-configuration check to `ConfigContainer`, where both `CheckpointConfig` and `DistributedInitConfig` are available. This preserves the rejection for the incompatible configuration and allows the supported one.

## Validation

- `uvx pre-commit run --all-files` — passed.
- `python3 -m compileall -q src/megatron/bridge/training/config.py tests/unit_tests/training/test_config.py` — passed.
- Added a focused unit test covering Gloo enabled and disabled configurations.
- The focused pytest could not run on macOS arm64 because the locked `nvidia-resiliency-ext` package has no compatible wheel.

## Scope

This changes validation only. It does not change defaults, enable memory-efficient checkpointing automatically, or modify checkpoint formats.
