### PR TITLE
fix(perf): update Nemotron 3 Super B200 configs

### DIFF
--- a/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
@@ -96,7 +96,7 @@ def nemotron_3_super_pretrain_64gpu_b200_bf16_config() -> ConfigContainer:
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.sequence_parallel = False
     cfg.model.expert_tensor_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 64
+    cfg.model.expert_model_parallel_size = 8
     cfg.train.global_batch_size = 512
     cfg.train.micro_batch_size = 1
 
@@ -143,7 +143,7 @@ def nemotron_3_super_pretrain_64gpu_b200_fp8mx_config() -> ConfigContainer:
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.sequence_parallel = False
     cfg.model.expert_tensor_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 64
+    cfg.model.expert_model_parallel_size = 8
     cfg.train.global_batch_size = 512
     cfg.train.micro_batch_size = 1
 
@@ -191,7 +191,7 @@ def nemotron_3_super_pretrain_64gpu_b200_nvfp4_config() -> ConfigContainer:
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.sequence_parallel = True
     cfg.model.expert_tensor_parallel_size = 1
-    cfg.model.expert_model_parallel_size = 64
+    cfg.model.expert_model_parallel_size = 8
     cfg.train.global_batch_size = 512
     cfg.train.micro_batch_size = 1
 

--- a/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
@@ -199,11 +199,12 @@ def nemotron_3_super_pretrain_64gpu_b200_nvfp4_config() -> ConfigContainer:
     cfg.model.moe_token_dispatcher_type = "flex"
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.moe_router_padding_for_quantization = True
-    cfg.model.recompute_modules = ["moe_act", "moe", "layernorm", "core_attn"]
+    cfg.model.recompute_modules = ["moe_act", "layernorm"]
     cfg.model.recompute_granularity = "selective"
     cfg.model.quant_recipe = load_quantization_recipe(str(_TE_QUANT_CFG_PATH))
 
-    cfg.model.cuda_graph_impl = "none"
+    cfg.model.cuda_graph_impl = "transformer_engine"
+    cfg.model.cuda_graph_scope = ["mamba", "attn", "moe_router", "moe_preprocess"]
 
     _apply_nemotron_3_super_perf_defaults(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.

--- a/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
+++ b/src/megatron/bridge/perf_recipes/nemotronh/b200/nemotronh.py
@@ -151,7 +151,7 @@ def nemotron_3_super_pretrain_64gpu_b200_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_token_dispatcher_type = "flex"
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.moe_router_padding_for_quantization = True
-    cfg.model.recompute_modules = ["moe_act", "layernorm"]
+    cfg.model.recompute_modules = ["moe_act", "moe", "layernorm", "core_attn"]
     cfg.model.recompute_granularity = "selective"
 
     cfg.model.cuda_graph_impl = "none"
@@ -199,11 +199,11 @@ def nemotron_3_super_pretrain_64gpu_b200_nvfp4_config() -> ConfigContainer:
     cfg.model.moe_token_dispatcher_type = "flex"
     cfg.model.moe_shared_expert_overlap = False
     cfg.model.moe_router_padding_for_quantization = True
-    cfg.model.recompute_modules = None
+    cfg.model.recompute_modules = ["moe_act", "moe", "layernorm", "core_attn"]
+    cfg.model.recompute_granularity = "selective"
     cfg.model.quant_recipe = load_quantization_recipe(str(_TE_QUANT_CFG_PATH))
 
-    cfg.model.cuda_graph_impl = "transformer_engine"
-    cfg.model.cuda_graph_scope = ["mamba", "attn", "moe_router", "moe_preprocess"]
+    cfg.model.cuda_graph_impl = "none"
 
     _apply_nemotron_3_super_perf_defaults(cfg)
     # Keep process settings next to the recipe so users can see the exact benchmark environment.

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -371,6 +371,23 @@ def test_nemotron_3_super_64gpu_b200_uses_single_nvlink_domain_ep(recipe_name):
     assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
 
 
+@pytest.mark.parametrize(
+    "recipe_name",
+    [
+        "nemotron_3_super_pretrain_64gpu_b200_fp8mx_config",
+        "nemotron_3_super_pretrain_64gpu_b200_nvfp4_config",
+    ],
+)
+def test_nemotron_3_super_64gpu_b200_low_precision_uses_selective_recompute(recipe_name):
+    """B200 MXFP8 and NVFP4 recipes recompute activations to fit EP8."""
+    module = importlib.import_module("megatron.bridge.perf_recipes.nemotronh.b200.nemotronh")
+    cfg = getattr(module, recipe_name)()
+
+    assert cfg.model.recompute_granularity == "selective"
+    assert cfg.model.recompute_modules == ["moe_act", "moe", "layernorm", "core_attn"]
+    assert cfg.model.cuda_graph_impl == "none"
+
+
 def test_nemotron_3_5_lightning_h100_convergence_recipe_uses_perf_execution_policy():
     """The H100 convergence recipe keeps safety checks while using the measured fast path."""
     from megatron.bridge.recipes.nemotronh import nemotron_3_5_lightning_pretrain_config

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -353,6 +353,24 @@ def test_nemotron_3_super_64gpu_h100_matches_benchmark_execution_configuration()
     assert benchmark_cfg.checkpoint.save is None
 
 
+@pytest.mark.parametrize(
+    "recipe_name",
+    [
+        "nemotron_3_super_pretrain_64gpu_b200_bf16_config",
+        "nemotron_3_super_pretrain_64gpu_b200_fp8mx_config",
+        "nemotron_3_super_pretrain_64gpu_b200_nvfp4_config",
+    ],
+)
+def test_nemotron_3_super_64gpu_b200_uses_single_nvlink_domain_ep(recipe_name):
+    """B200 BF16, MXFP8, and NVFP4 recipes keep HybridEP within one NVLink domain."""
+    module = importlib.import_module("megatron.bridge.perf_recipes.nemotronh.b200.nemotronh")
+    cfg = getattr(module, recipe_name)()
+
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 8
+    assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
+
+
 def test_nemotron_3_5_lightning_h100_convergence_recipe_uses_perf_execution_policy():
     """The H100 convergence recipe keeps safety checks while using the measured fast path."""
     from megatron.bridge.recipes.nemotronh import nemotron_3_5_lightning_pretrain_config

--- a/tests/unit_tests/recipes/test_nemotronh_recipes.py
+++ b/tests/unit_tests/recipes/test_nemotronh_recipes.py
@@ -371,21 +371,25 @@ def test_nemotron_3_super_64gpu_b200_uses_single_nvlink_domain_ep(recipe_name):
     assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == 8
 
 
-@pytest.mark.parametrize(
-    "recipe_name",
-    [
-        "nemotron_3_super_pretrain_64gpu_b200_fp8mx_config",
-        "nemotron_3_super_pretrain_64gpu_b200_nvfp4_config",
-    ],
-)
-def test_nemotron_3_super_64gpu_b200_low_precision_uses_selective_recompute(recipe_name):
-    """B200 MXFP8 and NVFP4 recipes recompute activations to fit EP8."""
+def test_nemotron_3_super_64gpu_b200_fp8mx_uses_selective_recompute():
+    """B200 MXFP8 recomputes activations to fit EP8."""
     module = importlib.import_module("megatron.bridge.perf_recipes.nemotronh.b200.nemotronh")
-    cfg = getattr(module, recipe_name)()
+    cfg = module.nemotron_3_super_pretrain_64gpu_b200_fp8mx_config()
 
     assert cfg.model.recompute_granularity == "selective"
     assert cfg.model.recompute_modules == ["moe_act", "moe", "layernorm", "core_attn"]
     assert cfg.model.cuda_graph_impl == "none"
+
+
+def test_nemotron_3_super_64gpu_b200_nvfp4_keeps_cuda_graphs_with_light_recompute():
+    """B200 NVFP4 retains CUDA graphs with graph-compatible recompute."""
+    module = importlib.import_module("megatron.bridge.perf_recipes.nemotronh.b200.nemotronh")
+    cfg = module.nemotron_3_super_pretrain_64gpu_b200_nvfp4_config()
+
+    assert cfg.model.recompute_granularity == "selective"
+    assert cfg.model.recompute_modules == ["moe_act", "layernorm"]
+    assert cfg.model.cuda_graph_impl == "transformer_engine"
+    assert cfg.model.cuda_graph_scope == ["mamba", "attn", "moe_router", "moe_preprocess"]
 
 
 def test_nemotron_3_5_lightning_h100_convergence_recipe_uses_perf_execution_policy():


### PR DESCRIPTION
## Summary

Update the 64-GPU B200 performance recipes for Nemotron 3 Super BF16, MXFP8, and NVFP4.

The previous EP=64 configuration exceeded the B200 NVLink domain size used by HybridEP. This change reduces EP to 8 so that each expert-parallel group remains within a single NVLink domain.

## Changes

- Set EP=8 for the B200 BF16, MXFP8, and NVFP4 recipes.
- Keep the remaining parallelism unchanged:
  - BF16/MXFP8: TP=1, PP=1, CP=1
  - NVFP4: TP=2, PP=1, CP=1 with sequence parallelism
- Add selective recompute for MXFP8:
  - `moe_act`
  - `moe`
  - `layernorm`
  - `core_attn`
- Add lightweight selective recompute for NVFP4:
  - `moe_act`
  - `layernorm`
- Retain Transformer Engine CUDA graphs and the existing graph scope for NVFP4.
- Add unit coverage for the B200 EP, recompute, and CUDA graph settings.

## Motivation

Nemotron 3 Super with EP=64 encounters HybridEP topology errors on B200 because the expert-parallel group spans beyond the eight-GPU NVLink domain.

After changing to EP=8, MXFP8 and NVFP4 require additional activation-memory reduction to avoid OOM. Selective recompute is enabled accordingly, while NVFP4 retains its CUDA graph configuration.

## Scope

This change applies only to the Nemotron 3 Super B200 performance recipes. Configurations for other GPU platforms are unchanged.