### PR TITLE
[peft] fix: Preserve Multi-LoRA slot reset initialization scale

### DIFF
--- a/src/megatron/bridge/peft/multi_lora_layers.py
+++ b/src/megatron/bridge/peft/multi_lora_layers.py
@@ -171,6 +171,8 @@ class MultiLoRALinear(AdapterWrapper):
         self.base_linear_is_parallel = attrs.base_linear_is_parallel
         self.replicate_adapter = attrs.replicate_adapter
         self.use_a2a = a2a_experimental
+        self._adapter_in_features = attrs.in_features
+        self._adapter_out_features = attrs.out_features
         # Row-parallel adapters gather their output to full width; column-parallel
         # adapters keep an output shard; replicated adapters already produce full width.
         self._gather_output = not self.replicate_adapter and (
@@ -315,8 +317,18 @@ class MultiLoRALinear(AdapterWrapper):
         from megatron.bridge.peft.utils import ParallelLinearAdapter
 
         adapter = self.adapters[idx]
-        col_fn = ParallelLinearAdapter._get_init_fn(None, self._column_init_method)
-        row_fn = ParallelLinearAdapter._get_init_fn(None, self._row_init_method)
+        col_fn = ParallelLinearAdapter._get_init_fn(
+            None,
+            self._column_init_method,
+            fan_in=self._adapter_in_features,
+            fan_out=self.max_rank,
+        )
+        row_fn = ParallelLinearAdapter._get_init_fn(
+            None,
+            self._row_init_method,
+            fan_in=self.max_rank,
+            fan_out=self._adapter_out_features,
+        )
         rng_context = (
             get_cuda_rng_tracker().fork(get_data_parallel_rng_tracker_name())
             if self.replicate_adapter

--- a/tests/unit_tests/peft/test_multi_lora_layers.py
+++ b/tests/unit_tests/peft/test_multi_lora_layers.py
@@ -61,7 +61,7 @@ from megatron.bridge.peft.multi_lora_layers import (
     load_adapter,
     set_tokens_per_adapter_slot,
 )
-from megatron.bridge.peft.utils import AdapterAttributes
+from megatron.bridge.peft.utils import AdapterAttributes, ParallelLinearAdapter
 
 
 # ======================================================================
@@ -434,6 +434,30 @@ class TestMultiLoRALinearSlots:
         layer.reset_adapter(1)
 
         assert torch.all(layer.adapters[1].linear_out.weight == 0)
+
+    def test_reset_adapter_preserves_full_fan_xavier_initialization(self) -> None:
+        """A reused TP-sharded slot must match construction-time initialization."""
+        in_features = 4096
+        rank = 32
+        tensor_parallel_size = 4
+        layer = _build_multi_lora_linear(in_features=in_features, dim=rank)
+        adapter = layer.adapters[0]
+        adapter.linear_in.weight = nn.Parameter(torch.empty(rank, in_features // tensor_parallel_size))
+
+        expected = torch.empty_like(adapter.linear_in.weight)
+        full_fan_xavier = ParallelLinearAdapter._get_init_fn(
+            None,
+            "xavier",
+            fan_in=in_features,
+            fan_out=rank,
+        )
+        torch.manual_seed(1234)
+        full_fan_xavier(expected)
+
+        torch.manual_seed(1234)
+        layer.reset_adapter(0)
+
+        torch.testing.assert_close(adapter.linear_in.weight, expected)
 
     def test_state_dict_contains_base_and_all_adapter_slots(self) -> None:
         layer = _build_multi_lora_linear(n_adapters=2, dim=8)


### PR DESCRIPTION
## What does this PR do?

Preserves construction-time initialization semantics when a dense Multi-LoRA adapter slot is cleared and reused under tensor parallelism.

Related to the slot lifecycle introduced in #4218 and the full-fan initialization invariant established by #5840 / #5843.

## Supported trigger and impact

With tensor parallelism greater than one, `clear_adapter_slot()` reinitializes a dense slot before it can be claimed for a new adapter. Construction now resolves Xavier/Kaiming from the full logical adapter dimensions, but reset resolved them from the local TP shard.

For a row-parallel LoRA-A with logical `in_features=4096`, `rank=32`, and TP=4, construction uses an expected standard deviation near `0.0220`; reset used about `0.0437`. Since the first LoRA-B gradient depends on A even though B starts at zero, a reused slot immediately acquired TP-dependent training semantics.

## Root cause and minimal fix

`MultiLoRALinear.reset_adapter()` called `ParallelLinearAdapter._get_init_fn()` without `fan_in` or `fan_out`. The initializer therefore inferred fans from the local parameter shard.

The wrapper now retains the logical input/output dimensions it already receives during construction and passes them to the existing initializer factory during reset. No new abstraction or public API is added.

## Regression evidence

Fail before on unmodified `da6680cc90141089050a954d83ed6eb9d1085007`:

```text
uv run --no-project --python 3.12 --with torch python /tmp/multilora_reset_reproducer.py <base-source-root>
expected_std=0.02208792
actual_std=0.04367097
Tensor-likes are not close!
exit 1
```

The unchanged deterministic reproducer after the fix:

```text
expected_std=0.02208792
actual_std=0.02208792
exit 0
```

Focused regression:

```text
uv run --no-sync python -m pytest tests/unit_tests/peft/test_multi_lora_layers.py::TestMultiLoRALinearSlots::test_reset_adapter_preserves_full_fan_xavier_initialization -q
1 passed
```

Adjacent initialization and slot lifecycle tests:

```text
uv run --no-sync python -m pytest tests/unit_tests/peft/test_multi_lora_layers.py::TestMultiLoRALinearSlots tests/unit_tests/peft/test_parallel_adapter_init.py -q
21 passed
```

Real two-process tensor-parallel verification:

```text
uv run --no-sync python -m torch.distributed.run --nproc_per_node=2 /tmp/distributed_verifier.py
expected_std=0.02201127 actual_std=0.02207492 tp=2
exit 0
```

Repository checks:

```text
git diff --check
passed

uv run --no-sync pre-commit run --all-files
passed
```

## Scope limitations

- Changes only dense `MultiLoRALinear` slot reset.
- Does not change slot routing, optimizer ownership, checkpoint format, or public APIs.
- Does not alter grouped-expert reset; that path already uses the same shape-derived initializer at construction and reset and rejects expert TP greater than one.
- No dependency, lockfile, CI workflow, or MCore changes.
