### PR TITLE
Add FP8 block-wise dequantization on load for GLM-5 checkpoints

### DIFF
--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -69,6 +69,34 @@ class GLM5Bridge(MegatronModelBridge):
             return False
         return super()._should_map_hf_config_field(hf_config, hf_name, megatron_name, value)
 
+    def maybe_modify_loaded_hf_weight(
+        self,
+        hf_param,
+        hf_state_dict,
+    ):
+        """Dequantize FP8 (float8_e4m3fn) weights using their ``*_scale_inv`` block-scale tensor.
+
+        The zai-org GLM-5/5.1/5.2 FP8 checkpoints ship linear weights (attention,
+        shared experts, and routed experts) as ``float8_e4m3fn`` with per 128x128
+        block scales stored in ``<key>_scale_inv`` (same layout as DeepSeek-V3).
+        The true bf16 weight is::
+
+            w_bf16 = fp8_weight.float() * scale_inv_block
+        """
+        hf_weights = super().maybe_modify_loaded_hf_weight(hf_param, hf_state_dict)
+        if isinstance(hf_weights, dict):
+            return {
+                key: self._maybe_dequantize_fp8(tensor, hf_param[key], hf_state_dict)
+                for key, tensor in hf_weights.items()
+            }
+        return self._maybe_dequantize_fp8(hf_weights, hf_param, hf_state_dict)
+
+    @staticmethod
+    def _maybe_dequantize_fp8(weight, param_name, hf_state_dict):
+        """Dequantize ``weight`` if it is stored as FP8 with a matching ``*_scale_inv``."""
+        scale_key = param_name + "_scale_inv"
+        return quantization_utils.maybe_dequantize_fp8_blockwise(weight, hf_state_dict.get(scale_key))
+
     def provider_bridge(self, hf_pretrained: PreTrainedCausalLM) -> MLAModelProvider:
         provider = super().provider_bridge(hf_pretrained)
         hf_config = hf_pretrained.config


### PR DESCRIPTION
# What does this PR do ?

`GLM5Bridge.maybe_modify_loaded_hf_weight` dequantizes `float8_e4m3fn` weights using the matching `*_scale_inv` block-scale tensor (`w_bf16 = fp8_weight.float() * scale_inv_block`) before the standard bf16 cast. Compound (dict) params (GatedMLPMapping gate/up) are dequantized per-component. Mirrors the existing DeepSeek-V3 / MiniMax-M2 overrides; reuses `quantization_utils.maybe_dequantize_fp8_blockwise`.

# Changelog

- Add support for GLM5/5.1/5.2 FP8 checkpoint loading support.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
