### PR TITLE
[inference] fix: Provide iterators for virtual pipeline chunks

### DIFF
--- a/examples/conversion/hf_to_megatron_generate_text.py
+++ b/examples/conversion/hf_to_megatron_generate_text.py
@@ -317,12 +317,13 @@ def main(args) -> None:
                 input_ids,
                 legacy_full_prefix=args.legacy_full_prefix,
             )
-            iterator = SingleBatchIterator(input_ids, position_ids, inference_context)
+            iterators = [SingleBatchIterator(input_ids, position_ids, inference_context) for _ in model]
+            data_iterator = iterators if len(iterators) > 1 else iterators[0]
 
             output = _run_megatron_forward(
                 fwd_bwd_function,
                 forward_step_func=text_forward_step,
-                data_iterator=iterator,
+                data_iterator=data_iterator,
                 model=model,
                 num_microbatches=1,
                 forward_only=True,

--- a/tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_text_cli.py
+++ b/tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_text_cli.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import os
 import sys
@@ -23,6 +24,7 @@ import types
 from pathlib import Path
 
 import pytest
+import torch
 
 
 _SCRIPT = Path(__file__).resolve().parents[4] / "examples" / "conversion" / "hf_to_megatron_generate_text.py"
@@ -110,4 +112,96 @@ def test_main_initializes_single_process_distributed_environment(monkeypatch: py
     )
 
     with pytest.raises(RuntimeError, match="stop after model-parallel initialization"):
+        module.main(args)
+
+
+@pytest.mark.unit
+def test_main_provides_an_iterator_for_each_virtual_pipeline_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    class InferenceContext:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+    class ModelChunk:
+        def cuda(self):
+            return self
+
+        def eval(self) -> None:
+            pass
+
+    def interleaved_forward(**kwargs):
+        assert isinstance(kwargs["data_iterator"], list), (
+            "interleaved pipeline parallelism expected each model chunk to have a data iterator"
+        )
+        assert len(kwargs["data_iterator"]) == len(kwargs["model"]) == 2
+        assert len({id(iterator) for iterator in kwargs["data_iterator"]}) == 2
+        raise RuntimeError("stop after interleaved schedule accepts iterators")
+
+    tokenizer = types.SimpleNamespace(
+        pad_token="<pad>",
+        eos_token_id=2,
+        encode=lambda prompt, return_tensors: torch.tensor([[1, 2]]),
+    )
+    parallel_state = types.SimpleNamespace()
+    stubs = {
+        "megatron.core": _module("megatron.core", parallel_state=parallel_state),
+        "megatron.core.inference.contexts": _module(
+            "megatron.core.inference.contexts", StaticInferenceContext=InferenceContext
+        ),
+        "megatron.core.inference.utils": _module(
+            "megatron.core.inference.utils",
+            InferenceMode=types.SimpleNamespace(active=contextlib.nullcontext),
+        ),
+        "megatron.core.pipeline_parallel.schedules": _module(
+            "megatron.core.pipeline_parallel.schedules", get_forward_backward_func=lambda: interleaved_forward
+        ),
+        "transformers": _module(
+            "transformers", AutoTokenizer=types.SimpleNamespace(from_pretrained=lambda *args, **kwargs: tokenizer)
+        ),
+        "megatron.bridge": _module("megatron.bridge", AutoBridge=object),
+        "megatron.bridge.models.hf_pretrained.utils": _module(
+            "megatron.bridge.models.hf_pretrained.utils", is_safe_repo=lambda **kwargs: True
+        ),
+        "megatron.bridge.utils.common_utils": _module(
+            "megatron.bridge.utils.common_utils",
+            disable_mtp_for_inference=lambda model: None,
+            get_last_rank=lambda: 1,
+            maybe_initialize_distributed=lambda: None,
+            print_rank_0=lambda message: None,
+        ),
+    }
+    for name, stub in stubs.items():
+        monkeypatch.setitem(sys.modules, name, stub)
+    monkeypatch.setattr(torch.Tensor, "cuda", lambda self: self)
+
+    spec = importlib.util.spec_from_file_location("hf_to_megatron_generate_text_vpp_under_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    provider = types.SimpleNamespace(
+        finalize=lambda: None,
+        initialize_model_parallel=lambda *, seed: None,
+        provide_distributed_model=lambda *, wrap_with_ddp: [ModelChunk(), ModelChunk()],
+        vocab_size=32,
+    )
+    bridge = types.SimpleNamespace(to_megatron_provider=lambda load_weights: provider)
+    module.AutoBridge = types.SimpleNamespace(from_hf_pretrained=lambda *args, **kwargs: bridge)
+    args = types.SimpleNamespace(
+        tp=1,
+        pp=2,
+        ep=1,
+        etp=1,
+        megatron_model_path=None,
+        hf_model_path="org/four-layer-model",
+        trust_remote_code=False,
+        hf_revision=None,
+        pipeline_model_parallel_layout="Et|t|t|tL",
+        prompt="hello",
+        apply_chat_template=False,
+        thinking_mode="adaptive",
+        max_new_tokens=1,
+        legacy_full_prefix=False,
+    )
+
+    with pytest.raises(RuntimeError, match="stop after interleaved schedule accepts iterators"):
         module.main(args)


### PR DESCRIPTION
## What changed

Create one independent `SingleBatchIterator` per local virtual-pipeline model chunk before calling the MCore forward/backward schedule. Preserve the existing scalar iterator for the normal one-chunk path.

## Bug and impact

The public text-generation example accepts flexible pipeline layouts. For a valid layout whose stage count implies virtual pipeline parallelism, such as `Et|t|t|tL` with `--pp 2` on a four-layer model, provider finalization infers VPP=2 and constructs two local model chunks.

MCore then selects its interleaved pipeline schedule, which requires a list containing one stateful iterator per model chunk. The example passed one scalar iterator, so generation aborted immediately with:

```text
AssertionError: interleaved pipeline parallelism expected each model chunk to have a data iterator
```

The fix is intentionally local to the schedule-call ownership boundary. Each chunk receives a distinct iterator because each iterator is consumed independently.

## Regression coverage

The focused CLI test drives a two-chunk layout through the generation entry point and asserts the interleaved schedule receives two distinct iterators.

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/examples/conversion \
  tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_text_cli.py::test_main_provides_an_iterator_for_each_virtual_pipeline_chunk -q
# before: 1 failed at the scalar-iterator assertion
# after: 1 passed

uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/examples/conversion \
  tests/unit_tests/examples/conversion/test_hf_to_megatron_generate_text_cli.py -q
# 2 passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# passed
```

## Scope

This does not change public APIs, layout parsing, model construction, sampling, or non-interleaved execution. The failure is an unconditional schedule call-shape assertion before pipeline communication, so the regression is deterministic without a GPU allocation.
