### PR TITLE
perf(recipe): enable fused GDN conv1d for Qwen3.5-VL perf recipes

### DIFF
--- a/src/megatron/bridge/perf_recipes/qwen_vl/common.py
+++ b/src/megatron/bridge/perf_recipes/qwen_vl/common.py
@@ -57,6 +57,19 @@ def _qwen35_vl_common(cfg: ConfigContainer) -> None:
     cfg.model.recompute_modules = []
     cfg.model.moe_router_fusion = True
 
+    # Fuse the GatedDeltaNet pre-gated-delta-rule path (causal conv1d + QK
+    # L2-norm) into Triton kernels. Qwen3.5-VL is 3/4 GDN layers, and this is
+    # the largest single fusion win measured for the model.
+    #
+    # Requires a Megatron-Core that carries gdn_pre_gated_delta_rule_fusion.
+    # Assigning it on an older core would silently add an unused attribute
+    # rather than raise, so guard on the field actually existing -- a silently
+    # inert perf flag is worse than an explicit no-op.
+    if hasattr(type(cfg.model), "gdn_pre_gated_delta_rule_fusion") or hasattr(
+        cfg.model, "gdn_pre_gated_delta_rule_fusion"
+    ):
+        cfg.model.gdn_pre_gated_delta_rule_fusion = True
+
     cfg.model.seq_length = 4096
     cfg.dataset.seq_length = 4096
 

--- a/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
+++ b/tests/unit_tests/scripts/performance/test_qwen35_vl_workload_base_configs.py
@@ -217,3 +217,28 @@ def test_qwen35_vl_35b_gb200_measured_performance_defaults(
     assert cuda_graph_module_names(config.model) == expected_graph_modules
     assert config.env_vars["NVTE_NORM_BWD_USE_CUDNN"] == 1
     assert config.env_vars["NVTE_NORM_FWD_USE_CUDNN"] == 1
+
+
+def test_qwen35_vl_perf_recipes_enable_gdn_conv_fusion(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Qwen3.5-VL perf recipes should fuse the GatedDeltaNet pre-gated-delta-rule path.
+
+    The flag lives in ``_qwen35_vl_common`` so it applies to every Qwen3.5-VL perf
+    recipe regardless of platform -- it selects Triton kernels, not a
+    hardware-specific path.
+
+    Skipped when the installed Megatron-Core predates
+    ``gdn_pre_gated_delta_rule_fusion``; the recipe guards on the same condition,
+    so on an older core the flag is intentionally not set. The assertion below
+    starts running as soon as the core is bumped.
+    """
+    patch_recipe_construction_dependencies(monkeypatch)
+
+    config = qwen35_vl_35b_a3b_pretrain_8gpu_gb200_bf16_config()
+
+    if not hasattr(type(config.model), "gdn_pre_gated_delta_rule_fusion") and not hasattr(
+        config.model, "gdn_pre_gated_delta_rule_fusion"
+    ):
+        pytest.skip("Megatron-Core does not expose gdn_pre_gated_delta_rule_fusion")
+
+    assert config.model.gdn_pre_gated_delta_rule_fusion is True
+


### PR DESCRIPTION
Set gdn_pre_gated_delta_rule_fusion on the Qwen3.5-VL perf recipes, which fuses the GatedDeltaNet pre-gated-delta-rule path (causal conv1d + QK L2-norm) into Triton kernels. Qwen3.5-VL runs 30 of its 40 layers as GDN (3 GDN : 1 full attention), so this path is a large share of the step.

# What does this PR do ?

Set gdn_pre_gated_delta_rule_fusion on the Qwen3.5-VL perf recipes, which fuses the GatedDeltaNet pre-gated-delta-rule path (causal conv1d + QK L2-norm) into Triton kernels. Qwen3.5-VL runs 30 of its 40 layers as GDN (3 GDN : 1 full attention), so this path is a large share of the step.

Measured on 8x GB300, real DataComp Energon data, BF16 -> +5.8%

PREREQUISITE: this requires a Megatron-Core that carries gdn_pre_gated_delta_rule_fusion: https://github.com/NVIDIA/Megatron-LM/pull/5532. The core currently pinned by main does not, so the assignment is guarded on the field existing. Assigning an unknown attribute on the model config would not raise -- it would silently create an unused attribute and the recipe would look enabled while running unfused -- so the guard is deliberate. Once the core is bumped the flag takes effect and the accompanying test stops skipping.

Tests: assert the flag is set on a Qwen3.5-VL perf recipe, skipping while the installed core predates the field so the test activates automatically after the core bump.

# Changelog

- Add specific line by line info of high level changes in this PR.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

