### PR TITLE
[training] fix: Preserve VLM trainability through PEFT

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -726,7 +726,24 @@ def _apply_peft_transformation(peft, base_model: list[MegatronModule]) -> list[M
         Model with PEFT transformation applied
     """
     print_rank_0("Applying PEFT transformation...")
+    component_freeze_fields = (
+        "freeze_language_model",
+        "freeze_vision_model",
+        "freeze_vision_projection",
+    )
+    preserve_provider_trainability = any(
+        getattr(getattr(model_chunk, "config", None), field, False)
+        for model_chunk in base_model
+        for field in component_freeze_fields
+    )
+    provider_trainable_params = (
+        {param for model_chunk in base_model for param in model_chunk.parameters() if param.requires_grad}
+        if preserve_provider_trainability
+        else set()
+    )
     transformed_model = peft(base_model, training=True)
+    for param in provider_trainable_params:
+        param.requires_grad = True
     peft.set_params_to_save(transformed_model)
 
     # Log PEFT statistics

--- a/tests/unit_tests/recipes/qwen_vl/test_qwen25_vl_recipes.py
+++ b/tests/unit_tests/recipes/qwen_vl/test_qwen25_vl_recipes.py
@@ -25,7 +25,9 @@ from typing import Callable
 
 import pytest
 import torch
+import torch.nn as nn
 
+from megatron.bridge.training.setup import _apply_peft_transformation
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_module_global
 
 
@@ -78,6 +80,21 @@ class _FakeAutoBridge:
     def to_megatron_provider(self, load_weights: bool = False):
         """Return a fake model config."""
         return _FakeModelCfg()
+
+
+class _TinyQwen25VLModel(nn.Module):
+    """Qwen-shaped model for checking the public recipe's trainable components."""
+
+    def __init__(self, config: _FakeModelCfg):
+        super().__init__()
+        self.config = config
+        self.language_model = nn.Module()
+        self.language_model.linear_qkv = nn.Linear(4, 4)
+        self.visual = nn.Module()
+        self.visual.patch_embed = nn.Linear(4, 4)
+        self.visual.blocks = nn.ModuleList([nn.Module()])
+        self.visual.blocks[0].qkv = nn.Linear(4, 4)
+        self.visual.merger = nn.Sequential(nn.Linear(4, 4))
 
 
 def _assert_basic_config(cfg):
@@ -328,6 +345,55 @@ def test_qwen25_vl_peft_freeze_defaults(monkeypatch: pytest.MonkeyPatch):
     assert cfg.model.freeze_language_model is False
     assert cfg.model.freeze_vision_model is False
     assert cfg.model.freeze_vision_projection is False
+
+
+def test_qwen25_vl_peft_freeze_overrides_control_trainable_components(monkeypatch: pytest.MonkeyPatch):
+    """Test the documented language-frozen, vision-trainable PEFT configuration."""
+    patch_recipe_module_global(monkeypatch, _qwen25_vl_module, "AutoBridge", _FakeAutoBridge)
+    cfg = _qwen25_vl_module.qwen25_vl_3b_peft_config(peft_scheme="lora")
+    cfg.model.freeze_language_model = True
+    cfg.model.freeze_vision_model = False
+    cfg.model.freeze_vision_projection = False
+    model = _TinyQwen25VLModel(cfg.model)
+
+    from megatron.bridge.models.qwen_vl.modeling_qwen25_vl import Qwen25VLModel
+
+    Qwen25VLModel.freeze(
+        model,
+        freeze_language_model=cfg.model.freeze_language_model,
+        freeze_vision_model=cfg.model.freeze_vision_model,
+        freeze_vision_projection=cfg.model.freeze_vision_projection,
+    )
+    [model] = _apply_peft_transformation(cfg.peft, [model])
+
+    trainable = {name for name, param in model.named_parameters() if param.requires_grad}
+    assert trainable == {
+        "language_model.linear_qkv.adapter.linear_in.weight",
+        "language_model.linear_qkv.adapter.linear_out.weight",
+        "visual.blocks.0.qkv.bias",
+        "visual.blocks.0.qkv.weight",
+        "visual.merger.0.bias",
+        "visual.merger.0.weight",
+        "visual.patch_embed.bias",
+        "visual.patch_embed.weight",
+    }
+    assert cfg.peft.params_to_save == trainable
+
+
+def test_qwen25_vl_peft_defaults_remain_adapter_only(monkeypatch: pytest.MonkeyPatch):
+    """Test that component preservation is opt-in through an explicit freeze override."""
+    patch_recipe_module_global(monkeypatch, _qwen25_vl_module, "AutoBridge", _FakeAutoBridge)
+    cfg = _qwen25_vl_module.qwen25_vl_3b_peft_config(peft_scheme="lora")
+    model = _TinyQwen25VLModel(cfg.model)
+
+    [model] = _apply_peft_transformation(cfg.peft, [model])
+
+    trainable = {name for name, param in model.named_parameters() if param.requires_grad}
+    assert trainable == {
+        "language_model.linear_qkv.adapter.linear_in.weight",
+        "language_model.linear_qkv.adapter.linear_out.weight",
+    }
+    assert cfg.peft.params_to_save == trainable
 
 
 def test_qwen25_vl_precision_config(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## What changed

Preserve the provider-selected trainable base parameters when an explicit VLM component-freeze policy is combined with PEFT. The restoration happens after adapter insertion and before PEFT computes its checkpoint parameter set.

## Supported trigger and impact

The Qwen2.5-VL guide documents LoRA with:

- `model.freeze_language_model=True`
- `model.freeze_vision_model=False`
- `model.freeze_vision_projection=False`

The provider correctly froze the language base model and left the vision encoder and merger trainable. The later generic PEFT transform then froze every base parameter, so training silently became language-adapter-only: the requested vision components received no gradients and were absent from adapter checkpoints.

## Root cause

Model-provider component freezing runs during construction. PEFT runs later in the pre-wrap hook and intentionally starts ordinary adapter-only training by freezing the full base model. The handoff did not preserve the provider's explicit mixed trainability policy.

This change snapshots provider-trainable parameters only when at least one VLM component-freeze flag is enabled, restores those parameters after PEFT transformation, and then lets `set_params_to_save()` capture the corrected final ownership. The all-false default remains adapter-only.

## Validation

Regression test at the unmodified base:

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/recipes/qwen_vl/test_qwen25_vl_recipes.py::test_qwen25_vl_peft_freeze_overrides_control_trainable_components -q
1 failed: only language adapter weights were trainable; six expected vision/projection parameters were absent
```

The unchanged test after the fix:

```text
1 passed
```

Focused and adjacent validation:

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/recipes/qwen_vl/test_qwen25_vl_recipes.py tests/unit_tests/bridge/training/test_setup.py tests/unit_tests/peft/test_lora.py::TestLoRA::test_lora_parameter_freezing -q
43 passed

git diff --check
passed

uv run --no-sync pre-commit run --all-files
passed
```

## Scope

No public API, dependency, CI workflow, distributed algorithm, or model architecture changes. No GPU/model download was required because the regression is deterministic parameter ownership at the provider-to-PEFT boundary.
