### PR TITLE
[data] fix: Initialize scalable MIMO workers

### DIFF
--- a/src/megatron/bridge/data/megatron_mimo/canonical_sampler.py
+++ b/src/megatron/bridge/data/megatron_mimo/canonical_sampler.py
@@ -29,12 +29,17 @@ reproduces the identical ordered global micro-batch under any deterministic samp
 
 from __future__ import annotations
 
+import functools
 import math
 from typing import Callable, Iterator
 
 from torch.utils.data import DataLoader, Dataset
 
-from megatron.bridge.data.samplers import MegatronPretrainingRandomSampler, MegatronPretrainingSampler
+from megatron.bridge.data.samplers import (
+    MegatronPretrainingRandomSampler,
+    MegatronPretrainingSampler,
+    _initialize_worker,
+)
 
 
 def canonical_grid_size(module_dp_sizes: list[int]) -> int:
@@ -203,6 +208,7 @@ def build_canonical_mimo_data_loader(
         data_sharding=data_sharding,
         drop_last=drop_last,
     )
+    worker_init_fn = functools.partial(_initialize_worker, worker_init_fn=None) if num_workers > 0 else None
     return DataLoader(
         dataset,
         batch_sampler=batch_sampler,
@@ -210,4 +216,5 @@ def build_canonical_mimo_data_loader(
         pin_memory=pin_memory,
         collate_fn=collate_fn,
         persistent_workers=persistent_workers,
+        worker_init_fn=worker_init_fn,
     )

--- a/tests/unit_tests/data/megatron_mimo/test_canonical_sampler.py
+++ b/tests/unit_tests/data/megatron_mimo/test_canonical_sampler.py
@@ -14,10 +14,14 @@
 
 """Unit tests for canonical-grid batch sampling (MegatronMIMO scalable reads)."""
 
+import multiprocessing
+
 import pytest
 
+import megatron.bridge.data.samplers as samplers
 from megatron.bridge.data.megatron_mimo.canonical_sampler import (
     build_canonical_group_batch_sampler,
+    build_canonical_mimo_data_loader,
     canonical_grid_size,
     covered_canonical_groups,
 )
@@ -96,6 +100,35 @@ class TestFactoryValidation:
                 groups=[0],
                 data_sharding=True,
             )
+
+
+def test_canonical_loader_releases_inherited_gpu_fds_in_worker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scalable MIMO workers must use the shared GPU descriptor cleanup."""
+    cleanup_calls = multiprocessing.Value("i", 0)
+
+    def record_cleanup() -> None:
+        cleanup_calls.value += 1
+
+    monkeypatch.setattr(samplers, "_close_nvidia_device_fds", record_cleanup)
+    dataloader = build_canonical_mimo_data_loader(
+        _FakeDataset(8),
+        consumed_samples=0,
+        dataloader_type="single",
+        micro_batch_size=2,
+        module_dp_sizes=[1],
+        dp_rank=0,
+        dp_size=1,
+        data_sharding=False,
+        drop_last=True,
+        num_workers=1,
+        pin_memory=False,
+        collate_fn=None,
+        persistent_workers=False,
+    )
+
+    next(iter(dataloader))
+
+    assert cleanup_calls.value == 1
 
 
 def _build(groups, *, dataloader_type, total=48, consumed=0, mbs=4, grid=2, data_sharding=True):


### PR DESCRIPTION
## What does this PR do?

Scalable MegatronMIMO data loaders now run the same GPU-descriptor cleanup used by the standard Bridge data-loader path before worker-side dataset or collation code.

The supported trigger is scalable MIMO data parallelism with `num_workers > 0` after CUDA/NCCL initialization. The maintained Qwen3.5-VL MIMO example exposes this mode and defaults to two persistent workers. Those workers previously inherited the parent process's NVIDIA device descriptors, which could retain GPU resources after a rank exited and interfere with distributed startup or shutdown.

## Root cause

[PR #5525](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/5525) introduced a canonical scalable-MIMO loader that constructs `torch.utils.data.DataLoader` directly. This path bypassed the `_initialize_worker` wrapper used by `build_pretraining_data_loader`, so it missed the descriptor-lifecycle invariant established by [PR #5984](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/5984) for [issue #5006](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/5006).

The fix reuses that existing initializer only when the canonical loader has subprocess workers. No API, configuration, sampler semantics, or zero-worker behavior changes.

## Validation

Deterministic GPU lifecycle reproducer, unchanged before and after the fix:

```text
uv run --no-project python reproduce_canonical_nvidia_fd_reclamation.py
```

- Before: exit 1; the live worker retained 51 NVIDIA descriptors and 1,132 MiB after the parent rank exited.
- After: exit 0; the same live worker held zero NVIDIA descriptors and memory returned to the 7 MiB baseline.

Focused regression and adjacent tests:

```text
uv run --no-sync python -m pytest -p no:cacheprovider tests/unit_tests/data/megatron_mimo/test_canonical_sampler.py tests/unit_tests/data/test_samplers.py::test_dataloader_worker_releases_gpu_fds_before_caller_initialization -q
```

Result: 21 passed.

Additional checks:

```text
git diff --check
uv run pre-commit run --all-files
```

Both passed.

## Scope

This fixes only canonical/scalable-MIMO loaders with positive worker counts. It does not change non-scalable loaders, multiprocessing start methods, model behavior, or training numerics.
