### PR TITLE
fix(peft): supply ROCm Transformer Engine grouped-linear fields

### DIFF
--- a/src/megatron/bridge/peft/utils.py
+++ b/src/megatron/bridge/peft/utils.py
@@ -2242,6 +2242,12 @@ class GroupedExpertLinearAdapter(nn.Module):
                     "skip_fp8_weight_update": None,
                     "save_original_input": helper.save_original_input,
                     "debug": False,
+                    # ROCm Transformer Engine unpacks these extra optional fields from
+                    # ``non_tensor_args``; CUDA builds never name them, so the entries
+                    # stay inert there (the tuple is assembled from TE's own field names).
+                    "m_splits_tensor": None,
+                    "actual_m_splits": None,
+                    "unpad_output": False,
                 }
                 unknown_arg_names = set(non_tensor_arg_names) - te_non_tensor_values.keys()
                 if unknown_arg_names:

--- a/tests/unit_tests/peft/test_utils.py
+++ b/tests/unit_tests/peft/test_utils.py
@@ -1953,6 +1953,97 @@ class TestGroupedExpertLinearAdapter:
         helper.prepare_forward.assert_called_once_with(x, num_gemms=3)
         helper.end_forward.assert_called_once_with()
 
+    def test_grouped_expert_linear_adapter_fp8_te_rocm_contract(self):
+        """FP8 dispatch should supply the extra non-tensor fields ROCm Transformer Engine unpacks."""
+        calls = []
+        expected = torch.randn(3, 2)
+
+        class TEROCmGroupedLinear:
+            @staticmethod
+            def apply(inp, non_tensor_args, *weights_and_biases):
+                calls.append((inp, non_tensor_args, weights_and_biases))
+                return expected
+
+            @staticmethod
+            def forward(ctx, inp, non_tensor_args, *weights_and_biases):
+                (
+                    m_splits,
+                    use_bias,
+                    is_first_microbatch,
+                    fp8,
+                    fp8_calibration,
+                    wgrad_store,
+                    input_quantizers,
+                    weight_quantizers,
+                    output_quantizers,
+                    grad_input_quantizers,
+                    grad_weight_quantizers,
+                    grad_output_quantizers,
+                    fuse_wgrad_accumulation,
+                    cpu_offloading,
+                    sequence_parallel,
+                    activation_dtype,
+                    is_grad_enabled,
+                    weight_workspaces,
+                    cache_weight,
+                    skip_fp8_weight_update,
+                    save_original_input,
+                    debug,
+                    m_splits_tensor,
+                    actual_m_splits,
+                    unpad_output,
+                ) = non_tensor_args
+                assert ctx is None
+                calls.append((inp, non_tensor_args, weights_and_biases))
+                return expected
+
+        helper = Mock()
+        helper.prepare_forward.side_effect = lambda inp, *, num_gemms: inp
+        helper._get_quantizers.return_value = tuple([None] * 3 for _ in range(6))
+        helper.apply_bias = False
+        helper.fp8 = True
+        helper.fp8_calibration = False
+        helper.wgrad_store = Mock()
+        helper.fuse_wgrad_accumulation = False
+        helper.sequence_parallel = False
+        helper.activation_dtype = torch.float32
+        helper.save_original_input = False
+
+        adapter = GroupedExpertLinearAdapter(
+            in_features=2,
+            out_features=2,
+            dim=2,
+            num_local_experts=3,
+            base_linear_name="decoder.layers.0.mlp.experts.linear_fc2",
+            activation="identity",
+            input_is_parallel=False,
+            model_parallel_config=MockModelParallelConfig(),
+        )
+        x = torch.randn(3, 2)
+        with (
+            torch.no_grad(),
+            patch.object(adapter, "_get_te_grouped_linear_helper", return_value=helper),
+            patch.object(peft_utils, "TEPytorchGroupedLinearAutograd", TEROCmGroupedLinear),
+            patch.object(peft_utils, "TEPytorchIsCPUOffloadEnabled", return_value=False),
+        ):
+            output = adapter._forward_te_grouped_linear_fp8(
+                x,
+                weight=adapter.linear_in([0, 1]),
+                m_splits=[1, 2],
+                projection="linear_in",
+                active_expert_indices=(0, 1),
+            )
+
+        torch.testing.assert_close(output, expected)
+        assert len(calls) == 1
+        _, non_tensor_args, weights_and_biases = calls[0]
+        assert len(non_tensor_args) == 25
+        assert non_tensor_args[0] == [1, 2]
+        # The three ROCm-only trailing fields take TE's public-wrapper defaults.
+        assert non_tensor_args[22:] == (None, None, False)
+        assert len(weights_and_biases) == 4
+        helper.end_forward.assert_called_once_with()
+
     def test_grouped_expert_linear_adapter_fp8_prefers_te_backend(self):
         """An active FP8 context should select TE instead of the public BF16 backend."""
         adapter = GroupedExpertLinearAdapter(


### PR DESCRIPTION
# What does this PR do ?

Makes the FP8 grouped-expert LoRA dispatch work with ROCm builds of Transformer Engine, whose private `_GroupedLinear` unpacks three extra optional fields from `non_tensor_args`.

# Changelog

- `GroupedExpertLinearAdapter._forward_te_grouped_linear_fp8`: add `m_splits_tensor=None`, `actual_m_splits=None`, `unpad_output=False` to `te_non_tensor_values`. The tuple is assembled from the field names parsed off the installed TE, so CUDA builds (which never name these fields) are unaffected; on ROCm the call no longer fails with "Unsupported Transformer Engine grouped-linear arguments".
- Test: a ROCm-shaped fake autograd function receives a 25-field tuple whose trailing three entries are `(None, None, False)`.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? — Transformer Engine only; the code path is already guarded by the existing `HAVE_TE_*` flags.

# Additional Information

- Ported from radixark/Megatron-Bridge#28 (author: @Arist12), where it was verified on MI300-class ROCm TE; upstream's tuple assembly was refactored since, so the change was re-applied by hand.

# Validation

- `tests/unit_tests/peft`: **444 passed, 7 skipped** (baseline 443). New test PASSED: `TestGroupedExpertLinearAdapter::test_grouped_expert_linear_adapter_fp8_te_rocm_contract`; the existing TE 2.14–2.18 contract tests still pass.
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. Baseline `upstream/main@2eae3c971` on the same box: `tests/unit_tests/peft` 443 passed / 7 skipped, the three model-bridge export files 181 passed, `test_qwen3_next_bridge.py` 23 passed. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
