### PR TITLE
[training] fix: Honor delayed MIMO evaluation start

### DIFF
--- a/src/megatron/bridge/training/train_megatron_mimo.py
+++ b/src/megatron/bridge/training/train_megatron_mimo.py
@@ -387,7 +387,12 @@ def train_megatron_mimo(
             )
 
         # Evaluation at specified intervals
-        if eval_interval and train_state.step % eval_interval == 0 and valid_data_iterator is not None:
+        if (
+            eval_interval
+            and (cfg.validation.start_eval_at_iter is None or train_state.step >= cfg.validation.start_eval_at_iter)
+            and train_state.step % eval_interval == 0
+            and valid_data_iterator is not None
+        ):
             if train_config.manual_gc and train_config.manual_gc_eval:
                 gc.collect()
             evaluate_and_print_results(

--- a/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
+++ b/tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py
@@ -506,6 +506,49 @@ def test_interval_evaluation_uses_evaluator_timer_ownership(use_canonical_valida
     mock_evaluate.assert_called_once()
 
 
+def test_interval_evaluation_honors_delayed_start():
+    """Periodic MegatronMIMO evaluation should wait for the configured start iteration."""
+    from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo
+
+    state = _make_global_state(save_dir=None, train_iters=6)
+    state.cfg.validation.eval_interval = 2
+    state.cfg.validation.start_eval_at_iter = 6
+
+    infra = _make_megatron_mimo_infra()
+
+    with (
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("megatron.bridge.training.train_megatron_mimo.get_num_microbatches", return_value=1),
+        patch("megatron.bridge.training.train_megatron_mimo.prepare_forward_step_func", return_value=Mock()),
+        patch("megatron.bridge.training.train_megatron_mimo.get_module_to_grid_tuple", return_value=[]),
+        patch(
+            "megatron.bridge.training.train_megatron_mimo.build_pg_collection_for_schedule",
+            return_value=Mock(spec=[]),
+        ),
+        patch(
+            "megatron.bridge.training.train_megatron_mimo.train_step_megatron_mimo",
+            return_value=({}, 0, 0.0, 0),
+        ),
+        patch("megatron.bridge.training.train_megatron_mimo.evaluate_and_print_results") as mock_evaluate,
+        patch("megatron.bridge.training.train_megatron_mimo.checkpoint_and_decide_exit", return_value=False),
+    ):
+        train_megatron_mimo(
+            forward_step_func=Mock(),
+            model=Mock(),
+            optimizer=Mock(),
+            schedulers={},
+            train_data_iterator=iter([object()]),
+            valid_data_iterator=iter([object()]),
+            global_state=state,
+            megatron_mimo_infra=infra,
+            multimodule_communicator=Mock(),
+            checkpoint_manager=MagicMock(),
+        )
+
+    mock_evaluate.assert_called_once()
+    assert mock_evaluate.call_args.kwargs["prefix"] == "iteration 6"
+
+
 def test_iteration_time_is_logged_once_by_shared_training_logger():
     """MIMO should not overwrite the shared interval-average timing metric."""
     from megatron.bridge.training.train_megatron_mimo import train_megatron_mimo


### PR DESCRIPTION
## What changed

MegatronMIMO training now honors `validation.start_eval_at_iter` when scheduling periodic validation.

With `validation.eval_interval=2` and `validation.start_eval_at_iter=6`, the supported MIMO loop previously evaluated at iterations 2, 4, and 6. Those premature evaluations consume validation samples, emit metrics and callbacks, and add validation wall time despite the configured delayed start.

The root cause was that the MIMO loop read the canonical validation interval but gated only on interval divisibility and iterator presence. Standard Bridge training and the pinned Megatron-Core loop also require the current iteration to reach `start_eval_at_iter`. The fix adds that same predicate at the MIMO evaluation boundary. This follows the canonical validation ownership introduced in #5341.

## Validation

The new regression test was run unchanged before and after the production fix:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/training/megatron_mimo tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_honors_delayed_start -q --tb=short
```

- Before: failed because the evaluator was called 3 times (iterations 2, 4, and 6), rather than once.
- After: `1 passed`; evaluation occurred only at iteration 6.

Adjacent validation:

```text
uv run --no-sync python -m pytest --confcutdir=tests/unit_tests/training/megatron_mimo tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_uses_evaluator_timer_ownership tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_interval_evaluation_honors_delayed_start tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::test_iteration_time_is_logged_once_by_shared_training_logger tests/unit_tests/training/megatron_mimo/test_megatron_mimo_checkpointing.py::TestTrainMegatronMIMOCheckpointIntegration -q --tb=short
```

- `9 passed`
- `git diff --check` passed.
- `uv run pre-commit run --all-files` passed.

## Scope

This changes only periodic evaluation scheduling in the non-colocated MIMO training loop. It does not add evaluation-at-start, multiple validation datasets, new configuration, or broader MIMO validation behavior.
