### PR TITLE
fix(training): restore gradient synchronization for copied model configs

### DIFF
--- a/src/megatron/bridge/training/setup.py
+++ b/src/megatron/bridge/training/setup.py
@@ -34,6 +34,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.core.transformer import MegatronModule
 from megatron.core.transformer.multi_token_prediction import get_mtp_ranks
+from megatron.core.utils import get_model_config
 from megatron.training.models.base import ModelConfig
 
 from megatron.bridge.data.loaders import build_train_valid_test_datasets_for_num_epochs, setup_data_iterators
@@ -469,7 +470,8 @@ def setup(
 
     _update_model_config_funcs(
         model,
-        cfg.model.transformer if isinstance(cfg.model, (GPTModelConfig, HybridModelConfig)) else cfg.model,
+        # Providers may copy their configuration while constructing the model.
+        get_model_config(model[0]),
         cfg.ddp,
         optimizer,
         align_grad_reduce=cfg.dist.align_grad_reduce,

--- a/tests/unit_tests/training/test_runtime_callbacks.py
+++ b/tests/unit_tests/training/test_runtime_callbacks.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import torch
+from megatron.core.enums import ModelType
+from megatron.core.pipeline_parallel import schedules
+from megatron.core.utils import get_model_config
+
+import megatron.bridge.training.setup as training_setup
+from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
+from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
+from megatron.bridge.models.nemotron_omni.nemotron_omni_provider import NemotronOmniModelProvider
+from megatron.bridge.models.transformer_config import TransformerConfig
+from megatron.bridge.training.state import GlobalState
+
+
+pytestmark = pytest.mark.unit
+
+
+class FakeDDP:
+    def __init__(self, config: TransformerConfig) -> None:
+        self.module = SimpleNamespace(config=config, model_type=ModelType.encoder_or_decoder)
+        self.no_sync = Mock(side_effect=contextlib.nullcontext)
+        self.start_grad_sync = Mock()
+        self.start_param_sync = Mock()
+
+
+def _make_configs(
+    kind: str,
+) -> tuple[GPTModelProvider | HybridModelProvider | GPTModelConfig | HybridModelConfig, TransformerConfig]:
+    dimensions = dict(num_layers=1, hidden_size=8, num_attention_heads=2)
+    if kind == "copied_omni":
+        provider = NemotronOmniModelProvider(**dimensions)
+        return provider, provider._copy_config_without_runtime_process_groups(deep=True)
+    if kind in ("gpt_provider", "hybrid_provider"):
+        provider = (GPTModelProvider if kind == "gpt_provider" else HybridModelProvider)(**dimensions)
+        return provider, provider
+    runtime = TransformerConfig(**dimensions)
+    builder = GPTModelConfig if kind == "gpt_builder" else HybridModelConfig
+    return builder(transformer=runtime, vocab_size=32), runtime
+
+
+def _run_setup(
+    provider: GPTModelProvider | HybridModelProvider | GPTModelConfig | HybridModelConfig,
+    model: list[FakeDDP],
+    ddp_config: SimpleNamespace,
+) -> tuple[MagicMock, SimpleNamespace]:
+    """Exercise the real setup call and installer without constructing a training job."""
+    cfg = SimpleNamespace(
+        _checkpoint_load_required=False,
+        checkpoint=SimpleNamespace(
+            finetune=False,
+            load="/checkpoint",
+            load_optim=True,
+            load_rng=True,
+            pretrained_checkpoint=None,
+            save=None,
+        ),
+        dataset=SimpleNamespace(),
+        ddp=SimpleNamespace(),
+        dist=SimpleNamespace(
+            align_grad_reduce=True,
+            disable_jit_fuser=False,
+            enable_megatron_core_experimental=False,
+            use_decentralized_pg=False,
+            use_gloo_process_groups=False,
+            use_torch_fsdp2=False,
+        ),
+        ft=None,
+        logger=SimpleNamespace(
+            filter_warnings=False,
+            log_progress=False,
+            logging_level="INFO",
+            modules_to_filter=[],
+            set_level_for_all_loggers=False,
+        ),
+        model=SimpleNamespace(
+            fine_grained_activation_offloading=False,
+            restore_modelopt_state=False,
+            should_pad_vocab=False,
+            vocab_size=32,
+        ),
+        optimizer=SimpleNamespace(overlap_param_gather_with_optimizer_step=False),
+        optimizer_config_override_provider=None,
+        peft=None,
+        profiling=SimpleNamespace(),
+        rng=SimpleNamespace(data_parallel_random_init=False),
+        scheduler=SimpleNamespace(),
+        tensor_inspect=SimpleNamespace(),
+        tokenizer=SimpleNamespace(use_tokenizer_vocab_size=False),
+        train=SimpleNamespace(micro_batch_size=1, num_epochs=None),
+    )
+    timer = MagicMock()
+    state = SimpleNamespace(
+        _eval_pgs=None,
+        cfg=cfg,
+        comet_logger=None,
+        initialize_async_checkpoint_worker=Mock(),
+        start_time=0.0,
+        tensorboard_logger=None,
+        timers=Mock(return_value=timer),
+        train_state=SimpleNamespace(step=1),
+        wandb_logger=None,
+    )
+    pg_collection = SimpleNamespace(dp=object())
+    checkpoint_manager = MagicMock(checkpointing_context={})
+    optimizer = MagicMock()
+    scheduler = MagicMock()
+    cfg.model = provider
+    cfg.ddp = ddp_config
+    pg_collection.cp = SimpleNamespace(size=lambda: 1)
+    pg_collection.tp = SimpleNamespace(size=lambda: 1)
+    start_time_tensor = Mock()
+    start_time_tensor.item.return_value = 0.0
+    with (
+        patch.multiple(
+            training_setup,
+            DistributedDataParallel=FakeDDP,
+            _build_distributed_model=Mock(return_value=model),
+            _should_load_checkpoint=Mock(return_value=False),
+            _validate_and_set_vocab_size=Mock(return_value=(32, False)),
+            barrier_and_log=Mock(),
+            build_tokenizer=Mock(return_value=SimpleNamespace(vocab_size=32)),
+            create_checkpoint_manager=Mock(return_value=checkpoint_manager),
+            finalize_tensor_inspect_post_model_initialization=Mock(),
+            initialize_megatron=Mock(return_value=pg_collection),
+            initialize_tensor_inspect_pre_model_initialization=Mock(),
+            maybe_load_dataloader_state=Mock(),
+            maybe_log_and_save_config=Mock(),
+            print_rank_0=Mock(),
+            set_experimental_flag=Mock(),
+            set_jit_fusion_options=Mock(),
+            setup_data_iterators=Mock(return_value=(None, None, None)),
+            setup_logging=Mock(),
+            setup_optimizer=Mock(return_value=(optimizer, scheduler)),
+            start_memory_history_recording=Mock(),
+        ),
+        patch.object(torch, "tensor", return_value=start_time_tensor),
+        patch.object(torch.distributed, "all_reduce"),
+    ):
+        training_setup.setup(state, Mock())
+    return optimizer, pg_collection
+
+
+@pytest.mark.parametrize("kind", ["copied_omni", "gpt_provider", "hybrid_provider", "gpt_builder", "hybrid_builder"])
+@pytest.mark.parametrize("chunk_count", [1, 2])
+@pytest.mark.parametrize("overlap", [False, True])
+def test_setup_installs_callbacks_on_scheduler_config(kind: str, chunk_count: int, overlap: bool) -> None:
+    provider, runtime = _make_configs(kind)
+    # The second chunk may have an independent config; the interleaved scheduler
+    # reads its callback lists from the first chunk's config.
+    chunks = [FakeDDP(runtime)]
+    if chunk_count == 2:
+        chunks.append(FakeDDP(TransformerConfig(num_layers=1, hidden_size=8, num_attention_heads=2)))
+    ddp_config = SimpleNamespace(overlap_grad_reduce=overlap, overlap_param_gather=overlap, align_param_gather=True)
+    optimizer, pg_collection = _run_setup(provider, chunks, ddp_config)
+
+    config = get_model_config(chunks[0])
+    assert config.finalize_model_grads_func is not None
+    assert config.finalize_model_grads_func.func is training_setup.finalize_model_grads
+    assert config.finalize_model_grads_func.keywords["pg_collection"] is pg_collection
+    assert config.grad_scale_func == optimizer.scale_loss
+    for name, method in (
+        ("no_sync_func", "no_sync"),
+        ("grad_sync_func", "start_grad_sync"),
+        ("param_sync_func", "start_param_sync"),
+    ):
+        callbacks = [getattr(chunk, method) for chunk in chunks]
+        expected = (callbacks[0] if chunk_count == 1 else callbacks) if overlap else None
+        assert getattr(config, name) == expected
+    if kind == "copied_omni":
+        assert config is not provider
+        assert provider.finalize_model_grads_func is None
+        assert provider.no_sync_func is None
+
+
+@pytest.mark.parametrize("copied", [False, True])
+def test_restart_binds_callbacks_to_rebuilt_model(copied: bool) -> None:
+    kind = "copied_omni" if copied else "gpt_provider"
+    provider, runtime = _make_configs(kind)
+    ddp_config = SimpleNamespace(overlap_grad_reduce=True, overlap_param_gather=True, align_param_gather=True)
+    first = FakeDDP(runtime)
+    first_optimizer, _ = _run_setup(provider, [first], ddp_config)
+    state = GlobalState()
+    state._cfg = SimpleNamespace(model=provider)
+    state.reset_for_restart()
+    rebuilt_config = provider._copy_config_without_runtime_process_groups(deep=True) if copied else provider
+    rebuilt = FakeDDP(rebuilt_config)
+    rebuilt_optimizer, _ = _run_setup(provider, [rebuilt], ddp_config)
+    assert rebuilt_config.no_sync_func is rebuilt.no_sync
+    assert rebuilt_config.grad_sync_func is rebuilt.start_grad_sync
+    assert rebuilt_config.param_sync_func is rebuilt.start_param_sync
+    assert rebuilt_config.grad_scale_func == rebuilt_optimizer.scale_loss
+    assert rebuilt_config.grad_scale_func != first_optimizer.scale_loss
+
+
+@pytest.mark.parametrize("forward_only", [False, True])
+@pytest.mark.parametrize("microbatches", [1, 3])
+def test_scheduler_finalizes_once_after_setup(forward_only: bool, microbatches: int) -> None:
+    provider, runtime = _make_configs("copied_omni")
+    model = FakeDDP(runtime)
+    ddp_config = SimpleNamespace(overlap_grad_reduce=False, overlap_param_gather=False)
+    finalizer = Mock()
+    with patch.object(training_setup, "finalize_model_grads", finalizer):
+        _, pg_collection = _run_setup(provider, [model], ddp_config)
+    runtime.timers = None
+    with (
+        patch.object(schedules.torch, "zeros", return_value=torch.tensor(0)),
+        patch.object(schedules, "forward_step", return_value=(None, 0)),
+        patch.object(schedules, "backward_step") as backward,
+    ):
+        schedules.forward_backward_no_pipelining(
+            forward_step_func=Mock(),
+            data_iterator=iter(()),
+            model=[model],
+            num_microbatches=microbatches,
+            seq_length=1,
+            micro_batch_size=1,
+            forward_only=forward_only,
+            pg_collection=pg_collection,
+        )
+    assert finalizer.call_count == int(not forward_only)
+    assert backward.call_count == (0 if forward_only else microbatches)

--- a/tests/unit_tests/training/test_runtime_callbacks.py
+++ b/tests/unit_tests/training/test_runtime_callbacks.py
@@ -12,6 +12,7 @@ from megatron.core.utils import get_model_config
 
 import megatron.bridge.training.setup as training_setup
 from megatron.bridge.models.gpt.gpt_builder import GPTModelConfig
+from megatron.bridge.models.gpt.model_config import BridgeGPTModelConfig
 from megatron.bridge.models.gpt_provider import GPTModelProvider
 from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
@@ -33,7 +34,10 @@ class FakeDDP:
 
 def _make_configs(
     kind: str,
-) -> tuple[GPTModelProvider | HybridModelProvider | GPTModelConfig | HybridModelConfig, TransformerConfig]:
+) -> tuple[
+    GPTModelProvider | HybridModelProvider | BridgeGPTModelConfig | HybridModelConfig,
+    TransformerConfig,
+]:
     dimensions = dict(num_layers=1, hidden_size=8, num_attention_heads=2)
     if kind == "copied_omni":
         provider = NemotronOmniModelProvider(**dimensions)
@@ -42,14 +46,16 @@ def _make_configs(
         provider = (GPTModelProvider if kind == "gpt_provider" else HybridModelProvider)(**dimensions)
         return provider, provider
     runtime = TransformerConfig(**dimensions)
-    builder = GPTModelConfig if kind == "gpt_builder" else HybridModelConfig
-    return builder(transformer=runtime, vocab_size=32), runtime
+    model_config = BridgeGPTModelConfig if kind == "gpt_builder" else HybridModelConfig
+    return model_config(transformer=runtime, vocab_size=32), runtime
 
 
 def _run_setup(
-    provider: GPTModelProvider | HybridModelProvider | GPTModelConfig | HybridModelConfig,
+    provider: GPTModelProvider | HybridModelProvider | BridgeGPTModelConfig | HybridModelConfig,
     model: list[FakeDDP],
     ddp_config: SimpleNamespace,
+    *,
+    build_model: bool = False,
 ) -> tuple[MagicMock, SimpleNamespace]:
     """Exercise the real setup call and installer without constructing a training job."""
     cfg = SimpleNamespace(
@@ -70,6 +76,7 @@ def _run_setup(
             enable_megatron_core_experimental=False,
             use_decentralized_pg=False,
             use_gloo_process_groups=False,
+            use_megatron_fsdp=False,
             use_torch_fsdp2=False,
         ),
         ft=None,
@@ -118,34 +125,63 @@ def _run_setup(
     pg_collection.tp = SimpleNamespace(size=lambda: 1)
     start_time_tensor = Mock()
     start_time_tensor.item.return_value = 0.0
+    setup_patches = {
+        "DistributedDataParallel": FakeDDP,
+        "_should_load_checkpoint": Mock(return_value=False),
+        "_validate_and_set_vocab_size": Mock(return_value=(32, False)),
+        "barrier_and_log": Mock(),
+        "build_tokenizer": Mock(return_value=SimpleNamespace(vocab_size=32)),
+        "classify_gtp_remat_chains": Mock(),
+        "configure_gtp_remat": Mock(),
+        "create_checkpoint_manager": Mock(return_value=checkpoint_manager),
+        "finalize_tensor_inspect_post_model_initialization": Mock(),
+        "initialize_megatron": Mock(return_value=pg_collection),
+        "initialize_tensor_inspect_pre_model_initialization": Mock(),
+        "maybe_load_dataloader_state": Mock(),
+        "maybe_log_and_save_config": Mock(),
+        "print_rank_0": Mock(),
+        "set_experimental_flag": Mock(),
+        "set_jit_fusion_options": Mock(),
+        "setup_data_iterators": Mock(return_value=(None, None, None)),
+        "setup_logging": Mock(),
+        "setup_optimizer": Mock(return_value=(optimizer, scheduler)),
+        "start_memory_history_recording": Mock(),
+    }
+    if not build_model:
+        setup_patches["_build_distributed_model"] = Mock(return_value=model)
     with (
         patch.multiple(
             training_setup,
-            DistributedDataParallel=FakeDDP,
-            _build_distributed_model=Mock(return_value=model),
-            _should_load_checkpoint=Mock(return_value=False),
-            _validate_and_set_vocab_size=Mock(return_value=(32, False)),
-            barrier_and_log=Mock(),
-            build_tokenizer=Mock(return_value=SimpleNamespace(vocab_size=32)),
-            create_checkpoint_manager=Mock(return_value=checkpoint_manager),
-            finalize_tensor_inspect_post_model_initialization=Mock(),
-            initialize_megatron=Mock(return_value=pg_collection),
-            initialize_tensor_inspect_pre_model_initialization=Mock(),
-            maybe_load_dataloader_state=Mock(),
-            maybe_log_and_save_config=Mock(),
-            print_rank_0=Mock(),
-            set_experimental_flag=Mock(),
-            set_jit_fusion_options=Mock(),
-            setup_data_iterators=Mock(return_value=(None, None, None)),
-            setup_logging=Mock(),
-            setup_optimizer=Mock(return_value=(optimizer, scheduler)),
-            start_memory_history_recording=Mock(),
+            **setup_patches,
         ),
         patch.object(torch, "tensor", return_value=start_time_tensor),
         patch.object(torch.distributed, "all_reduce"),
     ):
         training_setup.setup(state, Mock())
     return optimizer, pg_collection
+
+
+@pytest.mark.parametrize("kind", ["gpt_builder", "hybrid_builder"])
+def test_setup_builds_model_config_and_binds_its_runtime_config(kind: str) -> None:
+    """Cover the ModelConfig builder branch instead of supplying a prebuilt model."""
+    model_config, runtime = _make_configs(kind)
+    model = [FakeDDP(runtime)]
+
+    class RecordingBuilder:
+        def __init__(self, config: GPTModelConfig | HybridModelConfig) -> None:
+            assert config is model_config
+
+        def build_distributed_models(self, **kwargs) -> list[FakeDDP]:
+            assert kwargs["pg_collection"] is not None
+            return model
+
+    ddp_config = SimpleNamespace(overlap_grad_reduce=False, overlap_param_gather=False)
+    with patch.object(type(model_config), "get_builder_cls", return_value=RecordingBuilder):
+        optimizer, _ = _run_setup(model_config, model, ddp_config, build_model=True)
+
+    assert get_model_config(model[0]) is runtime
+    assert runtime.finalize_model_grads_func is not None
+    assert runtime.grad_scale_func == optimizer.scale_loss
 
 
 @pytest.mark.parametrize("kind", ["copied_omni", "gpt_provider", "hybrid_provider", "gpt_builder", "hybrid_builder"])

--- a/tests/unit_tests/training/test_runtime_callbacks.py
+++ b/tests/unit_tests/training/test_runtime_callbacks.py
@@ -18,7 +18,6 @@ from megatron.bridge.models.hybrid.hybrid_builder import HybridModelConfig
 from megatron.bridge.models.hybrid.hybrid_provider import HybridModelProvider
 from megatron.bridge.models.nemotron_omni.nemotron_omni_provider import NemotronOmniModelProvider
 from megatron.bridge.models.transformer_config import TransformerConfig
-from megatron.bridge.training.state import GlobalState
 
 
 pytestmark = pytest.mark.unit
@@ -69,7 +68,7 @@ def _run_setup(
             save=None,
         ),
         dataset=SimpleNamespace(),
-        ddp=SimpleNamespace(),
+        ddp=ddp_config,
         dist=SimpleNamespace(
             align_grad_reduce=True,
             disable_jit_fuser=False,
@@ -87,12 +86,7 @@ def _run_setup(
             modules_to_filter=[],
             set_level_for_all_loggers=False,
         ),
-        model=SimpleNamespace(
-            fine_grained_activation_offloading=False,
-            restore_modelopt_state=False,
-            should_pad_vocab=False,
-            vocab_size=32,
-        ),
+        model=provider,
         optimizer=SimpleNamespace(overlap_param_gather_with_optimizer_step=False),
         optimizer_config_override_provider=None,
         peft=None,
@@ -115,14 +109,12 @@ def _run_setup(
         train_state=SimpleNamespace(step=1),
         wandb_logger=None,
     )
-    pg_collection = SimpleNamespace(dp=object())
+    pg_collection = SimpleNamespace(
+        dp=object(), cp=SimpleNamespace(size=lambda: 1), tp=SimpleNamespace(size=lambda: 1)
+    )
     checkpoint_manager = MagicMock(checkpointing_context={})
     optimizer = MagicMock()
     scheduler = MagicMock()
-    cfg.model = provider
-    cfg.ddp = ddp_config
-    pg_collection.cp = SimpleNamespace(size=lambda: 1)
-    pg_collection.tp = SimpleNamespace(size=lambda: 1)
     start_time_tensor = Mock()
     start_time_tensor.item.return_value = 0.0
     setup_patches = {
@@ -171,7 +163,7 @@ def test_setup_builds_model_config_and_binds_its_runtime_config(kind: str) -> No
         def __init__(self, config: GPTModelConfig | HybridModelConfig) -> None:
             assert config is model_config
 
-        def build_distributed_models(self, **kwargs) -> list[FakeDDP]:
+        def build_distributed_models(self, **kwargs: object) -> list[FakeDDP]:
             assert kwargs["pg_collection"] is not None
             return model
 
@@ -184,9 +176,16 @@ def test_setup_builds_model_config_and_binds_its_runtime_config(kind: str) -> No
     assert runtime.grad_scale_func == optimizer.scale_loss
 
 
-@pytest.mark.parametrize("kind", ["copied_omni", "gpt_provider", "hybrid_provider", "gpt_builder", "hybrid_builder"])
-@pytest.mark.parametrize("chunk_count", [1, 2])
-@pytest.mark.parametrize("overlap", [False, True])
+@pytest.mark.parametrize(
+    ("kind", "chunk_count", "overlap"),
+    [
+        ("copied_omni", 1, False),
+        ("gpt_provider", 1, False),
+        ("hybrid_provider", 1, False),
+        # One representative case covers callback lists and overlap binding.
+        ("copied_omni", 2, True),
+    ],
+)
 def test_setup_installs_callbacks_on_scheduler_config(kind: str, chunk_count: int, overlap: bool) -> None:
     provider, runtime = _make_configs(kind)
     # The second chunk may have an independent config; the interleaved scheduler
@@ -216,29 +215,8 @@ def test_setup_installs_callbacks_on_scheduler_config(kind: str, chunk_count: in
         assert provider.no_sync_func is None
 
 
-@pytest.mark.parametrize("copied", [False, True])
-def test_restart_binds_callbacks_to_rebuilt_model(copied: bool) -> None:
-    kind = "copied_omni" if copied else "gpt_provider"
-    provider, runtime = _make_configs(kind)
-    ddp_config = SimpleNamespace(overlap_grad_reduce=True, overlap_param_gather=True, align_param_gather=True)
-    first = FakeDDP(runtime)
-    first_optimizer, _ = _run_setup(provider, [first], ddp_config)
-    state = GlobalState()
-    state._cfg = SimpleNamespace(model=provider)
-    state.reset_for_restart()
-    rebuilt_config = provider._copy_config_without_runtime_process_groups(deep=True) if copied else provider
-    rebuilt = FakeDDP(rebuilt_config)
-    rebuilt_optimizer, _ = _run_setup(provider, [rebuilt], ddp_config)
-    assert rebuilt_config.no_sync_func is rebuilt.no_sync
-    assert rebuilt_config.grad_sync_func is rebuilt.start_grad_sync
-    assert rebuilt_config.param_sync_func is rebuilt.start_param_sync
-    assert rebuilt_config.grad_scale_func == rebuilt_optimizer.scale_loss
-    assert rebuilt_config.grad_scale_func != first_optimizer.scale_loss
-
-
 @pytest.mark.parametrize("forward_only", [False, True])
-@pytest.mark.parametrize("microbatches", [1, 3])
-def test_scheduler_finalizes_once_after_setup(forward_only: bool, microbatches: int) -> None:
+def test_scheduler_finalizes_once_after_setup(forward_only: bool) -> None:
     provider, runtime = _make_configs("copied_omni")
     model = FakeDDP(runtime)
     ddp_config = SimpleNamespace(overlap_grad_reduce=False, overlap_param_gather=False)
@@ -255,11 +233,14 @@ def test_scheduler_finalizes_once_after_setup(forward_only: bool, microbatches: 
             forward_step_func=Mock(),
             data_iterator=iter(()),
             model=[model],
-            num_microbatches=microbatches,
+            num_microbatches=3,
             seq_length=1,
             micro_batch_size=1,
             forward_only=forward_only,
             pg_collection=pg_collection,
         )
-    assert finalizer.call_count == int(not forward_only)
-    assert backward.call_count == (0 if forward_only else microbatches)
+    if forward_only:
+        finalizer.assert_not_called()
+    else:
+        finalizer.assert_called_once_with([model], None, pg_collection=pg_collection, force_all_reduce=False)
+    assert backward.call_count == (0 if forward_only else 3)


### PR DESCRIPTION
# What does this PR do?

Install training callbacks on the configuration consumed by Megatron's scheduler. This fixes a silent gradient-synchronization failure when a provider, such as canonical Nemotron Omni, copies its configuration while constructing the model.

## Why the existing binding is incorrect

`setup()` currently passes the provider configuration (or the GPT/Hybrid builder's transformer configuration) to `_update_model_config_funcs()`. This assumes that the selected object is also the runtime model configuration.

Canonical Omni breaks that identity assumption:

1. The provider copies its configuration into `language_cfg` and passes it to the canonical model.
2. The model constructor stores that copy as `model.config`.
3. After building the model and optimizer, Bridge installs `finalize_model_grads_func`, `grad_scale_func`, and applicable synchronization callbacks on the original provider.
4. Megatron reads `get_model_config(model)`. Its finalization callback is still `None`, so the conditional scheduler call is skipped.

Conceptually, the existing path does this:

```python
runtime_config = deepcopy(provider_config)
model.config = runtime_config
install_callbacks(provider_config)
# provider_config.finalize_model_grads_func is set
# model.config.finalize_model_grads_func is still None
```

This PR obtains the callback target from `get_model_config(model[0])`, matching the scheduler's lookup. The existing installer continues to construct the callbacks and per-chunk callback lists. The reduction algorithms and normalization settings are unchanged.

## Training consequence—and why a run can look healthy

In the reproduced PP=1 configuration with `overlap_grad_reduce=False`, gradient finalization completes the required DP/CP reductions and applicable TP reductions for replicated parameters. The distributed optimizer assumes those operations have completed before it consumes its owned gradient slices. Without them, a shard can update from its owner's local contribution instead of the intended combined gradient.

A small example uses 512 zero-initialized parameters and fresh distributed Adam state. Every parameter receives a local contribution of `+1` on DP rank 0 and `-3` on DP rank 1. Rank 0 owns the first half of the optimizer update; rank 1 owns the second half.

| Case | Existing binding | Corrected binding |
|---|---|---|
| DP=2, TP=1; contributions `+1`, `-3` | Owned gradients remain `+1` and `-3`; 256 parameters decrease and 256 increase | The combined gradient is negative; all 512 parameters increase |
| TP=2, DP=1; replicated parameter contributions `+1`, `-1` | TP replicas update in opposite directions | Contributions cancel; all parameters remain zero |

Parameter all-gather can still give DP replicas identical final weights after the incorrect updates. It assembles the already-updated parameter shards; it does not combine the gradients or recompute the optimizer updates. Every replica therefore receives the same mixture of shard updates based on different ranks' local gradients. Backward also continues to produce nonzero gradients with useful learning signal. Consequently, matching DP weights, stable losses, or successful training completion do not establish that synchronization was correct.

This is a training-correctness finding. It does **not** establish that existing trained models are unusable, quantify model-quality degradation, or demonstrate a full-model TMPE improvement. Affected historical runs require their exact provider, entrypoint, runtime configuration, and overlap settings to be checked. This patch does not repair prior optimizer history or prescribe a checkpoint reset.

# Changelog

- Resolve the runtime configuration from the constructed model when installing training callbacks.
- Add regression coverage through the real `setup()` call and callback installer, with model construction and external services mocked.
- Cover copied Omni configurations and ordinary GPT/Hybrid providers, retain the GPT/Hybrid ModelConfig tests that traverse the actual builder dispatch, and include one representative two-chunk case for overlapped callback installation.
- Exercise the actual PP=1 scheduler with three microbatches: assert exactly one finalizer call with the correct model and process groups during training, and none during forward-only inference.

# Validation

Validation base: Bridge `2eae3c971dd6971beb403e6536987427b7e8a3b2`, with its pinned MCore `c9b53d0a87cb926f47115259593ecfeb351ca29f`.

- **Before/after regression:** running all eight new cases against unpatched `setup.py` produces three expected failures and five passes. Both copied-Omni binding cases fail because `config.finalize_model_grads_func` is `None`; the training scheduler case fails because the finalizer is called zero times. All eight pass with the fix.
- **Targeted unit tests:** **46 passed, 0 failed, 0 skipped.** This includes the eight new callback cases, existing setup and setup-restart-hook tests, and the four state-reset tests.
- **Two-GPU numerical validation: all eight cases passed for the unchanged production fix.** Tested existing/corrected bindings, DP=2 or TP=2, and both two-item/three-item loss contracts with actual Megatron DDP, scheduler, gradient finalization, and precision-aware distributed Adam (PyTorch 2.11.0+cu130).
- **Lint/format:** all repository pre-commit hooks passed; `git diff --check` passed.
- **Static typing limitation:** strict mypy was attempted in the lightweight local check environment, but did not pass because runtime imports were unavailable and the existing source reports typing errors. This is not a clean mypy result.

The eight new unit-test cases check callback binding and scheduler invocation. The GPT/Hybrid ModelConfig cases traverse the real `_build_distributed_model()` dispatch with a lightweight recording builder; other model construction is mocked. The scheduler test also mocks forward/backward computation and the finalizer itself. Numerical gradient correctness is covered by the separate two-GPU experiment described above, not by these unit tests.

The targeted test commands, in an environment with Bridge and its pinned MCore installed, are:

```bash
uv run python -m pytest tests/unit_tests/training/test_runtime_callbacks.py \
  tests/unit_tests/training/test_setup.py \
  tests/unit_tests/training/test_setup_restart_hooks.py -q
uv run python -m pytest tests/unit_tests/training/test_state.py -k reset_for_restart -q
```

To reproduce the original failure, run the new test file against unpatched `setup.py`:

```bash
uv run python -m pytest tests/unit_tests/training/test_runtime_callbacks.py \
  -q
```

The numerical check distinguishes both loss contracts: the two-item, already-normalized loss used by GRPO requires the sum `-2`; the three-item loss with two global tokens produces `-1`. The corrected binding preserves both contracts. Numerical topology coverage is PP=1, CP=1, with DP and TP tested separately. Callback-list tests cover multiple chunks and overlap wiring; they are not a claim of full distributed PP>1, CP>1, or FSDP qualification.

# GitHub Actions CI

The new regression tests live under `tests/unit_tests/training/`. Repository CI remains the merge gate; the standalone numerical experiment is additional validation, not a new CI job in this PR.

# Before your PR is "Ready for review"

- [x] Read and followed the contributor guidelines.
- [x] Added necessary regression tests.
- [x] Explained the behavioral change, impact, and validation limits above; no user-facing configuration change requires separate documentation.
- [x] No new dependency or optional-library requirement.

# Additional information

Related history: #4974 (July 23) explicitly preserved the provider configuration in the legacy Omni wrapper. #4885 (July 29 Pacific / July 30 UTC) introduced the canonical path using a copied runtime configuration and also removed the legacy wrapper's explicit `config=self`. This identifies a recurrence in that rewrite relative to its parent; it is not a claim that July was the first-ever occurrence or that every subsequent training run was affected.
