### PR TITLE
build: bump transformer-engine to 15288857

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ override-dependencies = [
     "torch; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "triton; sys_platform == 'never'",
-    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@eb63fb639341576fde6b6653d4b8a03e63d238e1",
+    "transformer-engine @ git+https://github.com/NVIDIA/TransformerEngine.git@15288857644368b8b7bdddd9bead7d6d3d04de80",
     "mlflow>=3.15.1",                                       # To address CVE-2025-15031
     "cachetools>=5.0.0",
     "cryptography>=43.0.0,<47",
@@ -169,7 +169,7 @@ requires-dist = []
 # above) changes — an out-of-date entry sends uv back to building TE.
 [[tool.uv.dependency-metadata]]
 name = "transformer-engine"
-version = "2.18.0+eb63fb63"
+version = "2.18.0+15288857"
 requires-dist = [
     "einops",
     "importlib-metadata>=1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ overrides = [
     { name = "tokenizers", specifier = ">=0.22.0,<0.23" },
     { name = "torch", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=eb63fb639341576fde6b6653d4b8a03e63d238e1" },
+    { name = "transformer-engine", git = "https://github.com/NVIDIA/TransformerEngine.git?rev=15288857644368b8b7bdddd9bead7d6d3d04de80" },
     { name = "triton", marker = "sys_platform == 'never'" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
@@ -35,7 +35,7 @@ version = "1.0.0+b7643bd"
 
 [[manifest.dependency-metadata]]
 name = "transformer-engine"
-version = "2.18.0+eb63fb63"
+version = "2.18.0+15288857"
 requires-dist = ["einops", "importlib-metadata>=1.0", "nvdlfw-inspect", "nvidia-cudnn-frontend>=1.25.0", "onnx", "onnxscript", "packaging", "pydantic", "torch>=2.1"]
 provides-extras = ["core-cu13", "pytorch"]
 
@@ -4865,8 +4865,8 @@ wheels = [
 
 [[package]]
 name = "transformer-engine"
-version = "2.18.0+eb63fb63"
-source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=eb63fb639341576fde6b6653d4b8a03e63d238e1#eb63fb639341576fde6b6653d4b8a03e63d238e1" }
+version = "2.18.0+15288857"
+source = { git = "https://github.com/NVIDIA/TransformerEngine.git?rev=15288857644368b8b7bdddd9bead7d6d3d04de80#15288857644368b8b7bdddd9bead7d6d3d04de80" }
 dependencies = [
     { name = "einops" },
     { name = "importlib-metadata" },


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What
- Bump transformer-engine to `15288857644368b8b7bdddd9bead7d6d3d04de80`, the HEAD of TE branch `release_v2.18_nemo_26.08.01`.
- Regenerate `uv.lock` (4 lines: manifest override, manifest dependency-metadata version, package version, package source).
- Update the `[[tool.uv.dependency-metadata]]` version to `2.18.0+15288857` so uv keeps skipping the from-source TE build.

## Why
The current pin `eb63fb63` is `v2.18` plus one cherry-pick (fused cross entropy memory fix, TE #3273). The `release_v2.18_nemo_26.08.01` branch has since gained one more commit that the 26.08.01 NeMo container should carry.

## Lockfile delta
```
Updated transformer-engine eb63fb639341576fde6b6653d4b8a03e63d238e1 -> 15288857644368b8b7bdddd9bead7d6d3d04de80
```

Incoming TE commit (release_v2.18_nemo_26.08.01, old pin..HEAD):
```
15288857 2026-09-08 Ravi Ghadia  Replace RuntimeError with warnings in ScaledSReLU (#3497)
```

## Test plan
- [ ] L0 CI green
- [ ] L1 CI green (label `needs-more-tests` applied)
- [ ] L2 CI green (label `full-test-suite` applied, TE bump)

## Quarantined tests (this bump)
_None yet._

</details>
