### PR TITLE
build: compile DeepEP hybrid extension with C++20

### DIFF
--- a/docker/patches/deepep.patch
+++ b/docker/patches/deepep.patch
@@ -1,8 +1,17 @@
 diff --git a/setup.py b/setup.py
-index 63ce332..4e13462 100644
+index d30d25e..b50d6ac 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -37,7 +37,7 @@ if __name__ == '__main__':
+@@ -52,7 +52,7 @@ def get_extension_hybrid_ep_cpp():
+     # Basic compile arguments
+     compile_args = {
+         "nvcc": [
+-            "-std=c++17",
++            "-std=c++20",
+             "-Xcompiler",
+             "-fPIC",
+             "--expt-relaxed-constexpr",
+@@ -191,7 +191,7 @@ def get_extension_deep_ep_cpp():
                   '-Wno-sign-compare', '-Wno-reorder', '-Wno-attributes']
      nvcc_flags = ['-O3', '-Xcompiler', '-O3']
      sources = ['csrc/deep_ep.cpp', 'csrc/kernels/runtime.cu', 'csrc/kernels/layout.cu', 'csrc/kernels/intranode.cu']
@@ -10,4 +19,4 @@ index 63ce332..4e13462 100644
 +    include_dirs = ['csrc/', '/usr/local/cuda/include/cccl/']
      library_dirs = []
      nvcc_dlink = []
-     extra_link_args = []
+     extra_link_args = ['-lcuda']


### PR DESCRIPTION
## What does this PR do?

Updates the DeepEP build patch so the hybrid_ep_cpp CUDA extension compiles as C++20. PyTorch 2.14 now enforces C++20 in the torch/all.h and ATen/ATen.h header guards, while the pinned DeepEP setup.py explicitly selected C++17.

## Changelog

- Change the hybrid_ep_cpp nvcc language standard from C++17 to C++20.
- Rebase the existing CCCL include-directory hunk onto the current default DeepEP revision.

## Validation

- pre-commit run --all-files: passed.
- Patch dry-run against DeepEP 34152ae28f80bcc3ee38d7a12cb2ad87cfd4ea72: passed.
- Patch dry-run against DeepEP 17cfb817bccec3a9c247013360cc550c2bac441e used by the failing nemo-ci job: passed.
- Full container build was not run because the local Docker daemon is unavailable.

Failure reproduced in https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/jobs/435079546.

## Before this PR is ready for review

- [x] Read and followed the contributor guidelines.
- [x] Evaluated test coverage; this build-patch compatibility change is covered by applying the patch against both relevant DeepEP revisions.
- [x] Evaluated documentation impact; no user-facing documentation change is needed.
- [x] DeepEP is an optional component; this change does not alter import behavior.