### PR TITLE
[training] fix: Remove duplicate MIMO iteration-time logging

### DIFF
--- a/src/megatron/bridge/training/train_megatron_mimo.py
+++ b/src/megatron/bridge/training/train_megatron_mimo.py
@@ -386,17 +386,6 @@ def train_megatron_mimo(
                 pg_collection=local_pg_collection,
             )
 
-            # Log iteration-time directly for MegatronMIMO models.
-            # training_log only logs this inside a hasattr(config.model, "kv_channels")
-            # block which MegatronMIMO models don't satisfy, so we log it here as a workaround.
-            if cfg.logger.log_timers_to_tensorboard and train_state.step % cfg.logger.log_interval == 0:
-                writer = global_state.tensorboard_logger
-                if writer:
-                    writer.add_scalar("iteration-time", iteration_time, train_state.step)
-                wandb_writer = global_state.wandb_logger
-                if wandb_writer:
-                    wandb_writer.log({"iteration-time": iteration_time}, train_state.step)
-
         # Evaluation at specified intervals
         if eval_interval and train_state.step % eval_interval == 0 and valid_data_iterator is not None:
             if train_config.manual_gc and train_config.manual_gc_eval:

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -13,7 +13,7 @@ import time
 from contextlib import ExitStack
 from types import SimpleNamespace
 from typing import Any, Dict
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
@@ -504,6 +504,55 @@ def test_interval_evaluation_uses_evaluator_timer_ownership(use_canonical_valida
         )
 
     mock_evaluate.assert_called_once()
+
+
+def test_iteration_time_is_logged_once_by_shared_training_logger():
+    """MIMO should not overwrite the shared interval-average timing metric."""
+    from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo
+
+    state = _make_global_state(save_dir=None, train_iters=2, step=1)
+    state.cfg.logger.skip_train_metrics_log = False
+    state.cfg.logger.log_timers_to_tensorboard = True
+    state.cfg.logger.log_interval = 2
+    state.tensorboard_logger = MagicMock()
+    state.timers.return_value.elapsed.return_value = 5.0
+
+    infra = _make_megatron_mimo_infra()
+
+    def log_interval_average(**_kwargs):
+        state.tensorboard_logger.add_scalar("iteration-time", 2.0, 2)
+        return False
+
+    with (
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("megatron.bridge.training.train_megatron_mimo.get_num_microbatches", return_value=1),
+        patch("megatron.bridge.training.train_megatron_mimo.prepare_forward_step_func", return_value=Mock()),
+        patch("megatron.bridge.training.train_megatron_mimo.get_module_to_grid_tuple", return_value=[]),
+        patch(
+            "megatron.bridge.training.train_megatron_mimo.build_pg_collection_for_schedule",
+            return_value=Mock(spec=[]),
+        ),
+        patch(
+            "megatron.bridge.training.train_megatron_mimo.train_step_megatron_mimo",
+            return_value=({}, 0, 0.0, 0),
+        ),
+        patch("megatron.bridge.training.train_megatron_mimo.training_log", side_effect=log_interval_average),
+        patch("megatron.bridge.training.train_megatron_mimo.checkpoint_and_decide_exit", return_value=False),
+    ):
+        train_megatron_mimo(
+            forward_step_func=Mock(),
+            model=Mock(),
+            optimizer=Mock(),
+            schedulers={},
+            train_data_iterator=iter([object()]),
+            valid_data_iterator=None,
+            global_state=state,
+            megatron_mimo_infra=infra,
+            multimodule_communicator=Mock(),
+            checkpoint_manager=MagicMock(),
+        )
+
+    assert state.tensorboard_logger.add_scalar.call_args_list == [call("iteration-time", 2.0, 2)]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

MegatronMIMO training currently emits two different `iteration-time` values under the same TensorBoard/W&B tag and training step at logging boundaries. This removes the stale MIMO-specific write and keeps the shared training logger as the sole owner of the metric.

## Supported trigger and impact

With MegatronMIMO training, timer logging enabled, a TensorBoard or W&B logger, and `log_interval > 1`, `train_megatron_mimo()` first calls `training_log()`. The shared helper records the interval-average duration. The MIMO loop then records the latest step duration under the identical tag and step.

The two points describe different windows, so the second write can overwrite the interval average or create conflicting telemetry. This makes supported performance monitoring materially misleading and also gives TensorBoard/W&B different semantics from MLflow/Comet.

## Root cause and minimal fix

The direct MIMO write was added as a workaround based on the assumption that `training_log()` gated `iteration-time` on `model.kv_channels`. The current shared helper emits the timer outside that guard. The fix deletes only the redundant write; per-step timing and `history_wct` accounting remain unchanged.

The regression test executes the MIMO loop with distinct interval-average and latest-step durations and asserts that only the shared interval-average point is emitted.

## Validation

Fail before on base `077224531ad4d6d0caef767a84e619b256aa5cb6`:

```text
uv run --no-project python reproduce_iteration_time.py src/megatron/bridge/training/train_megatron_mimo.py
exit 1: [('iteration-time', 2.0, 2), ('iteration-time', 5.0, 2)]
```

Pass after the fix with the unchanged reproducer:

```text
uv run --no-project python reproduce_iteration_time.py src/megatron/bridge/training/train_megatron_mimo.py
exit 0
```

Focused regression and adjacent unit coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_iteration_time_is_logged_once_by_shared_training_logger -q --tb=short
1 passed

uv run --no-sync python -m pytest tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py -q --tb=short
42 passed

uv run --no-sync pre-commit run --all-files
Passed

git diff --check
Passed
```

## Scope

This changes only MegatronMIMO metric emission. It does not change timer measurement, training behavior, logger configuration, non-MIMO training, public APIs, or checkpoint semantics.
