### PR TITLE
[inference] fix: Forward derived DeepSeek-V4 pipeline layouts

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_text.py
+++ b/examples/conversion/hf_to_megatron_generate_text.py
@@ -221,8 +221,8 @@ def main(args) -> None:
                         model_provider.pipeline_model_parallel_layout = saved_layout
                         break
 
-        # Once all overrides are set, finalize the model provider to ensure the post initialization logic is run
-        model_provider.finalize()
+        # Once all overrides are set, apply provider-specific derivations before post initialization.
+        model_provider.apply_overrides_and_finalize()
         model_provider.initialize_model_parallel(seed=0)
 
         # Load the Megatron model directly
@@ -233,8 +233,15 @@ def main(args) -> None:
             "expert_tensor_parallel_size": etp,
             "pipeline_dtype": torch.bfloat16,
         }
+        resolved_pipeline_layout = getattr(
+            model_provider.pipeline_model_parallel_layout,
+            "input_data",
+            model_provider.pipeline_model_parallel_layout,
+        )
         if args.pipeline_model_parallel_layout is not None:
             mp_overrides["pipeline_model_parallel_layout"] = args.pipeline_model_parallel_layout
+        elif isinstance(resolved_pipeline_layout, list):
+            mp_overrides["pipeline_model_parallel_layout"] = resolved_pipeline_layout
 
         model = bridge.load_megatron_model(
             args.megatron_model_path,
@@ -262,8 +269,8 @@ def main(args) -> None:
         if args.pipeline_model_parallel_layout is not None:
             model_provider.pipeline_model_parallel_layout = args.pipeline_model_parallel_layout
 
-        # Once all overrides are set, finalize the model provider to ensure the post initialization logic is run
-        model_provider.finalize()
+        # Once all overrides are set, apply provider-specific derivations before post initialization.
+        model_provider.apply_overrides_and_finalize()
         model_provider.initialize_model_parallel(seed=0)
         model = model_provider.provide_distributed_model(wrap_with_ddp=False)
 

--- a/tests/unit_tests/examples/test_hf_to_megatron_generate_text_loading.py
+++ b/tests/unit_tests/examples/test_hf_to_megatron_generate_text_loading.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "examples" / "conversion" / "hf_to_megatron_generate_text.py"
+
+
+class _PassthroughInit:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+def _module(name: str, **attrs: object) -> types.ModuleType:
+    module = types.ModuleType(name)
+    for attr_name, value in attrs.items():
+        setattr(module, attr_name, value)
+    return module
+
+
+@pytest.fixture
+def generation_module(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    stubs = {
+        "megatron.core": _module("megatron.core", parallel_state=_PassthroughInit()),
+        "megatron.core.inference.contexts": _module(
+            "megatron.core.inference.contexts", StaticInferenceContext=_PassthroughInit
+        ),
+        "megatron.core.inference.utils": _module("megatron.core.inference.utils", InferenceMode=_PassthroughInit),
+        "megatron.core.pipeline_parallel.schedules": _module(
+            "megatron.core.pipeline_parallel.schedules", get_forward_backward_func=lambda: None
+        ),
+        "transformers": _module("transformers", AutoTokenizer=_PassthroughInit),
+        "megatron.bridge": _module("megatron.bridge", AutoBridge=_PassthroughInit),
+        "megatron.bridge.models.hf_pretrained.utils": _module(
+            "megatron.bridge.models.hf_pretrained.utils", is_safe_repo=lambda **kwargs: True
+        ),
+        "megatron.bridge.utils.common_utils": _module(
+            "megatron.bridge.utils.common_utils",
+            disable_mtp_for_inference=lambda model: None,
+            get_last_rank=lambda: 0,
+            print_rank_0=lambda message: None,
+        ),
+    }
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    spec = importlib.util.spec_from_file_location("hf_to_megatron_generate_text_under_test", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+@pytest.mark.unit
+def test_checkpoint_load_forwards_provider_derived_pipeline_layout(
+    generation_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    layout = [
+        ["embedding", *(["decoder"] * 11)],
+        ["decoder"] * 11,
+        ["decoder"] * 11,
+        [*(["decoder"] * 10), "mtp", "loss"],
+    ]
+    checkpoint = tmp_path / "checkpoint"
+    iteration = checkpoint / "iter_0000000"
+    iteration.mkdir(parents=True)
+    (iteration / "run_config.yaml").write_text(
+        "model:\n"
+        "  pipeline_model_parallel_size: 1\n"
+        "  pipeline_model_parallel_layout:\n"
+        "    _target_: megatron.core.transformer.pipeline_parallel_layer_layout.PipelineParallelLayerLayout\n",
+        encoding="utf-8",
+    )
+
+    provider = types.SimpleNamespace(pipeline_model_parallel_layout=None)
+
+    def apply_overrides_and_finalize() -> None:
+        provider.pipeline_model_parallel_layout = layout
+
+    provider.apply_overrides_and_finalize = apply_overrides_and_finalize
+    provider.finalize = lambda: None
+    provider.initialize_model_parallel = lambda seed: None
+    bridge = types.SimpleNamespace(
+        to_megatron_provider=lambda load_weights: provider,
+        load_megatron_model=lambda *args, **kwargs: [],
+    )
+
+    class _Bridge:
+        @staticmethod
+        def from_hf_pretrained(*args: object, **kwargs: object) -> object:
+            return bridge
+
+    monkeypatch.setattr(generation_module, "AutoBridge", _Bridge)
+    monkeypatch.setattr(generation_module, "print_rank_0", lambda message: None)
+
+    recorded_overrides: dict[str, object] = {}
+
+    def load_model(*args: object, **kwargs: object) -> list[object]:
+        recorded_overrides.update(kwargs["mp_overrides"])
+        raise RuntimeError("stop after checkpoint loading contract")
+
+    bridge.load_megatron_model = load_model
+    args = types.SimpleNamespace(
+        tp=1,
+        pp=4,
+        ep=1,
+        etp=1,
+        megatron_model_path=str(checkpoint),
+        hf_model_path="deepseek-ai/DeepSeek-V4-Flash",
+        trust_remote_code=True,
+        hf_revision=None,
+        pipeline_model_parallel_layout=None,
+    )
+
+    with pytest.raises(RuntimeError, match="stop after checkpoint loading contract"):
+        generation_module.main(args)
+
+    assert recorded_overrides["pipeline_model_parallel_layout"] == layout


### PR DESCRIPTION
## What changed

DeepSeek-V4's maintained legacy full-prefix inference wrapper can load either a Hugging Face model or a native Megatron checkpoint with pipeline parallelism. Both branches called `finalize()` directly, bypassing the provider lifecycle that derives DeepSeek-V4's required flexible pipeline layout. The checkpoint branch also rebuilt a second provider without forwarding that derived layout.

For DeepSeek-V4-Flash at PP=4, the missing layout makes model construction treat 43 decoder layers as evenly divisible and fail before checkpoint weights load. At otherwise divisible PP sizes, it can also violate the required placement of hash-routed layers with the embedding stage.

This change:

- uses the existing `apply_overrides_and_finalize()` lifecycle in both supported loading branches;
- forwards the finalized layout's list representation into native checkpoint loading;
- preserves an explicitly supplied user layout; and
- adds a focused checkpoint-loading regression test.

This is the same provider-owned layout contract introduced for non-recipe DeepSeek-V4 paths in #4131 and previously preserved across the conversion boundary in #4306. It complements the stale-layout clearing added in #5978 by supplying a valid layout for the requested inference topology.

## Validation

The regression test was run unchanged before and after the production fix:

```text
PYTHONPATH="$PWD/src:$PWD/3rdparty/Megatron-LM" uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/examples tests/unit_tests/examples/test_hf_to_megatron_generate_text_loading.py::test_checkpoint_load_forwards_provider_derived_pipeline_layout -q
```

- Before: failed with `KeyError: 'pipeline_model_parallel_layout'` because the override was absent.
- After: `1 passed`.

Additional checks:

```text
uv run --no-sync pre-commit run --all-files
git diff --check
```

Both passed. Existing adjacent suites could not collect in the CPU-only workstation environment because the installed optional inference/checkpoint dependencies require CUDA or a newer resiliency package; those collection failures were not counted as validation.

## Scope

This only repairs model construction and checkpoint repartitioning for the maintained legacy full-prefix path. It does not add KV-cache support, change conversion APIs, modify checkpoint formats, or claim model-quality, convergence, performance, or full-suite validation.
