### PR TITLE
[training] fix: Clean up evaluation state on timeout

### DIFF
--- a/src/megatron/bridge/training/eval.py
+++ b/src/megatron/bridge/training/eval.py
@@ -325,7 +325,10 @@ def evaluate(
                 torch.distributed.all_reduce(done_cuda, op=torch.distributed.ReduceOp.MAX)
                 done = done_cuda.item()
                 if done:
+                    timers("evaluate").stop()
                     rerun_state_machine.set_mode(rerun_mode)
+                    for model_module in model:
+                        model_module.train()
                     print_rank_0("Exiting during evaluation, timelimit reached")
                     return None, None, True
 

--- a/tests/unit_tests/training/test_eval.py
+++ b/tests/unit_tests/training/test_eval.py
@@ -46,6 +46,31 @@ class _ModeTrackingModel:
         self.training = True
 
 
+class _StrictTimer:
+    def __init__(self):
+        self.started = False
+
+    def start(self, barrier=False):
+        assert not self.started, "timer has already been started"
+        self.started = True
+
+    def stop(self):
+        assert self.started, "timer is not started"
+        self.started = False
+
+
+class _StrictTimers:
+    def __init__(self):
+        self.timer = _StrictTimer()
+
+    def __call__(self, name, log_level=None):
+        assert name == "evaluate"
+        return self.timer
+
+    def log(self, names):
+        assert names == ["evaluate"]
+
+
 def _make_evaluate_state(*, eval_iters, exit_duration_in_mins=None):
     timer = MagicMock()
     timers = MagicMock(return_value=timer)
@@ -222,6 +247,32 @@ def test_evaluate_timelimit_fires_start_but_not_end_callback():
 
     assert result == (None, None, True)
     assert observed == [("on_eval_start", False)]
+
+
+def test_evaluate_timelimit_releases_lifecycle_state_before_next_evaluation():
+    state = _make_evaluate_state(eval_iters=1, exit_duration_in_mins=1)
+    state.timers = _StrictTimers()
+    model = _ModeTrackingModel()
+    callback_manager = CallbackManager()
+
+    validation_result = _run_evaluate(
+        state=state,
+        model=model,
+        callback_manager=callback_manager,
+        timelimit_hit=True,
+    )
+    test_result = _run_evaluate(
+        state=state,
+        model=model,
+        callback_manager=callback_manager,
+        is_test=True,
+        timelimit_hit=True,
+    )
+
+    assert validation_result == (None, None, True)
+    assert test_result == (None, None, True)
+    assert not state.timers.timer.started
+    assert model.training
 
 
 def test_evaluate_uses_injected_eval_data_parallel_size_for_microbatches():


### PR DESCRIPTION
## What

Clean up evaluation-owned timer and model mode state when `exit_duration_in_mins` is reached during evaluation.

## Supported trigger and impact

When both validation and test loaders are configured, terminal validation can cross the configured duration limit. The terminal caller then starts test evaluation. Before this change, validation returned without stopping the shared `evaluate` timer or restoring model train mode, so the next evaluation deterministically failed with `AssertionError: timer has already been started`.

## Root cause and fix

The duration-limit return bypassed the normal cleanup at the end of `evaluate()`. The early-return branch now performs the same owned timer stop and model-mode restoration before returning. The existing rerun-mode restoration, callback behavior, and APIs are unchanged.

## Validation

Fail before:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_eval.py::test_evaluate_timelimit_releases_lifecycle_state_before_next_evaluation -q
# 1 failed: AssertionError: timer has already been started
```

Pass after and adjacent coverage:

```text
uv run --no-sync python -m pytest tests/unit_tests/training/test_eval.py tests/unit_tests/training/test_pretrain.py -q
# tests/unit_tests/training/test_eval.py: 9 passed, including the unchanged regression
# tests/unit_tests/training/test_pretrain.py: 11 pre-existing tests passed

git diff --check
# passed

uv run --no-sync pre-commit run --all-files
# all hooks passed
```

The combined validation command also included a transient additional caller test that failed because its mock lacked a process group. That unneeded caller change and test were removed under the minimal-fix gate; neither is present in this PR.

## Scope

This does not change duration-limit policy, evaluation callbacks, public APIs, dependencies, CI configuration, or the Megatron-Core submodule.
