### PR TITLE
feat(ckpt): expose local BF16 export iterator

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -31,6 +31,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 
 
 if TYPE_CHECKING:
+    from megatron.bridge.models.conversion.param_mapping import LocalHFParam
     from megatron.bridge.peft.base import PEFT
 
 from megatron.core.transformer.module import MegatronModule
@@ -707,6 +708,22 @@ class AutoBridge(Generic[MegatronModelT]):
         if not isinstance(model, list):
             model = [model]
         return self._model_bridge.build_export_fp8_tasks(self.hf_pretrained, model)
+
+    def iter_local_hf_params(self, tasks: Iterable[WeightConversionTask]) -> Iterable["LocalHFParam"]:
+        """Yield local unquantized BF16 parameters as canonical HF views.
+
+        Args:
+            tasks: Reusable tasks from :meth:`get_conversion_tasks` in the
+                deterministic order they should be exported.
+
+        Returns:
+            An iterator over live local parameter views and their shard metadata.
+
+        Raises:
+            ValueError: If a locally owned task is quantized, is not BF16, or
+                cannot be represented without Bridge conversion collectives.
+        """
+        return self._model_bridge.iter_local_hf_params(tasks)
 
     def export_hf_weights(
         self,

--- a/src/megatron/bridge/models/conversion/model_bridge.py
+++ b/src/megatron/bridge/models/conversion/model_bridge.py
@@ -56,6 +56,7 @@ from transformers.modeling_utils import PreTrainedModel
 from megatron.bridge.models.common import ModelConfigOverrideMixin
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.param_mapping import (
+    LocalHFParam,
     LocalHFParamSpec,
     MegatronParamMapping,
 )
@@ -1501,6 +1502,44 @@ class MegatronModelBridge(
             else:
                 self.unquantized_state_dict = captured_state_dicts
         return megatron_model
+
+    def iter_local_hf_params(
+        self,
+        tasks: Iterable[WeightConversionTask],
+    ) -> Iterable[LocalHFParam]:
+        """Yield local unquantized BF16 parameters as canonical HF views.
+
+        The caller may reuse tasks from :meth:`build_conversion_tasks` across
+        iterations to cache parameter topology. Each pass reads ``param_weight``
+        again and yields live local views without Bridge collectives, dtype
+        conversion, or quantization sidecars.
+
+        Args:
+            tasks: Conversion tasks in deterministic export order.
+
+        Yields:
+            Canonical local HF parameter views in task and mapping order after
+            every locally owned task passes validation.
+
+        Raises:
+            ValueError: If a locally owned task has inconsistent metadata, is
+                not backed by unquantized BF16 storage, or needs conversion that
+                cannot be represented by local views.
+        """
+        params = []
+        for task in tasks:
+            if task.param_weight is None:
+                continue
+            if task.megatron_module is None:
+                raise ValueError(f"{task.global_param_name}: local parameter has no owning Megatron module")
+            params.extend(
+                task.mapping.local_hf_params(
+                    task.param_weight,
+                    global_param_name=task.global_param_name,
+                    megatron_module=task.megatron_module,
+                )
+            )
+        yield from params
 
     def stream_weights_hf_to_megatron(
         self,

--- a/src/megatron/bridge/models/conversion/param_mapping.py
+++ b/src/megatron/bridge/models/conversion/param_mapping.py
@@ -16,7 +16,7 @@ import json
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Tuple, TypeVar, Union
 
 import torch
 import torch.distributed
@@ -40,6 +40,7 @@ from megatron.bridge.utils.common_utils import extract_expert_number_from_param
 
 
 WeightType = TypeVar("WeightType", torch.Tensor, Dict[str, torch.Tensor])
+LocalHFShardGroup = Literal["tp", "etp", "replicated"]
 
 import logging
 
@@ -92,6 +93,22 @@ class LocalHFParamSpec:
             )
         selected[dim] //= self.split_count
         return torch.Size(selected)
+
+
+@dataclass(frozen=True)
+class LocalHFParam:
+    """A canonical HF-compatible view of one local unquantized BF16 parameter.
+
+    The tensor remains a live view of the local Megatron parameter. Its global
+    shape and sharding fields describe how an M-to-N transport can reconstruct
+    the corresponding logical HF parameter without Bridge collectives.
+    """
+
+    name: str
+    weight: torch.Tensor
+    global_weight_shape: torch.Size
+    shard_group: LocalHFShardGroup
+    shard_dim: int | None
 
 
 def _module_uses_fsdp(megatron_module: nn.Module) -> bool:
@@ -221,6 +238,78 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
         ):
             return ()
         return (LocalHFParamSpec(self.hf_param),)
+
+    def _local_hf_sharding(
+        self, weight: torch.Tensor, megatron_module: nn.Module
+    ) -> tuple[LocalHFShardGroup, int | None, int]:
+        """Describe the local tensor sharding for canonical HF views."""
+        if self.tp_size == 1:
+            return "replicated", None, 1
+        raise ValueError(
+            f"mapping {type(self).__name__} does not describe local HF sharding "
+            f"when tensor parallel size is {self.tp_size}"
+        )
+
+    def local_hf_params(
+        self,
+        weight: torch.Tensor,
+        *,
+        global_param_name: str,
+        megatron_module: nn.Module,
+    ) -> tuple[LocalHFParam, ...]:
+        """Materialize canonical local HF views for an unquantized BF16 parameter.
+
+        This method only selects views from local storage. It does not gather,
+        broadcast, dequantize, cast, or emit quantization sidecars.
+
+        Args:
+            weight: Local logical Megatron parameter storage.
+            global_param_name: Resolved global Megatron parameter name.
+            megatron_module: Local module that owns ``weight``.
+
+        Returns:
+            Canonical local HF parameter views in mapping-defined order.
+
+        Raises:
+            ValueError: If the storage is not plain BF16 or the mapping cannot
+                represent the parameter as local HF views.
+        """
+        if HAVE_TE_FP8_TENSOR_CLASS and isinstance(weight, FP8_TENSOR_CLASS):
+            raise ValueError(f"{global_param_name}: local HF parameter iteration does not support quantized storage")
+        if weight.dtype != torch.bfloat16:
+            raise ValueError(
+                f"{global_param_name}: local HF parameter iteration requires unquantized BF16 storage, "
+                f"got {weight.dtype}"
+            )
+        if isinstance(weight, DTensor) or _module_uses_fsdp(megatron_module):
+            raise ValueError(f"{global_param_name}: local HF parameter iteration does not support DTensor/FSDP")
+
+        specs = self.local_hf_param_specs(global_param_name)
+        if not specs:
+            raise ValueError(
+                f"{global_param_name}: mapping {type(self).__name__} cannot be represented as canonical local HF views"
+            )
+        shard_group, shard_dim, shard_size = self._local_hf_sharding(weight, megatron_module)
+
+        params = []
+        for spec in specs:
+            selected = spec.select(weight)
+            global_shape = list(selected.shape)
+            if shard_dim is not None:
+                normalized_shard_dim = shard_dim % selected.ndim
+                global_shape[normalized_shard_dim] *= shard_size
+            else:
+                normalized_shard_dim = None
+            params.append(
+                LocalHFParam(
+                    name=spec.name,
+                    weight=selected,
+                    global_weight_shape=torch.Size(global_shape),
+                    shard_group=shard_group,
+                    shard_dim=normalized_shard_dim,
+                )
+            )
+        return tuple(params)
 
     def set_process_groups_from_pg_collection(self, pg_collection: Any) -> None:
         """Override snapshotted Megatron-Core globals with a ``ProcessGroupCollection``.
@@ -989,6 +1078,12 @@ class MegatronParamMapping(ABC, Generic[WeightType]):
 class DirectMapping(MegatronParamMapping[torch.Tensor]):
     """Direct 1:1 weight mapping with no transformation or tensor parallelism."""
 
+    def _local_hf_sharding(
+        self, weight: torch.Tensor, megatron_module: nn.Module
+    ) -> tuple[LocalHFShardGroup, int | None, int]:
+        """Describe direct parameters as replicated local views."""
+        return "replicated", None, 1
+
     def hf_to_megatron(
         self,
         hf_weights: torch.Tensor,
@@ -1057,6 +1152,12 @@ class ColumnParallelMapping(MegatronParamMapping[torch.Tensor]):
         This mapping also handles bias terms, which are 1D tensors split
         along their only dimension following the same pattern.
     """
+
+    def _local_hf_sharding(
+        self, weight: torch.Tensor, megatron_module: nn.Module
+    ) -> tuple[LocalHFShardGroup, int | None, int]:
+        """Describe column-parallel local views."""
+        return ("etp" if self.is_expert else "tp"), 0, self.tp_size
 
     def hf_to_megatron(
         self,
@@ -1228,6 +1329,14 @@ class RowParallelMapping(MegatronParamMapping[torch.Tensor]):
         original unsharded weight and emits it under the external (HF) name.
     """
 
+    def _local_hf_sharding(
+        self, weight: torch.Tensor, megatron_module: nn.Module
+    ) -> tuple[LocalHFShardGroup, int | None, int]:
+        """Describe row-parallel local views."""
+        if weight.ndim == 1:
+            return "replicated", None, 1
+        return ("etp" if self.is_expert else "tp"), 1, self.tp_size
+
     def hf_to_megatron(
         self,
         hf_weights: torch.Tensor,
@@ -1376,6 +1485,12 @@ class ReplicatedMapping(MegatronParamMapping[torch.Tensor]):
     during *load* (HF → Megatron) and ensure we do **not** emit duplicates
     during *export* (Megatron → HF).
     """
+
+    def _local_hf_sharding(
+        self, weight: torch.Tensor, megatron_module: nn.Module
+    ) -> tuple[LocalHFShardGroup, int | None, int]:
+        """Describe fully replicated local views."""
+        return "replicated", None, 1
 
     def hf_to_megatron(
         self,
@@ -1644,6 +1759,19 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
             f"  AutoMapping.register_module_type('{module_type}', 'column|row|replicated')\n\n"
             f"Currently known module types:\n{json.dumps(known_types, indent=2)}"
         )
+
+    def _local_hf_sharding(
+        self, weight: torch.Tensor, megatron_module: nn.Module
+    ) -> tuple[LocalHFShardGroup, int | None, int]:
+        """Describe local HF sharding through the detected concrete mapping."""
+        mapping = self._mapping
+        if mapping is None:
+            try:
+                parallelism_type = self._detect_parallelism_type(megatron_module)
+                mapping = self._get_or_create_mapping(parallelism_type)
+            except ValueError as error:
+                raise ValueError(f"{self.megatron_param}: {error}") from error
+        return mapping._local_hf_sharding(weight, megatron_module)
 
     def hf_to_megatron(
         self,
@@ -2734,6 +2862,12 @@ class GatedMLPMapping(MegatronParamMapping[Dict[str, torch.Tensor]]):
             LocalHFParamSpec(self.hf_param["gate"], -2, 0, 2),
             LocalHFParamSpec(self.hf_param["up"], -2, 1, 2),
         )
+
+    def _local_hf_sharding(
+        self, weight: torch.Tensor, megatron_module: nn.Module
+    ) -> tuple[LocalHFShardGroup, int | None, int]:
+        """Describe fused gate/up projections as column-parallel views."""
+        return ("etp" if self.is_expert else "tp"), -2, self.tp_size
 
     def hf_to_megatron(
         self,

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -1205,6 +1205,21 @@ class TestAutoBridge:
                 mock_hf_model, mock_megatron_model, allowed_mismatched_params=None
             )
 
+    def test_iter_local_hf_params_uses_public_auto_bridge_api(self):
+        mock_hf_model = Mock(spec=PreTrainedCausalLM)
+        mock_hf_model.config = Mock(spec=PretrainedConfig)
+        mock_model_bridge = Mock()
+        tasks = [Mock()]
+        expected_params = [Mock()]
+        mock_model_bridge.iter_local_hf_params.return_value = iter(expected_params)
+
+        with patch.object(AutoBridge, "_model_bridge", mock_model_bridge):
+            bridge = AutoBridge(mock_hf_model)
+            params = list(bridge.iter_local_hf_params(tasks))
+
+        assert params == expected_params
+        mock_model_bridge.iter_local_hf_params.assert_called_once_with(tasks)
+
     def test_load_hf_weights_with_allowed_mismatched_params(self):
         """Test loading weights with allowed_mismatched_params."""
         # Setup mocks

--- a/tests/unit_tests/models/test_model_bridge.py
+++ b/tests/unit_tests/models/test_model_bridge.py
@@ -22,9 +22,17 @@ from transformers import PretrainedConfig
 
 from megatron.bridge.models.conversion import model_bridge as model_bridge_module
 from megatron.bridge.models.conversion import modelopt_utils
+from megatron.bridge.models.conversion import param_mapping as param_mapping_module
 from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
 from megatron.bridge.models.conversion.model_bridge import HFWeightTuple, MegatronModelBridge, WeightConversionTask
-from megatron.bridge.models.conversion.param_mapping import AutoMapping, GatedMLPMapping
+from megatron.bridge.models.conversion.param_mapping import (
+    AutoMapping,
+    DirectMapping,
+    FusedGatedExpertMapping,
+    GatedMLPMapping,
+    QKVMapping,
+    RowParallelMapping,
+)
 
 
 class DummyBridge(MegatronModelBridge):
@@ -54,6 +62,249 @@ def test_weight_conversion_task_round_trips_local_hf_views():
         "model.mlp.up_proj.weight",
     )
     assert torch.equal(task.combine_local_hf_weights(local_weights), logical)
+
+
+def test_iter_local_hf_params_yields_identity_bf16_view():
+    weight = torch.nn.Parameter(torch.arange(8, dtype=torch.bfloat16).reshape(2, 4))
+    task = WeightConversionTask(
+        param_name="decoder.proj.weight",
+        global_param_name="decoder.proj.weight",
+        mapping=DirectMapping("decoder.proj.weight", "model.proj.weight"),
+        megatron_module=torch.nn.Module(),
+        param_weight=weight,
+    )
+
+    [param] = DummyBridge().iter_local_hf_params([task])
+
+    assert param.name == "model.proj.weight"
+    assert param.weight is weight
+    assert param.global_weight_shape == torch.Size((2, 4))
+    assert param.shard_group == "replicated"
+    assert param.shard_dim is None
+
+
+def test_iter_local_hf_params_splits_gate_up_with_tp_metadata():
+    class TwoWayGatedMLPMapping(GatedMLPMapping):
+        @property
+        def tp_size(self):
+            return 2
+
+    weight = torch.nn.Parameter(torch.arange(32, dtype=torch.bfloat16).reshape(8, 4))
+    task = WeightConversionTask(
+        param_name="decoder.mlp.linear_fc1.weight",
+        global_param_name="decoder.mlp.linear_fc1.weight",
+        mapping=TwoWayGatedMLPMapping(
+            "decoder.mlp.linear_fc1.weight",
+            gate="model.mlp.gate_proj.weight",
+            up="model.mlp.up_proj.weight",
+        ),
+        megatron_module=torch.nn.Module(),
+        param_weight=weight,
+    )
+
+    gate, up = DummyBridge().iter_local_hf_params([task])
+
+    assert [gate.name, up.name] == ["model.mlp.gate_proj.weight", "model.mlp.up_proj.weight"]
+    assert gate.weight.data_ptr() == weight.data_ptr()
+    assert torch.equal(gate.weight, weight[:4])
+    assert torch.equal(up.weight, weight[4:])
+    assert gate.global_weight_shape == up.global_weight_shape == torch.Size((8, 4))
+    assert gate.shard_group == up.shard_group == "tp"
+    assert gate.shard_dim == up.shard_dim == 0
+
+
+def test_iter_local_hf_params_reports_row_parallel_shard_metadata():
+    class FourWayRowParallelMapping(RowParallelMapping):
+        @property
+        def tp_size(self):
+            return 4
+
+    weight = torch.nn.Parameter(torch.zeros((4, 2), dtype=torch.bfloat16))
+    task = WeightConversionTask(
+        param_name="decoder.mlp.linear_fc2.weight",
+        global_param_name="decoder.mlp.linear_fc2.weight",
+        mapping=FourWayRowParallelMapping("decoder.mlp.linear_fc2.weight", "model.mlp.down_proj.weight"),
+        megatron_module=torch.nn.Module(),
+        param_weight=weight,
+    )
+
+    [param] = DummyBridge().iter_local_hf_params([task])
+
+    assert param.global_weight_shape == torch.Size((4, 8))
+    assert param.shard_group == "tp"
+    assert param.shard_dim == 1
+
+
+def test_iter_local_hf_params_reports_fused_expert_etp_metadata(monkeypatch):
+    etp_group = object()
+    monkeypatch.setattr(param_mapping_module, "get_pg_size", lambda group: 2 if group is etp_group else 1)
+    mapping = FusedGatedExpertMapping(
+        "decoder.layers.0.mlp.experts.linear_fc1.weight2",
+        "model.layers.0.mlp.experts.gate_up_proj",
+    )
+    mapping.set_process_groups_from_pg_collection(SimpleNamespace(expt_tp=etp_group))
+    module = type("TEColumnParallelGroupedLinear", (torch.nn.Module,), {})()
+    weight = torch.nn.Parameter(torch.arange(32, dtype=torch.bfloat16).reshape(8, 4))
+    task = WeightConversionTask(
+        param_name=mapping.megatron_param,
+        global_param_name=mapping.megatron_param,
+        mapping=mapping,
+        megatron_module=module,
+        param_weight=weight,
+    )
+
+    gate, up = DummyBridge().iter_local_hf_params([task])
+
+    assert [gate.name, up.name] == [
+        "model.layers.0.mlp.experts.2.gate_proj.weight",
+        "model.layers.0.mlp.experts.2.up_proj.weight",
+    ]
+    assert gate.global_weight_shape == up.global_weight_shape == torch.Size((8, 4))
+    assert gate.shard_group == up.shard_group == "etp"
+    assert gate.shard_dim == up.shard_dim == 0
+
+
+def test_iter_local_hf_params_skips_remote_pp_placeholders():
+    remote = WeightConversionTask(
+        param_name="decoder.remote.weight",
+        global_param_name="decoder.remote.weight",
+        mapping=DirectMapping("decoder.remote.weight", "model.remote.weight"),
+        param_weight=None,
+        megatron_module=None,
+    )
+    local_weight = torch.nn.Parameter(torch.ones(2, dtype=torch.bfloat16))
+    local = WeightConversionTask(
+        param_name="decoder.local.weight",
+        global_param_name="decoder.local.weight",
+        mapping=DirectMapping("decoder.local.weight", "model.local.weight"),
+        param_weight=local_weight,
+        megatron_module=torch.nn.Module(),
+    )
+
+    params = list(DummyBridge().iter_local_hf_params([remote, local]))
+
+    assert [param.name for param in params] == ["model.local.weight"]
+
+
+def test_iter_local_hf_params_rejects_unsupported_qkv_mapping():
+    task = WeightConversionTask(
+        param_name="decoder.self_attention.linear_qkv.weight",
+        global_param_name="decoder.self_attention.linear_qkv.weight",
+        mapping=QKVMapping(
+            "decoder.self_attention.linear_qkv.weight",
+            q="model.self_attn.q_proj.weight",
+            k="model.self_attn.k_proj.weight",
+            v="model.self_attn.v_proj.weight",
+        ),
+        megatron_module=torch.nn.Module(),
+        param_weight=torch.nn.Parameter(torch.zeros((8, 4), dtype=torch.bfloat16)),
+    )
+
+    with pytest.raises(ValueError, match="QKVMapping.*cannot be represented as canonical local HF views"):
+        list(DummyBridge().iter_local_hf_params([task]))
+
+
+def test_iter_local_hf_params_preflights_before_yielding():
+    supported = WeightConversionTask(
+        param_name="decoder.proj.weight",
+        global_param_name="decoder.proj.weight",
+        mapping=DirectMapping("decoder.proj.weight", "model.proj.weight"),
+        megatron_module=torch.nn.Module(),
+        param_weight=torch.nn.Parameter(torch.zeros((2, 2), dtype=torch.bfloat16)),
+    )
+    unsupported = WeightConversionTask(
+        param_name="decoder.qkv.weight",
+        global_param_name="decoder.qkv.weight",
+        mapping=QKVMapping("decoder.qkv.weight", q="hf.q", k="hf.k", v="hf.v"),
+        megatron_module=torch.nn.Module(),
+        param_weight=torch.nn.Parameter(torch.zeros((4, 2), dtype=torch.bfloat16)),
+    )
+    exposed = []
+
+    with pytest.raises(ValueError, match="QKVMapping.*cannot be represented as canonical local HF views"):
+        exposed.extend(DummyBridge().iter_local_hf_params([supported, unsupported]))
+
+    assert exposed == []
+
+
+def test_iter_local_hf_params_preserves_task_and_mapping_order():
+    first_weight = torch.nn.Parameter(torch.ones((2, 2), dtype=torch.bfloat16))
+    fused_weight = torch.nn.Parameter(torch.arange(16, dtype=torch.bfloat16).reshape(4, 4))
+    tasks = [
+        WeightConversionTask(
+            param_name="decoder.first.weight",
+            global_param_name="decoder.first.weight",
+            mapping=DirectMapping("decoder.first.weight", "hf.first.weight"),
+            megatron_module=torch.nn.Module(),
+            param_weight=first_weight,
+        ),
+        WeightConversionTask(
+            param_name="decoder.fused.weight",
+            global_param_name="decoder.fused.weight",
+            mapping=GatedMLPMapping(
+                "decoder.fused.weight",
+                gate="hf.gate.weight",
+                up="hf.up.weight",
+            ),
+            megatron_module=torch.nn.Module(),
+            param_weight=fused_weight,
+        ),
+    ]
+
+    params = list(DummyBridge().iter_local_hf_params(tasks))
+
+    assert [param.name for param in params] == ["hf.first.weight", "hf.gate.weight", "hf.up.weight"]
+
+
+def test_iter_local_hf_params_recaptures_live_weights_from_reused_tasks():
+    weight = torch.nn.Parameter(torch.zeros(4, dtype=torch.bfloat16))
+    task = WeightConversionTask(
+        param_name="decoder.weight",
+        global_param_name="decoder.weight",
+        mapping=DirectMapping("decoder.weight", "hf.weight"),
+        megatron_module=torch.nn.Module(),
+        param_weight=weight,
+    )
+    bridge = DummyBridge()
+
+    [first] = bridge.iter_local_hf_params([task])
+    with torch.no_grad():
+        weight.fill_(7)
+    [second] = bridge.iter_local_hf_params([task])
+
+    assert first.weight.data_ptr() == second.weight.data_ptr() == weight.data_ptr()
+    assert torch.equal(second.weight, torch.full_like(weight, 7))
+
+
+def test_iter_local_hf_params_keeps_auto_conversion_cache_unmodified():
+    mapping = AutoMapping("decoder.weight", "hf.weight")
+    module = torch.nn.Module()
+    module.tensor_model_parallel = False
+    task = WeightConversionTask(
+        param_name="decoder.weight",
+        global_param_name="decoder.weight",
+        mapping=mapping,
+        megatron_module=module,
+        param_weight=torch.nn.Parameter(torch.zeros(4, dtype=torch.bfloat16)),
+    )
+
+    list(DummyBridge().iter_local_hf_params([task]))
+
+    assert mapping._mapping is None
+    assert mapping._detected_type is None
+
+
+def test_iter_local_hf_params_rejects_non_bf16_storage():
+    task = WeightConversionTask(
+        param_name="decoder.weight",
+        global_param_name="decoder.weight",
+        mapping=DirectMapping("decoder.weight", "hf.weight"),
+        megatron_module=torch.nn.Module(),
+        param_weight=torch.nn.Parameter(torch.zeros(4, dtype=torch.float32)),
+    )
+
+    with pytest.raises(ValueError, match="requires unquantized BF16 storage"):
+        list(DummyBridge().iter_local_hf_params([task]))
 
 
 def test_stream_weights_hf_to_megatron_uses_external_state_and_bridge_preprocessing(monkeypatch):


### PR DESCRIPTION
# What does this PR do ?

Expose reusable conversion tasks as deterministic, no-collective local BF16 HF parameter views for M-to-N and refit transports.

# Changelog

- Add `LocalHFParam` with the canonical HF name, live BF16 tensor view, global shape, shard group, and shard dimension.
- Add public `AutoBridge.iter_local_hf_params(tasks)` and bridge-level iteration with all-task preflight, deterministic task/mapping order, and safe skipping of remote PP placeholders.
- Reuse `LocalHFParamSpec` for identity, gate/up, and fused-expert views; reject mappings that require layout conversion.
- Add focused coverage for identity and fused views, TP/ETP metadata, remote placeholders, unsupported mappings, ordering, preflight atomicity, and repeated live-weight capture.

The boundary is intentionally narrow: this API accepts only local, unquantized BF16 storage. It performs no gather or broadcast, no dtype conversion, and emits no FP8/MXFP8 scales or other quantization sidecars. Quantized storage and mappings that require transformation continue to use their existing conversion paths.

# Validation

- 15 focused unit tests passed.
- `uv run pre-commit run --all-files` passed.

# GitHub Actions CI

An exact-head `/ok to test` comment will be posted after PR creation.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Read and followed the contributor guidelines.
- [x] Added focused tests for the new public behavior and failure boundaries.
- [x] Added public API documentation through docstrings.
- [x] This change does not affect optional-install components.

# Additional Information

This is the unquantized BF16 counterpart discussed during review of #5917; MXFP8 behavior remains isolated to that change.