### PR TITLE
fix(perf): disable DeepEP for DeepSeek V3 B200 fp8mx and nvfp4 recipes

### DIFF
--- a/src/megatron/bridge/perf_recipes/deepseek/b200/deepseek_v3.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/b200/deepseek_v3.py
@@ -131,28 +131,19 @@ def deepseek_v3_pretrain_256gpu_b200_fp8mx_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.virtual_pipeline_model_parallel_size = 2
     cfg.model.context_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 32
+    cfg.model.expert_model_parallel_size = 8
     cfg.model.sequence_parallel = False
     cfg.train.global_batch_size = 4096
     cfg.train.micro_batch_size = 1
 
-    cfg.model.recompute_modules = ["mla_up_proj", "mlp"]
-
-    cfg.model.moe_flex_dispatcher_backend = "deepep"
-    cfg.model.moe_hybridep_num_sms = 16
+    cfg.model.recompute_modules = ["mla_up_proj"]
 
     cfg.ddp.overlap_grad_reduce = True
     cfg.comm_overlap.overlap_grad_reduce = True
-    cfg.comm_overlap.delay_wgrad_compute = True
-    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
 
     set_deepseek_v3_pipeline_model_parallel_layout(cfg.model)
 
     _benchmark_common(cfg)
-    cfg.model.moe_flex_dispatcher_backend = "deepep"
-    cfg.model.moe_hybridep_num_sms = 16
-    cfg.comm_overlap.delay_wgrad_compute = True
-    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
     _enable_deepseek_transformer_engine_graph(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
@@ -165,6 +156,11 @@ def deepseek_v3_pretrain_256gpu_b200_fp8mx_config() -> ConfigContainer:
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
+        # HybridEP topology for the target system.
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
         # Transformer Engine overlap settings for this model.
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
@@ -182,12 +178,7 @@ def deepseek_v3_pretrain_256gpu_b200_nvfp4_config() -> ConfigContainer:
     cfg.mixed_precision.fp4_param_gather = False
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.virtual_pipeline_model_parallel_size = 2
-    cfg.model.expert_model_parallel_size = 32
     cfg.model.recompute_modules = ["mla_up_proj", "layernorm", "moe_act"]
-    cfg.model.moe_flex_dispatcher_backend = "deepep"
-    cfg.model.moe_hybridep_num_sms = 16
-    cfg.comm_overlap.delay_wgrad_compute = True
-    cfg.comm_overlap.overlap_moe_expert_parallel_comm = True
     set_deepseek_v3_pipeline_model_parallel_layout(cfg.model)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.
     cfg.env_vars = {
@@ -200,6 +191,11 @@ def deepseek_v3_pretrain_256gpu_b200_nvfp4_config() -> ConfigContainer:
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
+        # HybridEP topology for the target system.
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 8,
+        "USE_MNNVL": 0,
         # Transformer Engine overlap settings for this model.
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,

--- a/tests/unit_tests/recipes/test_perf_recipe_environment.py
+++ b/tests/unit_tests/recipes/test_perf_recipe_environment.py
@@ -46,10 +46,6 @@ _DEEPSEEK_NON_BASELINE_ENV_NAMES = {
     "QUANTIZATION_TYPE_DEBUG",
     "TORCHINDUCTOR_WORKER_START",
 }
-_DEEPSEEK_WITHOUT_HYBRID_EP_RECIPES = {
-    ("b200", "deepseek_v3_pretrain_256gpu_b200_fp8mx_config"),
-    ("b200", "deepseek_v3_pretrain_256gpu_b200_nvfp4_config"),
-}
 _VR200_CUDNN_LAYERNORM_RECIPES = {
     "deepseek_v3_pretrain_128gpu_vr200_fp8mx_config",
     "deepseek_v3_pretrain_256gpu_vr200_fp8mx_config",
@@ -204,12 +200,7 @@ def test_explicit_environment_invariants_across_all_flat_recipes():
             assert environment["NVTE_FWD_LAYERNORM_SM_MARGIN"] == 20
             assert environment["NVTE_BWD_LAYERNORM_SM_MARGIN"] == 20
             assert environment["NVTE_ALLOW_NONDETERMINISTIC_ALGO"] == 0
-
-            recipe_id = (path.parent.name, function_name)
-            if recipe_id in _DEEPSEEK_WITHOUT_HYBRID_EP_RECIPES:
-                assert not hybrid_ep_names
-            else:
-                assert hybrid_ep_names == _HYBRID_EP_ENV_NAMES
+            assert hybrid_ep_names == _HYBRID_EP_ENV_NAMES
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Ports https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/5471 to the flat perf_recipes system: drops DeepEP and lowers EP from 32 to 8 on the DeepSeek V3 B200 FP8-MX and NVFP4 recipes, which crash with an illegal memory access in DeepEP's internode_dispatch.