### PR TITLE
[build] fix: support Transformers 5.12.1 through 5.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "transformers>=5.15,<=5.15.0",
+    "transformers>=5.12.1,<=5.15.0",
     "mistral-common>=1.10.0",
     "peft>=0.18.1",
     "datasets>=2.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2191,7 +2191,7 @@ requires-dist = [
     { name = "timm" },
     { name = "torch", specifier = ">=2.6.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "transformers", specifier = "<=5.15.0,>=5.15" },
+    { name = "transformers", specifier = ">=5.12.1,<=5.15.0" },
     { name = "typing-extensions" },
     { name = "wandb", specifier = ">=0.25.0" },
 ]


### PR DESCRIPTION
## What

- Expand the supported Transformers range from `5.15.0` only to `>=5.12.1,<=5.15.0`.
- Regenerate `uv.lock` so the package metadata records the same range.

## Why

NeMo-RL currently supports Transformers through 5.12.1. The exact 5.15.0 Bridge requirement makes the `nemo-rl[mcore]` dependency set unsatisfiable even though Bridge is compatible with the agreed 5.12.1 lower bound.

The normal Bridge lock remains on Transformers 5.15.0; this change restores the downstream compatibility window without downgrading the development environment.

## Validation

- `uv lock --check`
- `uv run --with transformers==5.12.1 ...`: imported `megatron.bridge` successfully and reported Transformers 5.12.1
- `pre-commit run --all-files`

## Test plan

- [ ] L0 CI green
- [ ] L1 CI green (`needs-more-tests`)
