### PR TITLE
fix(peft): derive multi-LoRA slot buffers without a wrapped weight

### DIFF
--- a/src/megatron/bridge/peft/multi_lora_layers.py
+++ b/src/megatron/bridge/peft/multi_lora_layers.py
@@ -212,8 +212,18 @@ class MultiLoRALinear(AdapterWrapper):
         # forward never synchronizes each layer to recover split sizes.
         self.tokens_per_adapter_splits: Optional[Tuple[int, ...]] = None
         self.tokens_per_adapter_total: Optional[int] = None
-        device = next(to_wrap.parameters()).device
-        dtype = next(to_wrap.parameters()).dtype
+        # A tied output layer (``skip_weight_param_allocation=True``) owns no
+        # weight -- it forwards the shared embedding weight per call -- so there
+        # is no parameter to read device/dtype from; fall back to the wrapped
+        # module's model-parallel config.
+        reference = next(to_wrap.parameters(), None)
+        if reference is not None:
+            device, dtype = reference.device, reference.dtype
+        else:
+            dtype = to_wrap.config.params_dtype
+            device = (
+                torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+            )
         # Non-persistent: slot lifecycle is externally managed, not checkpointed.
         self.register_buffer("alpha_values", torch.ones(n_adapters, dtype=dtype, device=device), persistent=False)
         self.register_buffer(

--- a/tests/unit_tests/peft/test_multi_lora_layers.py
+++ b/tests/unit_tests/peft/test_multi_lora_layers.py
@@ -40,6 +40,7 @@ Single-GPU integration (needs CUDA + model-parallel init):
 
 import os
 from contextlib import ExitStack, nullcontext
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -293,6 +294,19 @@ class TestMultiLoRALinearSlots:
         assert layer.tokens_per_adapter_splits is None
         assert torch.equal(layer.alpha_values, torch.ones(3))
         assert torch.equal(layer.rank_values, torch.full((3,), 8.0))
+
+    def test_constructor_without_wrapped_parameters_uses_config_dtype(self) -> None:
+        """A tied output layer owns no weight; slot buffers fall back to the config dtype."""
+        base = nn.Module()
+        base.in_features, base.out_features = 16, 32
+        base.config = SimpleNamespace(params_dtype=torch.bfloat16)
+        assert next(base.parameters(), None) is None
+
+        layer = MultiLoRALinear(to_wrap=base, n_adapters=2, dim=8, alpha=16, full_name="output_layer")
+
+        assert layer.alpha_values.dtype == torch.bfloat16
+        assert layer.rank_values.dtype == torch.bfloat16
+        assert layer.alpha_values.device.type == ("cuda" if torch.cuda.is_available() else "cpu")
 
     def test_constructor_forwards_wrapped_module_runtime_config(self) -> None:
         """Adapter construction mirrors the single-LoRA path (LoRA.transform)."""


### PR DESCRIPTION
# What does this PR do ?

Lets `MultiLoRALinear` wrap a linear that owns no parameter (a tied output layer built with `skip_weight_param_allocation=True`) instead of raising `StopIteration` while deriving its slot buffers.

# Changelog

- `MultiLoRALinear.__init__`: place `alpha_values` / `rank_values` on the device of the adapter parameters constructed just above, so they follow the active construction context (`use_cpu_initialization` with a visible GPU, a `torch.device("meta")` build, or the accelerator) and no longer raise `StopIteration` for a tied output layer that owns no weight. The dtype stays the compute dtype: the wrapped weight's when there is one, else `to_wrap.config.params_dtype` (the adapters may still be fp32 at this point and the scaling must not promote the activation dtype).
- Tests: parameter-less wrapped module → buffers share the adapters' device and take `config.params_dtype`; construction under `torch.device("meta")` keeps the buffers on `meta`; a real `ColumnParallelLinear(skip_weight_param_allocation=True)` built with `use_cpu_initialization=True` on a GPU box keeps adapters and buffers on CPU.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? — no

# Additional Information

- Ported from radixark/Megatron-Bridge#38 (author: @yueming-yuan).
- Follow-up to #4218.

# Validation

- Revision 1 (589253d73): `tests/unit_tests/peft`: **444 passed, 7 skipped** (baseline 443). New test PASSED: `TestMultiLoRALinearSlots::test_constructor_without_wrapped_parameters_uses_config_dtype`.
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. Baseline `upstream/main@2eae3c971` on the same box: `tests/unit_tests/peft` 443 passed / 7 skipped, the three model-bridge export files 181 passed, `test_qwen3_next_bridge.py` 23 passed. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.

## Revision 2 (review: buffers must follow the construction device, not CUDA availability)

- Device now comes from `next(self.adapters.parameters()).device`; dtype unchanged (wrapped weight, else `params_dtype`).
- New tests: `TestMultiLoRALinearSlots::test_constructor_without_wrapped_parameters_respects_meta_device` and `TestMultiLoRALinearGPU::test_buffers_follow_cpu_initialization_with_cuda_visible`; the existing config-dtype test now also asserts the buffers sit on the adapters' device.
- Verified on 2× RTX 4090 (`nvcr.io/nvidia/pytorch:26.08-py3`, TE 2.18.0+27486e03, Megatron-Core `c9b53d0a8`): fail-before with revision 1's `multi_lora_layers.py` + these tests → `3 failed` (`assert 'cuda' == 'cpu'` ×2, `assert 'cuda' == 'meta'`); pass-after → `3 passed`; full `tests/unit_tests/peft` → **446 passed, 7 skipped** (baseline `upstream/main` 443 passed / 7 skipped, no new failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
