### PR TITLE
[docs] fix: correct Nemotron 3.5 Lightning page

### DIFF
--- a/docs/fern/versions/nightly/pages/models/nemotron/nemotron3.5-lightning.mdx
+++ b/docs/fern/versions/nightly/pages/models/nemotron/nemotron3.5-lightning.mdx
@@ -1,7 +1,7 @@
 # Nemotron 3.5 Lightning
-[Nemotron 3 Super](https://huggingface.co/collections/nvidia/nvidia-nemotron-v3)is a large language model (LLM) trained by NVIDIA, designed to deliver strong agentic, reasoning, and conversational capabilities. It is employs a hybrid **Latent Mixture-of-Experts (LatentMoE)** architecture, utilizing interleaved Mamba-2 and MoE layers, along with select Attention layers. Distinct from the Nano model, the Super model incorporates **Multi-Token Prediction (MTP)** layers for faster text generation and improved quality, and it is trained using **NVFP4** quantization to maximize compute efficiency. The model has **12B active parameters** and **120B parameters in total**.
+[NVIDIA Nemotron 3.5 Lightning 30B-A3B BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16) is a large language model trained by NVIDIA for reasoning, agentic, and conversational workloads. It uses a hybrid Mixture-of-Experts architecture with interleaved Mamba-2, MoE, and Attention layers, together with Multi-Token Prediction (MTP). This BF16 reference checkpoint has 30B total parameters and 3B active parameters.
 
-NeMo Megatron Bridge supports pretraining, full parameters finetuning, and LoRA finetuning this model. The finetuned model can be converted back to the 🤗 Hugging Face format for downstream evaluation.
+NeMo Megatron Bridge supports pretraining, full-parameter fine-tuning, and LoRA fine-tuning of this model. The fine-tuned model can be converted back to the 🤗 Hugging Face format for downstream evaluation.
 
 ```{important}
 Run all commands from `/opt/Megatron-Bridge` (e.g. `docker run -w /opt/Megatron-Bridge ...`)

--- a/docs/models/nemotron/nemotron3.5-lightning.md
+++ b/docs/models/nemotron/nemotron3.5-lightning.md
@@ -1,7 +1,7 @@
 # Nemotron 3.5 Lightning
-[Nemotron 3 Super](https://huggingface.co/collections/nvidia/nvidia-nemotron-v3)is a large language model (LLM) trained by NVIDIA, designed to deliver strong agentic, reasoning, and conversational capabilities. It is employs a hybrid **Latent Mixture-of-Experts (LatentMoE)** architecture, utilizing interleaved Mamba-2 and MoE layers, along with select Attention layers. Distinct from the Nano model, the Super model incorporates **Multi-Token Prediction (MTP)** layers for faster text generation and improved quality, and it is trained using **NVFP4** quantization to maximize compute efficiency. The model has **12B active parameters** and **120B parameters in total**.
+[NVIDIA Nemotron 3.5 Lightning 30B-A3B BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16) is a large language model trained by NVIDIA for reasoning, agentic, and conversational workloads. It uses a hybrid Mixture-of-Experts architecture with interleaved Mamba-2, MoE, and Attention layers, together with Multi-Token Prediction (MTP). This BF16 reference checkpoint has 30B total parameters and 3B active parameters.
 
-NeMo Megatron Bridge supports pretraining, full parameters finetuning, and LoRA finetuning this model. The finetuned model can be converted back to the 🤗 Hugging Face format for downstream evaluation.
+NeMo Megatron Bridge supports pretraining, full-parameter fine-tuning, and LoRA fine-tuning of this model. The fine-tuned model can be converted back to the 🤗 Hugging Face format for downstream evaluation.
 
 ```{important}
 Run all commands from `/opt/Megatron-Bridge` (e.g. `docker run -w /opt/Megatron-Bridge ...`)


### PR DESCRIPTION
## Summary

- replace the copied Nemotron 3 Super introduction on the Nemotron 3.5 Lightning page
- link directly to the public NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16 checkpoint
- correct the model description to 30B total / 3B active BF16 Lightning architecture
- regenerate the Fern documentation mirror

## History

The incorrect Super introduction was added when the interactive verification page was generated in #5774. Earlier checkpoint and naming updates in #5293 and #5303 already point the verification card and commands to Nemotron 3.5 Lightning.

## Validation

- `uv run --no-project --with pytest --with pyyaml python -m pytest tests/unit_tests/doc_consistency/test_model_verification_catalog.py -q`
- `uv run --no-project --with pyyaml python scripts/docs/generate_model_verification_catalog.py --check`
- checked-in pre-commit hooks passed via an isolated compatible pre-commit runner
