### PR TITLE
[perf] fix: align Qwen3 full-iteration topologies

### DIFF
--- a/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
+++ b/src/megatron/bridge/perf_recipes/qwen/gb200/qwen3_moe.py
@@ -567,7 +567,7 @@ def qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_full_iteration_config() -> Config
         "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,graph_capture_record_stream_reuse:True",
         "TORCH_NCCL_AVOID_RECORD_STREAMS": 0,
         "NCCL_NVLS_ENABLE": 0,
-        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 32,
+        "NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN": 8,
         "NUM_OF_TOKENS_PER_CHUNK_COMBINE_API": 128,
         "NVLINK_DOMAIN_SIZE": 72,
         "USE_MNNVL": 1,

--- a/tests/unit_tests/recipes/test_bseries_nvfp4_full_iteration_recipes.py
+++ b/tests/unit_tests/recipes/test_bseries_nvfp4_full_iteration_recipes.py
@@ -15,6 +15,7 @@
 """Configuration checks for Qwen3 235B Blackwell NVFP4 full-iteration recipes."""
 
 import pytest
+from scripts.common.benchmark_parallelism import data_parallel_size, topology_from_config
 
 from megatron.bridge.perf_recipes.qwen import (
     qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_full_iteration_config,
@@ -36,40 +37,59 @@ def _keep_recipe_construction_offline(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("recipe", "expected_parallelism", "expected_avoid_record_streams", "expected_nvlink_domain_size"),
+    (
+        "recipe",
+        "num_gpus",
+        "expected_data_parallel_size",
+        "expected_parallelism",
+        "expected_avoid_record_streams",
+        "expected_nvlink_domain_size",
+    ),
     [
         (
             qwen3_235b_a22b_pretrain_256gpu_b200_nvfp4_config,
+            256,
+            32,
             (1, 8, 3, 8),
             1,
             8,
         ),
         (
             qwen3_235b_a22b_pretrain_256gpu_b300_nvfp4_config,
+            256,
+            32,
             (1, 8, 3, 8),
             1,
             8,
         ),
         (
             qwen3_235b_a22b_pretrain_64gpu_gb200_nvfp4_full_iteration_config,
-            (1, 8, 3, 32),
+            64,
+            8,
+            (1, 8, 3, 8),
             0,
             72,
         ),
         (
             qwen3_235b_a22b_pretrain_256gpu_gb200_nvfp4_config,
+            256,
+            32,
             (1, 8, 3, 32),
             0,
             72,
         ),
         (
             qwen3_235b_a22b_pretrain_64gpu_gb300_nvfp4_full_iteration_config,
-            (1, 4, 12, 32),
+            64,
+            32,
+            (1, 2, 12, 32),
             0,
             72,
         ),
         (
             qwen3_235b_a22b_pretrain_256gpu_gb300_nvfp4_config,
+            256,
+            64,
             (1, 4, 12, 32),
             0,
             72,
@@ -77,7 +97,12 @@ def _keep_recipe_construction_offline(monkeypatch: pytest.MonkeyPatch) -> None:
     ],
 )
 def test_qwen3_235b_blackwell_nvfp4_full_iteration_stack(
-    recipe, expected_parallelism, expected_avoid_record_streams, expected_nvlink_domain_size
+    recipe,
+    num_gpus,
+    expected_data_parallel_size,
+    expected_parallelism,
+    expected_avoid_record_streams,
+    expected_nvlink_domain_size,
 ) -> None:
     cfg = recipe()
 
@@ -108,6 +133,7 @@ def test_qwen3_235b_blackwell_nvfp4_full_iteration_stack(
     assert cfg.env_vars["NVTE_USE_FAST_MATH"] == 1
     assert cfg.env_vars["TORCH_NCCL_AVOID_RECORD_STREAMS"] == expected_avoid_record_streams
     assert cfg.env_vars["NVLINK_DOMAIN_SIZE"] == expected_nvlink_domain_size
+    assert cfg.env_vars["NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN"] == cfg.model.expert_model_parallel_size
     assert "graph_capture_record_stream_reuse:True" in cfg.env_vars["PYTORCH_CUDA_ALLOC_CONF"]
 
     actual_parallelism = (
@@ -117,3 +143,6 @@ def test_qwen3_235b_blackwell_nvfp4_full_iteration_stack(
         cfg.model.expert_model_parallel_size,
     )
     assert actual_parallelism == expected_parallelism
+    assert (
+        data_parallel_size(num_gpus=num_gpus, topology=topology_from_config(cfg.model)) == expected_data_parallel_size
+    )


### PR DESCRIPTION
## Summary

Fix the Qwen3-235B 64-GPU NVFP4 full-iteration recipe expectations after #6054 corrected the underlying Blackwell topologies.

- keep the derived 64-GPU GB200 recipe on the valid `TP=1, PP=8, EP=8` grid and align its HybridEP domain setting to 8;
- update the 64-GPU GB300 expectation to the corrected `TP=1, PP=2, EP=32` grid;
- validate every covered recipe against its advertised 64- or 256-GPU world size and require the HybridEP domain to match EP.

## Root cause

#5965 added the full-iteration derived recipes and tests while the 64-GPU base recipes still had invalid oversized expert/pipeline grids. #6054 then correctly fixed those base recipes, but the overlapping change did not update the newly added derived-recipe assertions or the GB200 full-iteration environment override.

This caused `Launch_Unit_Tests_Core_0` and `Launch_Unit_Tests_Core_2` to fail on `main` in https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/34621607513.

## Validation

```text
uv run python -m pytest \
  tests/unit_tests/recipes/test_bseries_nvfp4_full_iteration_recipes.py \
  tests/unit_tests/recipes/test_qwen_perf_recipes.py -q

40 passed
```

`uv run pre-commit run --all-files` also passes.
