### PR TITLE
fix(peft): record base_linear_name on dense MultiLoRALinear

### DIFF
--- a/src/megatron/bridge/peft/multi_lora_layers.py
+++ b/src/megatron/bridge/peft/multi_lora_layers.py
@@ -151,6 +151,9 @@ class MultiLoRALinear(AdapterWrapper):
         self._adapter_enabled = True
         self.n_adapters = n_adapters
         self.max_rank = dim
+        # Read by forward's diagnostics (and by callers that route on the wrapped
+        # module's name), like MultiLoRAGroupedExpertLinear already does.
+        self.base_linear_name = full_name
         # Kept so a slot re-init (reset_adapter) mirrors the construction-time
         # init methods instead of hardcoding xavier/zero.
         self._column_init_method = column_init_method

--- a/tests/unit_tests/peft/test_multi_lora_layers.py
+++ b/tests/unit_tests/peft/test_multi_lora_layers.py
@@ -294,6 +294,13 @@ class TestMultiLoRALinearSlots:
         assert torch.equal(layer.alpha_values, torch.ones(3))
         assert torch.equal(layer.rank_values, torch.full((3,), 8.0))
 
+    def test_dense_layer_records_base_linear_name(self) -> None:
+        # forward's token-span guard formats this name in its diagnostic; only
+        # the MoE subclass assigned it, so the dense guard raised AttributeError
+        # instead of the intended RuntimeError.
+        layer = _build_multi_lora_linear(full_name="decoder.layers.0.mlp.linear_fc1")
+        assert layer.base_linear_name == "decoder.layers.0.mlp.linear_fc1"
+
     def test_constructor_forwards_wrapped_module_runtime_config(self) -> None:
         """Adapter construction mirrors the single-LoRA path (LoRA.transform)."""
         base = nn.Linear(16, 32)


### PR DESCRIPTION
# What does this PR do ?

Sets `base_linear_name` on the dense `MultiLoRALinear`, which its own forward diagnostics already read.

# Changelog

- `MultiLoRALinear.__init__`: assign `self.base_linear_name = full_name` (the grouped-expert subclass already did). Before, the sequence-parallel token-span guard in `forward` raised `AttributeError` instead of the intended `RuntimeError` naming the layer.
- Test: the dense layer records the wrapped module's full name.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? — no

# Additional Information

- Ported from radixark/Megatron-Bridge#26.

# Validation

- `tests/unit_tests/peft`: **444 passed, 7 skipped** (baseline 443). New test PASSED: `TestMultiLoRALinearSlots::test_dense_layer_records_base_linear_name`.
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. Baseline `upstream/main@2eae3c971` on the same box: `tests/unit_tests/peft` 443 passed / 7 skipped, the three model-bridge export files 181 passed, `test_qwen3_next_bridge.py` 23 passed. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
