### PR TITLE
fix(peft): reject unsupported lora_dtype in MultiLoRA

### DIFF
--- a/src/megatron/bridge/peft/multi_lora.py
+++ b/src/megatron/bridge/peft/multi_lora.py
@@ -95,6 +95,14 @@ class MultiLoRA(PEFT, ModuleMatcher):
                     f"MultiLoRA does not support {unsupported}=True; expert adapters use the "
                     f"per-expert layout at the same max rank as every other target module."
                 )
+        # Unlike single-LoRA, the grouped-GEMM path never casts adapter weights:
+        # the field is accepted for argument-surface parity but honoring it needs
+        # an explicit activation/weight-cast contract. Reject rather than ignore.
+        if self.lora_dtype is not None:
+            raise NotImplementedError(
+                f"MultiLoRA does not support lora_dtype={self.lora_dtype}; adapters run in the "
+                f"base model's dtype on the grouped-GEMM path."
+            )
 
         model = super().__call__(model, training=training)
         hooked = install_moe_slot_routing(model)

--- a/tests/unit_tests/peft/test_multi_lora.py
+++ b/tests/unit_tests/peft/test_multi_lora.py
@@ -338,6 +338,14 @@ class TestMultiLoRATransform:
         with pytest.raises(NotImplementedError, match=flag):
             peft(MoEModel(), training=True)
 
+    def test_lora_dtype_rejected(self) -> None:
+        # The field exists for argument-surface parity with single-LoRA but the
+        # grouped-GEMM path never honored it; silently ignoring it violates the
+        # class's own reject-don't-diverge policy.
+        peft = MultiLoRA(target_modules=["linear_fc1"], lora_dtype=torch.float32)
+        with pytest.raises(NotImplementedError, match="lora_dtype"):
+            peft(MoEModel(), training=True)
+
     def test_transform_skips_topk_router(self) -> None:
         router = _DummyTopKRouter()
         model = RouterModel(router)


### PR DESCRIPTION
# What does this PR do ?

Stops `MultiLoRA` from silently ignoring `lora_dtype`: a requested adapter dtype now raises `NotImplementedError` at build time.

# Changelog

- `MultiLoRA.__call__`: raise when `lora_dtype is not None`, alongside the existing checks for `normalize_moe_lora`, `share_expert_adapters` and `experts_shared_outer_loras`. The field is kept for argument-surface parity with single-LoRA, but neither `MultiLoRALinear` nor `MultiLoRAGroupedExpertLinear` ever consumed it, so adapters always ran in the base model's dtype.
- Test: `MultiLoRA(lora_dtype=torch.float32)` applied to a model raises with `lora_dtype` in the message.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? — no

# Additional Information

- Ported from radixark/Megatron-Bridge#26. If maintainers would rather implement `lora_dtype` for the fused path than reject it, happy to rework.

# Validation

- `tests/unit_tests/peft`: **444 passed, 7 skipped** (baseline 443). New test PASSED: `TestMultiLoRATransform::test_lora_dtype_rejected`.
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. Baseline `upstream/main@2eae3c971` on the same box: `tests/unit_tests/peft` 443 passed / 7 skipped, the three model-bridge export files 181 passed, `test_qwen3_next_bridge.py` 23 passed. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
