### PR TITLE
fix(model): honor explicit meta-device disable

### DIFF
--- a/src/megatron/bridge/models/model_provider.py
+++ b/src/megatron/bridge/models/model_provider.py
@@ -223,7 +223,7 @@ class ModelProviderMixin(abc.ABC, Generic[ModelT]):
             wrap_with_ddp: Whether to wrap model with DDP.
             data_parallel_random_init: Initialize parameters randomly across data parallel ranks.
             use_cpu_initialization: Override CPU initialization. None preserves the provider setting.
-            init_model_with_meta_device: Initialize model on meta device.
+            init_model_with_meta_device: Override meta-device initialization. None preserves the provider setting.
             pre_wrap_hook: A single callable or list of callables to modify the model before it's wrapped.
                 If provided, this will override all hooks registered via `register_pre_wrap_hook`.
                 If a list is provided, hooks will be executed in order.
@@ -510,7 +510,7 @@ class GetModelKwargs(TypedDict, total=False):
         wrap_with_ddp: Whether to wrap model with DDP.
         data_parallel_random_init: Initialize parameters randomly across data parallel ranks.
         use_cpu_initialization: Override CPU initialization. None preserves the provider setting.
-        init_model_with_meta_device: Initialize model on meta device.
+        init_model_with_meta_device: Override meta-device initialization. None preserves the provider setting.
         pre_wrap_hook: A single callable or list of callables that overrides all registered pre-wrap hooks.
         post_wrap_hook: A single callable that overrides all registered post-wrap hooks.
         mixed_precision_wrapper: Module wrapper to apply for fp16/bf16. None to skip.
@@ -606,7 +606,7 @@ def get_model(
         data_parallel_random_init: Whether to use random initialization for
             data parallel ranks (vs broadcasting from rank 0)
         use_cpu_initialization: Override CPU initialization. None preserves the provider setting
-        init_model_with_meta_device: Whether to initialize the model on the meta device
+        init_model_with_meta_device: Override meta-device initialization. None preserves the provider setting
         pre_wrap_hook: A callable or list of callables that takes a list of `MegatronModule`
             and returns a modified list, or `None` to clear the hook. If a list is provided,
             hooks will be executed in order.
@@ -645,8 +645,9 @@ def get_model(
 
     if use_cpu_initialization is not None:
         model_provider.use_cpu_initialization = use_cpu_initialization
-    if init_model_with_meta_device:
-        model_provider.init_model_with_meta_device = True
+    if init_model_with_meta_device is not None:
+        model_provider.init_model_with_meta_device = init_model_with_meta_device
+    if getattr(model_provider, "init_model_with_meta_device", False):
         with torch.device("meta"):
             model = _create_model(model_provider, model_type, pg_collection=pg_collection)
     else:

--- a/tests/unit_tests/models/test_model_instantiation.py
+++ b/tests/unit_tests/models/test_model_instantiation.py
@@ -832,6 +832,30 @@ class TestGetModel:
             )
 
     @patch("megatron.bridge.models.model_provider._create_model")
+    def test_get_model_explicitly_disables_meta_initialization(self, mock_create_model):
+        """Test that an explicit False overrides meta initialization."""
+
+        class ModelConstructionObserved(Exception):
+            pass
+
+        def record_meta_initialization(model_provider, *_args, **_kwargs):
+            assert model_provider.init_model_with_meta_device is False
+            raise ModelConstructionObserved
+
+        mock_create_model.side_effect = record_meta_initialization
+        model_provider = MockModelProvider()
+        model_provider.init_model_with_meta_device = True
+
+        with pytest.raises(ModelConstructionObserved):
+            get_model(
+                model_provider,
+                DistributedDataParallelConfig(),
+                init_model_with_meta_device=False,
+                wrap_with_ddp=False,
+                pg_collection=_PG(),
+            )
+
+    @patch("megatron.bridge.models.model_provider._create_model")
     def test_get_model_default_preserves_cpu_initialization(self, mock_create_model):
         """Test the direct construction entry point's omitted override."""
 

--- a/tests/unit_tests/models/test_model_instantiation.py
+++ b/tests/unit_tests/models/test_model_instantiation.py
@@ -831,29 +831,57 @@ class TestGetModel:
                 **override,
             )
 
+    @pytest.mark.parametrize("entry_point", ["get_model", "provide_distributed_model"])
+    @pytest.mark.parametrize(
+        ("initial_value", "override", "expected_value"),
+        [
+            pytest.param(True, {}, True, id="omitted-preserves-true"),
+            pytest.param(False, {}, False, id="omitted-preserves-false"),
+            pytest.param(True, {"init_model_with_meta_device": None}, True, id="none-preserves-true"),
+            pytest.param(False, {"init_model_with_meta_device": None}, False, id="none-preserves-false"),
+            pytest.param(True, {"init_model_with_meta_device": False}, False, id="false-disables"),
+            pytest.param(False, {"init_model_with_meta_device": True}, True, id="true-enables"),
+        ],
+    )
     @patch("megatron.bridge.models.model_provider._create_model")
-    def test_get_model_explicitly_disables_meta_initialization(self, mock_create_model):
-        """Test that an explicit False overrides meta initialization."""
+    def test_meta_initialization_override(
+        self, mock_create_model, initial_value, override, expected_value, entry_point
+    ):
+        """Model construction uses the effective meta-device setting."""
 
         class ModelConstructionObserved(Exception):
             pass
 
         def record_meta_initialization(model_provider, *_args, **_kwargs):
-            assert model_provider.init_model_with_meta_device is False
+            assert model_provider.init_model_with_meta_device is expected_value
+            expected_device = "meta" if expected_value else "cpu"
+            assert torch.empty(1).device.type == expected_device
             raise ModelConstructionObserved
 
         mock_create_model.side_effect = record_meta_initialization
         model_provider = MockModelProvider()
-        model_provider.init_model_with_meta_device = True
+        model_provider.init_model_with_meta_device = initial_value
 
-        with pytest.raises(ModelConstructionObserved):
-            get_model(
-                model_provider,
-                DistributedDataParallelConfig(),
-                init_model_with_meta_device=False,
-                wrap_with_ddp=False,
-                pg_collection=_PG(),
-            )
+        with (
+            patch("megatron.bridge.models.model_provider.torch.distributed.is_initialized", return_value=True),
+            pytest.raises(ModelConstructionObserved),
+        ):
+            if entry_point == "get_model":
+                get_model(
+                    model_provider,
+                    DistributedDataParallelConfig(),
+                    wrap_with_ddp=False,
+                    pg_collection=_PG(),
+                    **override,
+                )
+            else:
+                model_provider.provide_distributed_model(
+                    wrap_with_ddp=False,
+                    pg_collection=_PG(),
+                    **override,
+                )
+
+        assert torch.empty(1).device.type == "cpu"
 
     @patch("megatron.bridge.models.model_provider._create_model")
     def test_get_model_default_preserves_cpu_initialization(self, mock_create_model):


### PR DESCRIPTION
# What does this PR do?

Honor the tri-state `init_model_with_meta_device` override through `get_model` and `provide_distributed_model`.

# Changelog

- Apply explicit `True` and `False` overrides to the provider.
- Preserve the provider setting when the override is omitted or `None`.
- Use the effective provider setting for the construction device context.
- Document the contract and test both public entry points.

# Validation

The source-loaded CPU regression passes all override cases at `6585f50ab`, checking real CPU and meta tensor construction and restoration of the outer device context. The project pre-commit checks pass.

# GitHub Actions CI

The project test matrix awaits authorization for `6585f50abb7bde7caa7a8fee1881d2b6ad91ea77`.

# Before review

- [x] Contributor guidelines followed.
- [x] Regression tests added.
- [x] Public API documentation updated.

# Additional Information

Follow-up to #5925.
