### PR TITLE
[inference] fix: Initialize distributed text generation

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_text.py
+++ b/examples/conversion/hf_to_megatron_generate_text.py
@@ -33,7 +33,12 @@ from transformers import AutoTokenizer
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
-from megatron.bridge.utils.common_utils import disable_mtp_for_inference, get_last_rank, print_rank_0
+from megatron.bridge.utils.common_utils import (
+    disable_mtp_for_inference,
+    get_last_rank,
+    maybe_initialize_distributed,
+    print_rank_0,
+)
 
 
 class SingleBatchIterator:
@@ -173,6 +178,8 @@ def main(args) -> None:
               parallelism settings, and generation parameters
     """
     # pylint: disable=C0115,C0116
+    maybe_initialize_distributed()
+
     tp = args.tp
     pp = args.pp
     ep = args.ep

--- a/tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_text_cli.py
+++ b/tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_text_cli.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Focused tests for the text generation CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT = Path(__file__).resolve().parents[4] / "examples" / "conversion" / "hf_to_megatron_generate_text.py"
+_DISTRIBUTED_ENV = ("RANK", "WORLD_SIZE", "LOCAL_RANK", "MASTER_ADDR", "MASTER_PORT")
+
+
+def _module(name: str, **attrs: object) -> types.ModuleType:
+    module = types.ModuleType(name)
+    for attr_name, value in attrs.items():
+        setattr(module, attr_name, value)
+    return module
+
+
+@pytest.mark.unit
+def test_main_initializes_single_process_distributed_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    events = []
+
+    def initialize_distributed() -> None:
+        events.append("distributed")
+        defaults = {
+            "RANK": "0",
+            "WORLD_SIZE": "1",
+            "LOCAL_RANK": "0",
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "29500",
+        }
+        for name, value in defaults.items():
+            os.environ.setdefault(name, value)
+
+    stubs = {
+        "megatron.core": _module("megatron.core", parallel_state=types.SimpleNamespace()),
+        "megatron.core.inference.contexts": _module("megatron.core.inference.contexts", StaticInferenceContext=object),
+        "megatron.core.inference.utils": _module("megatron.core.inference.utils", InferenceMode=object),
+        "megatron.core.pipeline_parallel.schedules": _module(
+            "megatron.core.pipeline_parallel.schedules", get_forward_backward_func=lambda: None
+        ),
+        "transformers": _module("transformers", AutoTokenizer=object),
+        "megatron.bridge": _module("megatron.bridge", AutoBridge=object),
+        "megatron.bridge.models.hf_pretrained.utils": _module(
+            "megatron.bridge.models.hf_pretrained.utils", is_safe_repo=lambda **kwargs: True
+        ),
+        "megatron.bridge.utils.common_utils": _module(
+            "megatron.bridge.utils.common_utils",
+            disable_mtp_for_inference=lambda model: None,
+            get_last_rank=lambda: 0,
+            maybe_initialize_distributed=initialize_distributed,
+            print_rank_0=lambda message: None,
+        ),
+    }
+    for name, module in stubs.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    for name in _DISTRIBUTED_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+    spec = importlib.util.spec_from_file_location("hf_to_megatron_generate_text_cli_under_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def initialize_model_parallel(*, seed: int) -> None:
+        assert seed == 0
+        assert events == ["distributed"]
+        assert {name: os.environ[name] for name in _DISTRIBUTED_ENV} == {
+            "RANK": "0",
+            "WORLD_SIZE": "1",
+            "LOCAL_RANK": "0",
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "29500",
+        }
+        raise RuntimeError("stop after model-parallel initialization")
+
+    provider = types.SimpleNamespace(finalize=lambda: None, initialize_model_parallel=initialize_model_parallel)
+    bridge = types.SimpleNamespace(to_megatron_provider=lambda load_weights: provider)
+    module.AutoBridge = types.SimpleNamespace(from_hf_pretrained=lambda *args, **kwargs: bridge)
+    args = types.SimpleNamespace(
+        tp=1,
+        pp=1,
+        ep=1,
+        etp=1,
+        megatron_model_path=None,
+        hf_model_path="org/model",
+        trust_remote_code=False,
+        hf_revision=None,
+        pipeline_model_parallel_layout=None,
+    )
+
+    with pytest.raises(RuntimeError, match="stop after model-parallel initialization"):
+        module.main(args)


### PR DESCRIPTION
## What changed

Initialize the default distributed process group before the text-generation example configures Megatron model parallelism.

The example documents direct `uv run python` single-GPU execution. Without launcher-provided rendezvous variables, both its Hugging Face and Megatron-checkpoint paths reached `ModelProviderMixin.initialize_model_parallel()`, whose default `env://` initialization failed because `RANK` was unset. The later fallback in `provide_distributed_model()` could not help because model-parallel initialization happened first, and the checkpoint path does not call that provider method.

The fix reuses the existing standalone `maybe_initialize_distributed()` helper at the entry-point ownership boundary. Launcher-provided environments remain unchanged because the helper preserves existing values and is a no-op for an initialized process group.

## Regression coverage

The focused behavioral test clears all five launcher variables and verifies coherent rank-0/world-1 defaults are present before provider model-parallel initialization.

- Before the fix: failed because distributed initialization had not run before the provider boundary.
- After the fix: passed.
- Adjacent VLM entry-point lifecycle control: passed.

```text
uv run python -m pytest --confcutdir=tests/unit_tests/examples/conversion \
  tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_text_cli.py \
  tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_vlm_cli.py::test_main_initializes_distributed_before_model_parallel -q
# 2 passed

git diff --check
# passed

uv run pre-commit run --all-files
# passed
```

## Scope

This changes only the standalone text-generation example's initialization order. It does not change public APIs, model conversion, generation semantics, or distributed launcher behavior. The missing-rendezvous failure occurs before NCCL communicator creation, so the regression is deterministic without a GPU allocation.
