### PR TITLE
docs(model-verification): regenerate qwen catalog

### DIFF
--- a/docs/_static/model-verification/catalog-v1.json
+++ b/docs/_static/model-verification/catalog-v1.json
@@ -8477,30 +8477,32 @@
           "workflow": "inference"
         },
         {
-          "bridge_commit": "52601b0382f869c9ca14109acdcdef77cc4fa61a",
+          "bridge_commit": "5db2290dea4887a2ca9072c0d554707bf272945d",
           "command_topologies": [
             {
               "gpus_per_node": "8",
-              "nodes": "1",
-              "recipe": "qwen35_vl_35b_a3b_pretrain_mock_config",
-              "total_gpus": 8
+              "nodes": "2",
+              "recipe": "qwen35_vl_35b_a3b_pretrain_config",
+              "total_gpus": 16
             }
           ],
           "commands": [
-            "./scripts/training/train.sh --nodes 1 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_mock_config --dataset energon --deterministic --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 20 --warmup_iters 2 --save_dir work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-reference/checkpoints --save_interval 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.do_validation=false scheduler.lr_decay_iters=20 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 model.recompute_granularity=full model.recompute_method=uniform model.recompute_num_layers=1 checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 ddp.check_for_large_grads=true logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-reference/resolved-config.yaml"
+            "./scripts/training/train.sh --nodes 2 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_config --dataset energon --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 50 --warmup_iters 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.task_encoder.max_pixels=200704 dataset.do_validation=false dataset.pad_to_max_length=true scheduler.lr_decay_iters=50 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/h100-performance/resolved-config.yaml"
           ],
           "dimensions": {},
-          "enabled_features": {},
+          "enabled_features": {
+            "moe_dispatcher": "hybridep"
+          },
           "entry_id": "qwen3-6-35b-a3b-pretrain-h100",
-          "expected_result": "At the recorded bridge commit, this bounded projection-pretraining support run used the official DataComp download pipeline at repository commit 4a8df1992566, the DataComp-1B metadata at revision 086ebeee20d4, and img2dataset 1.40.0. The Energon dataset contains 519,827 training and 5,173 validation image-caption samples; each training record maps an image plus \"Describe this image.\" to its caption. The deterministic 20-step reference consumed 10,240 training samples without wrapping. It warm-started the imported Qwen3.6 checkpoint, froze the language and vision towers, and trained the vision projection at TP1/PP1/CP1/EP8/ETP1, DP8, MBS1/GBS512, and 64-way gradient accumulation with one-layer full-uniform recompute. Loss was finite from 3.610127 to 2.261159 with zero skipped or NaN iterations; steps 11-20 averaged 330,730.470 ms and 18.090 TFLOP/s/GPU. Complete 72,366,371,530-byte eight-shard model/optimizer/RNG checkpoints and eight nonempty Energon rank states were saved at both steps 10 and 20, and the process exited successfully in 1h54m51s. This verifies the DataComp workflow and bounded Qwen VLM pretraining support, not canonical DataComp/CLIP convergence.\n",
+          "expected_result": "The 16-H100 command completed all 50 full-model DataComp Energon steps at TP1/PP2/CP1/EP8/ETP1 and MBS1/GBS512 after warm-starting the immutable imported checkpoint for natural routing. Loss remained finite from 3.604611 to 3.458849 with zero skipped or NaN iterations. The 519,827/5,173 train/validation split was prepared with the official DataComp downloader at commit 4a8df1992566, DataComp-1B metadata revision 086ebeee20d4, img2dataset 1.40.0, and preparation manifest 6e273a96a756. This verifies bounded full-model training, not canonical DataComp/CLIP convergence or checkpoint resume.\n",
           "hardware": "H100",
-          "last_verified": "2026-07-28",
+          "last_verified": "2026-08-05",
           "metrics": {
-            "final_loss": 2.261159,
-            "initial_loss": 3.610127,
-            "last_10_steps_model_tflops_per_gpu_avg": 18.09,
-            "last_10_steps_step_time_ms_avg": 330730.47,
-            "last_10_steps_tokens_per_second_per_gpu_avg": 792.621
+            "final_loss": 3.458849,
+            "initial_loss": 3.604611,
+            "last_10_steps_model_tflops_per_gpu_avg": 135.61,
+            "last_10_steps_step_time_ms_avg": 22271.22,
+            "last_10_steps_tokens_per_second_per_gpu_avg": 5885.264
           },
           "precision": "bf16",
           "source_pointer": "items.pretrain.H100",
@@ -8720,100 +8722,27 @@
           "workflow": "peft"
         },
         {
-          "bridge_commit": "52601b0382f869c9ca14109acdcdef77cc4fa61a",
-          "command_topologies": [
-            {
-              "gpus_per_node": "8",
-              "nodes": "1",
-              "recipe": "qwen35_vl_35b_a3b_pretrain_mock_config",
-              "total_gpus": 8
-            }
-          ],
-          "commands": [
-            "./scripts/training/train.sh --nodes 1 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_mock_config --dataset energon --deterministic --load_dir work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-reference/checkpoints --max_steps 20 --warmup_iters 2 --save_dir work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-resume/checkpoints --save_interval 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.do_validation=false scheduler.lr_decay_iters=20 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 model.recompute_granularity=full model.recompute_method=uniform model.recompute_num_layers=1 checkpoint.ckpt_step=10 validation.eval_iters=0 validation.eval_interval=0 ddp.check_for_large_grads=true logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-resume/resolved-config.yaml"
-          ],
+          "bridge_commit": "5db2290dea4887a2ca9072c0d554707bf272945d",
+          "command_topologies": [],
+          "commands": [],
           "dimensions": {},
           "enabled_features": {},
           "entry_id": "qwen3-6-35b-a3b-checkpoint-resume-h100",
-          "expected_result": "A fresh process loaded the exact reference step-10 checkpoint without a fallback warm start, restored model, optimizer, scheduler, RNG, and all eight Energon data-order states, entered the loop at iteration 10, and completed steps 11-20 in a distinct output root with zero skipped or NaN iterations. Step-11 loss 2.324095 matches the uninterrupted reference exactly. Step-20 loss 2.262711 differs from reference 2.261159 by 0.001552, or 0.068637%, within the declared one-percent gate; every intermediate resumed step was also within 0.1% of its reference. The resumed process exited successfully in 59m52s and saved a complete 72,366,371,502-byte eight-shard model/optimizer/RNG checkpoint plus eight nonempty Energon rank states at step 20, with the tracker selecting iteration 20.\n",
+          "expected_result": "Unverified. The completed full-model pretrain run intentionally did not save checkpoints. Publish a resume command only after a new reference run saves a middle checkpoint and a fresh continuation restores its model, optimizer, scheduler, RNG, and Energon data-order state.\n",
           "hardware": "H100",
-          "last_verified": "2026-07-28",
+          "last_verified": null,
           "metrics": {
-            "final_loss": 2.262711,
-            "initial_loss": 2.324095,
-            "last_10_steps_model_tflops_per_gpu_avg": 17.65,
-            "last_10_steps_step_time_ms_avg": 339600.71,
-            "last_10_steps_tokens_per_second_per_gpu_avg": 771.918
+            "final_loss": null,
+            "initial_loss": null,
+            "last_10_steps_model_tflops_per_gpu_avg": null,
+            "last_10_steps_step_time_ms_avg": null,
+            "last_10_steps_tokens_per_second_per_gpu_avg": null
           },
           "precision": "bf16",
           "source_pointer": "items.checkpoint_resume.H100",
-          "status": "verified",
+          "status": "unverified",
           "variant": null,
           "workflow": "checkpoint_resume"
-        },
-        {
-          "bridge_commit": "5db2290dea4887a2ca9072c0d554707bf272945d",
-          "command_topologies": [
-            {
-              "gpus_per_node": "8",
-              "nodes": "2",
-              "recipe": "qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_functional_config",
-              "total_gpus": 16
-            }
-          ],
-          "commands": [
-            "./scripts/training/train.sh --nodes 2 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_functional_config --dataset energon --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 50 --warmup_iters 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.task_encoder.max_pixels=200704 dataset.do_validation=false dataset.pad_to_max_length=true scheduler.lr_decay_iters=50 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 checkpoint.load=null checkpoint.save=null validation.eval_iters=0 validation.eval_interval=0 logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/h100-performance/resolved-config.yaml"
-          ],
-          "dimensions": {},
-          "enabled_features": {},
-          "entry_id": "qwen3-6-35b-a3b-pretrain-performance-h100",
-          "expected_result": "The exact 16-H100 command completed all 50 DataComp Energon steps at TP1/PP2/CP1/EP8/ETP1, a 16/24 language-layer pipeline split, and MBS1/GBS512. The persisted config confirmed the 248,320-token model vocabulary, natural expert routing, HybridEP, selective core-attention, GDN output-norm, and MoE-activation recompute, scoped Transformer Engine CUDA graphs for language attention/router/preprocessing, a graph-free variable-shape vision encoder, and Transformer Engine fused cross entropy. Loss remained finite from 3.604611 to 3.458849 with zero skipped or NaN iterations. Steps 41-50 averaged 22,271.220 ms and 135.610 model TFLOP/s/GPU, and the process exited successfully without checkpoint output. The separate fixed-shape forced-balance tuning screen remains the source of the 185.150-TFLOP/s/GPU leader policy; it is not substituted for this real-data measurement.\n",
-          "hardware": "H100",
-          "last_verified": "2026-08-05",
-          "metrics": {
-            "final_loss": 3.458849,
-            "initial_loss": 3.604611,
-            "last_10_steps_model_tflops_per_gpu_avg": 135.61,
-            "last_10_steps_step_time_ms_avg": 22271.22,
-            "last_10_steps_tokens_per_second_per_gpu_avg": 5885.264
-          },
-          "precision": "bf16",
-          "source_pointer": "items.pretrain_performance.H100",
-          "status": "verified",
-          "variant": null,
-          "workflow": "pretrain_performance"
-        },
-        {
-          "bridge_commit": "5db2290dea4887a2ca9072c0d554707bf272945d",
-          "command_topologies": [
-            {
-              "gpus_per_node": "4",
-              "nodes": "2",
-              "recipe": "qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8mx_config",
-              "total_gpus": 8
-            }
-          ],
-          "commands": [
-            "./scripts/training/train.sh --nodes 2 --gpus-per-node 4 --recipe qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8mx_config --max_steps 50 logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/gb200-performance/resolved-config.yaml"
-          ],
-          "dimensions": {},
-          "enabled_features": {},
-          "entry_id": "qwen3-6-35b-a3b-pretrain-performance-gb200",
-          "expected_result": "On 8x GB200, the exact architecture-shared Qwen3.5/Qwen3.6-VL fixed-shape mock-data recipe completed 50 steps at TP1/PP1/CP1/EP8/ETP1, dense DP8 and expert DP1, MBS3/GBS480, and 20 microbatches per optimizer step. The persisted post-setup config confirmed forced expert balance, HybridEP, MXFP8, cuDNN LayerNorm, and Transformer Engine CUDA graphs for the MoE router and preprocessing scopes. Loss was finite from 12.81499 to 3.166235 with zero skipped or NaN iterations. Steps 41-50 averaged 26,880.420 ms and 210.360 model TFLOP/s/GPU, and the process exited successfully. This synthetic result is a throughput measurement, not a convergence claim.\n",
-          "hardware": "GB200",
-          "last_verified": "2026-07-30",
-          "metrics": {
-            "final_loss": 3.166235,
-            "initial_loss": 12.81499,
-            "last_10_steps_model_tflops_per_gpu_avg": 210.36,
-            "last_10_steps_step_time_ms_avg": 26880.42,
-            "last_10_steps_tokens_per_second_per_gpu_avg": 9142.714
-          },
-          "precision": "fp8_mx",
-          "source_pointer": "items.pretrain_performance.GB200",
-          "status": "verified",
-          "variant": null,
-          "workflow": "pretrain_performance"
         }
       ],
       "hf_id": "Qwen/Qwen3.6-35B-A3B",
@@ -8821,7 +8750,7 @@
       "min_transformers_version": "5.8.1",
       "slug": "qwen3.6-35b-a3b",
       "source_card": "examples/model_verification_cards/qwen3.6-35b-a3b/card.yaml",
-      "summary": "Performance scope: pretrain_performance.H100 uses the tuned 16-H100 library recipe with the same pinned DataComp source as functional pretraining. The corresponding real-data pretrain, SFT, and LoRA measurements are verified. pretrain_performance.GB200 retains its tuned fixed-shape synthetic benchmark. Functional timing and throughput remain sanity checks. This card verifies conversion, inference, and training.\n",
+      "summary": "Performance disclaimer: this card does not record a canonical pretrain performance result; reported timing and throughput metrics are functional verification observations, not standalone optimized performance results. Full-model H100 DataComp pretraining reaches 135.610 model TFLOP/s/GPU, approximately 136, with natural routing. Checkpoint resume is explicitly unverified pending a full-model rerun. This card otherwise verifies conversion, inference, SFT, long-context SFT, and PEFT.\n",
       "title": "qwen3_6_35b_a3b"
     },
     {

--- a/docs/fern/versions/nightly/pages/models/README.mdx
+++ b/docs/fern/versions/nightly/pages/models/README.mdx
@@ -4,7 +4,7 @@
 
 Choose a model to open its interactive import/export and training configurations. Every option comes directly from an authoritative YAML verification card; independent fields are never combined into synthetic commands.
 
-Current inventory: **25 model cards** and **358 concrete configurations**.
+Current inventory: **25 model cards** and **356 concrete configurations**.
 
 Each model page lets you select import/export, pretraining, benchmarking, SFT, LoRA, or long-context SFT and immediately see the exact command and expected result for the recorded precision and GPU.
 
@@ -165,7 +165,7 @@ Choose a model to inspect its recorded import/export, training, and precision co
       </a>
       <a class="verification-model-link" href="qwen/qwen3.6-35b-a3b#verified-qwen3.6-35b-a3b">
         <strong title="Qwen/Qwen3.6-35B-A3B">Qwen3.6-35B-A3B</strong>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
+        <span class="verification-status verification-status--partial" title="Partial">◐ Partial</span>
       </a>
       <a class="verification-model-link" href="qwen/qwen3.8-27b#verified-qwen3.8-27b">
         <strong title="Qwen/Qwen3.8-27B">Qwen3.8-27B</strong>

--- a/docs/fern/versions/nightly/pages/models/qwen/qwen3.6-35b-a3b.mdx
+++ b/docs/fern/versions/nightly/pages/models/qwen/qwen3.6-35b-a3b.mdx
@@ -28,7 +28,7 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
     <div class="verification-capability-tabs" role="tablist" aria-label="Workflow">
       <button type="button" role="tab" aria-selected="true" data-capability-tab="import-export">Import & Export</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="pretrain">Pretrain</button>
-      <button type="button" role="tab" aria-selected="false" data-capability-tab="benchmark">Benchmark</button>
+      <button type="button" role="tab" aria-selected="false" data-capability-tab="benchmark" disabled>Benchmark</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="sft">SFT</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="lora">LoRA</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="long-context">Long Context</button>
@@ -120,20 +120,6 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
         <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
       </span>
       <span class="verification-combination-meta">BF16</span>
-    </button>
-    <button type="button" class="verification-combination" data-capability="benchmark" data-precision="bf16" data-hardware="H100" data-status="verified" data-entry="qwen3-6-35b-a3b-pretrain-performance-h100" aria-controls="qwen3-6-35b-a3b-pretrain-performance-h100" aria-pressed="false">
-      <span class="verification-combination-heading">
-        <strong>Benchmark · H100</strong>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </span>
-      <span class="verification-combination-meta">BF16</span>
-    </button>
-    <button type="button" class="verification-combination" data-capability="benchmark" data-precision="fp8_mx" data-hardware="GB200" data-status="verified" data-entry="qwen3-6-35b-a3b-pretrain-performance-gb200" aria-controls="qwen3-6-35b-a3b-pretrain-performance-gb200" aria-pressed="false">
-      <span class="verification-combination-heading">
-        <strong>Benchmark · GB200</strong>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </span>
-      <span class="verification-combination-meta">FP8 MX</span>
     </button>
   </div>
   <div class="verification-model-details">
@@ -249,30 +235,30 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       <dl class="verification-model-detail-meta">
         <div><dt>Hardware</dt><dd>H100</dd></div>
         <div><dt>Precision</dt><dd>BF16</dd></div>
-        <div><dt>Last verified</dt><dd>2026-07-28</dd></div>
+        <div><dt>Last verified</dt><dd>2026-08-05</dd></div>
       </dl>
       <section class="verification-recorded-metrics">
         <h5>Recorded metrics</h5>
         <dl class="verification-metric-list">
           <div>
             <dt>Initial loss</dt>
-            <dd>3.610127</dd>
+            <dd>3.604611</dd>
           </div>
           <div>
             <dt>Final loss</dt>
-            <dd>2.261159</dd>
+            <dd>3.458849</dd>
           </div>
           <div>
             <dt>Step time · last 10 avg</dt>
-            <dd>330,730.470 ms</dd>
+            <dd>22,271.220 ms</dd>
           </div>
           <div>
             <dt>Model throughput · last 10 avg</dt>
-            <dd>18.090 TFLOP/s/GPU</dd>
+            <dd>135.610 TFLOP/s/GPU</dd>
           </div>
           <div>
             <dt>Token throughput · last 10 avg</dt>
-            <dd>792.621 tokens/s/GPU</dd>
+            <dd>5,885.264 tokens/s/GPU</dd>
           </div>
         </dl>
       </section>
@@ -283,12 +269,12 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
             <span>Command</span>
             <button type="button" class="verification-copy-command">Copy</button>
           </div>
-          <pre><code class="language-bash">./scripts/training/train.sh --nodes 1 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_mock_config --dataset energon --deterministic --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 20 --warmup_iters 2 --save_dir work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-reference/checkpoints --save_interval 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.do_validation=false scheduler.lr_decay_iters=20 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 model.recompute_granularity=full model.recompute_method=uniform model.recompute_num_layers=1 checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 ddp.check_for_large_grads=true logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-reference/resolved-config.yaml</code></pre>
+          <pre><code class="language-bash">./scripts/training/train.sh --nodes 2 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_config --dataset energon --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 50 --warmup_iters 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.task_encoder.max_pixels=200704 dataset.do_validation=false dataset.pad_to_max_length=true scheduler.lr_decay_iters=50 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/h100-performance/resolved-config.yaml</code></pre>
         </div>
       </section>
       <section class="verification-expected-result">
         <h5>Expected result</h5>
-        <p>At the recorded bridge commit, this bounded projection-pretraining support run used the official DataComp download pipeline at repository commit 4a8df1992566, the DataComp-1B metadata at revision 086ebeee20d4, and img2dataset 1.40.0. The Energon dataset contains 519,827 training and 5,173 validation image-caption samples; each training record maps an image plus &quot;Describe this image.&quot; to its caption. The deterministic 20-step reference consumed 10,240 training samples without wrapping. It warm-started the imported Qwen3.6 checkpoint, froze the language and vision towers, and trained the vision projection at TP1/PP1/CP1/EP8/ETP1, DP8, MBS1/GBS512, and 64-way gradient accumulation with one-layer full-uniform recompute. Loss was finite from 3.610127 to 2.261159 with zero skipped or NaN iterations; steps 11-20 averaged 330,730.470 ms and 18.090 TFLOP/s/GPU. Complete 72,366,371,530-byte eight-shard model/optimizer/RNG checkpoints and eight nonempty Energon rank states were saved at both steps 10 and 20, and the process exited successfully in 1h54m51s. This verifies the DataComp workflow and bounded Qwen VLM pretraining support, not canonical DataComp/CLIP convergence.
+        <p>The 16-H100 command completed all 50 full-model DataComp Energon steps at TP1/PP2/CP1/EP8/ETP1 and MBS1/GBS512 after warm-starting the immutable imported checkpoint for natural routing. Loss remained finite from 3.604611 to 3.458849 with zero skipped or NaN iterations. The 519,827/5,173 train/validation split was prepared with the official DataComp downloader at commit 4a8df1992566, DataComp-1B metadata revision 086ebeee20d4, img2dataset 1.40.0, and preparation manifest 6e273a96a756. This verifies bounded full-model training, not canonical DataComp/CLIP convergence or checkpoint resume.
 </p>
       </section>
     </article>
@@ -544,108 +530,6 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       <section class="verification-expected-result">
         <h5>Expected result</h5>
         <p>On the same 8x GB200 topology and MedPix schedule as the controlled SFT item, LoRA completed exactly 100 finite steps with zero skipped or NaN iterations. The persisted configs differ only in the evidence-output path, the intended PEFT LR/min-LR, and the LoRA block; model, data, topology, batch, schedule, and safety settings match. Step-1 loss 2.214827 differs from SFT&#x27;s 2.212866 by only 0.001961, or 0.088618%, ruling out an initial-forward configuration mismatch. The later loss difference reflects LoRA&#x27;s trainable parameter set and learning rate. Steps 91-100 averaged 5,511.530 ms and 68.410 model TFLOP/s/GPU.
-</p>
-      </section>
-    </article>
-    <article id="qwen3-6-35b-a3b-pretrain-performance-h100" class="verification-model-detail" data-entry-detail="qwen3-6-35b-a3b-pretrain-performance-h100" tabindex="-1">
-      <header class="verification-model-detail-heading">
-        <h4>Benchmark · H100</h4>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </header>
-      <dl class="verification-model-detail-meta">
-        <div><dt>Hardware</dt><dd>H100</dd></div>
-        <div><dt>Precision</dt><dd>BF16</dd></div>
-        <div><dt>Last verified</dt><dd>2026-08-05</dd></div>
-      </dl>
-      <section class="verification-recorded-metrics">
-        <h5>Recorded metrics</h5>
-        <dl class="verification-metric-list">
-          <div>
-            <dt>Initial loss</dt>
-            <dd>3.604611</dd>
-          </div>
-          <div>
-            <dt>Final loss</dt>
-            <dd>3.458849</dd>
-          </div>
-          <div>
-            <dt>Step time · last 10 avg</dt>
-            <dd>22,271.220 ms</dd>
-          </div>
-          <div>
-            <dt>Model throughput · last 10 avg</dt>
-            <dd>135.610 TFLOP/s/GPU</dd>
-          </div>
-          <div>
-            <dt>Token throughput · last 10 avg</dt>
-            <dd>5,885.264 tokens/s/GPU</dd>
-          </div>
-        </dl>
-      </section>
-      <section class="verification-command-section">
-        <h5>Exact command</h5>
-        <div class="verification-command">
-          <div class="verification-command-heading">
-            <span>Command</span>
-            <button type="button" class="verification-copy-command">Copy</button>
-          </div>
-          <pre><code class="language-bash">./scripts/training/train.sh --nodes 2 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_functional_config --dataset energon --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 50 --warmup_iters 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.task_encoder.max_pixels=200704 dataset.do_validation=false dataset.pad_to_max_length=true scheduler.lr_decay_iters=50 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 checkpoint.load=null checkpoint.save=null validation.eval_iters=0 validation.eval_interval=0 logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/h100-performance/resolved-config.yaml</code></pre>
-        </div>
-      </section>
-      <section class="verification-expected-result">
-        <h5>Expected result</h5>
-        <p>The exact 16-H100 command completed all 50 DataComp Energon steps at TP1/PP2/CP1/EP8/ETP1, a 16/24 language-layer pipeline split, and MBS1/GBS512. The persisted config confirmed the 248,320-token model vocabulary, natural expert routing, HybridEP, selective core-attention, GDN output-norm, and MoE-activation recompute, scoped Transformer Engine CUDA graphs for language attention/router/preprocessing, a graph-free variable-shape vision encoder, and Transformer Engine fused cross entropy. Loss remained finite from 3.604611 to 3.458849 with zero skipped or NaN iterations. Steps 41-50 averaged 22,271.220 ms and 135.610 model TFLOP/s/GPU, and the process exited successfully without checkpoint output. The separate fixed-shape forced-balance tuning screen remains the source of the 185.150-TFLOP/s/GPU leader policy; it is not substituted for this real-data measurement.
-</p>
-      </section>
-    </article>
-    <article id="qwen3-6-35b-a3b-pretrain-performance-gb200" class="verification-model-detail" data-entry-detail="qwen3-6-35b-a3b-pretrain-performance-gb200" tabindex="-1">
-      <header class="verification-model-detail-heading">
-        <h4>Benchmark · GB200</h4>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </header>
-      <dl class="verification-model-detail-meta">
-        <div><dt>Hardware</dt><dd>GB200</dd></div>
-        <div><dt>Precision</dt><dd>FP8 MX</dd></div>
-        <div><dt>Last verified</dt><dd>2026-07-30</dd></div>
-      </dl>
-      <section class="verification-recorded-metrics">
-        <h5>Recorded metrics</h5>
-        <dl class="verification-metric-list">
-          <div>
-            <dt>Initial loss</dt>
-            <dd>12.81499</dd>
-          </div>
-          <div>
-            <dt>Final loss</dt>
-            <dd>3.166235</dd>
-          </div>
-          <div>
-            <dt>Step time · last 10 avg</dt>
-            <dd>26,880.420 ms</dd>
-          </div>
-          <div>
-            <dt>Model throughput · last 10 avg</dt>
-            <dd>210.360 TFLOP/s/GPU</dd>
-          </div>
-          <div>
-            <dt>Token throughput · last 10 avg</dt>
-            <dd>9,142.714 tokens/s/GPU</dd>
-          </div>
-        </dl>
-      </section>
-      <section class="verification-command-section">
-        <h5>Exact command</h5>
-        <div class="verification-command">
-          <div class="verification-command-heading">
-            <span>Command</span>
-            <button type="button" class="verification-copy-command">Copy</button>
-          </div>
-          <pre><code class="language-bash">./scripts/training/train.sh --nodes 2 --gpus-per-node 4 --recipe qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8mx_config --max_steps 50 logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/gb200-performance/resolved-config.yaml</code></pre>
-        </div>
-      </section>
-      <section class="verification-expected-result">
-        <h5>Expected result</h5>
-        <p>On 8x GB200, the exact architecture-shared Qwen3.5/Qwen3.6-VL fixed-shape mock-data recipe completed 50 steps at TP1/PP1/CP1/EP8/ETP1, dense DP8 and expert DP1, MBS3/GBS480, and 20 microbatches per optimizer step. The persisted post-setup config confirmed forced expert balance, HybridEP, MXFP8, cuDNN LayerNorm, and Transformer Engine CUDA graphs for the MoE router and preprocessing scopes. Loss was finite from 12.81499 to 3.166235 with zero skipped or NaN iterations. Steps 41-50 averaged 26,880.420 ms and 210.360 model TFLOP/s/GPU, and the process exited successfully. This synthetic result is a throughput measurement, not a convergence claim.
 </p>
       </section>
     </article>

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -4,7 +4,7 @@
 
 Choose a model to open its interactive import/export and training configurations. Every option comes directly from an authoritative YAML verification card; independent fields are never combined into synthetic commands.
 
-Current inventory: **25 model cards** and **358 concrete configurations**.
+Current inventory: **25 model cards** and **356 concrete configurations**.
 
 Each model page lets you select import/export, pretraining, benchmarking, SFT, LoRA, or long-context SFT and immediately see the exact command and expected result for the recorded precision and GPU.
 
@@ -165,7 +165,7 @@ Choose a model to inspect its recorded import/export, training, and precision co
       </a>
       <a class="verification-model-link" href="qwen/qwen3.6-35b-a3b.html#verified-qwen3.6-35b-a3b">
         <strong title="Qwen/Qwen3.6-35B-A3B">Qwen3.6-35B-A3B</strong>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
+        <span class="verification-status verification-status--partial" title="Partial">◐ Partial</span>
       </a>
       <a class="verification-model-link" href="qwen/qwen3.8-27b.html#verified-qwen3.8-27b">
         <strong title="Qwen/Qwen3.8-27B">Qwen3.8-27B</strong>

--- a/docs/models/qwen/qwen3.6-35b-a3b.md
+++ b/docs/models/qwen/qwen3.6-35b-a3b.md
@@ -28,7 +28,7 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
     <div class="verification-capability-tabs" role="tablist" aria-label="Workflow">
       <button type="button" role="tab" aria-selected="true" data-capability-tab="import-export">Import & Export</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="pretrain">Pretrain</button>
-      <button type="button" role="tab" aria-selected="false" data-capability-tab="benchmark">Benchmark</button>
+      <button type="button" role="tab" aria-selected="false" data-capability-tab="benchmark" disabled>Benchmark</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="sft">SFT</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="lora">LoRA</button>
       <button type="button" role="tab" aria-selected="false" data-capability-tab="long-context">Long Context</button>
@@ -120,20 +120,6 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
         <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
       </span>
       <span class="verification-combination-meta">BF16</span>
-    </button>
-    <button type="button" class="verification-combination" data-capability="benchmark" data-precision="bf16" data-hardware="H100" data-status="verified" data-entry="qwen3-6-35b-a3b-pretrain-performance-h100" aria-controls="qwen3-6-35b-a3b-pretrain-performance-h100" aria-pressed="false">
-      <span class="verification-combination-heading">
-        <strong>Benchmark · H100</strong>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </span>
-      <span class="verification-combination-meta">BF16</span>
-    </button>
-    <button type="button" class="verification-combination" data-capability="benchmark" data-precision="fp8_mx" data-hardware="GB200" data-status="verified" data-entry="qwen3-6-35b-a3b-pretrain-performance-gb200" aria-controls="qwen3-6-35b-a3b-pretrain-performance-gb200" aria-pressed="false">
-      <span class="verification-combination-heading">
-        <strong>Benchmark · GB200</strong>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </span>
-      <span class="verification-combination-meta">FP8 MX</span>
     </button>
   </div>
   <div class="verification-model-details">
@@ -249,30 +235,30 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       <dl class="verification-model-detail-meta">
         <div><dt>Hardware</dt><dd>H100</dd></div>
         <div><dt>Precision</dt><dd>BF16</dd></div>
-        <div><dt>Last verified</dt><dd>2026-07-28</dd></div>
+        <div><dt>Last verified</dt><dd>2026-08-05</dd></div>
       </dl>
       <section class="verification-recorded-metrics">
         <h5>Recorded metrics</h5>
         <dl class="verification-metric-list">
           <div>
             <dt>Initial loss</dt>
-            <dd>3.610127</dd>
+            <dd>3.604611</dd>
           </div>
           <div>
             <dt>Final loss</dt>
-            <dd>2.261159</dd>
+            <dd>3.458849</dd>
           </div>
           <div>
             <dt>Step time · last 10 avg</dt>
-            <dd>330,730.470 ms</dd>
+            <dd>22,271.220 ms</dd>
           </div>
           <div>
             <dt>Model throughput · last 10 avg</dt>
-            <dd>18.090 TFLOP/s/GPU</dd>
+            <dd>135.610 TFLOP/s/GPU</dd>
           </div>
           <div>
             <dt>Token throughput · last 10 avg</dt>
-            <dd>792.621 tokens/s/GPU</dd>
+            <dd>5,885.264 tokens/s/GPU</dd>
           </div>
         </dl>
       </section>
@@ -283,12 +269,12 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
             <span>Command</span>
             <button type="button" class="verification-copy-command">Copy</button>
           </div>
-          <pre><code class="language-bash">./scripts/training/train.sh --nodes 1 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_mock_config --dataset energon --deterministic --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 20 --warmup_iters 2 --save_dir work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-reference/checkpoints --save_interval 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.do_validation=false scheduler.lr_decay_iters=20 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 model.recompute_granularity=full model.recompute_method=uniform model.recompute_num_layers=1 checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 ddp.check_for_large_grads=true logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/datacomp-deterministic-reference/resolved-config.yaml</code></pre>
+          <pre><code class="language-bash">./scripts/training/train.sh --nodes 2 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_config --dataset energon --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 50 --warmup_iters 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.task_encoder.max_pixels=200704 dataset.do_validation=false dataset.pad_to_max_length=true scheduler.lr_decay_iters=50 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 checkpoint.load=null validation.eval_iters=0 validation.eval_interval=0 logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/h100-performance/resolved-config.yaml</code></pre>
         </div>
       </section>
       <section class="verification-expected-result">
         <h5>Expected result</h5>
-        <p>At the recorded bridge commit, this bounded projection-pretraining support run used the official DataComp download pipeline at repository commit 4a8df1992566, the DataComp-1B metadata at revision 086ebeee20d4, and img2dataset 1.40.0. The Energon dataset contains 519,827 training and 5,173 validation image-caption samples; each training record maps an image plus &quot;Describe this image.&quot; to its caption. The deterministic 20-step reference consumed 10,240 training samples without wrapping. It warm-started the imported Qwen3.6 checkpoint, froze the language and vision towers, and trained the vision projection at TP1/PP1/CP1/EP8/ETP1, DP8, MBS1/GBS512, and 64-way gradient accumulation with one-layer full-uniform recompute. Loss was finite from 3.610127 to 2.261159 with zero skipped or NaN iterations; steps 11-20 averaged 330,730.470 ms and 18.090 TFLOP/s/GPU. Complete 72,366,371,530-byte eight-shard model/optimizer/RNG checkpoints and eight nonempty Energon rank states were saved at both steps 10 and 20, and the process exited successfully in 1h54m51s. This verifies the DataComp workflow and bounded Qwen VLM pretraining support, not canonical DataComp/CLIP convergence.
+        <p>The 16-H100 command completed all 50 full-model DataComp Energon steps at TP1/PP2/CP1/EP8/ETP1 and MBS1/GBS512 after warm-starting the immutable imported checkpoint for natural routing. Loss remained finite from 3.604611 to 3.458849 with zero skipped or NaN iterations. The 519,827/5,173 train/validation split was prepared with the official DataComp downloader at commit 4a8df1992566, DataComp-1B metadata revision 086ebeee20d4, img2dataset 1.40.0, and preparation manifest 6e273a96a756. This verifies bounded full-model training, not canonical DataComp/CLIP convergence or checkpoint resume.
 </p>
       </section>
     </article>
@@ -544,108 +530,6 @@ Choose a workflow, precision, and exact recorded combination. The command and ex
       <section class="verification-expected-result">
         <h5>Expected result</h5>
         <p>On the same 8x GB200 topology and MedPix schedule as the controlled SFT item, LoRA completed exactly 100 finite steps with zero skipped or NaN iterations. The persisted configs differ only in the evidence-output path, the intended PEFT LR/min-LR, and the LoRA block; model, data, topology, batch, schedule, and safety settings match. Step-1 loss 2.214827 differs from SFT&#x27;s 2.212866 by only 0.001961, or 0.088618%, ruling out an initial-forward configuration mismatch. The later loss difference reflects LoRA&#x27;s trainable parameter set and learning rate. Steps 91-100 averaged 5,511.530 ms and 68.410 model TFLOP/s/GPU.
-</p>
-      </section>
-    </article>
-    <article id="qwen3-6-35b-a3b-pretrain-performance-h100" class="verification-model-detail" data-entry-detail="qwen3-6-35b-a3b-pretrain-performance-h100" tabindex="-1">
-      <header class="verification-model-detail-heading">
-        <h4>Benchmark · H100</h4>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </header>
-      <dl class="verification-model-detail-meta">
-        <div><dt>Hardware</dt><dd>H100</dd></div>
-        <div><dt>Precision</dt><dd>BF16</dd></div>
-        <div><dt>Last verified</dt><dd>2026-08-05</dd></div>
-      </dl>
-      <section class="verification-recorded-metrics">
-        <h5>Recorded metrics</h5>
-        <dl class="verification-metric-list">
-          <div>
-            <dt>Initial loss</dt>
-            <dd>3.604611</dd>
-          </div>
-          <div>
-            <dt>Final loss</dt>
-            <dd>3.458849</dd>
-          </div>
-          <div>
-            <dt>Step time · last 10 avg</dt>
-            <dd>22,271.220 ms</dd>
-          </div>
-          <div>
-            <dt>Model throughput · last 10 avg</dt>
-            <dd>135.610 TFLOP/s/GPU</dd>
-          </div>
-          <div>
-            <dt>Token throughput · last 10 avg</dt>
-            <dd>5,885.264 tokens/s/GPU</dd>
-          </div>
-        </dl>
-      </section>
-      <section class="verification-command-section">
-        <h5>Exact command</h5>
-        <div class="verification-command">
-          <div class="verification-command-heading">
-            <span>Command</span>
-            <button type="button" class="verification-copy-command">Copy</button>
-          </div>
-          <pre><code class="language-bash">./scripts/training/train.sh --nodes 2 --gpus-per-node 8 --recipe qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_functional_config --dataset energon --pretrained_checkpoint work/model-verification/qwen3.6-35b-a3b/imported-megatron/iter_0000000 --max_steps 50 --warmup_iters 10 dataset.path=work/data/datacomp/energon dataset.task_encoder.hf_processor_path=Qwen/Qwen3.6-35B-A3B dataset.task_encoder.hf_processor_revision=995ad96eacd98c81ed38be0c5b274b04031597b0 dataset.task_encoder.max_pixels=200704 dataset.do_validation=false dataset.pad_to_max_length=true scheduler.lr_decay_iters=50 model.hf_model_id=Qwen/Qwen3.6-35B-A3B model.bos_token_id=248044 checkpoint.load=null checkpoint.save=null validation.eval_iters=0 validation.eval_interval=0 logger.log_interval=1 logger.log_throughput=true logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/h100-performance/resolved-config.yaml</code></pre>
-        </div>
-      </section>
-      <section class="verification-expected-result">
-        <h5>Expected result</h5>
-        <p>The exact 16-H100 command completed all 50 DataComp Energon steps at TP1/PP2/CP1/EP8/ETP1, a 16/24 language-layer pipeline split, and MBS1/GBS512. The persisted config confirmed the 248,320-token model vocabulary, natural expert routing, HybridEP, selective core-attention, GDN output-norm, and MoE-activation recompute, scoped Transformer Engine CUDA graphs for language attention/router/preprocessing, a graph-free variable-shape vision encoder, and Transformer Engine fused cross entropy. Loss remained finite from 3.604611 to 3.458849 with zero skipped or NaN iterations. Steps 41-50 averaged 22,271.220 ms and 135.610 model TFLOP/s/GPU, and the process exited successfully without checkpoint output. The separate fixed-shape forced-balance tuning screen remains the source of the 185.150-TFLOP/s/GPU leader policy; it is not substituted for this real-data measurement.
-</p>
-      </section>
-    </article>
-    <article id="qwen3-6-35b-a3b-pretrain-performance-gb200" class="verification-model-detail" data-entry-detail="qwen3-6-35b-a3b-pretrain-performance-gb200" tabindex="-1">
-      <header class="verification-model-detail-heading">
-        <h4>Benchmark · GB200</h4>
-        <span class="verification-status verification-status--verified" title="Verified">✓ Verified</span>
-      </header>
-      <dl class="verification-model-detail-meta">
-        <div><dt>Hardware</dt><dd>GB200</dd></div>
-        <div><dt>Precision</dt><dd>FP8 MX</dd></div>
-        <div><dt>Last verified</dt><dd>2026-07-30</dd></div>
-      </dl>
-      <section class="verification-recorded-metrics">
-        <h5>Recorded metrics</h5>
-        <dl class="verification-metric-list">
-          <div>
-            <dt>Initial loss</dt>
-            <dd>12.81499</dd>
-          </div>
-          <div>
-            <dt>Final loss</dt>
-            <dd>3.166235</dd>
-          </div>
-          <div>
-            <dt>Step time · last 10 avg</dt>
-            <dd>26,880.420 ms</dd>
-          </div>
-          <div>
-            <dt>Model throughput · last 10 avg</dt>
-            <dd>210.360 TFLOP/s/GPU</dd>
-          </div>
-          <div>
-            <dt>Token throughput · last 10 avg</dt>
-            <dd>9,142.714 tokens/s/GPU</dd>
-          </div>
-        </dl>
-      </section>
-      <section class="verification-command-section">
-        <h5>Exact command</h5>
-        <div class="verification-command">
-          <div class="verification-command-heading">
-            <span>Command</span>
-            <button type="button" class="verification-copy-command">Copy</button>
-          </div>
-          <pre><code class="language-bash">./scripts/training/train.sh --nodes 2 --gpus-per-node 4 --recipe qwen35_vl_35b_a3b_pretrain_8gpu_gb200_fp8mx_config --max_steps 50 logger.save_config_filepath=work/model-verification/qwen3.6-35b-a3b/gb200-performance/resolved-config.yaml</code></pre>
-        </div>
-      </section>
-      <section class="verification-expected-result">
-        <h5>Expected result</h5>
-        <p>On 8x GB200, the exact architecture-shared Qwen3.5/Qwen3.6-VL fixed-shape mock-data recipe completed 50 steps at TP1/PP1/CP1/EP8/ETP1, dense DP8 and expert DP1, MBS3/GBS480, and 20 microbatches per optimizer step. The persisted post-setup config confirmed forced expert balance, HybridEP, MXFP8, cuDNN LayerNorm, and Transformer Engine CUDA graphs for the MoE router and preprocessing scopes. Loss was finite from 12.81499 to 3.166235 with zero skipped or NaN iterations. Steps 41-50 averaged 26,880.420 ms and 210.360 model TFLOP/s/GPU, and the process exited successfully. This synthetic result is a throughput measurement, not a convergence claim.
 </p>
       </section>
     </article>


### PR DESCRIPTION
## Background / motivation

PR #5852 updated the Qwen3.6-35B-A3B verification card and recipe names without regenerating the checked-in model-verification catalog and rendered model pages. On current `main` (`5ed97996cc2b422904d18179375b6d7366915097`), this leaves the catalog generator check stale and makes the Qwen readme-consistency test reference the removed `qwen35_vl_35b_a3b_pretrain_16gpu_h100_bf16_functional_config` recipe.

## What changed

Regenerated the model-verification catalog and model pages from the committed verification cards.

## Details

- updates the catalog inventory from 358 to 356 concrete configurations
- refreshes the Qwen3.6-35B-A3B rendered content and navigation state
- removes stale benchmark entries and stale recipe references from generated outputs
- does not change verification cards, recipes, or test code

## Tested

- `uv run --no-project --with pyyaml python scripts/docs/generate_model_verification_catalog.py --check`
- `uv run --no-project --with pyyaml python skills/create-model-verification-card/scripts/validate_card.py examples/model_verification_cards/qwen3.6-35b-a3b/card.yaml`
- `uv run --no-sync python -m pytest tests/unit_tests/doc_consistency/test_model_verification_catalog.py::test_generated_outputs_and_navigation_are_current tests/unit_tests/doc_consistency/test_readme_consistency.py::test_qwen3_model_guides_match_fern_and_reference_exported_recipes -q` — 2 passed
- `uv run --no-sync pre-commit run --all-files` — all hooks passed

The pytest and pre-commit commands ran locally in `766267172432.dkr.ecr.us-east-1.amazonaws.com/megatron-bridge:fea55a0735dbc2efbd5479c0cd51d5b872cef000` (digest `sha256:89f3b4e6c97a97a3f5bc631907b4d138c2e79c668e5c0893852e6d3bc470bd28`), the CI image selected by the affected agent run.
