### PR TITLE
fix(model): keep pretrained GLM-5 router bias fixed

### DIFF
--- a/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
+++ b/src/megatron/bridge/models/glm_moe_dsa/glm5_bridge.py
@@ -104,6 +104,7 @@ class GLM5Bridge(MegatronModelBridge):
         provider.moe_shared_expert_overlap = True
         provider.moe_router_score_function = "sigmoid"
         provider.moe_router_enable_expert_bias = True
+        provider.moe_router_bias_update_rate = 0
         provider.moe_router_dtype = "fp32"
         provider.moe_permute_fusion = True
 

--- a/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
+++ b/tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py
@@ -142,6 +142,14 @@ def test_provider_bridge_maps_dsa_architecture_from_hf_config(
     assert provider.dsa_indexer_use_sparse_loss is True
 
 
+def test_provider_bridge_keeps_pretrained_router_bias_fixed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retain pretrained expert bias without updating it during fine-tuning."""
+    provider = _provider_from_hf_config(monkeypatch)
+
+    assert provider.moe_router_enable_expert_bias is True
+    assert provider.moe_router_bias_update_rate == 0
+
+
 def test_provider_bridge_uses_hybridep_dispatcher(monkeypatch: pytest.MonkeyPatch) -> None:
     """GLM-5 avoids the affected grouped all-to-all transport path."""
     provider = _provider_from_hf_config(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

Keep the pretrained GLM-5 family's router correction bias fixed during fine-tuning, matching the existing GLM-4.5 and GLM-4.7-Flash bridges.

## Changes

- Set `moe_router_bias_update_rate=0` while retaining `moe_router_enable_expert_bias=True`. This preserves the imported bias instead of inheriting MCore's dynamic-update default.
- Add a provider regression requiring both settings. Dynamic updates otherwise mutate a base-model buffer outside LoRA state; creating a fresh adapter does not restore that buffer.

This fixes post-optimizer router-state drift, not any separate pre-optimizer logprob mismatch. Recipes that intentionally adapt router bias can explicitly override the rate.

## Testing

```bash
uv run pre-commit run --all-files
uv run python -m pytest --noconftest tests/unit_tests/models/glm_moe_dsa/test_glm5_bridge.py -k provider_bridge -v
```

All hooks passed. Actual imported CPU tests: the new regression fails on the original provider; all four selected provider tests pass after the patch. No full-model parity claim.
