### PR TITLE
feat(recipe): add VR200 DeepSeek V4 and Nemotron 3.5 configs

### DIFF
--- a/src/megatron/bridge/perf_recipes/deepseek/__init__.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/__init__.py
@@ -62,3 +62,6 @@ from megatron.bridge.perf_recipes.deepseek.vr200.deepseek_v3 import (
     deepseek_v3_pretrain_256gpu_vr200_fp8mx_config,
     deepseek_v3_pretrain_256gpu_vr200_nvfp4_config,
 )
+from megatron.bridge.perf_recipes.deepseek.vr200.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_vr200_fp8mx_config,
+)

--- a/src/megatron/bridge/perf_recipes/deepseek/vr200/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/vr200/deepseek_v4.py
@@ -24,6 +24,10 @@ def deepseek_v4_flash_pretrain_128gpu_vr200_fp8mx_config() -> ConfigContainer:
     """DeepSeek V4 Flash pretrain: 128× VR200, MXFP8 (alias of GB300)."""
     cfg = deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config()
 
+    # Rubin's grouped GLU kernel rejects the runtime clamp parameters required by DeepSeek V4.
+    cfg.model.use_transformer_engine_op_fuser = False
+    cfg.model.moe_use_grouped_tensor = True
+
     # Keep the VR200 launch environment explicit instead of inheriting it from GB300.
     cfg.env_vars = {
         **COMMON_PERF_ENV_VARS,
@@ -37,7 +41,7 @@ def deepseek_v4_flash_pretrain_128gpu_vr200_fp8mx_config() -> ConfigContainer:
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
         "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
-        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 0,
         "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
         "NVTE_NORM_BWD_USE_CUDNN": 1,
         "NVTE_NORM_FWD_USE_CUDNN": 1,

--- a/src/megatron/bridge/perf_recipes/deepseek/vr200/deepseek_v4.py
+++ b/src/megatron/bridge/perf_recipes/deepseek/vr200/deepseek_v4.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""VR200 performance recipes for DeepSeek V4."""
+
+from megatron.bridge.perf_recipes.deepseek.gb300.deepseek_v4 import (
+    deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config,
+)
+from megatron.bridge.perf_recipes.environment import COMMON_PERF_ENV_VARS
+from megatron.bridge.training.config import ConfigContainer
+
+
+def deepseek_v4_flash_pretrain_128gpu_vr200_fp8mx_config() -> ConfigContainer:
+    """DeepSeek V4 Flash pretrain: 128× VR200, MXFP8 (alias of GB300)."""
+    cfg = deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config()
+
+    # Keep the VR200 launch environment explicit instead of inheriting it from GB300.
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+        "NVTE_ALLOW_NONDETERMINISTIC_ALGO": 0,
+    }
+    return cfg

--- a/src/megatron/bridge/perf_recipes/nemotronh/__init__.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/__init__.py
@@ -64,6 +64,8 @@ from megatron.bridge.perf_recipes.nemotronh.h100.nemotronh import (
     nemotronh_56b_pretrain_64gpu_h100_fp8cs_config,
 )
 from megatron.bridge.perf_recipes.nemotronh.vr200.nemotronh import (
+    nemotron_3_5_lightning_pretrain_8gpu_vr200_bf16_config,
+    nemotron_3_5_lightning_pretrain_8gpu_vr200_fp8mx_config,
     nemotron_3_nano_pretrain_8gpu_vr200_bf16_config,
     nemotron_3_nano_pretrain_8gpu_vr200_fp8mx_config,
     nemotron_3_nano_pretrain_8gpu_vr200_nvfp4_config,

--- a/src/megatron/bridge/perf_recipes/nemotronh/vr200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/vr200/nemotronh.py
@@ -20,6 +20,8 @@ from megatron.bridge.perf_recipes.nemotronh.common import (
 from megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh import (
     _build_nemotron_3_nano_gb300_mxfp8,
     _build_nemotron_3_super_gb300_mxfp8,
+    nemotron_3_5_lightning_pretrain_8gpu_gb300_bf16_config,
+    nemotron_3_5_lightning_pretrain_8gpu_gb300_fp8mx_config,
     nemotron_3_nano_pretrain_8gpu_gb300_bf16_config,
     nemotron_3_nano_pretrain_8gpu_gb300_nvfp4_config,
     nemotron_3_super_pretrain_64gpu_gb300_bf16_config,
@@ -236,5 +238,55 @@ def nemotron_3_ultra_pretrain_256gpu_vr200_fp8mx_config() -> ConfigContainer:
         "NVTE_CPU_OFFLOAD_V1": 1,
         # Enable TE's CuteDSL fused grouped MLP kernel on Rubin.
         "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+    }
+    return cfg
+
+
+def nemotron_3_5_lightning_pretrain_8gpu_vr200_bf16_config() -> ConfigContainer:
+    """Nemotron 3.5 Lightning pretrain: 8× VR200, BF16 (alias of GB300)."""
+    cfg = nemotron_3_5_lightning_pretrain_8gpu_gb300_bf16_config()
+
+    # Keep the VR200 launch environment explicit instead of inheriting it from GB300.
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
+    }
+    return cfg
+
+
+def nemotron_3_5_lightning_pretrain_8gpu_vr200_fp8mx_config() -> ConfigContainer:
+    """Nemotron 3.5 Lightning pretrain: 8× VR200, MXFP8 (alias of GB300)."""
+    cfg = nemotron_3_5_lightning_pretrain_8gpu_gb300_fp8mx_config()
+
+    # Keep the VR200 launch environment explicit instead of inheriting it from GB300.
+    cfg.env_vars = {
+        **COMMON_PERF_ENV_VARS,
+        "CUDA_DEVICE_MAX_CONNECTIONS": 32,
+        "NCCL_GRAPH_REGISTER": 0,
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": 1,
+        "NCCL_NVLS_ENABLE": 0,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
+        "NVLINK_DOMAIN_SIZE": 72,
+        "USE_MNNVL": 1,
+        "CUDNNFE_CLUSTER_OVERLAP_MARGIN": 8,
+        "NVTE_BWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_CUTEDSL_FUSED_GROUPED_MLP": 1,
+        "NVTE_FWD_LAYERNORM_SM_MARGIN": 20,
+        "NVTE_NORM_BWD_USE_CUDNN": 1,
+        "NVTE_NORM_FWD_USE_CUDNN": 1,
     }
     return cfg

--- a/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
@@ -132,10 +132,16 @@ def test_deepseek_v4_flash_128gpu_gb300_fp8mx_config() -> None:
     assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 32
 
 
-def test_deepseek_v4_flash_128gpu_vr200_fp8mx_matches_gb300_config() -> None:
+def test_deepseek_v4_flash_128gpu_vr200_fp8mx_uses_grouped_tensor_fallback() -> None:
     vr200_cfg = deepseek_v4_flash_pretrain_128gpu_vr200_fp8mx_config()
     gb300_cfg = deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config()
 
+    assert vr200_cfg.model.use_transformer_engine_op_fuser is False
+    assert vr200_cfg.model.moe_use_grouped_tensor is True
+    assert vr200_cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] == 0
+
+    gb300_cfg.model.use_transformer_engine_op_fuser = False
+    gb300_cfg.env_vars["NVTE_CUTEDSL_FUSED_GROUPED_MLP"] = 0
     assert vr200_cfg == gb300_cfg
 
 

--- a/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py
@@ -22,6 +22,7 @@ from megatron.bridge.perf_recipes.deepseek import (
     deepseek_v4_flash_pretrain_128gpu_b300_fp8mx_config,
     deepseek_v4_flash_pretrain_128gpu_gb200_fp8mx_config,
     deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config,
+    deepseek_v4_flash_pretrain_128gpu_vr200_fp8mx_config,
 )
 from megatron.bridge.utils.cuda_graph import cuda_graph_module_names, is_full_iteration_cuda_graph
 from tests.unit_tests.recipes.recipe_test_utils import patch_recipe_construction_dependencies
@@ -129,6 +130,13 @@ def test_deepseek_v4_flash_128gpu_gb300_fp8mx_config() -> None:
     assert cfg.model.moe_hybridep_num_sms is None
     assert is_full_iteration_cuda_graph(cfg.model)
     assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 32
+
+
+def test_deepseek_v4_flash_128gpu_vr200_fp8mx_matches_gb300_config() -> None:
+    vr200_cfg = deepseek_v4_flash_pretrain_128gpu_vr200_fp8mx_config()
+    gb300_cfg = deepseek_v4_flash_pretrain_128gpu_gb300_fp8mx_config()
+
+    assert vr200_cfg == gb300_cfg
 
 
 def test_deepseek_v4_flash_128gpu_b300_fp8mx_config() -> None:

--- a/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py
@@ -36,6 +36,8 @@ from megatron.bridge.perf_recipes.nemotronh import (
     nemotron_3_5_lightning_pretrain_8gpu_gb300_fp8mx_config,
     nemotron_3_5_lightning_pretrain_8gpu_gb300_fp8mx_fsdp_config,
     nemotron_3_5_lightning_pretrain_8gpu_gb300_nvfp4_config,
+    nemotron_3_5_lightning_pretrain_8gpu_vr200_bf16_config,
+    nemotron_3_5_lightning_pretrain_8gpu_vr200_fp8mx_config,
     nemotron_3_5_lightning_pretrain_16gpu_h100_bf16_config,
     nemotron_3_5_lightning_pretrain_16gpu_h100_fp8cs_config,
     nemotron_3_nano_pretrain_8gpu_b200_bf16_config,
@@ -98,6 +100,10 @@ _GB300_RECIPES = (
 _GB_FSDP_RECIPES = (
     nemotron_3_5_lightning_pretrain_8gpu_gb200_fp8mx_fsdp_config,
     nemotron_3_5_lightning_pretrain_8gpu_gb300_fp8mx_fsdp_config,
+)
+_VR200_RECIPES = (
+    nemotron_3_5_lightning_pretrain_8gpu_vr200_bf16_config,
+    nemotron_3_5_lightning_pretrain_8gpu_vr200_fp8mx_config,
 )
 _NEMOTRON_3_RECIPES = (
     nemotron_3_nano_pretrain_16gpu_h100_bf16_config,
@@ -255,6 +261,14 @@ _NEMOTRON_NANO_PERF_FACTORIES = (
         "megatron.bridge.perf_recipes.nemotronh.gb300.nemotronh",
         "nemotron_3_5_lightning_pretrain_8gpu_gb300_nvfp4_config",
     ),
+    (
+        "megatron.bridge.perf_recipes.nemotronh.vr200.nemotronh",
+        "nemotron_3_5_lightning_pretrain_8gpu_vr200_bf16_config",
+    ),
+    (
+        "megatron.bridge.perf_recipes.nemotronh.vr200.nemotronh",
+        "nemotron_3_5_lightning_pretrain_8gpu_vr200_fp8mx_config",
+    ),
 )
 
 
@@ -280,7 +294,15 @@ def test_standard_perf_recipes_do_not_expose_mtp_flag(recipe_factory: Callable[[
 
 @pytest.mark.parametrize(
     "recipe_factory",
-    (*_H100_RECIPES, *_B200_RECIPES, *_B300_RECIPES, *_GB200_RECIPES, *_GB300_RECIPES, *_GB_FSDP_RECIPES),
+    (
+        *_H100_RECIPES,
+        *_B200_RECIPES,
+        *_B300_RECIPES,
+        *_GB200_RECIPES,
+        *_GB300_RECIPES,
+        *_GB_FSDP_RECIPES,
+        *_VR200_RECIPES,
+    ),
     ids=lambda recipe: recipe.__name__,
 )
 def test_perf_recipes_enable_mtp(recipe_factory: Callable[[], ConfigContainer]) -> None:
@@ -528,6 +550,28 @@ def test_gb300_perf_recipe_topology(recipe_factory: Callable[[], ConfigContainer
     assert cfg.model.moe_hybridep_num_sms == 16
     assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 72
     assert cfg.env_vars["USE_MNNVL"] == 1
+
+
+@pytest.mark.parametrize(
+    ("vr200_factory", "gb300_factory"),
+    (
+        (
+            nemotron_3_5_lightning_pretrain_8gpu_vr200_bf16_config,
+            nemotron_3_5_lightning_pretrain_8gpu_gb300_bf16_config,
+        ),
+        (
+            nemotron_3_5_lightning_pretrain_8gpu_vr200_fp8mx_config,
+            nemotron_3_5_lightning_pretrain_8gpu_gb300_fp8mx_config,
+        ),
+    ),
+    ids=lambda value: value.__name__,
+)
+def test_vr200_perf_recipes_match_gb300_configs(
+    vr200_factory: Callable[[], ConfigContainer],
+    gb300_factory: Callable[[], ConfigContainer],
+) -> None:
+    """VR200 Nemotron 3.5 recipes match their GB300 configuration baselines."""
+    assert vr200_factory() == gb300_factory()
 
 
 @pytest.mark.parametrize("recipe_factory", _GB_FSDP_RECIPES, ids=lambda recipe: recipe.__name__)


### PR DESCRIPTION
# What does this PR do?

Adds VR200 benchmark recipes derived from the corresponding GB300 configurations for DeepSeek V4 Flash and Nemotron 3.5 Lightning. Each VR200 recipe defines its environment variables explicitly instead of inheriting the GB300 environment implicitly.

# Changelog

- Add the DeepSeek V4 Flash 128-GPU VR200 MXFP8 recipe.
- Add Nemotron 3.5 Lightning 8-GPU VR200 BF16 and MXFP8 recipes.
- Export the new recipes through their performance recipe family packages.
- Add regression coverage verifying that the VR200 configurations match their GB300 baselines.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the contributing guide for how to trigger CI.

Local validation:

- PASS: `uv run --no-project --with pre-commit pre-commit run --all-files`
- NOT RUN: `uv run python -m pytest tests/unit_tests/recipes/test_deepseek_v4_flash_perf_recipes.py tests/unit_tests/recipes/test_nemotron_3_5_lightning_perf_recipes.py -q`
  - Reason: `nvidia-resiliency-ext==0.6.0` has no macOS ARM64 wheel, and the existing no-sync environment lacks PyTorch.

# Before your PR is "Ready for review"

Pre-checks:

- [x] Read and followed the contributor guidelines.
- [x] Added focused regression tests.
- [x] No documentation update is required for these exported benchmark aliases.
- [x] No optional-install component behavior is changed.

# Additional Information

No related issue.
