### PR TITLE
fix(peft): validate tokens_per_adapter in set_tokens_per_adapter_slot

### DIFF
--- a/src/megatron/bridge/peft/multi_lora_layers.py
+++ b/src/megatron/bridge/peft/multi_lora_layers.py
@@ -712,11 +712,35 @@ def set_tokens_per_adapter_slot(model, tokens_per_adapter: torch.Tensor) -> None
     upcoming forward that belong to adapter slot ``i``. Must sum to the total
     token count of the micro-batch.
     """
+    if tokens_per_adapter.dim() != 1:
+        raise ValueError(
+            f"tokens_per_adapter must be a 1-D tensor of per-slot counts; got shape {tuple(tokens_per_adapter.shape)}"
+        )
+    if tokens_per_adapter.is_floating_point() or tokens_per_adapter.is_complex():
+        raise ValueError(f"tokens_per_adapter must be an integer tensor; got dtype {tokens_per_adapter.dtype}")
     # One host sync per micro-batch: cache immutable split sizes for every
     # layer's fallback and any sequence-parallel narrowing.
     token_splits = tuple(int(count) for count in tokens_per_adapter.tolist())
+    if any(count < 0 for count in token_splits):
+        raise ValueError(
+            f"tokens_per_adapter must be nonnegative (negative counts produce non-monotonic grouped-GEMM "
+            f"offsets); got {list(token_splits)}"
+        )
     total = sum(token_splits)
-    for module in _iter_multi_lora_modules(model):
+    modules = list(_iter_multi_lora_modules(model))
+    if modules:
+        n_adapters = modules[0].n_adapters
+        if len(token_splits) != n_adapters:
+            raise ValueError(
+                f"tokens_per_adapter has {len(token_splits)} entries but the model was built with "
+                f"n_adapters={n_adapters}"
+            )
+        # The dense grouped GEMM consumes the counts on the model's device; move them
+        # once here rather than per layer.
+        first_param = next(modules[0].parameters(), None)
+        if first_param is not None and tokens_per_adapter.device != first_param.device:
+            tokens_per_adapter = tokens_per_adapter.to(first_param.device)
+    for module in modules:
         module.tokens_per_adapter = tokens_per_adapter
         module.tokens_per_adapter_splits = token_splits
         module.tokens_per_adapter_total = total

--- a/tests/unit_tests/peft/test_multi_lora_layers.py
+++ b/tests/unit_tests/peft/test_multi_lora_layers.py
@@ -534,6 +534,20 @@ class TestMultiLoRAModelHelpers:
             assert module.tokens_per_adapter_splits == (3, 5)
             assert module.tokens_per_adapter_total == 8
 
+    def test_set_tokens_per_adapter_slot_validates_input(self) -> None:
+        # A wrong length silently mis-groups the grouped GEMM; negative counts
+        # produce non-monotonic (out-of-bounds) offsets; floats break the
+        # int32 cumsum contract -- all must fail loudly at the setter.
+        container = _MultiLoRAContainer(n_layers=1)
+        with pytest.raises(ValueError, match="1-D"):
+            set_tokens_per_adapter_slot(container, torch.tensor([[3, 5]], dtype=torch.int32))
+        with pytest.raises(ValueError, match="integer"):
+            set_tokens_per_adapter_slot(container, torch.tensor([3.0, 5.0]))
+        with pytest.raises(ValueError, match="nonnegative"):
+            set_tokens_per_adapter_slot(container, torch.tensor([3, -1], dtype=torch.int32))
+        with pytest.raises(ValueError, match="n_adapters"):
+            set_tokens_per_adapter_slot(container, torch.tensor([3, 5, 7], dtype=torch.int32))
+
     def test_init_and_clear_adapter_slot_across_model(self) -> None:
         container = _MultiLoRAContainer(n_layers=2)
 


### PR DESCRIPTION
# What does this PR do ?

Validates the per-slot token counts passed to `set_tokens_per_adapter_slot()` before they reach the multi-LoRA grouped GEMM.

# Changelog

- `set_tokens_per_adapter_slot`: reject non-1-D tensors, floating/complex dtypes, negative counts, and a count vector whose length differs from the model's `n_adapters`, each with a `ValueError` naming the problem; move the counts to the model's device once instead of per layer.
- Test: `TestMultiLoRAModelHelpers::test_set_tokens_per_adapter_slot_validates_input`.

Before this, a 2-D or float tensor broke the int32 cumsum offsets downstream, a negative count produced non-monotonic grouped-GEMM offsets, and a wrong-length vector silently mis-grouped the slot spans.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? — no

# Additional Information

- Ported from radixark/Megatron-Bridge#26. Follow-up to #4218 / #5768.

# Validation

- `tests/unit_tests/peft`: **444 passed, 7 skipped** (baseline 443). New test PASSED: `TestMultiLoRAModelHelpers::test_set_tokens_per_adapter_slot_validates_input`.
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. Baseline `upstream/main@2eae3c971` on the same box: `tests/unit_tests/peft` 443 passed / 7 skipped, the three model-bridge export files 181 passed, `test_qwen3_next_bridge.py` 23 passed. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
