### PR TITLE
fix(nemotron_omni): read and write exported modeling.py as UTF-8

### DIFF
--- a/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
+++ b/src/megatron/bridge/models/nemotron_omni/nemotron_omni_bridge.py
@@ -140,9 +140,11 @@ from .configuration_radio import RADIOConfig as _RADIOConfig
         if not modeling_path.is_file():
             raise FileNotFoundError(f"Nemotron Omni export is missing required artifact: {modeling_path}")
 
-        modeling_source = modeling_path.read_text()
+        modeling_source = modeling_path.read_text(encoding="utf-8")
         if self._HF_DYNAMIC_MODULE_IMPORTS.strip() not in modeling_source:
-            modeling_path.write_text(modeling_source.rstrip() + self._HF_DYNAMIC_MODULE_IMPORTS + "\n")
+            modeling_path.write_text(
+                modeling_source.rstrip() + self._HF_DYNAMIC_MODULE_IMPORTS + "\n", encoding="utf-8"
+            )
 
     # ------------------------------------------------------------------
     # Provider translation

--- a/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
+++ b/tests/unit_tests/models/nemotron_omni/test_nemotron_omni_conversion.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
@@ -419,6 +420,44 @@ def test_nemotron_omni_export_exposes_transitive_dynamic_modules(tmp_path):
     modeling_source = modeling_path.read_text()
     assert modeling_source.count("from .configuration_nemotron_h import NemotronHConfig") == 1
     assert modeling_source.count("from .configuration_radio import RADIOConfig") == 1
+
+
+def test_nemotron_omni_export_rewrites_modeling_as_utf8(tmp_path, monkeypatch):
+    """``modeling.py`` is UTF-8 source, so the rewrite must pin UTF-8.
+
+    Without an explicit ``encoding``, ``Path.read_text``/``write_text`` fall
+    back to the locale encoding, which is cp1252 on Windows and ASCII under
+    a C locale. Both raise on the non-ASCII characters that appear in real
+    modeling sources, failing the export after the weights are already
+    written.
+    """
+    modeling_path = tmp_path / "modeling.py"
+    # U+2581 is the SentencePiece word-boundary marker; U+2190 also appears
+    # in NVIDIA modeling sources. Neither survives a cp1252 round trip.
+    original = 'BOS = "<|begin▁of▁sentence|>"  # ←'
+    modeling_path.write_text(original + "\n", encoding="utf-8")
+
+    seen = {}
+    real_read, real_write = Path.read_text, Path.write_text
+
+    def spy_read(self, *args, **kwargs):
+        seen["read"] = kwargs.get("encoding")
+        return real_read(self, *args, **kwargs)
+
+    def spy_write(self, *args, **kwargs):
+        seen["write"] = kwargs.get("encoding")
+        return real_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", spy_read)
+    monkeypatch.setattr(Path, "write_text", spy_write)
+
+    NemotronOmniBridge().postprocess_hf_export_artifacts(tmp_path)
+
+    assert seen["read"] == "utf-8"
+    assert seen["write"] == "utf-8"
+    rewritten = modeling_path.read_text(encoding="utf-8")
+    assert original in rewritten
+    assert rewritten.count("from .configuration_nemotron_h import NemotronHConfig") == 1
 
 
 def test_nemotron_omni_export_requires_modeling_entrypoint(tmp_path):


### PR DESCRIPTION
`postprocess_hf_export_artifacts` reads the exported `modeling.py` with a bare `read_text()` and rewrites it with a bare `write_text()`, so both use `locale.getencoding()`. That is UTF-8 on CI and cp1252 on a Western Windows install, where the read raises on bytes a UTF-8 Python source routinely contains.

Not hypothetical for this codebase. Five files under `src/` cannot be decoded as cp1252 today, and reading one of them shows it directly:

```
read_text()        -> UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2408
read_text("utf-8") -> OK, 16838 chars   (U+2581, U+FF5C)
```

That is `deepseek/data/encoding_v4.py`, carrying the SentencePiece word-boundary marker and the DeepSeek delimiter, both ordinary in modeling sources. Since this is the final step of an HF export, the conversion fails after every weight is already written.

Thirteen call sites in `src/` already pass `encoding="utf-8"`, including `training/tokenizers/tokenizer.py:43` and `models/config.py`, so this follows the existing convention.

One limit worth stating: the suite gives no signal on my machine, since an autouse fixture imports `pyarrow` whose extension module is blocked here, so every test errors at setup. The added test was run directly and passes natively and under `PYTHONUTF8=1`. Pinning only the read moves the failure to a `UnicodeEncodeError` on the write, which is why both lines change.
