### PR TITLE
[ckpt] fix: Reject strict model state mismatches

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2840,6 +2840,7 @@ def _load_model_state_dict(module: torch.nn.Module, state_dict: dict[str, Any], 
             if non_extra:
                 print_rank_0(f"Warning: Exception during strict loading: {e}")
                 print_rank_0(f"Non-extra-state mismatched keys: {non_extra}")
+                raise
         else:
             # Re-raise if we were already in non-strict mode
             raise

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -3401,13 +3401,21 @@ class TestLoadModelWeightsFromCheckpoint:
 class TestLoadModelStateDictHelper:
     """Tests for _load_model_state_dict strict fallback behavior and logging."""
 
+    def test_strict_load_rejects_non_extra_state_mismatch(self):
+        module = torch.nn.Linear(2, 2)
+        state_dict = {"weight": torch.ones_like(module.weight)}
+
+        with pytest.raises(RuntimeError, match=r'Missing key\(s\) in state_dict: "bias"'):
+            _load_model_state_dict(module, state_dict, strict=True)
+
     @patch("megatron.bridge.training.checkpointing.print_rank_0")
     def test_load_model_state_dict_strict_fallback(self, mock_print_rank_0):
         module = Mock()
         load_return = Mock(missing_keys=["layer.weight"], unexpected_keys=[])
         module.load_state_dict.side_effect = [Exception("boom"), load_return]
 
-        _load_model_state_dict(module, {"w": 1}, strict=True)
+        with pytest.raises(Exception, match="boom"):
+            _load_model_state_dict(module, {"w": 1}, strict=True)
 
         assert module.load_state_dict.call_count == 2
         first_args, first_kwargs = module.load_state_dict.call_args_list[0]
@@ -3442,7 +3450,8 @@ class TestLoadModelStateDictHelper:
         err = Exception("strict mismatch")
         module.load_state_dict.side_effect = [err, load_return]
 
-        _load_model_state_dict(module, {"w": 1}, strict=True)
+        with pytest.raises(Exception, match="strict mismatch"):
+            _load_model_state_dict(module, {"w": 1}, strict=True)
 
         assert module.load_state_dict.call_count == 2
         assert mock_print_rank_0.call_count == 2


### PR DESCRIPTION
## What changed

Re-raise the original strict `load_state_dict` failure when the fallback reports any ordinary missing or unexpected model key. The existing Transformer Engine compatibility fallback remains permissive when every mismatch is an `._extra_state` key.

## Supported trigger and impact

Bridge ships recipes that set `checkpoint.dist_ckpt_strictness = "log_all"`. Pinned MCore can therefore return a reduced checkpoint state after logging a storage-key mismatch, while Bridge independently keeps `CheckpointLoadContext.strict=True` for the subsequent module load.

Previously, `_load_model_state_dict` caught that strict module-load failure, retried with `strict=False`, logged ordinary missing keys, and returned. Resume could then report success and continue with matching checkpoint weights loaded but missing weights left freshly initialized.

This is related to #1649, but has a different root cause: the checkpoint path is valid and storage loading succeeds; strict model-state validation is what was being swallowed.

## Root cause and fix

The compatibility fallback classified ordinary mismatches correctly but did not propagate the original exception. A bare `raise` in that existing branch restores strict module-loading semantics while preserving the original PyTorch diagnostic and the `._extra_state`-only compatibility behavior.

## Validation

Fail-before on `02fcce5a103ca0c88a945319075348729e0b666e`:

```bash
UV_PROJECT_ENVIRONMENT=.venv uv run --no-sync python /tmp/checkpoint_strict_load_reproducer.py src/megatron/bridge/training/checkpointing.py
# exit 1: strict load returned: weight_loaded=True, bias_left_initialized=True
```

Pass-after with the unchanged deterministic reproducer:

```bash
UV_PROJECT_ENVIRONMENT=.venv uv run --no-sync python /tmp/checkpoint_strict_load_reproducer.py src/megatron/bridge/training/checkpointing.py
# exit 0: strict ordinary mismatch rejected
```

Adjacent strict, extra-state-only, mixed-key, and non-strict contract checks passed. Repository checks:

```bash
git diff --check
UV_PROJECT_ENVIRONMENT=.venv uv run --no-sync pre-commit run --all-files
```

All pre-commit hooks passed. The focused repository pytest command was also attempted, but this workstation's test bootstrap failed before collection because its installed GPU/dependency stack does not match the pinned source; that unrelated bootstrap failure is not used as validation evidence. The added CPU unit test exercises the failure with a real `torch.nn.Linear` and will run in CI.

## Scope

No checkpoint format, storage strictness policy, public API, dependency, or PEFT non-strict behavior changes.
