### PR TITLE
fix(model): keep GLM-5 export max_position_embeddings from the reference config

### DIFF
--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -145,6 +145,21 @@ class GLM5Bridge(MegatronModelBridge):
 
         return provider
 
+    @classmethod
+    def megatron_to_hf_config(cls, provider: MLAModelProvider) -> dict:
+        """Convert a GLM-5 provider to an HF config dict without leaking training-only context length.
+
+        The generic ``CONFIG_MAPPING`` maps HF ``max_position_embeddings`` from Megatron ``seq_length``. For a
+        fine-tuned checkpoint that is the *training* sequence length (e.g. 8192), not the model's context
+        capability (1048576 for ``zai-org/GLM-5.2``), and ``conform_config_to_reference`` keeps the
+        Megatron-derived value because the key exists in the reference config. Drop it here so the reference
+        HF config supplies it; when no reference config is available the key is simply absent and transformers
+        falls back to the ``GlmMoeDsaConfig`` default.
+        """
+        hf_config = super().megatron_to_hf_config(provider)
+        hf_config.pop("max_position_embeddings", None)
+        return hf_config
+
     def mapping_registry(self) -> MegatronMappingRegistry:
         param_mappings = {
             # Embed

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -111,6 +111,25 @@ def test_megatron_config_export_keeps_generic_moe_aliases() -> None:
     assert mapped_config["n_routed_experts"] == 8
 
 
+def test_megatron_config_export_does_not_emit_training_seq_length_as_max_position_embeddings() -> None:
+    """``seq_length`` is the fine-tuning context, not the model's context capability; leave it to the reference."""
+    mapped_config = GLM5Bridge.megatron_to_hf_config(SimpleNamespace(num_moe_experts=8, seq_length=8192))
+
+    assert "max_position_embeddings" not in mapped_config
+    assert mapped_config["num_experts"] == 8
+
+
+def test_megatron_config_export_reference_supplies_max_position_embeddings() -> None:
+    """With a reference config, the exported value must be the reference one (1048576 for GLM-5.2), not seq_length."""
+    from megatron.bridge.models.conversion.utils import conform_config_to_reference
+
+    mapped_config = GLM5Bridge.megatron_to_hf_config(SimpleNamespace(num_moe_experts=256, seq_length=8192))
+    reference = {"max_position_embeddings": 1048576, "n_routed_experts": 256}
+    conformed = conform_config_to_reference(mapped_config, reference)
+
+    assert conformed["max_position_embeddings"] == 1048576
+
+
 @pytest.mark.parametrize(
     ("config_overrides", "expected_topk_freq", "expected_skip_topk_offset"),
     [


### PR DESCRIPTION
## What does this PR do?

Fixes #5994.

`GLM5Bridge` inherits the generic `CONFIG_MAPPING` entry `("max_position_embeddings", "seq_length")`. When a fine-tuned GLM-5.2 checkpoint is exported (`run_conversion.py export`, GPU backend), the HF `config.json` therefore gets `max_position_embeddings = 8192` (the training sequence length) instead of the model's `1048576`. `conform_config_to_reference` keeps the Megatron-derived value because the key exists in the reference config, so serving engines cap `max_model_len` at the training length.

This PR adds a `GLM5Bridge.megatron_to_hf_config` override (same pattern as #5528 / #5417 for Step3.7 and #5097 for Llama) that drops `max_position_embeddings` from the generated dict, so the reference HF config supplies it. When no reference config is available the key is simply absent and transformers falls back to the `GlmMoeDsaConfig` default.

Not touched on purpose: `head_dim` (transformers' `GlmMoeDsaConfig.__init__` sets `head_dim = qk_rope_head_dim` regardless of the file value) and the extra default keys — verified harmless by serving an export with Bridge's config unchanged (details in #5994).

## Tests

- New unit tests in `tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py`:
  - `test_megatron_config_export_does_not_emit_training_seq_length_as_max_position_embeddings`
  - `test_megatron_config_export_reference_supplies_max_position_embeddings`
- `pytest tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py` → 23 passed (run inside `nvcr.io/nvidia/nemo:26.08` with this branch on `PYTHONPATH`, GB200 node); `ruff check` / `ruff format --check` clean on the two files.
- End-to-end context: the 12-node GPU export of a GLM-5.2 SFT checkpoint (`--tp 1 --pp 6 --ep 8`) is what surfaced the issue; with the original `config.json` restored, the export serves correctly on vLLM (TP8×PP2, GB200).

## Checklist
- [x] Signed-off (DCO)
- [x] Unit tests added
- [ ] Docs: none needed (bug fix)
