### PR TITLE
[data] fix: Resume MegatronMIMO validation samples

### DIFF
--- a/src/megatron/bridge/data/megatron_mimo/loaders.py
+++ b/src/megatron/bridge/data/megatron_mimo/loaders.py
@@ -156,7 +156,11 @@ def build_megatron_mimo_data_loaders(
         consumed_samples=train_state.consumed_train_samples,
         split_micro_batch_size=micro_batch_size,
     )
-    valid_loader = _make_loader(valid_ds, consumed_samples=0, split_micro_batch_size=eval_micro_batch_size)
+    valid_loader = _make_loader(
+        valid_ds,
+        consumed_samples=train_state.consumed_valid_samples,
+        split_micro_batch_size=eval_micro_batch_size,
+    )
     test_loader = _make_loader(test_ds, consumed_samples=0, split_micro_batch_size=eval_micro_batch_size)
 
     return train_loader, valid_loader, test_loader

--- a/tests/unit_tests/data/megatron_mimo/test_loaders.py
+++ b/tests/unit_tests/data/megatron_mimo/test_loaders.py
@@ -142,7 +142,7 @@ def test_build_megatron_mimo_data_loaders_happy_path(monkeypatch):
     cfg = _make_happy_cfg(micro_batch_size=3)
     provider = FakeProvider()
 
-    train_state = SimpleNamespace(consumed_train_samples=0)
+    train_state = SimpleNamespace(consumed_train_samples=0, consumed_valid_samples=0)
     train_loader, valid_loader, test_loader = build_megatron_mimo_data_loaders(
         cfg,
         train_state=train_state,
@@ -173,7 +173,7 @@ def test_build_megatron_mimo_data_loaders_uses_eval_micro_batch_size_for_eval_sp
 
     build_megatron_mimo_data_loaders(
         cfg,
-        train_state=SimpleNamespace(consumed_train_samples=0),
+        train_state=SimpleNamespace(consumed_train_samples=0, consumed_valid_samples=0),
         megatron_mimo_provider=FakeProvider(),
         train_samples=10,
         valid_samples=4,
@@ -184,15 +184,12 @@ def test_build_megatron_mimo_data_loaders_uses_eval_micro_batch_size_for_eval_sp
 
 
 def test_build_megatron_mimo_data_loaders_wires_consumed_samples_for_resume(monkeypatch):
-    """Regression test for issue #11: train loader must receive
-    train_state.consumed_train_samples so data resumes after checkpoint load;
-    valid/test loaders always start from 0.
-    """
+    """Train and validation loaders resume from their persisted sample offsets."""
     builder_calls = _patch_happy_path_dependencies(monkeypatch)
     cfg = _make_happy_cfg(micro_batch_size=2)
     provider = FakeProvider()
 
-    train_state = SimpleNamespace(consumed_train_samples=50000)
+    train_state = SimpleNamespace(consumed_train_samples=50000, consumed_valid_samples=4000)
     build_megatron_mimo_data_loaders(
         cfg,
         train_state=train_state,
@@ -202,9 +199,9 @@ def test_build_megatron_mimo_data_loaders_wires_consumed_samples_for_resume(monk
         test_samples=2,
     )
 
-    # Train loader gets resume offset; valid/test always start from 0.
+    # Train and validation loaders get their own resume offsets; test always starts from 0.
     assert builder_calls[0]["consumed_samples"] == 50000
-    assert builder_calls[1]["consumed_samples"] == 0
+    assert builder_calls[1]["consumed_samples"] == 4000
     assert builder_calls[2]["consumed_samples"] == 0
 
 
@@ -310,7 +307,7 @@ def test_mimo_runtime_update_normalizes_zero_worker_provider_before_loader_const
     loader_cfg = _make_real_loader_cfg(monkeypatch, micro_batch_size=2)
     train_loader, _, _ = build_megatron_mimo_data_loaders(
         loader_cfg,
-        train_state=SimpleNamespace(consumed_train_samples=0),
+        train_state=SimpleNamespace(consumed_train_samples=0, consumed_valid_samples=0),
         megatron_mimo_provider=provider,
         train_samples=provider.train_size,
         valid_samples=0,
@@ -334,7 +331,7 @@ def test_train_loader_starts_from_consumed_samples_end_to_end(monkeypatch):
     consumed = 12  # pretend 3 iterations already ran before the crash
     cfg = _make_real_loader_cfg(monkeypatch, micro_batch_size=micro_batch_size)
     provider = IndexDatasetProvider(train_size=train_size)
-    train_state = SimpleNamespace(consumed_train_samples=consumed)
+    train_state = SimpleNamespace(consumed_train_samples=consumed, consumed_valid_samples=0)
 
     train_loader, _, _ = build_megatron_mimo_data_loaders(
         cfg,
@@ -354,14 +351,12 @@ def test_train_loader_starts_from_consumed_samples_end_to_end(monkeypatch):
     )
 
 
-def test_valid_and_test_loaders_always_start_from_zero_end_to_end(monkeypatch):
-    """Issue #11 end-to-end: valid/test loaders must start at 0 even when the train
-    checkpoint carries a non-zero consumed_train_samples.
-    """
+def test_valid_loader_starts_from_consumed_samples_end_to_end(monkeypatch):
+    """The validation loader resumes while the test loader starts from zero."""
     micro_batch_size = 2
     cfg = _make_real_loader_cfg(monkeypatch, micro_batch_size=micro_batch_size)
     provider = IndexDatasetProvider(train_size=16, valid_size=8, test_size=8)
-    train_state = SimpleNamespace(consumed_train_samples=10)
+    train_state = SimpleNamespace(consumed_train_samples=10, consumed_valid_samples=4)
 
     _, valid_loader, test_loader = build_megatron_mimo_data_loaders(
         cfg,
@@ -372,7 +367,7 @@ def test_valid_and_test_loaders_always_start_from_zero_end_to_end(monkeypatch):
         test_samples=8,
     )
 
-    assert next(iter(valid_loader)) == [0, 1]
+    assert next(iter(valid_loader)) == [4, 5]
     assert next(iter(test_loader)) == [0, 1]
 
 
@@ -387,7 +382,7 @@ def test_build_megatron_mimo_data_loaders_forwards_dataloader_type(monkeypatch):
 
     build_megatron_mimo_data_loaders(
         cfg,
-        train_state=SimpleNamespace(consumed_train_samples=0),
+        train_state=SimpleNamespace(consumed_train_samples=0, consumed_valid_samples=0),
         megatron_mimo_provider=provider,
         train_samples=10,
         valid_samples=4,


### PR DESCRIPTION
## What

Resume the MegatronMIMO validation loader from `TrainState.consumed_valid_samples` instead of restarting it at sample zero.

## Why

A supported MegatronMIMO run can perform interval validation, save a checkpoint, and resume. Evaluation advances `consumed_valid_samples`, `TrainState` persists and restores it, and setup restores that state before rebuilding the data iterators. The MIMO loader nevertheless passed a literal zero to its validation sampler.

After resume, this replayed early validation samples while the restored counter continued advancing, omitting later samples and making resumed validation metrics differ from uninterrupted execution. Both supported `single` and `cyclic` samplers derive their position from the supplied consumed-sample offset.

This closes a resume boundary left by the MIMO data-loader work in #3503.

## Fix

Pass the restored validation counter to the validation loader, matching the existing training-loader and standard Bridge validation behavior. Test loading remains at zero. The regression test exercises the real sequential sampler and asserts that a restored offset of 4 yields validation samples `[4, 5]`, while test samples remain `[0, 1]`.

## Validation

Fail-before on unmodified `ddf5f119367d5be9b56ec20dbe937beeed498e2b`:

```text
uv run --no-project --python 3.12 python reproducer.py <base-checkout>
validation_consumed_samples actual=0 expected=4
# exit 1
```

Pass-after with the unchanged reproducer:

```text
uv run --no-project --python 3.12 python reproducer.py <patched-checkout>
validation_consumed_samples actual=4 expected=4
# exit 0
```

Focused and adjacent loader tests:

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/data/megatron_mimo/test_loaders.py -q
# 11 passed
```

Static checks:

```text
git diff --check
uv run --no-sync pre-commit run --all-files
# passed
```

## Scope

This changes only MegatronMIMO validation resume sampling. It does not alter checkpoint formats, sampler algorithms, test evaluation behavior, multiple-validation-set support, or skip-training/full-validation semantics.
