### PR TITLE
[data] fix: Preserve RNG state during synchronous loading

### DIFF
--- a/src/megatron/bridge/data/samplers.py
+++ b/src/megatron/bridge/data/samplers.py
@@ -424,6 +424,22 @@ class RandomSeedDataset(Dataset):
     def __getitem__(self, idx: int) -> Any:
         """Get an item from the dataset, setting the random seed first."""
         seed = idx + self.curr_seed.value
+        if torch.utils.data.get_worker_info() is None:
+            python_rng_state = random.getstate()
+            numpy_rng_state = np.random.get_state()
+            cuda_devices = [torch.cuda.current_device()] if torch.cuda.is_available() else []
+            with torch.random.fork_rng(devices=cuda_devices):
+                try:
+                    torch.random.default_generator.manual_seed(seed)
+                    if cuda_devices:
+                        torch.cuda.manual_seed(seed)
+                    random.seed(seed)
+                    np.random.seed(seed)
+                    return self.dataset[idx]
+                finally:
+                    random.setstate(python_rng_state)
+                    np.random.set_state(numpy_rng_state)
+
         torch.manual_seed(seed)
         random.seed(seed)
         np.random.seed(seed)

--- a/tests/unit_tests/data/test_samplers.py
+++ b/tests/unit_tests/data/test_samplers.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+import random
+
+import numpy as np
 import pytest
 import torch
 from torch.utils.data import Dataset
@@ -108,3 +111,37 @@ def test_cyclic_sampler_resume_seeds_worker_dataset_for_current_epoch(
     expected_value = torch.randint(0, 1_000_000, (1,), generator=generator).item()
 
     assert actual_value.item() == expected_value
+
+
+def test_random_seed_dataset_preserves_main_process_rng_state() -> None:
+    """Synchronous dataset seeding must not overwrite the training RNG streams."""
+    dataset = RandomSeedDataset(_RandomValueDataset(), seed=100)
+    dataloader = build_pretraining_data_loader(
+        dataset=dataset,
+        consumed_samples=0,
+        dataloader_type="cyclic",
+        micro_batch_size=1,
+        num_workers=0,
+        data_sharding=False,
+    )
+
+    random.seed(999)
+    np.random.seed(999)
+    torch.manual_seed(999)
+    data_iterator = iter(dataloader)
+
+    python_generator = random.Random()
+    python_generator.setstate(random.getstate())
+    expected_python = python_generator.random()
+    numpy_generator = np.random.RandomState()
+    numpy_generator.set_state(np.random.get_state())
+    expected_numpy = numpy_generator.random_sample()
+    torch_generator = torch.Generator()
+    torch_generator.set_state(torch.random.get_rng_state())
+    expected_torch = torch.rand(1, generator=torch_generator)
+
+    next(data_iterator)
+
+    assert random.random() == expected_python
+    assert np.random.random_sample() == expected_numpy
+    assert torch.equal(torch.rand(1), expected_torch)


### PR DESCRIPTION
## Supported trigger and impact

A custom provider can return `RandomSeedDataset` through the supported cyclic loader with `num_workers=0`. PyTorch then executes `RandomSeedDataset.__getitem__` in the training process.

The wrapper seeded Python, NumPy, and Torch globally for each sample but did not restore those streams. The following collation, callback, or model code therefore consumed randomness derived from the last fetched sample. Because `torch.manual_seed` seeds default generators on all devices, untracked stochastic operations could become sample-dependent, differ across data-parallel ranks, and diverge after resume while training continued normally.

This is the synchronous sibling boundary of the worker epoch propagation covered by #5762.

## Root cause and minimal fix

`RandomSeedDataset.__getitem__` treated per-sample seeding as process-global state. For synchronous loading only, it now snapshots Python and NumPy RNGs and scopes Torch CPU/CUDA state with `torch.random.fork_rng()`. A `finally` block restores state even when the wrapped dataset raises. Worker-process behavior remains unchanged.

No loader, sampler-order, provider, configuration, or public signature changes.

## Regression evidence

The focused test initializes caller RNG streams after DataLoader iterator construction, computes their next draws from cloned states, fetches one item, and verifies that the real next draws are unchanged.

Before the production fix, the unchanged test failed:

```text
assert 0.9599609301949554 == 0.7813468849570298
1 failed
```

After the fix:

```text
1 passed
```

## Validation

The CPU-only package bootstrap avoids unrelated optional CUDA imports while importing the exact checkout's sampler module.

```text
CUDA_VISIBLE_DEVICES= BRIDGE_SOURCE_ROOT="$PWD/src" PYTHONPATH="$HARNESS_ROOT" \
  uv run --no-project --python 3.12 --with pytest==8.4.2 \
  --with torch==2.8.0 --with numpy==2.3.2 python -m pytest \
  -p bootstrap_sampler_test --confcutdir=tests/unit_tests/data \
  -p no:cacheprovider \
  tests/unit_tests/data/test_samplers.py::test_random_seed_dataset_preserves_main_process_rng_state -q
# fail before: 1 failed; pass after: 1 passed

# Same isolated invocation for the adjacent file:
tests/unit_tests/data/test_samplers.py -q
# 9 passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# all hooks passed
```

## Scope

The change is limited to zero-worker `RandomSeedDataset` fetches and one focused CPU regression. Multi-worker behavior is unchanged. No GPU training, distributed execution, convergence, model-quality, performance, or full-suite validation is claimed.
