### PR TITLE
[training] fix: Enable NVRx detection for MegatronMIMO

### DIFF
--- a/src/megatron/bridge/training/train_megatron_mimo.py
+++ b/src/megatron/bridge/training/train_megatron_mimo.py
@@ -47,6 +47,7 @@ from megatron.bridge.training.utils.train_utils import (
     prepare_forward_step_func,
     training_log,
 )
+from megatron.bridge.utils.common_utils import print_rank_0
 
 
 if TYPE_CHECKING:
@@ -299,6 +300,16 @@ def train_megatron_mimo(
         gc.disable()
         gc.collect()
 
+    nvrx_straggler_manager = global_state.nvrx_straggler_manager
+    wrapped_train_step = train_step_megatron_mimo
+    if nvrx_straggler_manager is not None:
+        try:
+            nvrx_straggler_manager.initialize()
+            wrapped_train_step = nvrx_straggler_manager.wrap_train_step_function(train_step_megatron_mimo)
+        except Exception as e:
+            print_rank_0(f"Failed to initialize NVRx straggler detection: {e}")
+            global_state._nvrx_straggler_manager = None
+
     logger.info(f"Rank {dist.get_rank()}: Starting MegatronMIMO training loop")
 
     # Main training loop
@@ -326,7 +337,7 @@ def train_megatron_mimo(
         timers("iteration-time", log_level=0).start(barrier=False)
 
         # Run single training step
-        loss_dict, skipped_iter, grad_norm, num_zeros_in_grad = train_step_megatron_mimo(
+        loss_dict, skipped_iter, grad_norm, num_zeros_in_grad = wrapped_train_step(
             forward_step_func=wrapped_forward_step_func,
             data_iterator=train_data_iterator,
             model=model,

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -522,6 +522,61 @@ class TestTrainMegatronMIMOCheckpointIntegration:
     @patch("megatron.bridge.training.train_megatron_mimo.get_num_microbatches", return_value=1)
     @patch("torch.distributed.get_rank", return_value=0)
     @patch("torch.distributed.get_world_size", return_value=1)
+    def test_enabled_nvrx_instruments_mimo_train_step(
+        self,
+        mock_world_size,
+        mock_rank,
+        mock_num_mb,
+        mock_prep_fwd,
+        mock_get_grid,
+        mock_build_pg,
+        mock_train_step,
+        mock_ckpt_exit,
+    ):
+        """Enabled NVRx should instrument the MegatronMIMO training step."""
+        from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo
+
+        del mock_world_size, mock_rank, mock_num_mb, mock_prep_fwd, mock_get_grid, mock_ckpt_exit
+        mock_train_step.return_value = ({}, 0, 0.0, 0)
+        instrumented_step = Mock(return_value=({}, 0, 0.0, 0))
+        nvrx_manager = Mock()
+        nvrx_manager.wrap_train_step_function.return_value = instrumented_step
+
+        infra = Mock()
+        infra.pg_collections = {"language": Mock()}
+        infra.module_to_grid_map = {"language": Mock()}
+        infra.topology = Mock()
+        mock_build_pg.return_value = Mock(spec=[])
+
+        state = _make_global_state(save_dir=None, train_iters=1, step=0)
+        state.nvrx_straggler_manager = nvrx_manager
+
+        train_megatron_mimo(
+            forward_step_func=Mock(),
+            model=Mock(),
+            optimizer=Mock(),
+            schedulers={"language": _make_scheduler_mock()},
+            train_data_iterator=Mock(),
+            valid_data_iterator=None,
+            global_state=state,
+            megatron_mimo_infra=infra,
+            multimodule_communicator=Mock(),
+            checkpoint_manager=MagicMock(),
+        )
+
+        nvrx_manager.initialize.assert_called_once_with()
+        nvrx_manager.wrap_train_step_function.assert_called_once_with(mock_train_step)
+        instrumented_step.assert_called_once()
+        mock_train_step.assert_not_called()
+
+    @patch("megatron.bridge.training.train_megatron_mimo.checkpoint_and_decide_exit", return_value=False)
+    @patch("megatron.bridge.training.train_megatron_mimo.train_step_megatron_mimo")
+    @patch("megatron.bridge.training.train_megatron_mimo.build_pg_collection_for_schedule")
+    @patch("megatron.bridge.training.train_megatron_mimo.get_module_to_grid_tuple")
+    @patch("megatron.bridge.training.train_megatron_mimo.prepare_forward_step_func")
+    @patch("megatron.bridge.training.train_megatron_mimo.get_num_microbatches", return_value=1)
+    @patch("torch.distributed.get_rank", return_value=0)
+    @patch("torch.distributed.get_world_size", return_value=1)
     def test_calls_checkpoint_and_decide_exit_with_pg_collection(
         self,
         mock_world_size,


### PR DESCRIPTION
## Problem

MegatronMIMO accepts an enabled `NVRxStragglerDetectionConfig`, but its dedicated training loop never initializes the NVRx manager or wraps the training step. The shared checkpoint/exit path consequently sees an uninitialized manager and every straggler check returns false.

For supported MegatronMIMO workloads, this silently disables NVRx performance reporting and prevents `stop_if_detected=True` from stopping and checkpointing after a detected straggler.

## Fix

Mirror the existing standard training-loop lifecycle in the MegatronMIMO loop:

- initialize the configured NVRx manager;
- wrap `train_step_megatron_mimo` for detector instrumentation;
- invoke the wrapped step; and
- preserve the standard graceful-disable behavior if initialization fails.

The change is limited to lifecycle wiring. It does not alter detector thresholds, reporting semantics, MIMO scheduling, or distributed ownership.

## Validation

The focused regression was first run against unmodified production code and failed because `initialize()` was called zero times. With the fix, the unchanged regression and its adjacent unit file pass:

```text
python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py -q
42 passed
```

Additional checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
```

Both passed.
