### PR TITLE
[peft] fix: Export trained DoRA magnitude vectors

### DIFF
--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -109,6 +109,7 @@ class AdapterWeightConversionTask:
     linear_in_task: "WeightConversionTask"
     linear_out_task: "WeightConversionTask"
     requires_expert_splits: bool = False
+    magnitude_task: Optional["WeightConversionTask"] = None
 
 
 @dataclass(frozen=True)
@@ -121,6 +122,7 @@ class AdapterWeight:
     dim: int
     linear_in_weight: "MegatronWeightTuple"
     linear_out_weight: "MegatronWeightTuple"
+    magnitude_weight: Optional["MegatronWeightTuple"] = None
 
 
 def _select_hf_base_param_name(base_mapping, adapter_key: Optional[str], expected_suffix: str) -> Optional[str]:
@@ -290,7 +292,7 @@ class MegatronPeftBridge:
         if not has_gate_up:
             return False
 
-        if linear_out_tensor.ndim != 2 or linear_out_tensor.shape[0] % 2 != 0:
+        if linear_out_tensor.ndim not in (1, 2) or linear_out_tensor.shape[0] % 2 != 0:
             return False
 
         if base_weight_shape is not None and linear_out_tensor.shape[0] != 2 * base_weight_shape[0]:
@@ -549,10 +551,10 @@ class MegatronPeftBridge:
 
     def _megatron_global_adapters_info_all_pp_ranks(
         self, megatron_model: Union[MegatronModel, List[MegatronModel]]
-    ) -> List[tuple[str, str, bool, bool, bool, int, int, int, int]]:
+    ) -> List[tuple[str, str, bool, bool, bool, bool, int, int, int, int]]:
         """Get all adapters' information tuple:
          (global_base_name, local_base_prefix, input_is_parallel, base_linear_is_parallel,
-          requires_expert_splits, alpha, dim, pp_rank, vp_stage)
+          requires_expert_splits, has_weight_magnitude, alpha, dim, pp_rank, vp_stage)
         across all pipeline parallel ranks."""
         # Cache the result after first call
         if hasattr(self, "_cached_param_objects_adapter"):
@@ -566,7 +568,7 @@ class MegatronPeftBridge:
         pp_group = parallel_state.get_pipeline_model_parallel_group()
         pp_rank = get_pg_rank(pp_group)
         model_config = unwrap_model(megatron_model)[0].config
-        global_param_objects: List[tuple[str, str, bool, bool, bool, int, int, int, int]] = []
+        global_param_objects: List[tuple[str, str, bool, bool, bool, bool, int, int, int, int]] = []
 
         for vp_stage, model in enumerate(megatron_model):
             for local_param_name, _ in itertools.chain(model.named_parameters(), persistent_buffers(model)):  # type: ignore[name-defined]
@@ -614,6 +616,7 @@ class MegatronPeftBridge:
                         input_is_parallel,
                         base_linear_is_parallel,
                         requires_expert_splits,
+                        hasattr(adapter, "weight_magnitude"),
                         adapter.alpha,
                         adapter.dim,
                         pp_rank,
@@ -656,6 +659,14 @@ class MegatronPeftBridge:
         linear_out_name += ".linear_out.weight"
         return linear_in_name, linear_out_name
 
+    def _construct_adapter_magnitude_name(self, prefix: str, adapter_key: Optional[str]) -> str:
+        """Build the Megatron parameter name for a DoRA magnitude vector."""
+
+        magnitude_name = prefix + ".adapter"
+        if adapter_key is not None:
+            magnitude_name += f".{adapter_key}"
+        return magnitude_name + ".weight_magnitude"
+
     def build_adapter_conversion_tasks(
         self,
         megatron_model: Union[MegatronModel, List[MegatronModel]],
@@ -688,6 +699,7 @@ class MegatronPeftBridge:
             input_is_parallel,
             base_linear_is_parallel,
             requires_expert_splits,
+            has_weight_magnitude,
             alpha,
             dim,
             pp_rank,
@@ -724,6 +736,7 @@ class MegatronPeftBridge:
 
             linear_in_module, linear_in_weight = None, None
             linear_out_module, linear_out_weight = None, None
+            magnitude_module, magnitude_weight = None, None
             if parallel_state.get_pipeline_model_parallel_rank() == pp_rank:
                 adapter, _ = self._get_adapter_wrap_module(local_base_prefix, megatron_model, vp_stage)
                 if isinstance(adapter, ModuleDict):
@@ -733,6 +746,9 @@ class MegatronPeftBridge:
                 local_linear_in_name, local_linear_out_name = self._construct_adapters_names(
                     local_base_prefix, adapter_key
                 )
+                if has_weight_magnitude:
+                    magnitude_module = adapter
+                    magnitude_weight = adapter.weight_magnitude
 
             # Pick mapping strategies based on base layer parallelism
             if base_linear_is_parallel:
@@ -741,6 +757,28 @@ class MegatronPeftBridge:
             else:
                 linear_in_mapping_cls = ReplicatedMapping
                 linear_out_mapping_cls = ReplicatedMapping
+
+            magnitude_task = None
+            if has_weight_magnitude:
+                global_magnitude_name = self._construct_adapter_magnitude_name(global_base_prefix, adapter_key)
+                local_magnitude_name = self._construct_adapter_magnitude_name(local_base_prefix, adapter_key)
+                magnitude_mapping_cls = (
+                    ColumnParallelMapping if base_linear_is_parallel and not input_is_parallel else ReplicatedMapping
+                )
+                assert hf_linear_out_name is not None
+                hf_magnitude_name = hf_linear_out_name.removesuffix(".lora_B.weight") + ".lora_magnitude_vector"
+                magnitude_task = WeightConversionTask(
+                    param_name=local_magnitude_name,
+                    global_param_name=global_magnitude_name,
+                    mapping=magnitude_mapping_cls(
+                        megatron_param=local_magnitude_name,
+                        hf_param=hf_magnitude_name,
+                    ),
+                    pp_rank=pp_rank,
+                    vp_stage=vp_stage,
+                    megatron_module=magnitude_module,
+                    param_weight=magnitude_weight,
+                )
 
             linear_in_task = WeightConversionTask(
                 param_name=local_linear_in_name,
@@ -777,6 +815,7 @@ class MegatronPeftBridge:
                     requires_expert_splits=requires_expert_splits,
                     linear_in_task=linear_in_task,
                     linear_out_task=linear_out_task,
+                    magnitude_task=magnitude_task,
                 )
             )
 
@@ -789,6 +828,7 @@ class MegatronPeftBridge:
 
         materialized: List[AdapterWeight] = []
         for adapter_task in adapter_tasks:
+            magnitude_weight = None
             if adapter_task.requires_expert_splits:
                 linear_in_tp_axis = 2 if isinstance(adapter_task.linear_in_task.mapping, RowParallelMapping) else 1
                 linear_in_tensor = self._materialize_grouped_expert_adapter_tensor(
@@ -810,6 +850,18 @@ class MegatronPeftBridge:
                 )
                 linear_out_tensor = next(iter(linear_out_dict.values()))
 
+            if adapter_task.magnitude_task is not None:
+                magnitude_dict = adapter_task.magnitude_task.mapping.megatron_to_hf(
+                    adapter_task.magnitude_task.param_weight,
+                    adapter_task.magnitude_task.megatron_module,
+                )
+                magnitude_tensor = next(iter(magnitude_dict.values()))
+                magnitude_weight = MegatronWeightTuple(
+                    adapter_task.magnitude_task.param_name,
+                    magnitude_tensor,
+                    adapter_task.magnitude_task.vp_stage,
+                )
+
             materialized.append(
                 AdapterWeight(
                     global_base_prefix=adapter_task.global_base_prefix,
@@ -826,6 +878,7 @@ class MegatronPeftBridge:
                         linear_out_tensor,
                         adapter_task.linear_out_task.vp_stage,
                     ),
+                    magnitude_weight=magnitude_weight,
                 )
             )
 
@@ -891,6 +944,31 @@ class MegatronPeftBridge:
             linear_in_tensor = adapter_weight.linear_in_weight.weight
             linear_out_tensor = adapter_weight.linear_out_weight.weight
             is_expert = is_expert_linear(adapter_task.global_base_prefix)
+            if adapter_weight.magnitude_weight is not None:
+                assert not is_expert, "DoRA export does not support expert linear layers"
+                magnitude_tensor = adapter_weight.magnitude_weight.weight
+                if cpu:
+                    magnitude_tensor = magnitude_tensor.cpu()
+                base_hf_weight_names = self._get_base_hf_param_names_for_adapter(
+                    mapping_registry,
+                    adapter_task.global_base_prefix,
+                    adapter_task.adapter_key,
+                    ".weight",
+                )
+                per_base_magnitude = self._get_fused_adapter_linear_out_slices(
+                    megatron_model,
+                    base_hf_weight_names,
+                    magnitude_tensor,
+                )
+                for base_name in base_hf_weight_names:
+                    current_magnitude = (
+                        per_base_magnitude.get(base_name) if per_base_magnitude is not None else magnitude_tensor
+                    )
+                    if isinstance(current_magnitude, _AbsentProjectionSentinel):
+                        continue
+                    assert current_magnitude is not None, f"No DoRA magnitude slice for {base_name!r}"
+                    hf_magnitude_name = base_name.removesuffix(".weight") + ".lora_magnitude_vector"
+                    yield HFWeightTuple(hf_magnitude_name, current_magnitude)
             is_grouped_expert = is_expert and ".local_experts." not in adapter_task.global_base_prefix
             is_shared_outer_lora = is_grouped_expert and linear_in_tensor.ndim != linear_out_tensor.ndim
 
@@ -1687,6 +1765,10 @@ def convert_adapter_weights_to_peft_state(
     for adapter_weight in adapter_weights:
         name = adapter_weight.param_name
         tensor = adapter_weight.weight
+        if not name.endswith(_HF_LORA_SUFFIXES):
+            adapter_state[f"base_model.model.{name}"] = tensor
+            module_weight_names.append(name)
+            continue
         base_name, lora_suffix = _split_hf_lora_weight_name(name)
         if tensor.ndim == 3:
             if base_name not in target_parameters:
@@ -1728,6 +1810,8 @@ def infer_rank_pattern_from_adapter_weights(
     for adapter_weight in adapter_weights:
         name = adapter_weight.param_name
         tensor = adapter_weight.weight
+        if not name.endswith(_HF_LORA_SUFFIXES):
+            continue
         base_name, lora_suffix = _split_hf_lora_weight_name(name)
         if lora_suffix != ".lora_A.weight":
             continue

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -807,6 +807,7 @@ def test_megatron_global_adapters_info_all_pp_ranks(monkeypatch):
         input_is_parallel,
         base_linear_is_parallel,
         requires_expert_splits,
+        has_weight_magnitude,
         alpha,
         dim,
         pp_rank,
@@ -816,6 +817,7 @@ def test_megatron_global_adapters_info_all_pp_ranks(monkeypatch):
     assert local_base_prefix == "decoder.layers.0.mlp.linear_fc1"
     assert input_is_parallel is True and base_linear_is_parallel is True
     assert requires_expert_splits is False
+    assert has_weight_magnitude is False
     assert alpha == 8 and dim == 2 and pp_rank == 0 and vp_stage == 0
 
 
@@ -868,6 +870,7 @@ def test_build_adapter_conversion_tasks(monkeypatch):
             False,
             False,
             False,
+            True,
             4,
             8,
             0,
@@ -878,6 +881,7 @@ def test_build_adapter_conversion_tasks(monkeypatch):
     adapter = SimpleNamespace(
         linear_in=SimpleNamespace(weight=torch.ones(2, 2)),
         linear_out=SimpleNamespace(weight=torch.ones(2, 2)),
+        weight_magnitude=torch.tensor([3.0, 4.0]),
         alpha=4,
         dim=8,
     )
@@ -906,6 +910,8 @@ def test_build_adapter_conversion_tasks(monkeypatch):
     assert task.adapter_key is None
     assert task.linear_in_task.param_weight.shape == torch.Size([2, 2])
     assert task.linear_out_task.param_weight.shape == torch.Size([2, 2])
+    assert task.magnitude_task is not None
+    torch.testing.assert_close(task.magnitude_task.param_weight, torch.tensor([3.0, 4.0]))
 
 
 def test_build_adapter_conversion_tasks_excludes_base_prefix_before_mapping(monkeypatch):
@@ -917,6 +923,7 @@ def test_build_adapter_conversion_tasks_excludes_base_prefix_before_mapping(monk
         (
             "mtp.layers.0.mtp_model_layer.layers.0.self_attention.linear_proj.adapter",
             "mtp.layers.0.mtp_model_layer.layers.0.self_attention.linear_proj",
+            False,
             False,
             False,
             False,
@@ -968,6 +975,13 @@ def test_materialize_adapter_weights(monkeypatch):
                 megatron_module=None,
                 param_weight=None,
             ),
+            magnitude_task=WeightConversionTask(
+                param_name="magnitude_name",
+                global_param_name="magnitude_name",
+                mapping=DummyMapping(torch.tensor([3.0, 4.0])),
+                megatron_module=None,
+                param_weight=None,
+            ),
         )
     ]
 
@@ -975,6 +989,8 @@ def test_materialize_adapter_weights(monkeypatch):
     assert len(materials) == 1
     assert torch.all(materials[0].linear_in_weight.weight == torch.ones(2, 2))
     assert torch.all(materials[0].linear_out_weight.weight == 2 * torch.ones(2, 2))
+    assert materials[0].magnitude_weight is not None
+    torch.testing.assert_close(materials[0].magnitude_weight.weight, torch.tensor([3.0, 4.0]))
 
 
 def test_materialize_adapter_weights_grouped_expert_fc1_uses_expert_tp_axis(monkeypatch):
@@ -1189,6 +1205,7 @@ def test_stream_adapter_weights_megatron_to_hf(monkeypatch):
         dim=4,
         linear_in_weight=MegatronWeightTuple("local_in", torch.ones(2, 2), vp_stage=0),
         linear_out_weight=MegatronWeightTuple("local_out", 2 * torch.ones(2, 2), vp_stage=0),
+        magnitude_weight=MegatronWeightTuple("magnitude", torch.tensor([3.0, 4.0]), vp_stage=0),
     )
 
     monkeypatch.setattr(
@@ -1218,11 +1235,13 @@ def test_stream_adapter_weights_megatron_to_hf(monkeypatch):
             show_progress=False,
         )
     )
-    assert len(weights) == 2
-    assert weights[0].param_name.endswith("lora_A.weight")
-    assert weights[1].param_name.endswith("lora_B.weight")
-    torch.testing.assert_close(weights[0].weight, torch.ones(2, 2))
-    torch.testing.assert_close(weights[1].weight, 2 * torch.ones(2, 2))
+    assert len(weights) == 3
+    assert weights[0].param_name.endswith("lora_magnitude_vector")
+    assert weights[1].param_name.endswith("lora_A.weight")
+    assert weights[2].param_name.endswith("lora_B.weight")
+    torch.testing.assert_close(weights[0].weight, torch.tensor([3.0, 4.0]))
+    torch.testing.assert_close(weights[1].weight, torch.ones(2, 2))
+    torch.testing.assert_close(weights[2].weight, 2 * torch.ones(2, 2))
 
 
 def test_stream_adapter_weights_megatron_to_hf_qkv(monkeypatch):


### PR DESCRIPTION
## What changed

Dense DoRA training registers `weight_magnitude` as independently trainable state and uses it on every enabled forward. The Hugging Face adapter export path previously discovered and serialized only LoRA A/B weights while writing `use_dora: true`, so PEFT reload initialized a new magnitude vector and could silently change adapter outputs.

This patch carries the magnitude vector through adapter discovery, PP ownership, TP gathering, materialization, and PEFT serialization. Column-parallel output magnitudes are gathered along dimension zero; row-parallel and replicated magnitudes stay replicated. Fused QKV and FC1 exports split the magnitude consistently with their B weights. Ordinary LoRA and intentionally unsupported expert DoRA are unchanged.

This fixes the missing runtime boundary in the LoRA/DoRA adapter export introduced by #2574.

## Validation

- Before: a deterministic production-path reproducer exported only `lora_A.weight` and `lora_B.weight`, then failed because `lora_magnitude_vector` was missing.
- After: the unchanged reproducer exported A, B, and the exact trained magnitude vector.
- Focused adjacent serialization check passed: PEFT state conversion retains the magnitude key and rank inference continues to inspect only A weights.
- `git diff --check`
- `uv run pre-commit run --all-files`

The focused pytest invocation was attempted locally but the CPU-only environment failed during CUDA dependency import before test collection; it did not reach the changed tests.

## Scope

This change covers supported dense DoRA adapter export only. It does not add expert DoRA support or change adapter import/merge semantics.
