### PR TITLE
fix(peft): reuse grouped expert outputs for LoRA

### DIFF
--- a/src/megatron/bridge/peft/lora_layers.py
+++ b/src/megatron/bridge/peft/lora_layers.py
@@ -22,6 +22,53 @@ from megatron.core.transformer.moe.moe_utils import apply_random_logits
 
 from megatron.bridge.peft.adapter_wrapper import AdapterWrapper
 from megatron.bridge.peft.lora_merge import LoRAMerge
+from megatron.bridge.peft.utils import ParallelLinearAdapter
+
+
+class _AddExpertLoRA(torch.autograd.Function):
+    """Accumulate an expert LoRA projection into a consumed grouped-linear output."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        rank_input: torch.Tensor,
+        weight: torch.Tensor,
+        base_output: torch.Tensor,
+        destination: torch.Tensor,
+    ):
+        if (
+            base_output.ndim != 2
+            or rank_input.ndim != 2
+            or not base_output.is_contiguous()
+            or base_output.storage_offset() != 0
+            or base_output.untyped_storage().nbytes() != base_output.numel() * base_output.element_size()
+            or destination.shape != base_output.shape
+            or destination.data_ptr() != base_output.data_ptr()
+            or destination.requires_grad
+        ):
+            raise RuntimeError("Grouped-linear output does not cover one complete contiguous allocation")
+        if rank_input.shape[0] != base_output.shape[0] or weight.shape != (
+            base_output.shape[1],
+            rank_input.shape[1],
+        ):
+            raise RuntimeError("Expert LoRA projection does not match the grouped-linear output")
+        if rank_input.device != base_output.device or weight.device != base_output.device:
+            raise RuntimeError("Expert LoRA projection and grouped-linear output must share a device")
+        if rank_input.dtype != base_output.dtype or weight.dtype != base_output.dtype:
+            raise RuntimeError("Expert LoRA projection and grouped-linear output must share a dtype")
+
+        ctx.save_for_backward(rank_input, weight)
+        ctx.mark_dirty(destination)
+        torch.addmm(destination, rank_input, weight.t(), beta=1, out=destination)
+        return destination
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        rank_input, weight = ctx.saved_tensors
+        grad_rank_input = grad_output @ weight if ctx.needs_input_grad[0] else None
+        grad_weight = grad_output.t() @ rank_input if ctx.needs_input_grad[1] else None
+        grad_base_output = grad_output if ctx.needs_input_grad[2] else None
+        return grad_rank_input, grad_weight, grad_base_output, None
 
 
 class LoRALinear(AdapterWrapper):
@@ -62,6 +109,51 @@ class LoRALinear(AdapterWrapper):
         """Return the wrapped linear bias."""
         return getattr(self.to_wrap, "bias", None)
 
+    def _can_reuse_grouped_expert_output(self, x: torch.Tensor, linear_output: torch.Tensor) -> bool:
+        adapter = self.adapter
+        grouped_linear_type = getattr(te, "GroupedLinear", None)
+        if grouped_linear_type is None or not isinstance(self.to_wrap, grouped_linear_type):
+            return False
+        if not isinstance(adapter, ParallelLinearAdapter) or not adapter.is_expert:
+            return False
+        if not isinstance(adapter.activation, nn.Identity) or not isinstance(adapter.dropout, nn.Identity):
+            return False
+        if not adapter.disable_sequence_parallel_comm:
+            return False
+        if adapter.config.cpu_offloading and adapter.config.cpu_offloading_activations:
+            return False
+        linear_in = adapter.linear_in
+        linear_out = adapter.linear_out
+        surface = adapter.base_linear_name.rsplit(".", maxsplit=1)[-1]
+        if surface == "linear_fc1":
+            if adapter.input_is_parallel:
+                return False
+        elif surface == "linear_fc2":
+            if not adapter.input_is_parallel:
+                return False
+        else:
+            return False
+        return (
+            not adapter.use_a2a
+            and getattr(adapter.config, "expert_tensor_parallel_size", 1) == 1
+            and x.ndim == 2
+            and linear_output.ndim == 2
+            and linear_in.input_size == x.shape[-1]
+            and linear_out.output_size_per_partition == linear_out.output_size
+            and linear_out.weight.shape[0] == linear_output.shape[-1]
+            and linear_out.bias is None
+            and not linear_out.gradient_accumulation_fusion
+            and linear_out.gtp_remat_size == 1
+        )
+
+    def _reuse_grouped_expert_output(self, x: torch.Tensor, linear_output: torch.Tensor) -> torch.Tensor:
+        adapter = self.adapter
+        rank_output, _ = adapter.linear_in(x)
+        rank_output = adapter.activation(rank_output)
+        rank_output = rank_output * (adapter.alpha / adapter.dim)
+        destination = linear_output.detach()
+        return _AddExpertLoRA.apply(rank_output, adapter.linear_out.weight, linear_output, destination)
+
     def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any):
         """Forward pass that combines the wrapped module output with the adapter output.
 
@@ -80,12 +172,15 @@ class LoRALinear(AdapterWrapper):
         linear_output, bias, layernorm_output = self.base_linear_forward(x, *args, **kwargs)
         if not self._adapter_enabled:
             return linear_output if not self._base_returns_tuple else (linear_output, bias)
-        # Serialize full-width branch buffers to keep long-context peak at two outputs.
-        combined_output = linear_output.clone()
-        del linear_output
-        adapter_output = self.adapter_forward(self.adapter, layernorm_output.contiguous(), *args, **kwargs)
-        adapter_output = adapter_output.reshape(combined_output.shape)
-        combined_output.add_(adapter_output)
+        adapter_input = layernorm_output.contiguous()
+        if self._can_reuse_grouped_expert_output(adapter_input, linear_output):
+            combined_output = self._reuse_grouped_expert_output(adapter_input, linear_output)
+        else:
+            combined_output = linear_output.clone()
+            del linear_output
+            adapter_output = self.adapter_forward(self.adapter, adapter_input, *args, **kwargs)
+            adapter_output = adapter_output.reshape(combined_output.shape)
+            combined_output.add_(adapter_output)
         if not self._base_returns_tuple:
             return combined_output
         return combined_output, bias

--- a/tests/unit_tests/peft/test_adapter_wrapper.py
+++ b/tests/unit_tests/peft/test_adapter_wrapper.py
@@ -29,7 +29,7 @@ import torch.nn as nn
 
 from megatron.bridge.peft.adapter_wrapper import AdapterWrapper
 from megatron.bridge.peft.base import PEFT
-from megatron.bridge.peft.lora_layers import LoRALinear
+from megatron.bridge.peft.lora_layers import LoRALinear, _AddExpertLoRA
 
 
 class MockLinear(nn.Module):
@@ -477,6 +477,132 @@ class TestAdapterWrapper:
         assert torch.isfinite(x.grad).all()
         assert base.weight.grad is not None
         assert adapter.weight.grad is not None
+
+    @pytest.mark.parametrize(
+        ("surface", "input_is_parallel"),
+        (("linear_fc1", False), ("linear_fc2", True)),
+    )
+    def test_grouped_expert_linear_reuses_base_output_with_exact_gradients(
+        self, surface: str, input_is_parallel: bool
+    ):
+        """The grouped expert path must not allocate a second full-width output."""
+
+        class ViewLinearFunction(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, weight):
+                ctx.save_for_backward(x, weight)
+                output = x @ weight.t()
+                return output.view_as(output)
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                x, weight = ctx.saved_tensors
+                return grad_output @ weight, grad_output.t() @ x
+
+        class GroupedViewLinear(nn.Module):
+            def __init__(self, in_features, out_features):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(out_features, in_features))
+
+            def forward(self, x, *_):
+                return ViewLinearFunction.apply(x, self.weight), None
+
+        class RankLinear(nn.Module):
+            def __init__(self, in_features, out_features):
+                super().__init__()
+                self.input_size = in_features
+                self.weight = nn.Parameter(torch.randn(out_features, in_features))
+
+            def forward(self, x):
+                return x @ self.weight.t(), None
+
+        class OutputLinear(nn.Module):
+            def __init__(self, in_features, out_features):
+                super().__init__()
+                self.output_size = out_features
+                self.output_size_per_partition = out_features
+                self.weight = nn.Parameter(torch.randn(out_features, in_features))
+                self.bias = None
+                self.gradient_accumulation_fusion = False
+                self.gtp_remat_size = 1
+
+            def forward(self, _):
+                raise AssertionError("The fused path must not materialize the LoRA output")
+
+        class ExpertAdapter(nn.Module):
+            def __init__(self, in_features, out_features, rank):
+                super().__init__()
+                self.is_expert = True
+                self.input_is_parallel = input_is_parallel
+                self.disable_sequence_parallel_comm = True
+                self.activation = nn.Identity()
+                self.dropout = nn.Identity()
+                self.config = Mock(
+                    cpu_offloading=False,
+                    cpu_offloading_activations=False,
+                    expert_tensor_parallel_size=1,
+                )
+                self.base_linear_name = f"decoder.layers.0.mlp.experts.{surface}"
+                self.use_a2a = False
+                self.dim = rank
+                self.alpha = rank
+                self.linear_in = RankLinear(in_features, rank)
+                self.linear_out = OutputLinear(rank, out_features)
+
+        torch.manual_seed(7)
+        base = GroupedViewLinear(9, 7)
+        adapter = ExpertAdapter(9, 7, 3)
+        wrapper = LoRALinear(base, adapter)
+        x = torch.randn(11, 9, requires_grad=True)
+        upstream = torch.randn(11, 7)
+        expected = x @ base.weight.t() + (x @ adapter.linear_in.weight.t()) @ adapter.linear_out.weight.t()
+        expected_grads = torch.autograd.grad(
+            expected,
+            (x, base.weight, adapter.linear_in.weight, adapter.linear_out.weight),
+            upstream,
+            retain_graph=True,
+        )
+        base_ptr = []
+        base.register_forward_hook(lambda _module, _inputs, output: base_ptr.append(output[0].data_ptr()))
+
+        with (
+            patch("megatron.bridge.peft.lora_layers.te.GroupedLinear", GroupedViewLinear),
+            patch("megatron.bridge.peft.lora_layers.ParallelLinearAdapter", ExpertAdapter),
+        ):
+            actual, _ = wrapper(x)
+            assert wrapper._can_reuse_grouped_expert_output(x, actual)
+            adapter.config.expert_tensor_parallel_size = 2
+            assert not wrapper._can_reuse_grouped_expert_output(x, actual)
+            adapter.config.expert_tensor_parallel_size = 1
+            adapter.use_a2a = True
+            assert not wrapper._can_reuse_grouped_expert_output(x, actual)
+            adapter.use_a2a = False
+            adapter.input_is_parallel = not input_is_parallel
+            assert not wrapper._can_reuse_grouped_expert_output(x, actual)
+            adapter.input_is_parallel = input_is_parallel
+            adapter.base_linear_name = "decoder.layers.0.mlp.experts.linear_fc3"
+            assert not wrapper._can_reuse_grouped_expert_output(x, actual)
+            adapter.base_linear_name = f"decoder.layers.0.mlp.experts.{surface}"
+        actual_grads = torch.autograd.grad(
+            actual,
+            (x, base.weight, adapter.linear_in.weight, adapter.linear_out.weight),
+            upstream,
+        )
+
+        torch.testing.assert_close(actual, expected)
+        assert actual.data_ptr() == base_ptr[0]
+        for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+            torch.testing.assert_close(actual_grad, expected_grad)
+
+    def test_expert_lora_storage_reuse_rejects_partial_views(self):
+        """Storage reuse must fail closed when the grouped output is not the full allocation."""
+        rank_input = torch.randn(4, 2, requires_grad=True)
+        weight = torch.randn(3, 2, requires_grad=True)
+        oversized = torch.randn(5, 3)
+
+        with pytest.raises(RuntimeError, match="complete contiguous allocation"):
+            partial = oversized[:4]
+            _AddExpertLoRA.apply(rank_input, weight, partial, partial.detach())
 
     def test_peft_enable_disable_adapter_layers_manual(self, mock_linear_simple, simple_adapter):
         """Test manual adapter enable/disable via PEFT helpers."""


### PR DESCRIPTION
# What does this PR do ?

Reuse consumed grouped-expert outputs when adding LoRA updates, avoiding a second full-width expert output allocation while preserving exact gradients.

# Changelog

- Add an autograd-safe accumulation path for eligible grouped expert FC1 and FC2 adapters.
- Fail closed to the existing allocation path when storage, parallelism, dtype, or adapter invariants do not hold.
- Test output aliasing, forward values, gradients, FC1/FC2 guards, and partial-view rejection.

# GitHub Actions CI

- `ruff check` and `ruff format --check` pass on both changed files.
- The focused CUDA preflight passed in the immutable GLM runtime, including value/gradient parity, alias safety, and peak allocation.
- Exact two-node B300 GLM 5.3 lifecycle XID 1050342 completed a 262,144-token forward/backward, optimizer step, republish, resample, and durable checkpoint with this commit.
- Local pytest collection is blocked on this CPU host because the repository environment requires CUDA headers and Transformer Engine; maintainer CI is still required.

# Before your PR is "Ready for review"

- [x] Make sure you read and followed the contributor guidelines
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? No.

# Additional Information

- No issue linked; this is a focused memory fix for existing grouped-expert LoRA behavior.
