### PR TITLE
Support 3D-MoE LoRA export for shared-outer routed-expert adapters

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -866,6 +866,7 @@ class AutoBridge(Generic[MegatronModelT]):
         show_progress: bool = True,
         exclude_adapter_base_prefixes: Iterable[str] | None = None,
         expand_shared_outer: bool = False,
+        stack_3d_moe: bool = False,
     ) -> Iterable["HFWeightTuple"]:
         """
         Export only adapter weights from a Megatron model without merging them into base tensors.
@@ -881,6 +882,11 @@ class AutoBridge(Generic[MegatronModelT]):
                 skip before resolving HuggingFace parameter mappings.
             expand_shared_outer: Replicate the shared factor across experts under per-expert
                 names (vLLM 2D ``pack_moe``) instead of a shared ``[1, ...]`` tensor (SGLang).
+                Default ``False``; no effect for non-shared-outer adapters.
+            stack_3d_moe: Emit shared-outer routed-expert LoRA as the two stacked 3D
+                tensors vLLM's 3D-MoE consumer (``FusedMoE3DWithLoRA``) looks up
+                (``...experts.base_layer`` for gate_up_proj, bare ``...experts`` for
+                down_proj), instead of the per-expert 2D ``pack_moe`` layout.
                 Default ``False``; no effect for non-shared-outer adapters.
 
         Yields:
@@ -899,6 +905,7 @@ class AutoBridge(Generic[MegatronModelT]):
             show_progress=show_progress,
             exclude_adapter_base_prefixes=exclude_adapter_base_prefixes,
             expand_shared_outer=expand_shared_outer,
+            stack_3d_moe=stack_3d_moe,
         )
 
     def save_hf_adapter(

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -2555,6 +2555,7 @@ def stream_adapter_weights_megatron_to_hf(
     show_progress: bool = True,
     exclude_adapter_base_prefixes: Optional[Iterable[str]] = None,
     expand_shared_outer: bool = False,
+    stack_3d_moe: bool = False,
 ) -> Iterable[HFWeightTuple]:
     """Bridge only adapter weights from Megatron to HuggingFace format."""
     ...
@@ -2648,6 +2649,7 @@ def register_bridge_implementation(
         show_progress: bool = True,
         exclude_adapter_base_prefixes: Optional[Iterable[str]] = None,
         expand_shared_outer: bool = False,
+        stack_3d_moe: bool = False,
     ) -> Iterable[HFWeightTuple]:
         bridge = bridge_class()
         return bridge.stream_adapter_weights_megatron_to_hf(
@@ -2656,6 +2658,7 @@ def register_bridge_implementation(
             show_progress=show_progress,
             exclude_adapter_base_prefixes=exclude_adapter_base_prefixes,
             expand_shared_outer=expand_shared_outer,
+            stack_3d_moe=stack_3d_moe,
         )
 
     # Set meaningful names for debugging

--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -854,12 +854,19 @@ class MegatronPeftBridge:
         show_progress: bool = True,
         exclude_adapter_base_prefixes: Iterable[str] | None = None,
         expand_shared_outer: bool = False,
+        stack_3d_moe: bool = False,
     ) -> Iterable["HFWeightTuple"]:
         """Stream only adapter weights without merging them into base tensors.
 
         Each adapter is classified into one export topology (default / packed-expert
         / shared-outer) by :meth:`_select_adapter_emitter` and emitted by the
         matching ``_emit_*_adapter`` method. The loop holds no per-topology logic.
+
+        ``stack_3d_moe`` emits shared-outer routed-expert LoRA as the two stacked
+        3D tensors vLLM's ``FusedMoE3DWithLoRA`` consumer looks up (``...experts.base_layer``
+        for gate_up_proj, bare ``...experts`` for down_proj), instead of the per-expert
+        2D ``pack_moe`` layout. It is the vLLM-3D-MoE analogue of ``expand_shared_outer``
+        and takes precedence over it for shared-outer adapters.
         """
         from megatron.bridge.models.conversion.model_bridge import HFWeightTuple
 
@@ -897,6 +904,7 @@ class MegatronPeftBridge:
                     num_moe_experts,
                     cpu,
                     expand_shared_outer=expand_shared_outer,
+                    stack_3d_moe=stack_3d_moe,
                 )
                 continue
 
@@ -1037,6 +1045,7 @@ class MegatronPeftBridge:
         num_moe_experts: int,
         cpu: bool,
         expand_shared_outer: bool,
+        stack_3d_moe: bool = False,
     ) -> Iterable["HFWeightTuple"]:
         """Stream a shared-outer grouped-expert LoRA adapter (SGLang PR #21466).
 
@@ -1045,11 +1054,33 @@ class MegatronPeftBridge:
         ``[1, ...]`` tensor under the expert-agnostic HF name. With
         ``expand_shared_outer``, it is replicated under per-expert 2D names
         (vLLM 2D ``pack_moe`` contract); the training-side parameter stays shared.
+
+        With ``stack_3d_moe``, the whole adapter is emitted as the two stacked 3D
+        tensors vLLM's 3D-MoE consumer (``FusedMoE3DWithLoRA``) looks up:
+        ``...experts.base_layer`` (gate_up_proj) and bare ``...experts`` (down_proj),
+        with axis order ``lora_A=(E, r, in)`` and ``lora_B=(out, r, E)``. This is the
+        vLLM-3D-MoE analogue of the 2D ``expand_shared_outer`` path and is required
+        for 3D-MoE models (``is_3d_moe_weight=True``) that are not using vLLM's 2D
+        mixed MoE LoRA format.
         """
 
         from megatron.bridge.models.conversion.model_bridge import HFWeightTuple
 
         is_expert = is_expert_linear(adapter_task.global_base_prefix)
+
+        if stack_3d_moe:
+            yield from self._stream_shared_outer_adapter_weights_3d_moe(
+                megatron_model,
+                mapping_registry,
+                adapter_task,
+                linear_in_tensor,
+                linear_out_tensor,
+                num_moe_experts,
+                cpu,
+                is_expert,
+            )
+            return
+
         for side_tensor, side_suffix in (
             (linear_in_tensor, ".linear_in.weight"),
             (linear_out_tensor, ".linear_out.weight"),
@@ -1113,6 +1144,96 @@ class MegatronPeftBridge:
                     chunk = per_base.get(base_name)
                     assert chunk is not None, f"unknown projection name: {base_name!r}"
                     yield HFWeightTuple(side_hf_names[index], chunk)
+
+    def _stream_shared_outer_adapter_weights_3d_moe(
+        self,
+        megatron_model: List[MegatronModel],
+        mapping_registry: "MegatronMappingRegistry",
+        adapter_task: AdapterWeightConversionTask,
+        linear_in_tensor: torch.Tensor,
+        linear_out_tensor: torch.Tensor,
+        num_moe_experts: int,
+        cpu: bool,
+        is_expert: bool,
+    ) -> Iterable["HFWeightTuple"]:
+        """Emit a shared-outer routed-expert LoRA adapter in vLLM 3D-MoE layout.
+
+        vLLM's 3D-MoE LoRA consumer (``FusedMoE3DWithLoRA`` → ``_stack_moe_lora_weights``)
+        looks up exactly two stacked 3D tensors per registered ``...experts`` module:
+
+          * ``...experts.base_layer.lora_{A,B}.weight`` — gate_up_proj (gate+up fused)
+          * ``...experts.lora_{A,B}.weight``            — down_proj (bare)
+
+        with axis order ``lora_A=(E, r, in)`` and ``lora_B=(out, r, E)``. The
+        per-expert 2D names emitted by the ``expand_shared_outer`` path never match,
+        so vLLM silently drops the routed-expert LoRA. This stacks the full global
+        expert set (``num_moe_experts``) into those two 3D tensors; vLLM EP-slices
+        ``[expert_start:expert_end]`` at load time, so the global stack is a no-op for
+        non-EP and correct for EP.
+
+        Each adapter task is either FC1 (gate_up → ``base_layer``) or FC2 (down →
+        bare), distinguished by the HF base weight names it resolves to. A fused FC1
+        ``linear_out`` carries gate+up on its output dim already, matching vLLM's
+        ``2*moe_intermediate`` w13 fused stack, so no gate/up re-split is needed.
+        """
+        from megatron.bridge.models.conversion.model_bridge import HFWeightTuple
+
+        # Resolve the HF base names for expert 0 to discover this adapter's projection
+        # (gate_up vs down) and the expert-agnostic stem (...experts).
+        base_hf_weight_names = self._get_base_hf_param_names_for_adapter(
+            mapping_registry,
+            adapter_task.global_base_prefix,
+            adapter_task.adapter_key,
+            ".weight0",
+        )
+        if not base_hf_weight_names:
+            return
+
+        is_gate_up = any(
+            self._is_fused_fc1_gate_proj(n) or self._is_fused_fc1_up_proj(n)
+            for n in base_hf_weight_names
+        )
+        # stem e.g. "model.layers.0.mlp.experts.gate_proj.weight" -> "...mlp.experts".
+        stem = self._strip_hf_expert_index(base_hf_weight_names[0]).split(".experts")[0] + ".experts"
+
+        # --- lora_A: shared linear_in (r, in) -> broadcast to (E, r, in) ---
+        # Shared-outer keeps lora_A as a 2D tensor reused across experts; expand it
+        # along a leading expert axis. (A per-expert lora_A would be unexpected here,
+        # but the selection path handles it uniformly if it ever occurs.)
+        if linear_in_tensor.ndim == 2:
+            lora_a_3d = linear_in_tensor.unsqueeze(0).expand(num_moe_experts, -1, -1).contiguous()
+        else:
+            gathered_in = self._gather_expert_adapter_weight(linear_in_tensor)
+            lora_a_3d = torch.stack(
+                [
+                    self._select_expert_adapter_weight(linear_in_tensor, gathered_in, i, num_moe_experts)
+                    for i in range(num_moe_experts)
+                ],
+                dim=0,
+            )
+        if cpu:
+            lora_a_3d = lora_a_3d.cpu()
+
+        # --- lora_B: per-expert linear_out (E, out, r) -> permute to (out, r, E) ---
+        # ``_select_expert_adapter_weight`` returns the per-expert slice across EP
+        # ranks uniformly (EP>1 gathers, EP=1 indexes the local expert dim); stacking
+        # all global experts yields the (E, out, r) tensor vLLM expects, already
+        # carrying gate+up fused on the output dim for FC1.
+        gathered_out = self._gather_expert_adapter_weight(linear_out_tensor)
+        linear_out_all = torch.stack(
+            [
+                self._select_expert_adapter_weight(linear_out_tensor, gathered_out, i, num_moe_experts)
+                for i in range(num_moe_experts)
+            ],
+            dim=0,
+        )
+        lora_b_3d = linear_out_all.permute(1, 2, 0).contiguous()
+        if cpu:
+            lora_b_3d = lora_b_3d.cpu()
+
+        suffix = "base_layer." if is_gate_up else ""
+        yield HFWeightTuple(f"{stem}.{suffix}lora_A.weight", lora_a_3d)
+        yield HFWeightTuple(f"{stem}.{suffix}lora_B.weight", lora_b_3d)
 
     def _get_fused_adapter_linear_out_slices(
         self,

--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -1190,8 +1190,7 @@ class MegatronPeftBridge:
             return
 
         is_gate_up = any(
-            self._is_fused_fc1_gate_proj(n) or self._is_fused_fc1_up_proj(n)
-            for n in base_hf_weight_names
+            self._is_fused_fc1_gate_proj(n) or self._is_fused_fc1_up_proj(n) for n in base_hf_weight_names
         )
         # stem e.g. "model.layers.0.mlp.experts.gate_proj.weight" -> "...mlp.experts".
         stem = self._strip_hf_expert_index(base_hf_weight_names[0]).split(".experts")[0] + ".experts"
@@ -1220,13 +1219,17 @@ class MegatronPeftBridge:
         # all global experts yields the (E, out, r) tensor vLLM expects, already
         # carrying gate+up fused on the output dim for FC1.
         gathered_out = self._gather_expert_adapter_weight(linear_out_tensor)
-        linear_out_all = torch.stack(
-            [
-                self._select_expert_adapter_weight(linear_out_tensor, gathered_out, i, num_moe_experts)
-                for i in range(num_moe_experts)
-            ],
-            dim=0,
-        )
+        if gathered_out is None and linear_out_tensor.ndim > 2:
+            # EP=1: tensor is already (E, out, r), skip the per-expert stack loop.
+            linear_out_all = linear_out_tensor
+        else:
+            linear_out_all = torch.stack(
+                [
+                    self._select_expert_adapter_weight(linear_out_tensor, gathered_out, i, num_moe_experts)
+                    for i in range(num_moe_experts)
+                ],
+                dim=0,
+            )
         lora_b_3d = linear_out_all.permute(1, 2, 0).contiguous()
         if cpu:
             lora_b_3d = lora_b_3d.cpu()

--- a/tests/unit_tests/models/test_adapter_export.py
+++ b/tests/unit_tests/models/test_adapter_export.py
@@ -1701,13 +1701,21 @@ class TestStreamSharedOuterAdapterWeights:
     # ------------------------------------------------------------------
 
     def _mapping_gate_up(self):
-        """Mapping whose HF names are gate_proj/up_proj (FC1 → base_layer)."""
+        """Mapping whose HF names are gate_proj/up_proj (FC1 → base_layer).
+
+        Mirrors a ``GatedMLPMapping``: any ``.weightN`` suffix resolves to a dict
+        with both ``gate`` and ``up`` so ``_get_base_hf_param_names_for_adapter``
+        yields both projections.
+        """
         mapping = MagicMock()
 
         def lookup(name):
             idx = name.rsplit(".weight", 1)[1]
             return SimpleNamespace(
-                hf_param=f"model.layers.0.mlp.experts.{idx}.gate_proj.weight"
+                hf_param={
+                    "gate": f"model.layers.0.mlp.experts.{idx}.gate_proj.weight",
+                    "up": f"model.layers.0.mlp.experts.{idx}.up_proj.weight",
+                }
             )
 
         mapping.megatron_to_hf_lookup.side_effect = lookup
@@ -1719,9 +1727,7 @@ class TestStreamSharedOuterAdapterWeights:
 
         def lookup(name):
             idx = name.rsplit(".weight", 1)[1]
-            return SimpleNamespace(
-                hf_param=f"model.layers.0.mlp.experts.{idx}.down_proj.weight"
-            )
+            return SimpleNamespace(hf_param=f"model.layers.0.mlp.experts.{idx}.down_proj.weight")
 
         mapping.megatron_to_hf_lookup.side_effect = lookup
         return mapping
@@ -1749,8 +1755,8 @@ class TestStreamSharedOuterAdapterWeights:
         """FC1 (gate_up): base_layer.lora_A=(E,r,in), lora_B=(2*mi,r,E)."""
         bridge = self._make_bridge()
         E, r, hid, mi = 4, 2, 6, 3
-        linear_in = torch.randn(r, hid)            # shared (r, hid)
-        linear_out = torch.randn(E, 2 * mi, r)    # per-expert fused gate_up (E, 2*mi, r)
+        linear_in = torch.randn(r, hid)  # shared (r, hid)
+        linear_out = torch.randn(E, 2 * mi, r)  # per-expert fused gate_up (E, 2*mi, r)
 
         with (
             patch.object(bridge, "_gather_expert_adapter_weight", return_value=None),
@@ -1783,8 +1789,8 @@ class TestStreamSharedOuterAdapterWeights:
         """FC2 (down): bare lora_A=(E,r,mi), lora_B=(hid,r,E)."""
         bridge = self._make_bridge()
         E, r, hid, mi = 4, 2, 6, 3
-        linear_in = torch.randn(r, mi)            # shared (r, mi)
-        linear_out = torch.randn(E, hid, r)       # per-expert (E, hid, r)
+        linear_in = torch.randn(r, mi)  # shared (r, mi)
+        linear_out = torch.randn(E, hid, r)  # per-expert (E, hid, r)
 
         with (
             patch.object(bridge, "_gather_expert_adapter_weight", return_value=None),
@@ -1833,10 +1839,10 @@ class TestStreamSharedOuterAdapterWeights:
 
         # Reference closed-form layout (matches vLLM _stack_moe_lora_weights contract).
         stem = "model.layers.0.mlp.experts"
-        exp_base_a = gate_up_a_shared.unsqueeze(0).expand(E, -1, -1).contiguous()       # (E,r,hid)
-        exp_base_b = torch.cat([gate_b, up_b], dim=1).permute(1, 2, 0).contiguous()      # (2*mi,r,E)
-        exp_down_a = down_a_shared.unsqueeze(0).expand(E, -1, -1).contiguous()          # (E,r,mi)
-        exp_down_b = down_b.permute(1, 2, 0).contiguous()                                # (hid,r,E)
+        exp_base_a = gate_up_a_shared.unsqueeze(0).expand(E, -1, -1).contiguous()  # (E,r,hid)
+        exp_base_b = torch.cat([gate_b, up_b], dim=1).permute(1, 2, 0).contiguous()  # (2*mi,r,E)
+        exp_down_a = down_a_shared.unsqueeze(0).expand(E, -1, -1).contiguous()  # (E,r,mi)
+        exp_down_b = down_b.permute(1, 2, 0).contiguous()  # (hid,r,E)
 
         # --- bridge 3D path (from raw shared-outer tensors) ---
         # FC1 fused linear_out = cat(gate_b, up_b) per expert on output dim -> (E, 2*mi, r)
@@ -1848,15 +1854,7 @@ class TestStreamSharedOuterAdapterWeights:
             gu = self._run_3d(bridge, gate_up_a_shared, fc1_linear_out, E, self._mapping_gate_up())
             dn = self._run_3d(bridge, down_a_shared, down_b, E, self._mapping_down())
 
-        torch.testing.assert_close(
-            gu[f"{stem}.base_layer.lora_A.weight"], exp_base_a
-        )
-        torch.testing.assert_close(
-            gu[f"{stem}.base_layer.lora_B.weight"], exp_base_b
-        )
-        torch.testing.assert_close(
-            dn[f"{stem}.lora_A.weight"], exp_down_a
-        )
-        torch.testing.assert_close(
-            dn[f"{stem}.lora_B.weight"], exp_down_b
-        )
+        torch.testing.assert_close(gu[f"{stem}.base_layer.lora_A.weight"], exp_base_a)
+        torch.testing.assert_close(gu[f"{stem}.base_layer.lora_B.weight"], exp_base_b)
+        torch.testing.assert_close(dn[f"{stem}.lora_A.weight"], exp_down_a)
+        torch.testing.assert_close(dn[f"{stem}.lora_B.weight"], exp_down_b)

--- a/tests/unit_tests/models/test_adapter_export.py
+++ b/tests/unit_tests/models/test_adapter_export.py
@@ -1695,3 +1695,168 @@ class TestStreamSharedOuterAdapterWeights:
         ]
         for _, shape in results[False]:
             assert shape == (2, 4)
+
+    # ------------------------------------------------------------------
+    # stack_3d_moe: vLLM 3D-MoE consumer layout (base_layer / bare 3D)
+    # ------------------------------------------------------------------
+
+    def _mapping_gate_up(self):
+        """Mapping whose HF names are gate_proj/up_proj (FC1 → base_layer)."""
+        mapping = MagicMock()
+
+        def lookup(name):
+            idx = name.rsplit(".weight", 1)[1]
+            return SimpleNamespace(
+                hf_param=f"model.layers.0.mlp.experts.{idx}.gate_proj.weight"
+            )
+
+        mapping.megatron_to_hf_lookup.side_effect = lookup
+        return mapping
+
+    def _mapping_down(self):
+        """Mapping whose HF names are down_proj (FC2 → bare)."""
+        mapping = MagicMock()
+
+        def lookup(name):
+            idx = name.rsplit(".weight", 1)[1]
+            return SimpleNamespace(
+                hf_param=f"model.layers.0.mlp.experts.{idx}.down_proj.weight"
+            )
+
+        mapping.megatron_to_hf_lookup.side_effect = lookup
+        return mapping
+
+    def _run_3d(self, bridge, linear_in, linear_out, num_experts, mapping_registry, megatron_model=None, cpu=False):
+        task = SimpleNamespace(global_base_prefix="mlp.experts", adapter_key=None)
+        gen = bridge._stream_shared_outer_adapter_weights(
+            megatron_model=megatron_model,
+            mapping_registry=mapping_registry,
+            adapter_task=task,
+            linear_in_tensor=linear_in,
+            linear_out_tensor=linear_out,
+            num_moe_experts=num_experts,
+            cpu=cpu,
+            expand_shared_outer=True,
+            stack_3d_moe=True,
+        )
+        return {t.param_name: t.weight for t in gen}
+
+    @patch(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_expert_model_parallel_world_size",
+        return_value=1,
+    )
+    def test_stack_3d_moe_gate_up_emits_base_layer_3d(self, _mock_ep):
+        """FC1 (gate_up): base_layer.lora_A=(E,r,in), lora_B=(2*mi,r,E)."""
+        bridge = self._make_bridge()
+        E, r, hid, mi = 4, 2, 6, 3
+        linear_in = torch.randn(r, hid)            # shared (r, hid)
+        linear_out = torch.randn(E, 2 * mi, r)    # per-expert fused gate_up (E, 2*mi, r)
+
+        with (
+            patch.object(bridge, "_gather_expert_adapter_weight", return_value=None),
+            patch("megatron.bridge.models.conversion.peft_bridge.is_expert_linear", return_value=True),
+        ):
+            out = self._run_3d(bridge, linear_in, linear_out, E, self._mapping_gate_up())
+
+        assert set(out.keys()) == {
+            "model.layers.0.mlp.experts.base_layer.lora_A.weight",
+            "model.layers.0.mlp.experts.base_layer.lora_B.weight",
+        }
+        assert out["model.layers.0.mlp.experts.base_layer.lora_A.weight"].shape == (E, r, hid)
+        assert out["model.layers.0.mlp.experts.base_layer.lora_B.weight"].shape == (2 * mi, r, E)
+        # lora_A is the shared factor broadcast across experts.
+        torch.testing.assert_close(
+            out["model.layers.0.mlp.experts.base_layer.lora_A.weight"],
+            linear_in.unsqueeze(0).expand(E, -1, -1).contiguous(),
+        )
+        # lora_B is (out, r, E) = permute(1,2,0) of (E, 2*mi, r).
+        torch.testing.assert_close(
+            out["model.layers.0.mlp.experts.base_layer.lora_B.weight"],
+            linear_out.permute(1, 2, 0).contiguous(),
+        )
+
+    @patch(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_expert_model_parallel_world_size",
+        return_value=1,
+    )
+    def test_stack_3d_moe_down_emits_bare_3d(self, _mock_ep):
+        """FC2 (down): bare lora_A=(E,r,mi), lora_B=(hid,r,E)."""
+        bridge = self._make_bridge()
+        E, r, hid, mi = 4, 2, 6, 3
+        linear_in = torch.randn(r, mi)            # shared (r, mi)
+        linear_out = torch.randn(E, hid, r)       # per-expert (E, hid, r)
+
+        with (
+            patch.object(bridge, "_gather_expert_adapter_weight", return_value=None),
+            patch("megatron.bridge.models.conversion.peft_bridge.is_expert_linear", return_value=True),
+        ):
+            out = self._run_3d(bridge, linear_in, linear_out, E, self._mapping_down())
+
+        assert set(out.keys()) == {
+            "model.layers.0.mlp.experts.lora_A.weight",
+            "model.layers.0.mlp.experts.lora_B.weight",
+        }
+        assert out["model.layers.0.mlp.experts.lora_A.weight"].shape == (E, r, mi)
+        assert out["model.layers.0.mlp.experts.lora_B.weight"].shape == (hid, r, E)
+        torch.testing.assert_close(
+            out["model.layers.0.mlp.experts.lora_A.weight"],
+            linear_in.unsqueeze(0).expand(E, -1, -1).contiguous(),
+        )
+        torch.testing.assert_close(
+            out["model.layers.0.mlp.experts.lora_B.weight"],
+            linear_out.permute(1, 2, 0).contiguous(),
+        )
+
+    @patch(
+        "megatron.bridge.models.conversion.peft_bridge.parallel_state.get_expert_model_parallel_world_size",
+        return_value=1,
+    )
+    def test_stack_3d_moe_matches_vllm_consumer_layout(self, _mock_ep):
+        """The bridge 3D emit matches vLLM's _stack_moe_lora_weights expected layout.
+
+        vLLM's 3D-MoE consumer (``FusedMoE3DWithLoRA``) reshapes the on-disk 3D tensors
+        as ``lora_a.reshape(E, -1, in)`` and ``lora_b.reshape(out, -1, E).permute(2,0,1)``,
+        so the emitted tensors must be ``lora_A=(E, r, in)`` and ``lora_B=(out, r, E)``.
+        This is the layout verl's former ``_restructure_routed_expert_lora`` workaround
+        produced (the two are bit-identical). Here we assert the closed-form reference:
+        the shared ``linear_in`` broadcast to ``(E, r, in)`` and the per-expert
+        ``linear_out`` permuted to ``(out, r, E)``, with gate+up fused on the output dim.
+        """
+        bridge = self._make_bridge()
+        E, r, hid, mi = 4, 2, 6, 3
+        torch.manual_seed(0)
+        gate_up_a_shared = torch.randn(r, hid)
+        down_a_shared = torch.randn(r, mi)
+        gate_b = torch.randn(E, mi, r)
+        up_b = torch.randn(E, mi, r)
+        down_b = torch.randn(E, hid, r)
+
+        # Reference closed-form layout (matches vLLM _stack_moe_lora_weights contract).
+        stem = "model.layers.0.mlp.experts"
+        exp_base_a = gate_up_a_shared.unsqueeze(0).expand(E, -1, -1).contiguous()       # (E,r,hid)
+        exp_base_b = torch.cat([gate_b, up_b], dim=1).permute(1, 2, 0).contiguous()      # (2*mi,r,E)
+        exp_down_a = down_a_shared.unsqueeze(0).expand(E, -1, -1).contiguous()          # (E,r,mi)
+        exp_down_b = down_b.permute(1, 2, 0).contiguous()                                # (hid,r,E)
+
+        # --- bridge 3D path (from raw shared-outer tensors) ---
+        # FC1 fused linear_out = cat(gate_b, up_b) per expert on output dim -> (E, 2*mi, r)
+        fc1_linear_out = torch.cat([gate_b, up_b], dim=1)
+        with (
+            patch.object(bridge, "_gather_expert_adapter_weight", return_value=None),
+            patch("megatron.bridge.models.conversion.peft_bridge.is_expert_linear", return_value=True),
+        ):
+            gu = self._run_3d(bridge, gate_up_a_shared, fc1_linear_out, E, self._mapping_gate_up())
+            dn = self._run_3d(bridge, down_a_shared, down_b, E, self._mapping_down())
+
+        torch.testing.assert_close(
+            gu[f"{stem}.base_layer.lora_A.weight"], exp_base_a
+        )
+        torch.testing.assert_close(
+            gu[f"{stem}.base_layer.lora_B.weight"], exp_base_b
+        )
+        torch.testing.assert_close(
+            dn[f"{stem}.lora_A.weight"], exp_down_a
+        )
+        torch.testing.assert_close(
+            dn[f"{stem}.lora_B.weight"], exp_down_b
+        )

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1705,6 +1705,7 @@ class TestAutoBridge:
                         show_progress=False,
                         exclude_adapter_base_prefixes=None,
                         expand_shared_outer=False,
+                        stack_3d_moe=False,
                     )
 
     def test_export_adapter_weights_forwards_expand_shared_outer(self):


### PR DESCRIPTION
# What does this PR do ?

Support vLLM 3D-MoE LoRA export (`stack_3d_moe`) for shared-outer routed-expert adapters

# Changelog

- New `stack_3d_moe: bool` flag on `export_adapter_weights` / `stream_adapter_weights_megatron_to_hf`. When set, shared-outer routed-expert LoRA is emitted as the two stacked 3D tensors vLLM's `FusedMoE3DWithLoRA` consumer looks up (`...experts.base_layer.lora_{A,B}.weight` for gate_up_proj, bare `...experts.lora_{A,B}.weight` for down_proj), with axis order `lora_A=(E, r, in)` and `lora_B=(out, r, E)`. This is the 3D-MoE analogue of the existing 2D `expand_shared_outer` path and takes precedence over it for shared-outer adapters. Without this, vLLM 3D-MoE models (`is_3d_moe_weight=True`, e.g. Qwen3.5/3.6 VLM) silently drop every routed-expert LoRA → garbled output, reward=0.
- 3 new tests — `test_stack_3d_moe_gate_up_emits_base_layer_3d`, `test_stack_3d_moe_down_emits_bare_3d`, `test_stack_3d_moe_matches_vllm_consumer_layout`.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Related to # (issue)
