### PR TITLE
cp: `fix(training): restrict HybridEP padding to THD (#5915)` into `r0.6.0`

### DIFF
--- a/docs/parallelisms.md
+++ b/docs/parallelisms.md
@@ -225,21 +225,24 @@ model_config = GPTModelProvider(
 apply_flex_dispatcher_backend(model_config, moe_flex_dispatcher_backend="hybridep")
 ```
 
-Megatron Bridge automatically enables `moe_hybridep_pad_uneven_dispatch_inputs`
-when an eager model config uses the HybridEP flex backend. HybridEP requires
-equal per-rank dispatch shapes, but dynamically packed THD batches can produce
-different local token counts. The safety path takes the group-wide maximum token
-count, aligns it for the kernel, pads each rank before dispatch, and removes the
-padding after combine.
+When a combined training recipe selects offline or in-batch packing together
+with eager HybridEP, Megatron Bridge automatically enables
+`moe_hybridep_pad_uneven_dispatch_inputs`. These recipe paths produce THD
+packed-sequence metadata whose local token counts can differ across ranks, while
+HybridEP requires equal dispatch shapes. The safety path takes the group-wide
+maximum token count, aligns it for the kernel, pads each rank before dispatch,
+and removes the padding after combine.
 
-This adds a MAX all-reduce and temporary padding overhead, including when every
-rank already supplies the same number of tokens. The safety path does not enable
-HybridEP or sequence packing; configure those separately.
+Unpacked BSHD recipes preserve their configured setting and avoid the extra MAX
+all-reduce, host synchronization, and temporary padding allocations by default.
+Direct model-provider callers do not have a combined recipe from which Bridge
+can infer the layout; callers that pass uneven THD inputs must enable the setting
+explicitly. An explicit enabled setting remains enabled for any layout.
 
 CUDA-graph configs preserve their explicit padding setting because the uneven-input
 path performs a host scalar synchronization that is not capture-safe. They must
-provide equal per-rank dispatch shapes. Disable CUDA graphs when runtime token
-counts can differ so Bridge can enable safe padding.
+provide equal per-rank dispatch shapes. Disable CUDA graphs when packed THD token
+counts can differ so the recipe can enable safe padding.
 
 **GPU Architecture Requirements:**
 

--- a/docs/training/packed-sequences.md
+++ b/docs/training/packed-sequences.md
@@ -113,8 +113,10 @@ The durable constraints for packed sequences in Bridge are:
   evaluation CP constraints and `CP * TP` when sequence parallelism is enabled
 - for fine-tuning with CP enabled, per-token loss behavior and reduction
   settings matter
-- Megatron Bridge automatically enables safe uneven-input padding for eager
-  HybridEP configs; this pads only to the group-wide aligned maximum before
+- combined recipes using offline or in-batch packing automatically enable safe
+  uneven-input padding for eager HybridEP; unpacked BSHD recipes preserve their
+  configured setting
+- the THD safety path pads only to the group-wide aligned maximum before
   dispatch and trims the padding after combine
 - CUDA-graph-friendly packed metadata requires additional padding constraints
 
@@ -124,7 +126,9 @@ opt out of packed sequences or related packing modes.
 HybridEP CUDA-graph configs preserve their explicit uneven-input setting because
 the safety path performs a host scalar synchronization that is not capture-safe.
 They must provide equal per-rank dispatch shapes. Disable CUDA graphs when packed
-runtime token counts can differ so Bridge can enable safe padding.
+THD token counts can differ so the recipe can enable safe padding. Direct model-
+provider callers must explicitly enable the setting when they supply uneven THD
+inputs because no combined recipe is available to infer their layout.
 
 ## Relationship to Long-Sequence Training
 

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -40,7 +40,6 @@ from typing import (
 
 import torch
 from megatron.core import parallel_state
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -1068,7 +1067,8 @@ class MegatronModelBridge(
         if not isinstance(megatron_model, list):
             megatron_model = [megatron_model]
 
-        use_megatron_fsdp = isinstance(megatron_model[0], FullyShardedDataParallel)
+        ddp_config = getattr(megatron_model[0], "ddp_config", None)
+        use_megatron_fsdp = ddp_config is not None and ddp_config.use_megatron_fsdp
         if use_megatron_fsdp:
             original_megatron_model = megatron_model
         unwrapped_model_list = unwrap_model(megatron_model)

--- a/src/megatron/bridge/models/conversion/utils.py
+++ b/src/megatron/bridge/models/conversion/utils.py
@@ -46,13 +46,26 @@ def unwrap_model(model, module_instances=None):
     if module_instances is None:
         from megatron.core.distributed import DistributedDataParallel as DDP
         from megatron.core.distributed import TorchFullyShardedDataParallel as torch_FSDP
-        from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-            FullyShardedDataParallel as megatron_FSDP,
-        )
+        from megatron.core.distributed.fsdp import mcore_fsdp_adapter
         from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
         from megatron.core.transformer.module import Float16Module
 
-        module_instances = (DDP, torch_FSDP, megatron_FSDP, Float16Module, MegatronFSDP)
+        fsdp_module_instances = tuple(
+            module_type
+            for module_type in (
+                getattr(mcore_fsdp_adapter, "FullyShardedDataParallel", None),
+                getattr(mcore_fsdp_adapter, "FullyShardedDataParallelV1", None),
+                getattr(mcore_fsdp_adapter, "FullyShardedDataParallelV2", None),
+            )
+            if isinstance(module_type, type)
+        )
+        module_instances = (
+            DDP,
+            torch_FSDP,
+            *fsdp_module_instances,
+            Float16Module,
+            MegatronFSDP,
+        )
 
     return_list = True
     if not isinstance(model, list):

--- a/src/megatron/bridge/models/hybrid/hybrid_provider.py
+++ b/src/megatron/bridge/models/hybrid/hybrid_provider.py
@@ -17,7 +17,7 @@ import inspect
 import logging
 import warnings
 from dataclasses import dataclass, field
-from typing import Callable, Literal
+from typing import Callable, Literal, Self
 
 import torch
 from megatron.core.models.hybrid.hybrid_layer_specs import (
@@ -273,6 +273,12 @@ class HybridModelProvider(TransformerConfig, ModelProviderMixin[MCoreHybridModel
 
         return _configure_mamba_chunk_size(resolved_spec, self.mamba_chunk_size)
 
+    def _copy_config_without_runtime_process_groups(self, *, deep: bool) -> Self:
+        """Copy this config without the runtime-only process-group collection."""
+        model_config = copy.copy(self)
+        model_config._pg_collection = None
+        return copy.deepcopy(model_config) if deep else model_config
+
     def provide(self, pre_process=None, post_process=None, vp_stage=None) -> MCoreHybridModel:
         """Configure and instantiate a Megatron Core Hybrid model based on this configuration.
 
@@ -302,20 +308,30 @@ class HybridModelProvider(TransformerConfig, ModelProviderMixin[MCoreHybridModel
         pre_process = pre_process if pre_process is not None else is_pp_first_stage(self._pg_collection.pp)
         post_process = post_process if post_process is not None else is_pp_last_stage(self._pg_collection.pp)
 
-        return MCoreHybridModel(
-            config=self,
-            hybrid_stack_spec=hybrid_stack_spec,
-            vocab_size=padded_vocab_size,
-            max_sequence_length=self.seq_length,
-            hybrid_layer_pattern=self.hybrid_layer_pattern,
-            fp16_lm_cross_entropy=self.fp16_lm_cross_entropy,
-            parallel_output=self.parallel_output,
-            share_embeddings_and_output_weights=self.share_embeddings_and_output_weights,
-            position_embedding_type=self.position_embedding_type,
-            rotary_percent=self.rotary_percent,
-            rotary_base=self.rotary_base,
-            seq_len_interpolation_factor=self.seq_len_interpolation_factor,
-            pre_process=pre_process,
-            post_process=post_process,
-            pg_collection=self._pg_collection,
-        )
+        # MCore creates independent per-layer configs by deep-copying this config. Detach
+        # runtime-only process groups during construction and pass them through the dedicated
+        # argument instead; torch.distributed.ProcessGroup cannot be deep-copied. The model must
+        # retain this provider as its root config because Bridge installs DDP schedule callbacks
+        # on the provider after wrapping the model.
+        pg_collection = self._pg_collection
+        self._pg_collection = None
+        try:
+            return MCoreHybridModel(
+                config=self,
+                hybrid_stack_spec=hybrid_stack_spec,
+                vocab_size=padded_vocab_size,
+                max_sequence_length=self.seq_length,
+                hybrid_layer_pattern=self.hybrid_layer_pattern,
+                fp16_lm_cross_entropy=self.fp16_lm_cross_entropy,
+                parallel_output=self.parallel_output,
+                share_embeddings_and_output_weights=self.share_embeddings_and_output_weights,
+                position_embedding_type=self.position_embedding_type,
+                rotary_percent=self.rotary_percent,
+                rotary_base=self.rotary_base,
+                seq_len_interpolation_factor=self.seq_len_interpolation_factor,
+                pre_process=pre_process,
+                post_process=post_process,
+                pg_collection=pg_collection,
+            )
+        finally:
+            self._pg_collection = pg_collection

--- a/src/megatron/bridge/models/transformer_config.py
+++ b/src/megatron/bridge/models/transformer_config.py
@@ -71,6 +71,12 @@ def _resolve_string_fields(config: MCoreTransformerConfig) -> None:
         config.pipeline_dtype = str_to_dtype(config.pipeline_dtype)
 
 
+_HYBRIDEP_PADDING_FIELDS = (
+    "moe_hybridep_pad_uneven_dispatch_inputs",
+    "moe_hybridep_pad_variable_tokens",
+)
+
+
 def _set_moe_expert_tensor_parallel_default(config: MCoreTransformerConfig) -> None:
     """Default expert tensor parallelism to one when expert parallelism is enabled.
 
@@ -82,14 +88,13 @@ def _set_moe_expert_tensor_parallel_default(config: MCoreTransformerConfig) -> N
         config.expert_tensor_parallel_size = 1
 
 
-def _enable_safe_hybridep_dispatch(config: MCoreTransformerConfig) -> None:
-    """Ensure eager HybridEP can dispatch different token counts across ranks.
+def _enable_safe_hybridep_dispatch(config: MCoreTransformerConfig, *, uses_thd: bool) -> None:
+    """Enable uneven-input padding for an eager HybridEP THD recipe.
 
-    Bridge model configs are finalized before runtime batches expose whether their
-    THD token counts differ by rank. HybridEP requires equal dispatch shapes, so use
-    Megatron Core's padding path for eager Bridge-configured HybridEP dispatchers.
-    CUDA-graph configs retain their explicit setting because the padding path's host
-    scalar synchronization is not capture-safe; those configs require equal inputs.
+    The combined training recipe owns the tensor layout, so it requests this
+    path only when its dataset produces THD packed-sequence metadata. CUDA-graph
+    configs retain their explicit setting because the padding path's host scalar
+    synchronization is not capture-safe; those configs require equal inputs.
     """
 
     def _uses_legacy_full_iteration(value: object) -> bool:
@@ -101,29 +106,27 @@ def _enable_safe_hybridep_dispatch(config: MCoreTransformerConfig) -> None:
             for item in values
         )
 
+    has_cuda_graph_impl = hasattr(config, "cuda_graph_impl")
     cuda_graph_impl = getattr(config, "cuda_graph_impl", "none")
+    uses_legacy_full_iteration = not has_cuda_graph_impl and (
+        _uses_legacy_full_iteration(getattr(config, "cuda_graph_modules", None))
+        or _uses_legacy_full_iteration(getattr(config, "cuda_graph_scope", None))
+    )
     cuda_graphs_enabled = (
         cuda_graph_impl not in (None, "none")
         or getattr(config, "enable_cuda_graph", False)
         or getattr(config, "external_cuda_graph", False)
-        or _uses_legacy_full_iteration(getattr(config, "cuda_graph_modules", None))
-        or _uses_legacy_full_iteration(getattr(config, "cuda_graph_scope", None))
+        or uses_legacy_full_iteration
     )
     if (
-        config.moe_token_dispatcher_type != "flex"
-        or config.moe_flex_dispatcher_backend != "hybridep"
+        not uses_thd
+        or getattr(config, "moe_token_dispatcher_type", None) != "flex"
+        or getattr(config, "moe_flex_dispatcher_backend", None) != "hybridep"
         or cuda_graphs_enabled
     ):
         return
 
-    padding_fields = tuple(
-        field_name
-        for field_name in (
-            "moe_hybridep_pad_uneven_dispatch_inputs",
-            "moe_hybridep_pad_variable_tokens",
-        )
-        if hasattr(config, field_name)
-    )
+    padding_fields = tuple(field_name for field_name in _HYBRIDEP_PADDING_FIELDS if hasattr(config, field_name))
     if not padding_fields:
         raise AttributeError("Megatron Core TransformerConfig does not expose a HybridEP uneven-input padding field")
     for padding_field in padding_fields:
@@ -176,7 +179,6 @@ class TransformerConfig(MCoreTransformerConfig):
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
         _set_moe_expert_tensor_parallel_default(self)
-        _enable_safe_hybridep_dispatch(self)
         MCoreTransformerConfig.__post_init__(self)
 
         # In-batch packing produces variable-length packed sequences across microbatches,
@@ -253,7 +255,6 @@ class MLATransformerConfig(TransformerConfig, MCoreMLATransformerConfig):
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
         _set_moe_expert_tensor_parallel_default(self)
-        _enable_safe_hybridep_dispatch(self)
         MCoreMLATransformerConfig.__post_init__(self)
 
         if getattr(self, "_enable_in_batch_packing", False) and self.pipeline_model_parallel_size > 1:
@@ -308,7 +309,6 @@ class HeterogeneousTransformerConfig(TransformerConfig, MCoreHeterogeneousTransf
         if self.sequence_parallel and self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
         _set_moe_expert_tensor_parallel_default(self)
-        _enable_safe_hybridep_dispatch(self)
         MCoreHeterogeneousTransformerConfig.__post_init__(self)
 
     def get_config_for_layer(self, layer_number: int) -> MCoreTransformerConfig:

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -67,6 +67,7 @@ from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
 from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+from megatron.bridge.models.transformer_config import _enable_safe_hybridep_dispatch
 from megatron.bridge.peft.base import PEFT
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.flex_dispatcher_backend import validate_flex_dispatcher_backend
@@ -1149,6 +1150,7 @@ class ConfigContainer(Container):
         enable_in_batch_packing = getattr(self.dataset, "enable_in_batch_packing", False)
         enable_offline_packing = getattr(self.dataset, "enable_offline_packing", False)
         offline_packing_specs = getattr(self.dataset, "offline_packing_specs", None)
+        uses_thd = enable_offline_packing or enable_in_batch_packing
 
         if enable_offline_packing and enable_in_batch_packing:
             raise ValueError("enable_offline_packing and enable_in_batch_packing are mutually exclusive.")
@@ -1230,8 +1232,9 @@ class ConfigContainer(Container):
 
         # Propagate in-batch packing flag to model config so TransformerConfig.finalize()
         # can enable variable_seq_lengths for pipeline parallelism.
+        transformer_config = getattr(self.model, "transformer", self.model)
         if enable_in_batch_packing:
-            self.model._enable_in_batch_packing = True
+            transformer_config._enable_in_batch_packing = True
             if hasattr(self.dataset, "in_batch_packing_pad_to_multiple_of"):
                 self.dataset.in_batch_packing_pad_to_multiple_of = collate_padding_multiple
         elif isinstance(
@@ -1242,6 +1245,8 @@ class ConfigContainer(Container):
                 self.dataset.pad_to_multiple_of,
                 collate_padding_multiple,
             )
+
+        _enable_safe_hybridep_dispatch(transformer_config, uses_thd=uses_thd)
 
         if hasattr(self.dataset, "finalize"):
             self.dataset.finalize()

--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -21,7 +21,6 @@ from typing import Any, Callable, NamedTuple, Optional
 import torch
 from megatron.core.config import set_experimental_flag
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig, finalize_model_grads
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 from megatron.core.jit import disable_jit_fuser
 from megatron.core.optimizer import MegatronOptimizer
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
@@ -65,6 +64,12 @@ from megatron.bridge.training.utils.checkpoint_utils import checkpoint_exists, i
 from megatron.bridge.training.utils.log_utils import append_to_progress_log, barrier_and_log, setup_logging
 from megatron.bridge.training.utils.train_utils import start_memory_history_recording
 from megatron.bridge.utils.common_utils import get_rank_safe, print_rank_0
+
+
+try:
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV1 as megatron_FSDP
+except ImportError:
+    from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 
 
 def _get_embedding_ranks(

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch.profiler
 from megatron.core.distributed import DistributedDataParallel as DDP
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
+from megatron.core.distributed.fsdp import mcore_fsdp_adapter
 from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.num_microbatches_calculator import (
     get_current_global_batch_size,
@@ -1684,6 +1684,22 @@ def _delete_cuda_graphs(cuda_graph_helper: TECudaGraphHelper):
     gc.collect()
 
 
+def _get_megatron_fsdp_types(adapter: Any = mcore_fsdp_adapter) -> tuple[type, ...]:
+    """Return the concrete MCore FSDP wrapper types exposed by an adapter version."""
+    return tuple(
+        module_type
+        for module_type in (
+            getattr(adapter, "FullyShardedDataParallel", None),
+            getattr(adapter, "FullyShardedDataParallelV1", None),
+            getattr(adapter, "FullyShardedDataParallelV2", None),
+        )
+        if isinstance(module_type, type)
+    )
+
+
+_MEGATRON_FSDP_TYPES = _get_megatron_fsdp_types()
+
+
 def _maybe_register_fsdp_buffers(
     config: ConfigContainer,
     model: list[MegatronModule],
@@ -1697,7 +1713,7 @@ def _maybe_register_fsdp_buffers(
     ):
         print_rank_0("[Megatron-FSDP] Registering FSDP communication buffers manually")
         for model_chunk in model:
-            if isinstance(model_chunk, megatron_FSDP) and getattr(
+            if isinstance(model_chunk, _MEGATRON_FSDP_TYPES) and getattr(
                 model_chunk.ddp_config, "fsdp_manual_registration", False
             ):
                 fsdp_param_and_grad_buffer = getattr(model_chunk, "param_and_grad_buffer", None)

--- a/tests/unit_tests/models/hybrid/test_hybrid_provider.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_provider.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from unittest.mock import Mock, patch
 
 import pytest
@@ -23,6 +24,16 @@ from megatron.core.transformer.enums import AttnBackend
 
 from megatron.bridge.models.hybrid import hybrid_provider
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+
+
+def _copy_attention_config(config):
+    try:
+        from megatron.core.transformer.attention_layer_config import AttentionLayerConfig
+    except ModuleNotFoundError as error:
+        if error.name != "megatron.core.transformer.attention_layer_config":
+            raise
+        return copy.deepcopy(config)
+    return AttentionLayerConfig.from_config(config)
 
 
 class TestHybridModelProvider:
@@ -93,6 +104,41 @@ class TestHybridModelProvider:
                 assert result == mock_instance
                 mock_model.assert_called_once()
                 assert mock_model.call_args.kwargs["hybrid_stack_spec"] is hybrid_provider.default_hybrid_stack_spec
+
+    def test_provide_preserves_runtime_config_identity_without_copying_process_groups(self):
+        class UncopyableProcessGroupCollection:
+            pp = object()
+
+            def __deepcopy__(self, memo):
+                raise TypeError("runtime process groups cannot be copied")
+
+        provider = HybridModelProvider(
+            num_layers=2,
+            hidden_size=128,
+            num_attention_heads=1,
+            vocab_size=1000,
+        )
+        pg_collection = UncopyableProcessGroupCollection()
+        provider._pg_collection = pg_collection
+
+        def create_model(**kwargs):
+            assert kwargs["config"] is provider
+            assert kwargs["config"]._pg_collection is None
+            copied_config = _copy_attention_config(kwargs["config"])
+            assert copied_config._pg_collection is None
+            return Mock(config=kwargs["config"])
+
+        with patch(
+            "megatron.bridge.models.hybrid.hybrid_provider.MCoreHybridModel", side_effect=create_model
+        ) as mock_model:
+            model = provider.provide(pre_process=True, post_process=True)
+
+        assert provider._pg_collection is pg_collection
+        assert mock_model.call_args.kwargs["pg_collection"] is pg_collection
+
+        runtime_grad_sync = Mock()
+        provider.grad_sync_func = runtime_grad_sync
+        assert model.config.grad_sync_func is runtime_grad_sync
 
     def test_provide_method_with_vocab_padding(self):
         provider = HybridModelProvider(

--- a/tests/unit_tests/models/test_conversion_unwrap_utils.py
+++ b/tests/unit_tests/models/test_conversion_unwrap_utils.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from megatron.bridge.models.conversion.utils import unwrap_model
+
+
+def test_unwrap_model_uses_fsdp_wrapper_types(monkeypatch):
+    class FSDPV1(torch.nn.Module):
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
+
+    class FSDPV2(FSDPV1):
+        pass
+
+    def fsdp_factory(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "megatron.core.distributed.fsdp.mcore_fsdp_adapter.FullyShardedDataParallel",
+        fsdp_factory,
+    )
+    monkeypatch.setattr(
+        "megatron.core.distributed.fsdp.mcore_fsdp_adapter.FullyShardedDataParallelV1",
+        FSDPV1,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "megatron.core.distributed.fsdp.mcore_fsdp_adapter.FullyShardedDataParallelV2",
+        FSDPV2,
+        raising=False,
+    )
+
+    module = torch.nn.Linear(1, 1)
+
+    assert unwrap_model(FSDPV2(FSDPV1(module))) is module

--- a/tests/unit_tests/models/test_transformer_config.py
+++ b/tests/unit_tests/models/test_transformer_config.py
@@ -21,6 +21,7 @@ import pytest
 import torch
 
 from megatron.bridge.models.transformer_config import (
+    _HYBRIDEP_PADDING_FIELDS,
     HeterogeneousTransformerConfig,
     MLATransformerConfig,
     TransformerConfig,
@@ -45,6 +46,20 @@ def _make_config(**kwargs) -> TransformerConfig:
     return TransformerConfig(**defaults)
 
 
+def _make_hybridep_config(config_type=TransformerConfig, **kwargs):
+    """Build a HybridEP config using the padding field exposed by this MCore ref."""
+    defaults = dict(
+        num_layers=2,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_moe_experts=8,
+        moe_token_dispatcher_type="flex",
+        moe_flex_dispatcher_backend="hybridep",
+    )
+    padding_field = next(field for field in _HYBRIDEP_PADDING_FIELDS if field in config_type.__dataclass_fields__)
+    return config_type(**defaults, **{padding_field: False}, **kwargs), padding_field
+
+
 class TestEnableSafeHybridepDispatch:
     """Tests for cross-branch Megatron Core HybridEP padding compatibility."""
 
@@ -56,9 +71,16 @@ class TestEnableSafeHybridepDispatch:
             cuda_graph_impl="none",
         )
 
-        _enable_safe_hybridep_dispatch(cfg)
+        _enable_safe_hybridep_dispatch(cfg, uses_thd=True)
 
         assert cfg.moe_hybridep_pad_variable_tokens is True
+
+    def test_bshd_preserves_disabled_padding(self):
+        cfg, padding_field = _make_hybridep_config()
+
+        _enable_safe_hybridep_dispatch(cfg, uses_thd=False)
+
+        assert getattr(cfg, padding_field) is False
 
     def test_cuda_graph_config_does_not_require_padding_field(self):
         cfg = SimpleNamespace(
@@ -67,7 +89,7 @@ class TestEnableSafeHybridepDispatch:
             cuda_graph_impl="full_iteration",
         )
 
-        _enable_safe_hybridep_dispatch(cfg)
+        _enable_safe_hybridep_dispatch(cfg, uses_thd=True)
 
 
 # ---------------------------------------------------------------------------
@@ -251,19 +273,14 @@ class TestTransformerConfigFinalize:
             cfg.finalize()
         assert cfg.expert_tensor_parallel_size is None
 
-    def test_hybridep_finalization_enables_uneven_dispatch_padding(self):
-        """HybridEP must safely handle different token counts on each EP rank."""
-        cfg = _make_config(
-            num_moe_experts=8,
-            moe_token_dispatcher_type="flex",
-            moe_flex_dispatcher_backend="hybridep",
-            moe_hybridep_pad_uneven_dispatch_inputs=False,
-        )
+    def test_hybridep_finalization_preserves_uneven_dispatch_padding(self):
+        """Generic model finalization must not infer the recipe tensor layout."""
+        cfg, padding_field = _make_hybridep_config()
 
         with patch(_FINALIZE_PATCH):
             cfg.finalize()
 
-        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
+        assert getattr(cfg, padding_field) is False
 
     def test_non_hybridep_finalization_preserves_uneven_dispatch_padding(self):
         """Other flex backends must retain their configured padding behavior."""
@@ -323,21 +340,13 @@ class TestMLATransformerConfigFinalize:
             cfg.finalize()
         assert cfg.expert_tensor_parallel_size == 1
 
-    def test_hybridep_finalization_enables_uneven_dispatch_padding(self):
-        cfg = MLATransformerConfig(
-            num_layers=2,
-            hidden_size=64,
-            num_attention_heads=4,
-            num_moe_experts=8,
-            moe_token_dispatcher_type="flex",
-            moe_flex_dispatcher_backend="hybridep",
-            moe_hybridep_pad_uneven_dispatch_inputs=False,
-        )
+    def test_hybridep_finalization_preserves_uneven_dispatch_padding(self):
+        cfg, padding_field = _make_hybridep_config(MLATransformerConfig)
 
         with patch(_MLA_FINALIZE_PATCH):
             cfg.finalize()
 
-        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
+        assert getattr(cfg, padding_field) is False
 
 
 # ---------------------------------------------------------------------------
@@ -386,15 +395,10 @@ class TestHeterogeneousTransformerConfigFinalize:
             cfg.finalize()
         assert cfg.sequence_parallel is True
 
-    def test_hybridep_finalization_enables_uneven_dispatch_padding(self):
-        cfg = self._make_hetero(
-            num_moe_experts=8,
-            moe_token_dispatcher_type="flex",
-            moe_flex_dispatcher_backend="hybridep",
-            moe_hybridep_pad_uneven_dispatch_inputs=False,
-        )
+    def test_hybridep_finalization_preserves_uneven_dispatch_padding(self):
+        cfg, padding_field = _make_hybridep_config(HeterogeneousTransformerConfig)
 
         with patch(_HETERO_FINALIZE_PATCH):
             cfg.finalize()
 
-        assert cfg.moe_hybridep_pad_uneven_dispatch_inputs is True
+        assert getattr(cfg, padding_field) is False

--- a/tests/unit_tests/recipes/test_moonlight_recipes.py
+++ b/tests/unit_tests/recipes/test_moonlight_recipes.py
@@ -109,6 +109,7 @@ class _FakeMoonlightModelProvider:
         self.pipeline_model_parallel_layout = None
         self.moe_token_dispatcher_type = "alltoall"
         self.moe_enable_deepep = False
+        self.moe_hybridep_pad_uneven_dispatch_inputs = False
         self.moe_shared_expert_overlap = True
 
         # Set parallelism defaults if not provided

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -14,6 +14,7 @@
 
 import os
 from dataclasses import fields
+from types import SimpleNamespace
 from typing import Any, Optional, Union
 from unittest.mock import MagicMock, patch
 
@@ -31,6 +32,7 @@ from megatron.bridge.data.builders import (
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.mla_provider import MLAModelProvider
 from megatron.bridge.models.t5_provider import T5ModelProvider
+from megatron.bridge.models.transformer_config import _HYBRIDEP_PADDING_FIELDS
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import (
     CheckpointConfig,
@@ -959,6 +961,97 @@ class TestConfigContainerValidation:
 
         try:
             container.validate()  # Should pass without error
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    @pytest.mark.parametrize("packing_mode", ["offline", "in_batch"])
+    @patch("torch.cuda.get_device_properties", return_value=SimpleNamespace(major=9, name="NVIDIA H100"))
+    def test_thd_recipe_enables_hybridep_padding(self, _mock_device, packing_mode):
+        """Recipe-owned THD packing enables safe HybridEP uneven-input padding."""
+        from megatron.bridge.data.packing import PackedSequenceSpecs
+
+        gpt_model_cfg = create_test_gpt_config(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+        )
+        padding_field = next(field for field in _HYBRIDEP_PADDING_FIELDS if hasattr(gpt_model_cfg, field))
+
+        if packing_mode == "offline":
+            train_cfg = create_test_training_config(micro_batch_size=1, global_batch_size=32)
+            dataset_cfg = create_test_gpt_sft_dataset_config(sequence_length=512)
+            dataset_cfg.enable_offline_packing = True
+            dataset_cfg.offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=512)
+        else:
+            train_cfg = create_test_training_config(micro_batch_size=2, global_batch_size=32)
+            dataset_cfg = create_test_direct_hf_sft_dataset_config(sequence_length=512)
+            dataset_cfg.enable_in_batch_packing = True
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            container.validate()
+            assert getattr(gpt_model_cfg, padding_field) is True
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    @pytest.mark.parametrize("configured_padding", [False, True])
+    @patch("torch.cuda.get_device_properties", return_value=SimpleNamespace(major=9, name="NVIDIA H100"))
+    def test_bshd_recipe_preserves_hybridep_padding_setting(self, _mock_device, configured_padding):
+        """An unpacked BSHD recipe does not gain automatic padding or lose an explicit setting."""
+        padding_field = next(
+            field for field in _HYBRIDEP_PADDING_FIELDS if field in GPTModelProvider.__dataclass_fields__
+        )
+        gpt_model_cfg = create_test_gpt_config(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            **{padding_field: configured_padding},
+        )
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+        )
+
+        try:
+            container.validate()
+            assert getattr(gpt_model_cfg, padding_field) is configured_padding
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    @patch("torch.cuda.get_device_properties", return_value=SimpleNamespace(major=9, name="NVIDIA H100"))
+    def test_thd_recipe_ignores_stale_cuda_graph_scope_when_impl_none(self, _mock_device):
+        """A deprecated scope that validation clears must not suppress eager THD safety."""
+        from megatron.bridge.data.packing import PackedSequenceSpecs
+
+        gpt_model_cfg = create_test_gpt_config(
+            num_moe_experts=8,
+            moe_token_dispatcher_type="flex",
+            moe_flex_dispatcher_backend="hybridep",
+            cuda_graph_impl="none",
+            use_te_rng_tracker=True,
+        )
+        padding_field = next(field for field in _HYBRIDEP_PADDING_FIELDS if hasattr(gpt_model_cfg, field))
+        gpt_model_cfg.cuda_graph_scope = ["full_iteration"]
+        dataset_cfg = create_test_gpt_sft_dataset_config(sequence_length=512)
+        dataset_cfg.enable_offline_packing = True
+        dataset_cfg.offline_packing_specs = PackedSequenceSpecs(packed_sequence_size=512)
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=1,
+            model_config=gpt_model_cfg,
+            train_config=create_test_training_config(micro_batch_size=1, global_batch_size=32),
+            dataset_config_override=dataset_cfg,
+        )
+
+        try:
+            container.validate()
+            assert getattr(gpt_model_cfg, padding_field) is True
+            assert cuda_graph_module_names(gpt_model_cfg) == []
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 

--- a/tests/unit_tests/training/test_setup.py
+++ b/tests/unit_tests/training/test_setup.py
@@ -465,3 +465,7 @@ def test_restart_rebinds_overlap_callbacks_to_rebuilt_model():
         _update_model_config_funcs([rebuilt_model], transformer_config, ddp_config, optimizer=None)
 
     assert transformer_config.no_sync_func.__self__ is rebuilt_model
+
+
+def test_megatron_fsdp_runtime_check_uses_wrapper_type():
+    assert isinstance(training_setup.megatron_FSDP, type)

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -19,11 +19,11 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel as megatron_FSDP
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 
 from megatron.bridge.training.train import (
     _dummy_train_step,
+    _get_megatron_fsdp_types,
     _handle_mxfp8_param_buffer_copy,
     _maybe_register_fsdp_buffers,
     _should_skip_and_handle_iteration,
@@ -45,6 +45,21 @@ pytestmark = pytest.mark.unit
 class TestFSDPRegistration:
     """Unit tests for FSDP buffer manual registration."""
 
+    def test_get_megatron_fsdp_types_ignores_factory(self):
+        class FSDPV1:
+            pass
+
+        class FSDPV2:
+            pass
+
+        adapter = SimpleNamespace(
+            FullyShardedDataParallel=lambda: None,
+            FullyShardedDataParallelV1=FSDPV1,
+            FullyShardedDataParallelV2=FSDPV2,
+        )
+
+        assert _get_megatron_fsdp_types(adapter) == (FSDPV1, FSDPV2)
+
     def test_maybe_register_fsdp_buffers_execution(self):
         """Test that manual registration is called when conditions are met."""
         # Setup mocks
@@ -53,7 +68,8 @@ class TestFSDPRegistration:
         config.ddp.fsdp_manual_registration = True
 
         # Mock model chunk
-        model_chunk = Mock(spec=megatron_FSDP)
+        fsdp_type = _get_megatron_fsdp_types()[0]
+        model_chunk = Mock(spec=fsdp_type)
         # Mock ddp_config on the chunk
         model_chunk.ddp_config = Mock()
         model_chunk.ddp_config.fsdp_manual_registration = True


### PR DESCRIPTION
## Summary

Manual backport of #5915 to `r0.6.0`.

- enables HybridEP uneven-input padding for release-supported offline and in-batch THD packing
- preserves the configured padding value for unpacked BSHD
- preserves CUDA graph behavior
- adapts the focused tests to the release branch direct-provider configuration

The main-only native Energon THD path was intentionally excluded because its implementation is not present on `r0.6.0`.

## Verification

- `python -m py_compile` passed for all changed Python files
- `git diff --check` passed
- independent review completed; its release-specific Energon finding was addressed
- focused pytest could not be run on the workstation because the pinned `nvidia-resiliency-ext==0.6.0` wheel requires a newer manylinux baseline; release CI will execute the test suite

Signed-off-by: Chen Cui <chcui@nvidia.com>