### PR TITLE
[ckpt] fix: honor CPU initialization in native loads

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -1433,10 +1433,13 @@ class AutoBridge(Generic[MegatronModelT]):
         # else: checkpoint_path remains as the input path (no iter folders found)
 
         skip_temp_dist_context = dist.is_initialized()
+        use_cpu_init = kwargs.get("use_cpu_initialization")
+        if use_cpu_init is None:
+            use_cpu_init = skip_temp_dist_context and dist.get_backend() == "gloo"
         # Load the state dict
         model = load_megatron_model(
             str(checkpoint_path),
-            use_cpu_init=(skip_temp_dist_context and dist.get_backend() == "gloo"),
+            use_cpu_init=use_cpu_init,
             skip_temp_dist_context=skip_temp_dist_context,
             mp_overrides=mp_overrides,
         )

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -2387,6 +2387,29 @@ class TestAutoBridge:
                         assert call_args.args[0] == "checkpoint_path"  # path argument
                         assert "skip_temp_dist_context" in call_args.kwargs
 
+    def test_load_megatron_model_honors_cpu_initialization(self):
+        """Test explicit CPU initialization reaches the checkpoint loader."""
+        bridge = AutoBridge.__new__(AutoBridge)
+        bridge.hf_pretrained = Mock(spec=PreTrainedCausalLM)
+        bridge.trust_remote_code = False
+
+        with (
+            patch("megatron.bridge.training.model_load_save.load_megatron_model") as mock_load_megatron_model,
+            patch("torch.distributed.is_initialized", return_value=False),
+            patch.object(Path, "iterdir", return_value=[]),
+        ):
+            mock_model = Mock()
+            mock_load_megatron_model.return_value = mock_model
+
+            result = bridge.load_megatron_model(
+                "checkpoint_path",
+                wrap_with_ddp=False,
+                use_cpu_initialization=True,
+            )
+
+        assert result == [mock_model]
+        assert mock_load_megatron_model.call_args.kwargs["use_cpu_init"] is True
+
     def test_load_megatron_model_registers_prefix_when_trust_remote_code(self):
         """Test that load_megatron_model registers transformers_modules prefix when trust_remote_code=True."""
         mock_hf_model = Mock(spec=PreTrainedCausalLM)


### PR DESCRIPTION
## Summary

`AutoBridge.load_megatron_model()` accepts the typed `use_cpu_initialization` model-provider option, but discarded it before calling the native checkpoint loader. A supported load such as:

```python
bridge.load_megatron_model(
    checkpoint_path,
    wrap_with_ddp=False,
    use_cpu_initialization=True,
)
```

therefore entered the default GPU/NCCL initialization path instead of the requested CPU/Gloo path. For large models, that can cause avoidable GPU allocation or initialization failure during checkpoint loading.

The method now forwards this existing option to the lower loader. When the option is omitted or `None`, the current backend-derived behavior is preserved.

## Root cause

`AutoBridge.load_megatron_model()` declared `**kwargs: Unpack[GetModelKwargs]` and documented those values as provider arguments, but never read `kwargs`. It derived `use_cpu_init` only from an already initialized Gloo process group, so an explicit request made before distributed initialization was silently replaced with `False`.

## Validation

Fail before the production fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_load_megatron_model_honors_cpu_initialization -q
1 failed: expected use_cpu_init=True, received False
```

Pass after the fix:

```text
uv run --no-sync python -m pytest tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_load_megatron_model_honors_cpu_initialization -q
1 passed

uv run --no-sync python -m pytest tests/unit_tests/models/test_auto_bridge.py -k 'load_megatron_model' -q
5 passed, 93 deselected

uv run --no-sync pre-commit run --all-files
all configured hooks passed

git diff --check
passed
```

## Scope

- No public signature or configuration surface changes.
- Only the existing `use_cpu_initialization` option is consumed; other `GetModelKwargs` behavior is unchanged.
- This does not add driverless CPU-only Transformer Engine compatibility or alter model layer specs; it only preserves an explicit initialization choice on the existing native-checkpoint load path.
