### PR TITLE
fix(perf): re-enable PCT binding for Nemotron-3 Super bf16 on B300

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -564,12 +564,6 @@ def main(
     # Disable PCT binding for certain models on specific hardware/precision combos
     if (
         (
-            model_family_name == "nemotronh"
-            and model_recipe_name == "nemotron_3_super"
-            and compute_dtype == "bf16"
-            and gpu == "b300"
-        )
-        or (
             model_family_name == "deepseek"
             and model_recipe_name == "deepseek_v3"
             and gpu == "b300"


### PR DESCRIPTION
PCT binding was force-disabled for the nemotronh/nemotron_3_super/bf16/b300 combination, which silently dropped the numactl -C core pinning from the launch command and cost ~7.3% throughput. Removing that clause restores the pinning and raises measured performance on 64x B300 (8 nodes, 50 steps) from 684 to 744 TFLOP/s/GPU, back in line with the 26.06.01 container baseline of 739.