### PR TITLE
[data] fix: Release inherited GPU descriptors in workers

### DIFF
--- a/src/megatron/bridge/data/samplers.py
+++ b/src/megatron/bridge/data/samplers.py
@@ -2,13 +2,33 @@
 
 """Dataloaders."""
 
+import functools
 import multiprocessing
+import os
 import random
 from typing import Any, Callable, Iterator, Optional
 
 import numpy as np
 import torch
 from torch.utils.data import DataLoader, Dataset
+
+
+def _close_nvidia_device_fds() -> None:
+    """Close inherited NVIDIA device descriptors in a DataLoader worker."""
+    for fd in os.listdir("/proc/self/fd"):
+        try:
+            path = os.readlink(f"/proc/self/fd/{fd}")
+            if path.startswith("/dev/nvidia"):
+                os.close(int(fd))
+        except OSError:
+            pass
+
+
+def _initialize_worker(worker_id: int, *, worker_init_fn: Optional[Callable]) -> None:
+    """Release inherited GPU descriptors, then invoke the caller initializer."""
+    _close_nvidia_device_fds()
+    if worker_init_fn is not None:
+        worker_init_fn(worker_id)
 
 
 def build_pretraining_data_loader(
@@ -111,6 +131,10 @@ def build_pretraining_data_loader(
     else:
         raise Exception("{} dataloader type is not supported.".format(dataloader_type))
 
+    maybe_worker_init_fn = None
+    if num_workers > 0:
+        maybe_worker_init_fn = functools.partial(_initialize_worker, worker_init_fn=worker_init_fn)
+
     # Torch dataloader.
     return DataLoader(
         dataset,
@@ -119,7 +143,7 @@ def build_pretraining_data_loader(
         pin_memory=pin_memory,
         collate_fn=collate_fn,
         persistent_workers=persistent_workers,
-        worker_init_fn=worker_init_fn,
+        worker_init_fn=maybe_worker_init_fn,
     )
 
 

--- a/tests/unit_tests/data/test_samplers.py
+++ b/tests/unit_tests/data/test_samplers.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+import multiprocessing
+
 import pytest
 import torch
 from torch.utils.data import Dataset
 
+import megatron.bridge.data.samplers as samplers
 from megatron.bridge.data.samplers import (
     MegatronPretrainingRandomSampler,
     MegatronPretrainingSampler,
@@ -109,6 +112,36 @@ def test_cyclic_sampler_resume_seeds_worker_dataset_for_current_epoch(
     expected_value = torch.randint(0, 1_000_000, (1,), generator=generator).item()
 
     assert actual_value.item() == expected_value
+
+
+def test_dataloader_worker_releases_gpu_fds_before_caller_initialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Worker setup must release inherited GPU descriptors on every loader path."""
+    cleanup_calls = multiprocessing.Value("i", 0)
+    caller_calls = multiprocessing.Value("i", 0)
+
+    def record_cleanup() -> None:
+        cleanup_calls.value += 1
+
+    def record_caller_init(_worker_id: int) -> None:
+        assert cleanup_calls.value == 1
+        caller_calls.value += 1
+
+    monkeypatch.setattr(samplers, "_close_nvidia_device_fds", record_cleanup)
+    dataloader = build_pretraining_data_loader(
+        dataset=_RandomValueDataset(),
+        consumed_samples=0,
+        dataloader_type="single",
+        micro_batch_size=1,
+        num_workers=1,
+        data_sharding=False,
+        persistent_workers=False,
+        worker_init_fn=record_caller_init,
+    )
+
+    next(iter(dataloader))
+
+    assert cleanup_calls.value == 1
+    assert caller_calls.value == 1
 
 
 def test_cyclic_sampler_non_sharded_tail_keeps_data_parallel_epochs_aligned() -> None:


### PR DESCRIPTION
## Summary

- close inherited `/dev/nvidia*` descriptors when Bridge-owned DataLoader workers start
- run any caller-provided `worker_init_fn` after descriptor cleanup
- add a regression test covering cleanup order and callback preservation

## Supported trigger and impact

Bridge constructs CUDA model and optimizer state before it creates the standard pretraining data iterators. With the supported default `num_workers=2` and persistent workers, Linux fork workers inherit the rank's NVIDIA device descriptors. If a rank exits while a worker remains alive, that worker can keep the rank's GPU allocation referenced, preventing reclamation during failure recovery or restart.

The shared worker initialization boundary now closes only inherited NVIDIA device descriptors before delegating to the existing callback. The approach matches the defensive cleanup already used by the pinned Megatron-Core data loader ([upstream context](https://github.com/NVIDIA/Megatron-LM/pull/3684)).

## Regression evidence

A deterministic single-GPU process-lifecycle reproducer was run unchanged before and after the patch:

`uv run --no-project python reproduce_nvidia_fd_reclamation.py`

- Before: exited 1; the surviving worker held 51 NVIDIA device descriptors and retained 1,135 MiB after the rank exited. GPU usage returned to baseline only after terminating the worker.
- After: exited 0; the surviving worker held zero NVIDIA device descriptors and retained 0 MiB after the rank exited.

Focused and adjacent tests:

`uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/data/test_samplers.py tests/unit_tests/data/test_loaders.py -q`

Result: 11 passed.

Additional checks:

- `uv run --no-sync pre-commit run --all-files` — passed
- `git diff --check` — passed

## Scope

This changes only Bridge-owned DataLoaders with `num_workers > 0`. Zero-worker behavior and caller-owned external DataLoaders are unchanged. No public API, dependency, or configuration surface changes.
