### PR TITLE
[training] fix: Restore signal handler after pretrain

### DIFF
--- a/src/megatron/bridge/training/pretrain.py
+++ b/src/megatron/bridge/training/pretrain.py
@@ -259,6 +259,13 @@ def _cleanup_after_pretrain_failure(state: GlobalState, should_destroy_process_g
         logger.exception("Failed to abort async checkpointing after pretrain failure")
 
     try:
+        if state._signal_handler is not None:
+            state._signal_handler.release()
+            state._signal_handler = None
+    except Exception:
+        logger.exception("Failed to release the signal handler after pretrain failure")
+
+    try:
         destroy_global_state()
     except Exception:
         logger.exception("Failed to destroy Megatron global state after pretrain failure")

--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -1574,6 +1574,9 @@ def _finish_train(global_state: GlobalState, checkpoint_manager: CheckpointManag
         global_state._comet_logger.end()
 
     _delete_cuda_graphs(None)
+    if global_state._signal_handler is not None:
+        global_state._signal_handler.release()
+        global_state._signal_handler = None
     destroy_global_state()
 
 

--- a/tests/unit_tests/training/test_pretrain.py
+++ b/tests/unit_tests/training/test_pretrain.py
@@ -83,6 +83,8 @@ class TestPretrainProcessGroupOwnership:
     def test_framework_owned_failure_is_logged_before_cleanup_and_abort(self, caplog):
         """Test Bridge logs the original failure before cleaning up framework-owned state."""
         state = MagicMock()
+        signal_handler = MagicMock()
+        state._signal_handler = signal_handler
         async_queue = MagicMock()
         state._async_calls_queue = async_queue
         original_error = RuntimeError("setup failed after distributed initialization")
@@ -112,6 +114,8 @@ class TestPretrainProcessGroupOwnership:
                 _pretrain(state, MagicMock())
 
         assert exc_info.value is original_error
+        signal_handler.release.assert_called_once_with()
+        assert state._signal_handler is None
         mock_destroy_global_state.assert_called_once_with()
         mock_dist.barrier.assert_not_called()
         mock_dist.distributed_c10d._abort_process_group.assert_called_once_with()

--- a/tests/unit_tests/training/test_train.py
+++ b/tests/unit_tests/training/test_train.py
@@ -14,6 +14,7 @@
 
 """Tests for train module utility functions."""
 
+import signal
 import time
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -22,6 +23,7 @@ import pytest
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 
 from megatron.bridge.training.fsdp_compat import MEGATRON_FSDP_TYPES
+from megatron.bridge.training.state import GlobalState
 from megatron.bridge.training.train import (
     _delete_cuda_graphs,
     _dummy_train_step,
@@ -99,6 +101,7 @@ class TestCheckpointManagerLifecycle:
             tensorboard_logger=None,
             wandb_logger=None,
             _comet_logger=None,
+            _signal_handler=None,
         )
         pg_collection = SimpleNamespace(
             pp=SimpleNamespace(size=Mock(return_value=1)),
@@ -134,6 +137,36 @@ class TestCheckpointManagerLifecycle:
             _finish_train(state, checkpoint_manager)
 
         assert checkpoint_manager.finalize_calls == [(True, False), (True, True)]
+
+    def test_natural_completion_restores_original_signal_handler(self):
+        """Terminal training cleanup should restore the caller's signal handler."""
+        original_handler = signal.getsignal(signal.SIGTERM)
+
+        def caller_handler(_signum, _frame):
+            pass
+
+        signal.signal(signal.SIGTERM, caller_handler)
+        state = GlobalState()
+        state.cfg = SimpleNamespace(
+            train=SimpleNamespace(exit_signal_handler=True, exit_signal=signal.SIGTERM),
+            nvrx_straggler=None,
+            logger=SimpleNamespace(wandb_project=None),
+        )
+
+        try:
+            with (
+                patch("megatron.bridge.training.train.safe_shutdown_nvrx_straggler_manager"),
+                patch("megatron.bridge.training.train.fault_tolerance"),
+                patch("megatron.bridge.training.train._delete_cuda_graphs"),
+                patch("megatron.bridge.training.train.destroy_global_state"),
+            ):
+                _finish_train(state, Mock())
+
+            assert signal.getsignal(signal.SIGTERM) is caller_handler
+        finally:
+            if state._signal_handler is not None:
+                state._signal_handler.release()
+            signal.signal(signal.SIGTERM, original_handler)
 
 
 class TestTrainStepAttentionLogitMonitoring:


### PR DESCRIPTION
## Summary

- restore the caller's original signal disposition when training finishes normally
- release the same handler during best-effort cleanup after an ordinary `pretrain()` failure
- cover the real OS-level handler lifecycle and the exceptional cleanup path

## User impact

With `train.exit_signal_handler=True`, assigning the training config enters `DistributedSignalHandler` and replaces the process signal disposition. Normal `_finish_train()` and ordinary failure cleanup destroyed Megatron global state without releasing that handler. If `pretrain()` returned to a long-lived caller, a later SIGTERM was consumed by a stale Bridge closure whose flag no training loop would poll, so the caller's prior handler was not invoked and the process could remain alive until force-killed.

The fix releases and clears the handler at the two terminal lifecycle boundaries. Failure cleanup keeps the release best-effort so a cleanup error cannot replace the original training exception. In-process restart behavior remains owned by the existing `reset_for_restart()` path.

This completes the terminal lifecycle for the handler installed in #3823; #5068 separately established that swallowing SIGTERM is materially incorrect when graceful handling is disabled.

## Validation

Fail-before on the unmodified base:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestCheckpointManagerLifecycle::test_natural_completion_restores_original_signal_handler -q
1 failed: signal.getsignal(SIGTERM) was still DistributedSignalHandler's closure
```

Pass-after with the unchanged regression test:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestCheckpointManagerLifecycle::test_natural_completion_restores_original_signal_handler -q
1 passed
```

Focused adjacent lifecycle checks:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_train.py::TestCheckpointManagerLifecycle tests/unit_tests/training/test_pretrain.py::TestPretrainProcessGroupOwnership tests/unit_tests/training/test_state.py::TestGlobalState::test_disabled_signal_handler_does_not_intercept_sigterm tests/unit_tests/training/test_state.py::TestGlobalState::test_set_signal_handler_installs_os_trap tests/unit_tests/training/test_state.py::TestGlobalState::test_sigterm_flips_signal_received_flag tests/unit_tests/training/test_state.py::TestGlobalState::test_reset_for_restart -q
12 passed
```

```text
uv run --no-sync pre-commit run --all-files
All configured hooks passed
```

## Scope

No configuration, public API, distributed ownership, checkpoint semantics, dependency, or CI changes. GPU validation is not required because the violated contract is the process-level Python signal disposition.
