### PR TITLE
fix(perf): honor --enable_pct_binding on B300 instead of silently ove…

### DIFF
--- a/scripts/performance/setup_experiment.py
+++ b/scripts/performance/setup_experiment.py
@@ -561,19 +561,6 @@ def main(
             "to the cache directory. NullTokenizer to be used soon."
         )
 
-    # Disable PCT binding for certain models on specific hardware/precision combos
-    if (
-        (
-            model_family_name == "deepseek"
-            and model_recipe_name == "deepseek_v3"
-            and gpu == "b300"
-            and config_variant != "large_scale"
-        )
-        or (model_family_name == "llama" and task == "pretrain" and gpu == "b300")
-        or (model_family_name == "kimi" and task == "pretrain" and gpu == "b300")
-    ):
-        enable_pct_binding = False
-
     if wandb_key is not None:
         assert wandb_project_name is not None and wandb_experiment_name is not None, (
             "both wandb_project_name and wandb_experiment_name are required for logging with WandB"


### PR DESCRIPTION
setup_experiment.py silently overwrote the user-supplied --enable_pct_binding with False for deepseek_v3/llama pretrain/kimi pretrain on B300, so those runs dropped the -C priority-core args from numactl and ran without PCT binding despite the flag being set; this removes the override so the flag is honored as documented (pass --enable_pct_binding false for the old behavior).

