### PR TITLE
[perf] fix: Sync HybridEP topology after EP overrides

### DIFF
--- a/scripts/performance/run_script.py
+++ b/scripts/performance/run_script.py
@@ -59,7 +59,7 @@ def _dump_env_rank0() -> None:
 def _apply_perf_recipe_overrides(recipe, cli_overrides: list[str], args):
     """Apply Hydra and argparse overrides to a flat performance recipe."""
     from utils.overrides import _apply_flat_cli_environment_compatibility, set_cli_overrides, set_user_overrides
-    from utils.utils import explicit_environment_override_names
+    from utils.utils import apply_target_topology_environment, explicit_environment_override_names
 
     if not hasattr(recipe, "env_vars"):
         logger.warning(
@@ -68,6 +68,7 @@ def _apply_perf_recipe_overrides(recipe, cli_overrides: list[str], args):
         )
         recipe.env_vars = {}
     base_env_vars = dict(recipe.env_vars)
+    base_expert_model_parallel_size = getattr(recipe.model, "expert_model_parallel_size", 1)
     base_dispatcher_backend = getattr(recipe.model, "moe_flex_dispatcher_backend", None)
     comm_overlap = getattr(recipe, "comm_overlap", None)
     base_moe_a2a_overlap = bool(
@@ -85,13 +86,20 @@ def _apply_perf_recipe_overrides(recipe, cli_overrides: list[str], args):
             recipe.env_vars[name] = hydra_env_vars[name]
         else:
             recipe.env_vars.pop(name, None)
-    return _apply_flat_cli_environment_compatibility(
+    recipe = _apply_flat_cli_environment_compatibility(
         recipe,
         args,
         base_dispatcher_backend=base_dispatcher_backend,
         base_moe_a2a_overlap=base_moe_a2a_overlap,
         protected_env_names=protected_env_names,
     )
+    if getattr(recipe.model, "expert_model_parallel_size", 1) != base_expert_model_parallel_size:
+        apply_target_topology_environment(
+            recipe,
+            gpu=args.gpu,
+            protected_env_names=protected_env_names,
+        )
+    return recipe
 
 
 def _prepare_perf_recipe(args, cli_overrides: list[str]):

--- a/scripts/training/run_recipe.py
+++ b/scripts/training/run_recipe.py
@@ -397,6 +397,34 @@ def _apply_benchmark_runtime_defaults(
     return recipe
 
 
+def _sync_benchmark_topology_environment(
+    recipe: ConfigContainer,
+    metadata: BenchmarkRecipeMetadata,
+    cli_overrides: list[str],
+    *,
+    base_env_vars: dict,
+    base_expert_model_parallel_size: int,
+) -> ConfigContainer:
+    """Keep derived HybridEP environment aligned with an EP override."""
+    if getattr(getattr(recipe, "model", None), "expert_model_parallel_size", 1) == base_expert_model_parallel_size:
+        return recipe
+
+    if not hasattr(recipe, "env_vars"):
+        recipe.env_vars = {}
+    performance_script_dir = SCRIPT_DIR.parent / "performance"
+    if str(performance_script_dir) not in sys.path:
+        sys.path.insert(0, str(performance_script_dir))
+    from utils.utils import apply_target_topology_environment, explicit_environment_override_names
+
+    protected_env_names = explicit_environment_override_names(cli_overrides, base_env_vars, recipe.env_vars)
+    apply_target_topology_environment(
+        recipe,
+        gpu=metadata.hardware,
+        protected_env_names=protected_env_names,
+    )
+    return recipe
+
+
 def _apply_benchmark_dataset_defaults(
     recipe: ConfigContainer,
     metadata: BenchmarkRecipeMetadata,
@@ -482,6 +510,10 @@ def main(argv: list[str] | None = None) -> None:
 
     recipe = _load_selected_recipe(args)
     if benchmark_metadata is not None:
+        benchmark_base_env_vars = dict(getattr(recipe, "env_vars", {}))
+        benchmark_base_expert_model_parallel_size = getattr(
+            getattr(recipe, "model", None), "expert_model_parallel_size", 1
+        )
         recipe = _apply_benchmark_dataset_defaults(recipe, benchmark_metadata)
     recipe = _apply_dataset(recipe, args)
     recipe = apply_determinism(recipe, deterministic=args.deterministic)
@@ -491,6 +523,14 @@ def main(argv: list[str] | None = None) -> None:
         benchmark_canonical_topology = topology_from_config(getattr(recipe, "model", None))
         benchmark_canonical_global_batch_size = getattr(getattr(recipe, "train", None), "global_batch_size", 1)
     recipe = apply_cli_overrides(recipe, cli_overrides)
+    if benchmark_metadata is not None:
+        recipe = _sync_benchmark_topology_environment(
+            recipe,
+            benchmark_metadata,
+            cli_overrides,
+            base_env_vars=benchmark_base_env_vars,
+            base_expert_model_parallel_size=benchmark_base_expert_model_parallel_size,
+        )
     recipe = sync_model_pipeline_layout(recipe, cli_overrides=cli_overrides)
     benchmark_world_size = None
     if benchmark_metadata is not None:

--- a/tests/unit_tests/scripts/performance/test_recipe_environment.py
+++ b/tests/unit_tests/scripts/performance/test_recipe_environment.py
@@ -518,6 +518,65 @@ def test_flat_environment_preparation_applies_cli_overrides(monkeypatch):
     assert calls == [("overrides", base_recipe, cli_overrides, args)]
 
 
+def test_flat_hydra_ep_override_updates_hybridep_topology_environment(monkeypatch):
+    """A model EP override must update the environment consumed by HybridEP."""
+    recipe = SimpleNamespace(
+        env_vars={
+            "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+            "NVLINK_DOMAIN_SIZE": 72,
+            "USE_MNNVL": 1,
+        },
+        model=SimpleNamespace(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=4,
+            context_parallel_size=1,
+            expert_model_parallel_size=32,
+            moe_flex_dispatcher_backend="hybridep",
+        ),
+        comm_overlap=None,
+    )
+    args = SimpleNamespace(
+        gpu="vr200",
+        moe_a2a_overlap=None,
+        tensor_model_parallel_size=None,
+        pipeline_model_parallel_size=None,
+        context_parallel_size=None,
+        expert_model_parallel_size=None,
+        nccl_ub=None,
+        model_family_name="qwen",
+        model_recipe_name="qwen3_235b_a22b",
+        task="pretrain",
+    )
+
+    def apply_hydra(config, overrides):
+        assert overrides == ["model.expert_model_parallel_size=64"]
+        config.model.expert_model_parallel_size = 64
+        return config
+
+    override_utils = types.ModuleType("utils.overrides")
+    override_utils.set_cli_overrides = apply_hydra
+    override_utils.set_user_overrides = lambda config, _args: config
+    override_utils._apply_flat_cli_environment_compatibility = lambda config, *_args, **_kwargs: config
+    monkeypatch.setitem(sys.modules, "utils.overrides", override_utils)
+    environment_module = types.ModuleType("megatron.bridge.perf_recipes.environment")
+    environment_module.HYBRID_EP_ENV_NAMES = {
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN",
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API",
+        "NVLINK_DOMAIN_SIZE",
+        "USE_MNNVL",
+    }
+    monkeypatch.setitem(sys.modules, "megatron.bridge.perf_recipes", types.ModuleType("megatron.bridge.perf_recipes"))
+    monkeypatch.setitem(sys.modules, "megatron.bridge.perf_recipes.environment", environment_module)
+
+    result = run_script._apply_perf_recipe_overrides(
+        recipe,
+        ["model.expert_model_parallel_size=64"],
+        args,
+    )
+
+    assert result.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 64
+
+
 def test_flat_deterministic_environment_reaches_training_exec(monkeypatch):
     """The flat training interpreter must start with deterministic process values."""
     from megatron.bridge.recipes.utils.determinism_utils import apply_determinism_overrides

--- a/tests/unit_tests/scripts/training/test_run_recipe.py
+++ b/tests/unit_tests/scripts/training/test_run_recipe.py
@@ -571,6 +571,63 @@ def test_benchmark_dry_run_accepts_config_overrides(monkeypatch):
     )
 
 
+def test_benchmark_ep_override_updates_hybridep_topology_environment(monkeypatch):
+    """The exact-recipe launcher must keep HybridEP environment aligned with EP."""
+    module, handles = _load_module()
+    monkeypatch.setenv("WORLD_SIZE", "256")
+    config = SimpleNamespace(
+        env_vars={
+            "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+            "NVLINK_DOMAIN_SIZE": 72,
+            "USE_MNNVL": 1,
+        },
+        optimizer=SimpleNamespace(optimizer="adam", use_precision_aware_optimizer=False),
+        model=SimpleNamespace(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=4,
+            context_parallel_size=1,
+            expert_model_parallel_size=32,
+            expert_tensor_parallel_size=1,
+            moe_flex_dispatcher_backend="hybridep",
+        ),
+        train=SimpleNamespace(global_batch_size=2048),
+        dataset=SimpleNamespace(),
+    )
+    handles.recipe_runner.load_recipe.return_value = config
+
+    def apply_overrides(recipe, overrides):
+        assert "model.expert_model_parallel_size=64" in overrides
+        recipe.model.expert_model_parallel_size = 64
+        return recipe
+
+    handles.recipe_runner.apply_cli_overrides.side_effect = apply_overrides
+    environment_module = types.ModuleType("megatron.bridge.perf_recipes.environment")
+    environment_module.HYBRID_EP_ENV_NAMES = {
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN",
+        "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API",
+        "NVLINK_DOMAIN_SIZE",
+        "USE_MNNVL",
+    }
+    monkeypatch.setitem(sys.modules, "megatron", _package("megatron"))
+    monkeypatch.setitem(sys.modules, "megatron.bridge", _package("megatron.bridge"))
+    monkeypatch.setitem(sys.modules, "megatron.bridge.perf_recipes", _package("megatron.bridge.perf_recipes"))
+    monkeypatch.setitem(sys.modules, "megatron.bridge.perf_recipes.environment", environment_module)
+
+    module.main(
+        [
+            "--recipe",
+            "qwen3_235b_a22b_pretrain_256gpu_vr200_nvfp4_config",
+            "--mode",
+            "pretrain",
+            "--dry-run",
+            "--expert_model_parallel_size",
+            "64",
+        ]
+    )
+
+    assert config.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == 64
+
+
 def test_benchmark_recipe_weak_scales_noncanonical_world_size(monkeypatch):
     module, handles = _load_module()
     monkeypatch.setenv("WORLD_SIZE", "8")


### PR DESCRIPTION
## What changed

When a supported Qwen performance launch overrides `expert_model_parallel_size`, recompute the HybridEP topology environment from the effective recipe before process bootstrap. This covers both flat performance recipes and the preferred exact-recipe launcher while preserving explicit `env_vars` overrides.

## User impact

A VR200 HybridEP recipe can validly change EP from 32 to 64 on 256 ranks (TP=1, PP=4, ETP=1). Before this change, the model used EP=64 while `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN` remained 32. HybridEP therefore received a topology that disagreed with the effective parallel configuration and could fail during runtime initialization.

The root cause was that target-topology environment finalization ran for target selection and legacy argparse compatibility, but not after Hydra overrides in the flat runner and not after overrides in the exact-recipe runner.

## Validation

Fail-before:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/training/test_run_recipe.py::test_benchmark_ep_override_updates_hybridep_topology_environment -q --tb=short
FAILED: assert 32 == 64
```

Pass-after:

```text
uv run python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/training/test_run_recipe.py::test_benchmark_ep_override_updates_hybridep_topology_environment -q --tb=short
1 passed

uv run python -m pytest --confcutdir=tests/unit_tests/scripts tests/unit_tests/scripts/training/test_run_recipe.py -q --tb=short
136 passed
```

The flat-runner regression and four directly adjacent topology/environment contract cases also pass (`5 passed`). `git diff --check` and `uv run pre-commit run --all-files` pass.

## Scope

This only re-finalizes existing derived HybridEP topology values when the effective EP size changes. It does not change canonical recipe defaults, add hardware/model support, alter explicit environment overrides, or modify MCore.
