### PR TITLE
[training] fix: Use global DP for DistTrain sample accounting

### DIFF
--- a/src/megatron/bridge/training/train.py
+++ b/src/megatron/bridge/training/train.py
@@ -123,6 +123,15 @@ except ImportError:
     HAS_OPTIMIZER_CUDA_GRAPH = False
 
 
+def _get_sample_accounting_data_parallel_size(
+    config: ConfigContainer, data_distribution_group: torch.distributed.ProcessGroup
+) -> int:
+    """Return the data-parallel size used by the global batch contract."""
+    if hasattr(config.model, "dist_train") and getattr(config.model.dist_train, "use_dist_train", False) is True:
+        return config.data_parallel_size
+    return data_distribution_group.size()
+
+
 def train(
     forward_step_func: ForwardStepCallable,
     model: list[MegatronModule],
@@ -338,7 +347,7 @@ def train(
     print_rank_0(f"Starting training loop at iteration {start_iteration}")
     p2p_communicator = P2PCommunicator(pp_group=pg_collection.pp, config=model_config)
     data_distribution_group = get_data_distribution_group(pg_collection, config.model)
-    dp_size = data_distribution_group.size()
+    dp_size = _get_sample_accounting_data_parallel_size(config, data_distribution_group)
     # Anchor for interval-average throughput logging: training_log reports the FLOPS
     # performed over each logging interval as the delta of
     # floating_point_operations_so_far. Seed it with the current cumulative (0 fresh,
@@ -1606,7 +1615,8 @@ def _should_skip_and_handle_iteration(
 
     # Update step and sample counters
     global_state.train_state.step += 1
-    dp_size = get_data_distribution_group(pg_collection, cfg.model).size()
+    data_distribution_group = get_data_distribution_group(pg_collection, cfg.model)
+    dp_size = _get_sample_accounting_data_parallel_size(cfg, data_distribution_group)
     batch_size = dp_size * cfg.train.micro_batch_size * get_num_microbatches()
     global_state.train_state.consumed_train_samples += batch_size
     global_state.train_state.skipped_train_samples += batch_size

--- a/tests/functional_tests/test_groups/training/test_pretrain_dist_train.py
+++ b/tests/functional_tests/test_groups/training/test_pretrain_dist_train.py
@@ -21,6 +21,7 @@ from megatron.bridge.models.qwen_vl.qwen3_vl_provider import DistTrainConfig, Qw
 from megatron.bridge.models.qwen_vl.qwen3_vl_step import forward_step as qwen3_vl_forward_step
 from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam_with_cosine_annealing
 from megatron.bridge.recipes.utils.tokenizer_utils import DEFAULT_NULL_TOKENIZER_VOCAB_SIZE
+from megatron.bridge.training.callbacks import Callback, CallbackContext
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
 from megatron.bridge.training.config import (
     CheckpointConfig,
@@ -35,6 +36,16 @@ from megatron.bridge.training.config import (
 )
 from megatron.bridge.training.pretrain import pretrain
 from tests.functional_tests.utils import initialize_distributed
+
+
+class DistTrainSampleAccountingCallback(Callback):
+    """Validate that every module grid records the configured global batch size."""
+
+    def __init__(self, expected_samples: int) -> None:
+        self.expected_samples = expected_samples
+
+    def on_train_end(self, context: CallbackContext) -> None:
+        assert context.state.train_state.consumed_train_samples == self.expected_samples
 
 
 class TestPretrainDistTrain:
@@ -183,4 +194,8 @@ class TestPretrainDistTrain:
             ),
         )
 
-        pretrain(cfg, qwen3_vl_forward_step)
+        pretrain(
+            cfg,
+            qwen3_vl_forward_step,
+            callbacks=[DistTrainSampleAccountingCallback(total_iters * global_batch_size)],
+        )

--- a/tests/unit_tests/training/test_pg_collection_wiring.py
+++ b/tests/unit_tests/training/test_pg_collection_wiring.py
@@ -88,6 +88,45 @@ def test_should_skip_iteration_uses_passed_pg_collection(monkeypatch):
     assert state.train_state.skipped_train_samples == expected_batch
 
 
+def test_should_skip_dist_train_iteration_uses_language_dp_for_sample_accounting(monkeypatch):
+    """DistTrain sample counters must agree across heterogeneous module grids."""
+    from megatron.bridge.training import train as train_module
+    from megatron.bridge.training.state import GlobalState
+
+    state = GlobalState()
+    model_config = SimpleNamespace(dist_train=SimpleNamespace(use_dist_train=True))
+    state.cfg = SimpleNamespace(
+        model=model_config,
+        data_parallel_size=2,
+        train=SimpleNamespace(
+            iterations_to_skip={1},
+            micro_batch_size=2,
+            exit_signal_handler=False,
+            exit_signal=signal.SIGTERM,
+        ),
+    )
+
+    # The supported DistTrain layout has vision DP=4 and language DP=2. The
+    # microbatch calculator and global batch contract use language DP on every rank.
+    vision_data_distribution_group = SimpleNamespace(size=lambda: 4)
+    fake_vision_pg = SimpleNamespace()
+    monkeypatch.setattr(train_module, "get_num_microbatches", lambda: 8)
+    monkeypatch.setattr(
+        train_module,
+        "get_data_distribution_group",
+        lambda _pg_collection, _model_config: vision_data_distribution_group,
+    )
+    monkeypatch.setattr(train_module, "_dummy_train_step", lambda *args, **kwargs: None)
+
+    did_skip = train_module._should_skip_and_handle_iteration(state, None, fake_vision_pg)
+
+    assert did_skip is True
+    assert state.train_state.step == 1
+    expected_global_batch = 2 * 2 * 8
+    assert state.train_state.consumed_train_samples == expected_global_batch
+    assert state.train_state.skipped_train_samples == expected_global_batch
+
+
 def test_train_stops_nsys_profiler_when_skipped_iteration_reaches_profile_end(monkeypatch):
     """Skipping the stop iteration must still close an active Nsys capture."""
     from megatron.bridge.training import profiling as profiling_module


### PR DESCRIPTION
## Summary

DistTrain can assign different data-parallel degrees to its vision and language
module grids. Bridge initialized the global-batch and microbatch contract from
the language grid, but advanced `TrainState` sample counters using each rank's
module-local data-distribution group.

With the supported Qwen3-VL DistTrain configuration from #2367 (vision DP 4,
language DP 2, MBS 2, GBS 32), vision ranks therefore recorded 64 samples per
step while language ranks recorded 32. A rank-zero checkpoint could serialize
the vision-derived count, causing incorrect sample/token reporting and resume
offsets.

## Root cause and fix

Both the ordinary and skipped-iteration accounting paths derived `dp_size` from
`get_data_distribution_group(...).size()`. That group is intentionally
module-local in DistTrain and is not the owner of the global batch contract.

The fix uses the already finalized `ConfigContainer.data_parallel_size` for
DistTrain accounting and preserves the existing group-local behavior for every
other training mode. The same small helper is used by normal and skipped
iterations so their counters cannot drift.

## Regression evidence

Focused fail-before on unmodified
`ddf5f119367d5be9b56ec20dbe937beeed498e2b`:

```text
uv run --no-sync python -m pytest -q \
  tests/unit_tests/training/test_pg_collection_wiring.py::test_should_skip_dist_train_iteration_uses_language_dp_for_sample_accounting
# 1 failed: expected 32, actual 64
```

The unchanged focused check and standard-training control after the fix:

```text
uv run --no-sync python -m pytest -q \
  tests/unit_tests/training/test_pg_collection_wiring.py::test_should_skip_dist_train_iteration_uses_language_dp_for_sample_accounting \
  tests/unit_tests/training/test_pg_collection_wiring.py::test_should_skip_iteration_uses_passed_pg_collection
# 2 passed
```

Real eight-rank DistTrain validation used the existing five-iteration functional
test with a callback asserting each rank's final counter:

```text
srun --mpi=pmix --no-kill -N 1 -n 8 --ntasks-per-node=8 <container> \
  uv run --no-sync python -m pytest -q \
  tests/functional_tests/test_groups/training/test_pretrain_dist_train.py::TestPretrainDistTrain::test_pretrain_dist_train \
  -s --tb=short
```

- Before: training completed five iterations; four vision ranks failed with
  `assert 320 == 160`. The launcher was terminated after pytest failure because
  rank cleanup remained active.
- After: exit 0; all eight rank-local pytest processes reported `1 passed` and
  observed 160 consumed samples.

Adjacent and repository checks:

```text
uv run --no-sync python -m pytest -q tests/unit_tests/training/test_pg_collection_wiring.py
# 6 passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# passed
```

## Scope

- No configuration, public API, checkpoint format, dependency, or CI changes.
- Does not change data loading, module-local reductions, or DistTrain process
  groups; only global sample accounting uses the global language-DP contract.
- Standard training and GTP retain their existing group-derived accounting.
