### PR TITLE
fix(data): harden HF SFT output directory creation

### DIFF
--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -19,6 +19,7 @@ import json
 import logging
 import math
 import re
+import time
 import warnings
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -60,6 +61,9 @@ from megatron.bridge.utils.common_utils import get_rank_safe, print_rank_0
 
 
 logger = logging.getLogger(__name__)
+
+_SHARED_FS_DIRECTORY_RESTAT_ATTEMPTS = 3
+_SHARED_FS_DIRECTORY_RESTAT_DELAY_S = 0.1
 
 _SEMANTIC_DATASET_KWARGS = {
     "add_bos",
@@ -471,9 +475,23 @@ def _load_hf_examples(
     return normalize_sft_examples(load_and_adapt_hf_dataset(source), preprocessing)
 
 
+def _ensure_hf_output_root(root: Path) -> None:
+    """Create the HF output root despite transient shared-filesystem metadata races."""
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except (FileExistsError, FileNotFoundError):
+        # Shared filesystems can briefly report a concurrently created parent as both existing and missing.
+        for attempt in range(_SHARED_FS_DIRECTORY_RESTAT_ATTEMPTS):
+            if root.is_dir():
+                return
+            if attempt + 1 < _SHARED_FS_DIRECTORY_RESTAT_ATTEMPTS:
+                time.sleep(_SHARED_FS_DIRECTORY_RESTAT_DELAY_S)
+        raise
+
+
 def _write_hf_examples(root: Path, output_name: str, examples: list[dict[str, Any]]) -> None:
     output_path = root / f"{output_name}.jsonl"
-    root.mkdir(parents=True, exist_ok=True)
+    _ensure_hf_output_root(root)
     for index_path in _hf_jsonl_index_paths(output_path):
         index_path.unlink(missing_ok=True)
     with output_path.open("w", encoding="utf-8") as output_file:
@@ -937,6 +955,11 @@ class GPTSFTDatasetBuilder:
             Elements can be None if the corresponding data file doesn't exist
             or if dataset building is skipped for the split.
         """
+        # Dataset-root resolution runs on every rank. Wait for those mkdir calls to
+        # finish before rank 0 materializes files in the shared root.
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+
         # Prepare packed data if needed
         if get_rank_safe() == 0:
             self.prepare_data()

--- a/tests/unit_tests/data/builders/test_gpt_sft_config.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_config.py
@@ -673,6 +673,50 @@ def test_hf_source_materializes_requested_jsonl_splits(monkeypatch, tmp_path):
     assert not (tmp_path / "test.jsonl").exists()
 
 
+@pytest.mark.parametrize("mkdir_error", [FileExistsError, FileNotFoundError])
+def test_write_hf_examples_tolerates_shared_fs_mkdir_race(tmp_path, monkeypatch, mkdir_error):
+    root = tmp_path / "output"
+    root.mkdir()
+
+    def raise_mkdir(self, parents=False, exist_ok=False):
+        assert self == root
+        assert parents is True
+        assert exist_ok is True
+        raise mkdir_error("stale shared filesystem state")
+
+    monkeypatch.setattr(type(root), "mkdir", raise_mkdir)
+
+    builder_mod._write_hf_examples(root, "training", [{"prompt": "question", "completion": "answer"}])
+
+    assert json.loads((root / "training.jsonl").read_text()) == {"prompt": "question", "completion": "answer"}
+
+
+def test_hf_output_root_restats_before_propagating_mkdir_race(monkeypatch, tmp_path):
+    root = tmp_path / "output"
+    is_dir_results = iter((False, True))
+    sleep_delays = []
+    mkdir_mock = MagicMock(side_effect=FileExistsError("stale shared filesystem state"))
+
+    monkeypatch.setattr(type(root), "mkdir", mkdir_mock)
+    monkeypatch.setattr(type(root), "is_dir", lambda _self: next(is_dir_results))
+    monkeypatch.setattr(builder_mod.time, "sleep", sleep_delays.append)
+
+    builder_mod._ensure_hf_output_root(root)
+
+    assert sleep_delays == [builder_mod._SHARED_FS_DIRECTORY_RESTAT_DELAY_S]
+
+
+def test_hf_output_root_propagates_mkdir_error_for_missing_directory(monkeypatch, tmp_path):
+    root = tmp_path / "output"
+    mkdir_mock = MagicMock(side_effect=FileExistsError("not a directory"))
+
+    monkeypatch.setattr(type(root), "mkdir", mkdir_mock)
+    monkeypatch.setattr(builder_mod.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(FileExistsError):
+        builder_mod._ensure_hf_output_root(root)
+
+
 def test_hf_source_can_split_validation_from_training(monkeypatch, tmp_path):
     def _fake_load(source):
         source = resolve_hf_dataset_source(source)
@@ -815,6 +859,20 @@ def test_builder_owns_runtime_materialization_and_shared_construction(monkeypatc
     assert dataset_calls[0][1]["dataset_kwargs"]["chat_loss_mode"] == "assistant"
     assert all(call[1]["enable_in_batch_packing"] is True for call in dataset_calls)
     assert all(call[1]["in_batch_packing_pad_to_multiple_of"] == 8 for call in dataset_calls)
+
+
+def test_builder_synchronizes_before_and_after_rank_zero_preparation(monkeypatch, tmp_path):
+    builder = GPTSFTDatasetBuilder(config=_hf_config(tmp_path), tokenizer=object())
+    events = []
+
+    monkeypatch.setattr(builder_mod, "get_rank_safe", lambda: 0)
+    monkeypatch.setattr(builder_mod.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(builder_mod.torch.distributed, "barrier", lambda: events.append("barrier"))
+    monkeypatch.setattr(builder, "prepare_data", lambda: events.append("prepare"))
+    monkeypatch.setattr(builder, "_build_datasets", lambda: events.append("build") or [None, None, None])
+
+    assert builder.build() == [None, None, None]
+    assert events == ["barrier", "prepare", "barrier", "build"]
 
 
 def test_hf_rewrite_regenerates_existing_builder_managed_packed_data(monkeypatch, tmp_path):


### PR DESCRIPTION
# What does this PR do ?

Prevent intermittent rank-0 failures while materializing Hugging Face text SFT datasets on shared filesystems. Dataset-root creation now finishes on every rank before rank 0 writes JSONL files, and transient shared-filesystem `mkdir` errors are accepted only after the output root becomes visible as a directory.

# Changelog

- Synchronize distributed ranks before rank 0 starts SFT data preparation, while retaining the existing post-preparation barrier.
- Retry directory visibility checks for transient `FileExistsError` and `FileNotFoundError` from recursive `mkdir` calls.
- Re-raise the original `mkdir` error when the output root does not become a directory.
- Add unit coverage for transient error handling, delayed directory visibility, invalid output roots, and barrier ordering.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

If you haven't finished some of the above items you can still open "Draft" PR.

# Additional Information

- Fixes #6023
- Related to #3886 and #3888
