### PR TITLE
[ckpt] fix: Handle returned checkpoint mismatch keys

### DIFF
--- a/src/megatron/bridge/training/checkpointing.py
+++ b/src/megatron/bridge/training/checkpointing.py
@@ -2465,14 +2465,16 @@ def _load_model_weights_from_checkpoint(
     if fully_parallel_load:
         pg_collection = get_pg_collection(model)
         load_strategy = FullyParallelLoadStrategyWrapper(load_strategy, pg_collection.dp_cp)
-    state_dict = dist_checkpointing.load(
+    load_result = dist_checkpointing.load(
         sharded_state_dict, checkpoint_path, load_strategy, strict=dist_ckpt_strictness
     )
+    # MCore's return_* strictness modes append missing and unexpected key sets.
+    state_dict = load_result[0] if isinstance(load_result, tuple) else load_result
     # we keep weights only for bridge use, remove extra state
     # because they are not needed and could cause unexpected issues.
     delete_extra_state(state_dict)
     if return_state_dict:
-        return state_dict
+        return load_result
 
     if len(model) == 1:
         _load_model_state_dict(model[0], state_dict["model"], strict)
@@ -3750,6 +3752,9 @@ def _load_global_dist_base_checkpoint(
         strict=ckpt_cfg.dist_ckpt_strictness,
         validate_access_integrity=validate_sharding_integrity,
     )
+    # MCore's return_* strictness modes append missing and unexpected key sets.
+    if isinstance(state_dict, tuple):
+        state_dict = state_dict[0]
     return state_dict, checkpoint_name, release, CheckpointType.GLOBAL
 
 

--- a/tests/unit_tests/training/test_checkpointing.py
+++ b/tests/unit_tests/training/test_checkpointing.py
@@ -3097,7 +3097,7 @@ class TestLoadModelWeightsFromCheckpoint:
     @patch("megatron.bridge.training.checkpointing.TorchDistLoadShardedStrategy")
     @patch("megatron.bridge.training.checkpointing.FullyParallelLoadStrategyWrapper")
     @patch("megatron.bridge.training.checkpointing.get_pg_collection")
-    def test_load_model_weights_single_model_success(
+    def test_load_model_weights_single_model_with_strictness_diagnostics(
         self,
         mock_get_pg_collection,
         mock_fully_parallel_wrapper,
@@ -3111,11 +3111,11 @@ class TestLoadModelWeightsFromCheckpoint:
         mock_full_state_dict,
         mock_metadata,
     ):
-        """Test successful loading of weights for a single model."""
+        """Test loading a model when strictness also returns diagnostics."""
         # Setup mocks
         mock_dist_ckpt.load_common_state_dict.return_value = mock_common_state_dict
         mock_dist_ckpt.load_content_metadata.return_value = mock_metadata
-        mock_dist_ckpt.load.return_value = mock_full_state_dict
+        mock_dist_ckpt.load.return_value = (mock_full_state_dict, set(), set())
         mock_strategy_cls.return_value = Mock()
         mock_generate_state_dict.return_value = {"model": {"weight": torch.randn(10, 10)}}
         mock_unwrap_model.return_value = mock_model
@@ -3137,7 +3137,7 @@ class TestLoadModelWeightsFromCheckpoint:
                 checkpoint_path="/test/checkpoint",
                 model=mock_model,
                 fully_parallel_load=False,
-                dist_ckpt_strictness="assume_ok_unexpected",
+                dist_ckpt_strictness="return_all",
                 strict=True,
             )
 
@@ -4655,6 +4655,32 @@ class TestCheckpointPathOverride:
         mock_dist_ckpt.load.assert_called_once()
         load_call_args = mock_dist_ckpt.load.call_args
         assert load_call_args[0][1] == "/direct/iter_0001000"
+
+    @pytest.mark.parametrize("strictness", ["return_unexpected", "return_all"])
+    @patch("megatron.bridge.training.checkpointing.TorchDistLoadShardedStrategy")
+    @patch("megatron.bridge.training.checkpointing.dist_checkpointing")
+    def test_load_global_dist_unwraps_strictness_result(self, mock_dist_ckpt, mock_strategy_cls, strictness):
+        """Strictness diagnostics must not replace the loaded state dictionary."""
+        from megatron.bridge.training.checkpointing import _load_global_dist_base_checkpoint
+
+        loaded_state_dict = {"checkpoint_version": 3.0, "model": {}}
+        mock_strategy_cls.return_value = Mock()
+        mock_dist_ckpt.load.return_value = (loaded_state_dict, set(), set())
+        mock_pg = Mock()
+        mock_pg.dp_cp = Mock()
+
+        state_dict, _, _, _ = _load_global_dist_base_checkpoint(
+            load_dir="/checkpoints",
+            ckpt_cfg=CheckpointConfig(dist_ckpt_strictness=strictness),
+            rank0=False,
+            sharded_state_dict={"model": {}},
+            iteration=1000,
+            release=False,
+            pg_collection=mock_pg,
+        )
+
+        assert state_dict.get("checkpoint_version") == 3.0
+        assert mock_dist_ckpt.load.call_args.kwargs["strict"] == strictness
 
     @patch("megatron.bridge.training.checkpointing.HAVE_MEGATRON_FSDP", True)
     def test_load_fsdp_dtensor_uses_override_rank0(self):


### PR DESCRIPTION
## Problem

`CheckpointConfig.dist_ckpt_strictness` documents and accepts `return_unexpected` and `return_all`. For those modes, Megatron Core returns `(state_dict, missing_keys, unexpected_keys)`. Bridge passed that tuple into mapping consumers during training resume and model-weight loading, causing supported loads to fail before model state could be restored.

## Root cause and fix

Both Bridge load paths assumed `dist_checkpointing.load()` always returned a state dictionary. They now select the state-dictionary element only where Bridge needs a mapping. `_load_model_weights_from_checkpoint(..., return_state_dict=True)` still returns the full diagnostic tuple, preserving its existing return contract.

## Regression evidence

Focused command:

    uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadModelWeightsFromCheckpoint::test_load_model_weights_single_model_with_strictness_diagnostics tests/unit_tests/training/test_checkpointing.py::TestCheckpointPathOverride::test_load_global_dist_unwraps_strictness_result -q

On unmodified `main`, the model-loading case fails with `TypeError: tuple indices must be integers or slices, not str`, while the two global-load parameters fail when the tuple reaches mapping use. After the patch, all three cases pass.

Adjacent validation:

    uv run --no-sync python -m pytest tests/unit_tests/training/test_checkpointing.py::TestLoadModelWeightsFromCheckpoint tests/unit_tests/training/test_checkpointing.py::TestCheckpointPathOverride -q
    # 11 passed

    uv run --no-sync pre-commit run --all-files
    # all hooks passed

    git diff --check
    # passed

The CPU checks used inert shims only for unavailable optional GPU dependencies; checkpoint behavior itself was exercised through the real Bridge functions with the Megatron Core return contract mocked at the storage boundary.

## Scope

No public API, checkpoint format, default strictness, or mismatch-key semantics are changed. This only handles the already-supported tuple return shape.