### PR TITLE
[data] fix: Repeat tiny cyclic datasets across ranks

### DIFF
--- a/src/megatron/bridge/data/samplers.py
+++ b/src/megatron/bridge/data/samplers.py
@@ -488,6 +488,9 @@ class MegatronPretrainingRandomSampler:
         Handles randomization within an epoch and data sharding.
         """
         active_total_samples = self.total_samples - self.last_batch_size
+        repeat_small_dataset = active_total_samples == 0
+        if repeat_small_dataset:
+            active_total_samples = self.micro_batch_times_data_parallel_size
         self.epoch = self.consumed_samples // active_total_samples
         current_epoch_samples = self.consumed_samples % active_total_samples
         assert current_epoch_samples % self.micro_batch_times_data_parallel_size == 0
@@ -496,7 +499,14 @@ class MegatronPretrainingRandomSampler:
             self.dataset.set_epoch(self.epoch)
 
         # data sharding and random sampling
-        if self.data_sharding:
+        if repeat_small_dataset:
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            random_idx = torch.randperm(self.total_samples, generator=g).tolist()
+            repeat_count = (active_total_samples + self.total_samples - 1) // self.total_samples
+            idx_range_total = (random_idx * repeat_count)[:active_total_samples]
+            idx_range = idx_range_total[self.data_parallel_rank :: self.data_parallel_size]
+        elif self.data_sharding:
             bucket_size = (self.total_samples // self.micro_batch_times_data_parallel_size) * self.micro_batch_size
             bucket_offset = current_epoch_samples // self.data_parallel_size
             start_idx = self.data_parallel_rank * bucket_size

--- a/tests/unit_tests/data/test_samplers.py
+++ b/tests/unit_tests/data/test_samplers.py
@@ -136,3 +136,33 @@ def test_cyclic_sampler_non_sharded_tail_keeps_data_parallel_epochs_aligned() ->
 
     assert len({index for batch in second_step for index in batch}) == 6
     assert second_step == resumed_step
+
+
+@pytest.mark.parametrize("data_sharding", [False, True])
+def test_cyclic_sampler_repeats_dataset_smaller_than_distributed_microbatch(data_sharding: bool) -> None:
+    """Cyclic loading must form a synchronized batch from a tiny finite split."""
+
+    def make_sampler(rank: int, consumed_samples: int = 0) -> MegatronPretrainingRandomSampler:
+        return MegatronPretrainingRandomSampler(
+            list(range(3)),
+            total_samples=3,
+            consumed_samples=consumed_samples,
+            micro_batch_size=2,
+            data_parallel_rank=rank,
+            data_parallel_size=2,
+            data_sharding=data_sharding,
+        )
+
+    def cyclic_batches(sampler: MegatronPretrainingRandomSampler):
+        while True:
+            yield from sampler
+
+    uninterrupted = [cyclic_batches(make_sampler(rank)) for rank in range(2)]
+    first_step = [next(rank_batches) for rank_batches in uninterrupted]
+    second_step = [next(rank_batches) for rank_batches in uninterrupted]
+    resumed_step = [next(iter(make_sampler(rank, consumed_samples=4))) for rank in range(2)]
+
+    first_step_indices = [index for batch in first_step for index in batch]
+    assert len(first_step_indices) == 4
+    assert set(first_step_indices) == {0, 1, 2}
+    assert second_step == resumed_step


### PR DESCRIPTION
## What

Allow cyclic sampling to form a synchronized data-parallel microbatch when a finite dataset is smaller than `micro_batch_size * data_parallel_size`.

This boundary was found while reviewing merged PR #5944, which fixed rank alignment for ragged cyclic tails when at least one complete distributed microbatch exists.

## Supported trigger and impact

GPT-SFT supports `dataloader_type="cyclic"`, including as an accepted path for in-batch packing. Its validation and test datasets retain their finite source lengths. With a three-row evaluation split, evaluation microbatch size 2, and evaluation DP size 2, the first validation iterator previously raised `ZeroDivisionError` before producing a batch or metric.

The same failure affected both `data_sharding=True` and `False`.

## Root cause and minimal fix

`MegatronPretrainingRandomSampler` truncated each epoch to complete distributed microbatches. When the whole dataset was smaller than one such microbatch, the active epoch length became zero and the epoch calculation divided by it.

For this one boundary, the sampler now repeats a deterministic shuffled dataset only until it fills one distributed microbatch, then applies the existing DP stride. This matches cyclic sampling semantics, keeps ranks aligned, and preserves uninterrupted-versus-resumed ordering. Existing sampling paths are unchanged once a complete distributed microbatch already fits.

Open PR #5937 is adjacent but not a duplicate: it adjusts the training-side minimum for cyclic loaders and still requires at least one complete distributed microbatch; it does not change this sampler or finite validation/test behavior.

## Regression evidence

The unchanged focused test on unmodified `origin/main`:

```text
uv run --no-project --python 3.12 python /tmp/run_isolated_pytest.py <checkout> --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_samplers.py::test_cyclic_sampler_repeats_dataset_smaller_than_distributed_microbatch -q --tb=short
# 2 failed: ZeroDivisionError for data_sharding=False and True
```

The same test after the fix:

```text
# 2 passed
```

Focused adjacent validation:

```text
uv run --no-project --python 3.12 python /tmp/run_isolated_pytest.py <checkout> --confcutdir=tests/unit_tests/data tests/unit_tests/data/test_samplers.py -q --tb=short
# 11 passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# passed
```

The small bootstrap only exposes the data package directly to avoid unrelated eager accelerator imports on this CPU workstation; it does not mock sampler behavior.

## Scope

CPU sampler-contract validation only. No model-quality, convergence, performance, GPU/distributed integration, or full-suite claims. No dependency, configuration, public API, MCore submodule, or workflow changes.
