### PR TITLE
[peft] fix: Track recompute patches by model lifetime

### DIFF
--- a/src/megatron/bridge/peft/recompute.py
+++ b/src/megatron/bridge/peft/recompute.py
@@ -17,7 +17,8 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Iterable, Set
+from typing import Iterable, MutableSet
+from weakref import WeakSet
 
 import torch
 from megatron.core.utils import unwrap_model
@@ -25,7 +26,7 @@ from megatron.core.utils import unwrap_model
 from megatron.bridge.utils.common_utils import print_rank_0
 
 
-PEFT_RECOMPUTE_PATCHED: Set[int] = set()
+PEFT_RECOMPUTE_PATCHED: WeakSet[torch.nn.Module] = WeakSet()
 
 
 def _iter_unwrapped_models(model) -> Iterable[torch.nn.Module]:
@@ -40,7 +41,9 @@ def _iter_unwrapped_models(model) -> Iterable[torch.nn.Module]:
             yield unwrapped
 
 
-def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] | None = None) -> Set[int]:
+def maybe_enable_recompute_inputs_grad(
+    model, peft_recompute_patched: MutableSet[torch.nn.Module] | None = None
+) -> MutableSet[torch.nn.Module]:
     """Enable grad on recompute-block inputs when only adapters are trainable.
 
     Root cause analysis:
@@ -67,7 +70,7 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
 
     recompute_block_types = (TransformerBlock, HybridStack)
 
-    patched_registry = peft_recompute_patched or PEFT_RECOMPUTE_PATCHED
+    patched_registry = PEFT_RECOMPUTE_PATCHED if peft_recompute_patched is None else peft_recompute_patched
 
     try:
         for unwrapped_model in _iter_unwrapped_models(model):
@@ -75,7 +78,7 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
             if cfg is None or getattr(cfg, "recompute_method", None) is None:
                 continue
 
-            if id(unwrapped_model) in patched_registry:
+            if unwrapped_model in patched_registry:
                 continue
 
             params = list(unwrapped_model.named_parameters())
@@ -111,7 +114,7 @@ def maybe_enable_recompute_inputs_grad(model, peft_recompute_patched: Set[int] |
                 if _patch_recompute_block(module):
                     patched = True
             if patched:
-                patched_registry.add(id(unwrapped_model))
+                patched_registry.add(unwrapped_model)
                 print_rank_0(
                     "[PEFT+Recompute] Patched recompute-block forward to enable grad on "
                     "hidden_states input. This ensures checkpoint backward is called when "

--- a/tests/unit_tests/peft/test_recompute.py
+++ b/tests/unit_tests/peft/test_recompute.py
@@ -14,6 +14,8 @@
 
 """Unit tests for PEFT-specific recompute helpers."""
 
+import gc
+import weakref
 from types import SimpleNamespace
 
 import pytest
@@ -85,7 +87,7 @@ def test_maybe_enable_recompute_inputs_grad_patches_block(monkeypatch, block_cls
     model = DummyModel(block_cls)
     patched_registry = maybe_enable_recompute_inputs_grad(model, set())
 
-    assert id(model) in patched_registry
+    assert len(patched_registry) == 1
 
     patched_forward = model.block.forward
 
@@ -98,3 +100,25 @@ def test_maybe_enable_recompute_inputs_grad_patches_block(monkeypatch, block_cls
     # Second invocation should be a no-op (no duplicate patch)
     maybe_enable_recompute_inputs_grad(model, patched_registry)
     assert model.block.forward is patched_forward
+
+
+def test_recompute_patch_registry_tracks_model_lifetime(monkeypatch):
+    _patch_recompute_blocks(monkeypatch)
+    recompute_mod.PEFT_RECOMPUTE_PATCHED.clear()
+
+    # Python permits ID reuse after an object is collected. Make that reuse
+    # deterministic so a stale integer registry entry cannot hide the bug.
+    monkeypatch.setattr(recompute_mod, "id", lambda model: 12345, raising=False)
+
+    first_model = DummyModel(DummyHybridStack)
+    maybe_enable_recompute_inputs_grad(first_model)
+    first_model_ref = weakref.ref(first_model)
+    del first_model
+    gc.collect()
+    assert first_model_ref() is None
+
+    second_model = DummyModel(DummyHybridStack)
+    maybe_enable_recompute_inputs_grad(second_model)
+    second_model.block(torch.zeros(2, 2))
+
+    assert second_model.block.last_input_requires_grad is True


### PR DESCRIPTION
## Summary

- track PEFT recompute patches by live model identity instead of raw object IDs
- release registry entries automatically when a model is collected
- cover sequential model lifetimes with deterministic ID reuse

## Bug

The documented in-process restart path reconstructs the training model in the same Python process. The PEFT recompute helper kept `id(model)` values forever, even after the associated model was collected. Python may reuse an ID for a later model, causing that distinct model to be treated as already patched.

For PP=1 hybrid models with adapter-only training and full activation recompute, the skipped `HybridStack` hook leaves the frozen embedding output non-differentiable. Re-entrant checkpoint backward is then not entered, so adapter gradients are lost while the forward path can still produce a finite loss.

## Fix

Use a `WeakSet` of live model roots. This preserves same-model idempotence without carrying identity state across model lifetimes. The patch does not change checkpoint, forward, configuration, or adapter transformation behavior.

## Regression evidence

The new lifecycle test deterministically models valid post-collection ID reuse. Against unmodified `main`, the second HybridStack receives `hidden_states.requires_grad == False` and the test fails. With this patch, the second model is independently patched and the test passes.

A focused re-entrant-checkpoint reproducer also failed before with a detached output and no adapter gradient, then passed after with a nonzero adapter gradient.

## Validation

- `uv run --no-sync python -m pytest tests/unit_tests/peft/test_recompute.py -q` — 3 passed (focused CPU import isolation for unrelated optional GPU packages)
- `git diff --check` — passed
- `uv run --no-sync pre-commit run --all-files` — passed

## Scope

This only changes recompute-patch lifetime bookkeeping and its focused unit coverage. No dependencies, workflows, conversion APIs, model support, or MCore code are changed.