### PR TITLE
[perf] fix: correct Qwen3 235B Blackwell 64-GPU topologies

### DIFF
--- a/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
@@ -131,7 +131,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb200_fp8cs_config() -> ConfigContainer:
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
-        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
@@ -181,7 +181,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
-        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,
@@ -541,7 +541,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_config() -> ConfigContainer:
         # NCCL user-buffer and launch settings.
         "NCCL_NVLS_ENABLE": 0,
         # HybridEP topology for the target system.
-        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,

--- a/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
@@ -105,7 +105,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb200_fp8cs_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = None
-    cfg.model.expert_model_parallel_size = 32
+    cfg.model.expert_model_parallel_size = 8
     cfg.model.sequence_parallel = False
     cfg.train.global_batch_size = 2048
     cfg.train.micro_batch_size = 1
@@ -159,7 +159,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config() -> ConfigContainer:
     cfg.model.pipeline_model_parallel_size = 8
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = 3
-    cfg.model.expert_model_parallel_size = 32
+    cfg.model.expert_model_parallel_size = 8
     cfg.model.sequence_parallel = False
     cfg.train.global_batch_size = 2048
     cfg.train.micro_batch_size = 1

--- a/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb300/qwen3_moe.py
@@ -30,7 +30,7 @@ from megatron.bridge.perf_recipes.qwen.common import (
 
 
 def qwen3_235b_a22b_pretrain_64gpu_gb300_bf16_config() -> ConfigContainer:
-    """Qwen3 235B-A22B pretrain: 64× GB300, BF16, EP=64."""
+    """Qwen3 235B-A22B pretrain: 64× GB300, BF16, PP=2, EP=32."""
     cfg = qwen3_235b_a22b_pretrain_config()
     cfg.mixed_precision = _perf_precision("bf16")
     cfg.model.bias_activation_fusion = True
@@ -43,7 +43,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb300_bf16_config() -> ConfigContainer:
     cfg.model.moe_router_force_load_balancing = True
 
     cfg.model.tensor_model_parallel_size = 1
-    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.pipeline_model_parallel_size = 2
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.expert_model_parallel_size = 32
@@ -84,7 +84,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb300_bf16_config() -> ConfigContainer:
 
 
 def qwen3_235b_a22b_pretrain_64gpu_gb300_fp8cs_config() -> ConfigContainer:
-    """Qwen3 235B-A22B pretrain: 64× GB300, FP8 current-scaling, EP=64."""
+    """Qwen3 235B-A22B pretrain: 64× GB300, FP8 current-scaling, PP=2, EP=32."""
     cfg = qwen3_235b_a22b_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_cs")
     cfg.model.bias_activation_fusion = True
@@ -97,7 +97,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb300_fp8cs_config() -> ConfigContainer:
     cfg.model.moe_router_force_load_balancing = True
 
     cfg.model.tensor_model_parallel_size = 1
-    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.pipeline_model_parallel_size = 2
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = None
     cfg.model.expert_model_parallel_size = 32
@@ -138,7 +138,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb300_fp8cs_config() -> ConfigContainer:
 
 
 def qwen3_235b_a22b_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
-    """Qwen3 235B-A22B pretrain: 64× GB300, MXFP8, EP=64."""
+    """Qwen3 235B-A22B pretrain: 64× GB300, MXFP8, PP=2, EP=32."""
     cfg = qwen3_235b_a22b_pretrain_config()
     cfg.mixed_precision = _perf_precision("fp8_mx")
     cfg.model.bias_activation_fusion = True
@@ -151,7 +151,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb300_fp8mx_config() -> ConfigContainer:
     cfg.model.moe_router_force_load_balancing = True
 
     cfg.model.tensor_model_parallel_size = 1
-    cfg.model.pipeline_model_parallel_size = 4
+    cfg.model.pipeline_model_parallel_size = 2
     cfg.model.context_parallel_size = 1
     cfg.model.virtual_pipeline_model_parallel_size = 12
     cfg.model.expert_model_parallel_size = 32

--- a/tests/unit_tests/recipes/test_qwen_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_perf_recipes.py
@@ -20,6 +20,7 @@ non-NVFP4 (FP8 current-scaling) siblings keep it enabled.
 """
 
 import pytest
+from scripts.common.benchmark_parallelism import data_parallel_size, topology_from_config
 
 from megatron.bridge.perf_recipes.qwen import (
     qwen3_30b_a3b_pretrain_8gpu_b200_fp8cs_config,
@@ -35,7 +36,9 @@ from megatron.bridge.perf_recipes.qwen import (
     qwen3_235b_a22b_pretrain_64gpu_b200_nvfp4_config,
     qwen3_235b_a22b_pretrain_64gpu_b300_fp8cs_config,
     qwen3_235b_a22b_pretrain_64gpu_b300_nvfp4_config,
+    qwen3_235b_a22b_pretrain_64gpu_gb200_bf16_config,
     qwen3_235b_a22b_pretrain_64gpu_gb200_fp8cs_config,
+    qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config,
     qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_config,
     qwen3_235b_a22b_pretrain_64gpu_gb300_fp8cs_config,
     qwen3_235b_a22b_pretrain_64gpu_gb300_nvfp4_config,
@@ -49,6 +52,21 @@ from megatron.bridge.perf_recipes.qwen import (
     qwen3_235b_a22b_pretrain_256gpu_gb300_nvfp4_config,
     qwen3_235b_a22b_pretrain_256gpu_vr200_nvfp4_config,
 )
+
+
+@pytest.mark.parametrize(
+    "recipe_func",
+    [
+        qwen3_235b_a22b_pretrain_64gpu_gb200_bf16_config,
+        qwen3_235b_a22b_pretrain_64gpu_gb200_fp8cs_config,
+        qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config,
+        qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_config,
+    ],
+)
+def test_qwen3_235b_64gpu_gb200_topology_is_valid(recipe_func):
+    cfg = recipe_func()
+
+    assert data_parallel_size(num_gpus=64, topology=topology_from_config(cfg.model)) == 8
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/recipes/test_qwen_perf_recipes.py
+++ b/tests/unit_tests/recipes/test_qwen_perf_recipes.py
@@ -40,7 +40,9 @@ from megatron.bridge.perf_recipes.qwen import (
     qwen3_235b_a22b_pretrain_64gpu_gb200_fp8cs_config,
     qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config,
     qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_config,
+    qwen3_235b_a22b_pretrain_64gpu_gb300_bf16_config,
     qwen3_235b_a22b_pretrain_64gpu_gb300_fp8cs_config,
+    qwen3_235b_a22b_pretrain_64gpu_gb300_fp8mx_config,
     qwen3_235b_a22b_pretrain_64gpu_gb300_nvfp4_config,
     qwen3_235b_a22b_pretrain_256gpu_b200_fp8cs_config,
     qwen3_235b_a22b_pretrain_256gpu_b200_nvfp4_config,
@@ -55,18 +57,25 @@ from megatron.bridge.perf_recipes.qwen import (
 
 
 @pytest.mark.parametrize(
-    "recipe_func",
+    ("recipe_func", "expected_data_parallel_size", "expected_hybridep_domain_size"),
     [
-        qwen3_235b_a22b_pretrain_64gpu_gb200_bf16_config,
-        qwen3_235b_a22b_pretrain_64gpu_gb200_fp8cs_config,
-        qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config,
-        qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_config,
+        (qwen3_235b_a22b_pretrain_64gpu_gb200_bf16_config, 8, 8),
+        (qwen3_235b_a22b_pretrain_64gpu_gb200_fp8cs_config, 8, 8),
+        (qwen3_235b_a22b_pretrain_64gpu_gb200_fp8mx_config, 8, 8),
+        (qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_config, 8, 8),
+        (qwen3_235b_a22b_pretrain_64gpu_gb300_bf16_config, 32, 32),
+        (qwen3_235b_a22b_pretrain_64gpu_gb300_fp8cs_config, 32, 32),
+        (qwen3_235b_a22b_pretrain_64gpu_gb300_fp8mx_config, 32, 32),
+        (qwen3_235b_a22b_pretrain_64gpu_gb300_nvfp4_config, 32, 32),
     ],
 )
-def test_qwen3_235b_64gpu_gb200_topology_is_valid(recipe_func):
+def test_qwen3_235b_64gpu_blackwell_topology_is_valid(
+    recipe_func, expected_data_parallel_size, expected_hybridep_domain_size
+):
     cfg = recipe_func()
 
-    assert data_parallel_size(num_gpus=64, topology=topology_from_config(cfg.model)) == 8
+    assert data_parallel_size(num_gpus=64, topology=topology_from_config(cfg.model)) == expected_data_parallel_size
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == expected_hybridep_domain_size
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

The public Qwen3-235B 64-GPU GB200 and GB300 performance recipes encode expert/pipeline grids larger than their advertised world size:

- GB200 FP8-CS and MXFP8 use PP=8, ETP=1, EP=32, requiring 256 ranks. NVFP4 inherits FP8-CS.
- GB300 BF16, FP8-CS, and MXFP8 use PP=4, ETP=1, EP=32, requiring 128 ranks. NVFP4 inherits FP8-CS.

Both the Bridge benchmark launcher and Megatron-Core reject these topologies before training starts because 64 is not divisible by `ETP * EP * PP`.

The fix preserves each platform's established HybridEP layout: GB200 uses PP=8/EP=8 and GB300 uses PP=2/EP=32. GB200's HybridEP rank-domain setting is also reduced to 8 so it divides the corrected ETP×EP communication group; GB300 retains 32. A focused regression validates all four precision variants on both platforms.

## Validation

Fail-before, using isolated reproducers that execute the exact recipe source and Bridge topology helpers from the unmodified base:

```text
uv run --no-sync python <gb200-topology-reproducer> <exact-base-worktree>
ValueError: world size must be divisible by ETP * EP * PP (1 * 32 * 8 = 256)

uv run --no-sync python <gb300-topology-reproducer> <exact-base-worktree>
ValueError: world size must be divisible by ETP * EP * PP (1 * 32 * 4 = 128)
```

Pass-after, with the reproducers unchanged except for adding the HybridEP rank-domain invariant:

```text
uv run --no-sync python <gb200-topology-reproducer> <patched-worktree>
PASS: BF16, FP8-CS, MXFP8, and inherited NVFP4 use valid 64-GPU topology/domain settings

uv run --no-sync python <gb300-topology-reproducer> <patched-worktree>
PASS: all affected factories plus 256-GPU and Qwen3-Next controls
```

Additional checks:

- `uv run --no-sync pre-commit run --all-files` — passed
- `git diff --check` — passed
- Added a focused parameterized regression covering GB200 and GB300 BF16, FP8-CS, MXFP8, and NVFP4.

The focused pytest target could not collect on the CPU-only workstation because installed optional GPU dependencies import unavailable CUDA/Triton components before the test module loads. This environment failure is not presented as candidate evidence.

## Scope

This only corrects the topology and matching HybridEP rank-domain setting of the advertised Qwen3-235B 64-GPU Blackwell workloads. The 256-GPU recipes, model semantics, public APIs, dependencies, and CI configuration are unchanged.
