### PR TITLE
[training] fix: Run non-loss evaluation on every pipeline rank

### DIFF
--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -332,7 +332,7 @@ def evaluate(
         collected_non_loss_data = None
         if non_loss_data_func is not None:
             collected_non_loss_data = non_loss_data_func(model)
-        elif process_non_loss_data_func is not None and is_last_rank():
+        elif process_non_loss_data_func is not None:
             # Handle finetuning vs pretraining for non-loss data collection
             non_loss_data_iterator = data_iterator
             non_loss_seq_length = default_seq_length

--- a/tests/unit_tests/training/test_eval.py
+++ b/tests/unit_tests/training/test_eval.py
@@ -306,3 +306,38 @@ def test_evaluate_preserves_multimodule_data_parallel_accounting():
         )
 
     assert forward_backward_func.call_args.kwargs["num_microbatches"] == 2
+
+
+def test_evaluate_runs_non_loss_collection_on_every_pipeline_rank():
+    state = _make_evaluate_state(eval_iters=0)
+    model = _ModeTrackingModel()
+    forward_backward_func = MagicMock(return_value=[])
+    rerun_state_machine = MagicMock()
+    pg_collection = SimpleNamespace(
+        pp=SimpleNamespace(size=lambda: 2),
+        dp=SimpleNamespace(size=lambda: 1),
+        dp_cp=object(),
+    )
+
+    with (
+        patch("megatron.bridge.training.eval.prepare_forward_step_func", return_value=MagicMock()),
+        patch("megatron.bridge.training.eval.get_model_config", return_value=SimpleNamespace()),
+        patch("megatron.bridge.training.eval.get_rerun_state_machine", return_value=rerun_state_machine),
+        patch("megatron.bridge.training.eval.is_full_iteration_cuda_graph", return_value=False),
+        patch("megatron.bridge.training.eval.get_forward_backward_func", return_value=forward_backward_func),
+        patch("megatron.bridge.training.eval.is_last_rank", return_value=False),
+    ):
+        result = evaluate(
+            state=state,
+            forward_step_func=MagicMock(),
+            data_iterator=object(),
+            model=[model],
+            process_non_loss_data_func=MagicMock(),
+            config=SimpleNamespace(timers=state.timers),
+            p2p_communicator=MagicMock(),
+            pg_collection=pg_collection,
+        )
+
+    assert result == ({}, [], False)
+    forward_backward_func.assert_called_once()
+    assert forward_backward_func.call_args.kwargs["collect_non_loss_data"] is True


### PR DESCRIPTION
## What does this PR do?

Fixes a pipeline-parallel validation hang when the public non-loss processing callback is enabled.

With pipeline parallelism greater than one, `evaluate()` selected MCore's communicating forward/backward schedule but launched the non-loss collection pass only on the final world rank. The terminal pipeline stage then waited in `recv_forward()` for an earlier stage that had skipped the schedule.

The fix lets every rank participate in the collection schedule. Output ownership remains unchanged: MCore retains arbitrary forward data only on the terminal pipeline stage, and Bridge still invokes `process_non_loss_data_func` only on the final rank when a writer is present.

## Supported trigger and impact

- PP greater than one
- `process_non_loss_data_func` is set and `non_loss_data_func` is unset
- all ranks call `evaluate()`, `evaluate_and_print_results()`, or the experimental training path that forwards this option

Before this change, validation hangs deterministically. No TensorBoard writer is required to trigger the hang.

## Validation

- Exact-base two-GPU reproducer:
  `timeout 90s uv run --no-project python -m torch.distributed.run --standalone --nproc_per_node=2 reproduce_eval_non_loss_pp.py`
  - Before: exit 124; rank 0 returned while rank 1 remained in `recv_forward()`.
  - After: exit 0; both ranks returned and the terminal rank retained the expected payload.
- Focused and adjacent unit tests:
  `uv run --no-project python -m pytest tests/unit_tests/training/test_eval.py -q` — 8 passed.
- `git diff --check` — passed.
- `uv run pre-commit run --all-files` — passed.

## Scope

This changes only schedule participation for the existing callback-backed non-loss collection path. It does not change the direct `non_loss_data_func` path, output-processing ownership, public APIs, dependencies, CI workflows, or MCore.
