### PR TITLE
feat(peft): seed multi-LoRA slot re-initialization in init_adapter_slot

### DIFF
--- a/src/megatron/bridge/peft/multi_lora_layers.py
+++ b/src/megatron/bridge/peft/multi_lora_layers.py
@@ -926,17 +926,43 @@ def install_moe_slot_routing(model) -> int:
     return installed
 
 
-def init_adapter_slot(model, idx: int, rank: int, alpha: float) -> None:
+def init_adapter_slot(model, idx: int, rank: int, alpha: float, seed: int | None = None) -> None:
     """Claim slot ``idx`` across every multi-LoRA layer for an adapter.
 
     A model-wide adapter is the set of slot-``idx`` chunks across all layers;
     this initialises that set with the given ``rank``/``alpha``. Thin iterator
     over the model — per-slot setup (rank/alpha bookkeeping + rank-mask
     invariant) lives on the layer itself in
-    :meth:`MultiLoRALinear.init_adapter_slot` /
+    :meth:`MultiLoRALinear.init_adapter_slot`.
+
+    Without ``seed`` the slot keeps whatever weights construction or the last
+    :func:`clear_adapter_slot` re-init left behind (DP-consistent but not
+    reproducible). With ``seed`` every layer's slot weights are re-initialised
+    deterministically first: the RNG-tracker streams are reseeded from ``seed``
+    for the duration and restored afterwards, so a given seed reproduces the
+    same adapter weights on every rank and every run (layers draw sequentially
+    from the reseeded streams).
     """
-    for module in _iter_multi_lora_modules(model):
-        module.init_adapter_slot(idx, rank, alpha)
+    if seed is None:
+        for module in _iter_multi_lora_modules(model):
+            module.init_adapter_slot(idx, rank, alpha)
+        return
+
+    from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
+
+    tracker = get_cuda_rng_tracker()
+    saved_states = tracker.get_states()
+    # Rebuild each stream from the seed through tracker.add, which mints the
+    # tracker's native state representation (byte tensor or graph-safe generator).
+    tracker.reset()
+    for offset, name in enumerate(sorted(saved_states)):
+        tracker.add(name, seed + offset + 1)
+    try:
+        for module in _iter_multi_lora_modules(model):
+            module.reset_adapter(idx)
+            module.init_adapter_slot(idx, rank, alpha)
+    finally:
+        tracker.set_states(saved_states)
 
 
 def clear_adapter_slot(model, idx: int) -> None:

--- a/tests/unit_tests/peft/test_multi_lora_layers.py
+++ b/tests/unit_tests/peft/test_multi_lora_layers.py
@@ -148,6 +148,7 @@ def adapter_deps_patch() -> ExitStack:
     # has no initialized CUDA state on CPU; stub ``fork()`` to a no-op context.
     tracker = MagicMock()
     tracker.fork.side_effect = lambda *args, **kwargs: nullcontext()
+    tracker.get_states.return_value = {}
     stack.enter_context(patch("megatron.core.tensor_parallel.random.get_cuda_rng_tracker", return_value=tracker))
     return stack
 
@@ -522,6 +523,34 @@ class TestMultiLoRAModelHelpers:
         found = list(_iter_multi_lora_modules(chunks))
 
         assert len(found) == 3
+
+    def test_init_adapter_slot_unseeded_keeps_slot_weights(self) -> None:
+        container = _MultiLoRAContainer(n_layers=2)
+        for module in container.mods:
+            with torch.no_grad():
+                module.adapters[0].linear_in.weight.fill_(7.0)
+
+        init_adapter_slot(container, 0, rank=8, alpha=16)
+
+        for module in container.mods:
+            assert torch.all(module.adapters[0].linear_in.weight == 7.0)
+            assert module.alpha_values[0] == 16
+
+    def test_init_adapter_slot_seeded_reinitializes_every_layer(self) -> None:
+        container = _MultiLoRAContainer(n_layers=2)
+        for module in container.mods:
+            with torch.no_grad():
+                module.adapters[0].linear_in.weight.fill_(7.0)
+                module.adapters[0].linear_out.weight.fill_(7.0)
+
+        init_adapter_slot(container, 0, rank=4, alpha=16, seed=123)
+
+        for module in container.mods:
+            # reset_adapter ran: A re-drawn (xavier, so not the fill value), B zero-initialized.
+            assert not torch.all(module.adapters[0].linear_in.weight == 7.0)
+            assert torch.count_nonzero(module.adapters[0].linear_out.weight) == 0
+            assert module.alpha_values[0] == 16
+            assert module.rank_values[0] == 4
 
     def test_set_tokens_per_adapter_slot(self) -> None:
         container = _MultiLoRAContainer(n_layers=2)
@@ -1003,6 +1032,28 @@ class TestMultiLoRALinearGPU:
         b = mlora.adapters[idx].linear_out.weight
         assert not torch.allclose(a, torch.full_like(a, 7.0))  # A re-initialized (xavier)
         assert torch.count_nonzero(b) == 0  # B zero-initialized
+
+    def test_init_adapter_slot_seeded_is_reproducible(self):
+        mlora = self._build()
+        init_adapter_slot([mlora], 0, rank=4, alpha=16, seed=99)
+        first = mlora.adapters[0].linear_in.weight.detach().clone()
+
+        # Perturb the weights and advance the tracker streams arbitrarily.
+        with torch.no_grad():
+            mlora.adapters[0].linear_in.weight.fill_(3.0)
+        mlora.clear_adapter_slot(0)
+
+        init_adapter_slot([mlora], 0, rank=4, alpha=16, seed=99)
+        assert torch.equal(mlora.adapters[0].linear_in.weight, first)
+
+        init_adapter_slot([mlora], 0, rank=4, alpha=16, seed=100)
+        assert not torch.equal(mlora.adapters[0].linear_in.weight, first)
+
+        # The tracker streams were restored: an unseeded re-init still works and differs per call.
+        mlora.clear_adapter_slot(0)
+        after_clear = mlora.adapters[0].linear_in.weight.detach().clone()
+        mlora.clear_adapter_slot(0)
+        assert not torch.equal(mlora.adapters[0].linear_in.weight, after_clear)
 
     def test_reset_adapter_deterministic_via_rng_tracker(self):
         from megatron.core.process_groups_config import ProcessGroupCollection


### PR DESCRIPTION
# What does this PR do ?

Adds an optional `seed` to the model-level `init_adapter_slot()` so a multi-LoRA adapter slot can be (re)initialised reproducibly across ranks and runs.

# Changelog

- `init_adapter_slot(model, idx, rank, alpha, seed=None)`: with `seed`, snapshot the CUDA RNG-tracker states, rebuild every stream from the seed via `tracker.add` (so byte-tensor and graph-safe generator states both work), call `reset_adapter(idx)` then `init_adapter_slot(idx, rank, alpha)` on every multi-LoRA layer in model order, and restore the saved states in a `finally`. Without `seed` behaviour is unchanged.
- Tests: CPU tests for the unseeded (weights kept) and seeded (every layer re-drawn, B zeroed) paths in `TestMultiLoRAModelHelpers`; a GPU test in `TestMultiLoRALinearGPU` that the same seed reproduces identical weights, a different seed does not, and the tracker streams are restored afterwards.

Motivation: in disaggregated multi-LoRA serving/training a slot is reused for many adapters. Today its weights come from construction or from the previous `clear_adapter_slot()` re-init, which is DP-consistent but not reproducible; RL pipelines that restart an adapter need a deterministic init.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) — no

# Additional Information

- Ported from radixark/Megatron-Bridge#34, where it has been in production use since 2026-08-30.
- Follow-up to #4218 / #5155 / #5156.

# Validation

- `tests/unit_tests/peft`: **446 passed, 7 skipped** (baseline 443). New tests PASSED by name: `TestMultiLoRAModelHelpers::test_init_adapter_slot_unseeded_keeps_slot_weights`, `TestMultiLoRAModelHelpers::test_init_adapter_slot_seeded_reinitializes_every_layer`, `TestMultiLoRALinearGPU::test_init_adapter_slot_seeded_is_reproducible` (GPU, NCCL + model-parallel init).
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. Baseline `upstream/main@2eae3c971` on the same box: `tests/unit_tests/peft` 443 passed / 7 skipped, the three model-bridge export files 181 passed, `test_qwen3_next_bridge.py` 23 passed. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.

# Revision 2 (review follow-up, 5c77076d6)

- Reseed through `model_parallel_cuda_manual_seed(seed + 100 * pp_rank)` instead of a rank-independent `seed + offset` per stream, so `model-parallel-rng` keeps `+2718+tp_rank`, `expert-parallel-rng` keeps `+1024+100*ep_rank+etp_rank` and `data-parallel-rng` stays equal across replicas; TP/EP/ETP shards draw distinct values while DP replicas match, exactly as the base weights do.
- `reset()` / `add()` moved inside the `try`; `finally` restores the tracker states and the default CUDA generator.
- New two-rank module `tests/unit_tests/peft/test_multi_lora_seeded_slot_distributed.py` (`torch.distributed.run --nproc_per_node=2`): TP=2 shards distinct and reproducible per rank, DP=2 identical, EP=2 expert stream distinct while the data-parallel stream matches. CPU tests stub the topology-aware reseed.
- Validation (2× RTX 4090, `nvcr.io/nvidia/pytorch:26.08-py3`, TE 2.18.0+27486e03, Megatron-Core at `.main.commit`): fail-before with the previous `multi_lora_layers.py` → `2 failed, 1 passed` on the new module (TP=2 shards collapse); pass-after → `3 passed` on both ranks; `tests/unit_tests/peft` single-process 446 passed / 10 skipped with no new failures against `main` (443 / 7); the three seeded tests PASSED by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
