### PR TITLE
feat(peft): emit fully shared grouped-expert LoRA once with collapse_shared_experts

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -884,6 +884,7 @@ class AutoBridge(Generic[MegatronModelT]):
         exclude_adapter_base_prefixes: Iterable[str] | None = None,
         expand_shared_outer: bool = False,
         stack_3d_moe: bool = False,
+        collapse_shared_experts: bool = False,
     ) -> Iterable["HFWeightTuple"]:
         """
         Export only adapter weights from a Megatron model without merging them into base tensors.
@@ -905,6 +906,12 @@ class AutoBridge(Generic[MegatronModelT]):
                 (``...experts.base_layer`` for gate_up_proj, bare ``...experts`` for
                 down_proj), instead of the per-expert 2D ``pack_moe`` layout.
                 Default ``False``; no effect for non-shared-outer adapters.
+            collapse_shared_experts: For grouped-expert adapters shared by every expert
+                (``share_expert_adapters=True``) that export under a packed HF expert name
+                (e.g. GPT-OSS ``experts.gate_up_proj``), emit the shared lora_A/lora_B once as
+                ``[1, ...]`` tensors (SGLang shared-LoRA layout) instead of replicating them
+                into a ``[num_experts, ...]`` stack. Default ``False``; no effect on per-expert
+                or shared-outer adapters.
 
         Yields:
             HFWeightTuple: Named tuples of (param_name, weight_tensor) for adapter parameters
@@ -923,6 +930,7 @@ class AutoBridge(Generic[MegatronModelT]):
             exclude_adapter_base_prefixes=exclude_adapter_base_prefixes,
             expand_shared_outer=expand_shared_outer,
             stack_3d_moe=stack_3d_moe,
+            collapse_shared_experts=collapse_shared_experts,
         )
 
     def save_hf_adapter(

--- a/src/megatron/bridge/models/conversion/peft_bridge.py
+++ b/src/megatron/bridge/models/conversion/peft_bridge.py
@@ -855,6 +855,7 @@ class MegatronPeftBridge:
         exclude_adapter_base_prefixes: Iterable[str] | None = None,
         expand_shared_outer: bool = False,
         stack_3d_moe: bool = False,
+        collapse_shared_experts: bool = False,
     ) -> Iterable["HFWeightTuple"]:
         """Stream only adapter weights without merging them into base tensors.
 
@@ -867,6 +868,13 @@ class MegatronPeftBridge:
         for gate_up_proj, bare ``...experts`` for down_proj), instead of the per-expert
         2D ``pack_moe`` layout. It is the vLLM-3D-MoE analogue of ``expand_shared_outer``
         and takes precedence over it for shared-outer adapters.
+
+        ``collapse_shared_experts`` applies to grouped-expert adapters whose lora_A *and*
+        lora_B are both 2D, i.e. one adapter shared by every expert
+        (``share_expert_adapters=True``) exported under a packed HF expert name such as
+        GPT-OSS ``...experts.gate_up_proj``. By default that adapter is replicated into a
+        ``[num_experts, ...]`` stack; with the flag it is emitted once as a ``[1, ...]``
+        tensor (the SGLang shared-LoRA layout also used for shared-outer adapters).
         """
         from megatron.bridge.models.conversion.model_bridge import HFWeightTuple
 
@@ -940,6 +948,33 @@ class MegatronPeftBridge:
 
             if packed_expert:
                 linear_in_hf_names, linear_out_hf_names = self._build_lora_hf_names(base_hf_weight_names)
+                if collapse_shared_experts and linear_in_tensor.ndim == 2 and linear_out_tensor.ndim == 2:
+                    # One 2D A/B pair serves every expert (kept identical across EP ranks by the
+                    # shared-adapter sync), so emit it once as [1, ...] instead of replicating
+                    # it num_moe_experts times. A fused gate/up linear_out is still split per HF
+                    # projection name through the packed-expert builder (single expert).
+                    shared_linear_in = linear_in_tensor.unsqueeze(0)
+                    if adapter_task.adapter_key is None:
+                        shared_linear_out_by_base = self._build_packed_expert_linear_out_by_base(
+                            megatron_model,
+                            base_hf_weight_names,
+                            [linear_out_tensor],
+                            is_expert=is_expert_linear(adapter_task.global_base_prefix),
+                        )
+                    else:
+                        shared_linear_out_by_base = {
+                            base_name: linear_out_tensor.unsqueeze(0) for base_name in base_hf_weight_names
+                        }
+                    if cpu:
+                        shared_linear_in = shared_linear_in.cpu()
+                    for index, base_name in enumerate(base_hf_weight_names):
+                        shared_linear_out = shared_linear_out_by_base[base_name]
+                        if cpu:
+                            shared_linear_out = shared_linear_out.cpu()
+                        yield HFWeightTuple(linear_in_hf_names[index], shared_linear_in)
+                        yield HFWeightTuple(linear_out_hf_names[index], shared_linear_out)
+                    continue
+
                 per_expert_linear_in, per_expert_linear_out = self._collect_packed_expert_adapter_tensors(
                     linear_in_tensor,
                     linear_out_tensor,

--- a/tests/unit_tests/models/test_model_bridge_lora.py
+++ b/tests/unit_tests/models/test_model_bridge_lora.py
@@ -1225,6 +1225,86 @@ def test_stream_adapter_weights_megatron_to_hf(monkeypatch):
     torch.testing.assert_close(weights[1].weight, 2 * torch.ones(2, 2))
 
 
+def _shared_grouped_expert_adapter(linear_in: torch.Tensor, linear_out: torch.Tensor):
+    prefix = "decoder.layers.0.mlp.experts.linear_fc1"
+    task = AdapterWeightConversionTask(
+        global_base_prefix=prefix,
+        adapter_key=None,
+        alpha=2,
+        dim=4,
+        linear_in_task=WeightConversionTask(
+            param_name="local_in", global_param_name=f"{prefix}.adapter.linear_in.weight", mapping=Mock()
+        ),
+        linear_out_task=WeightConversionTask(
+            param_name="local_out", global_param_name=f"{prefix}.adapter.linear_out.weight", mapping=Mock()
+        ),
+    )
+    weight = AdapterWeight(
+        global_base_prefix=prefix,
+        adapter_key=None,
+        alpha=2,
+        dim=4,
+        linear_in_weight=MegatronWeightTuple("local_in", linear_in, vp_stage=0),
+        linear_out_weight=MegatronWeightTuple("local_out", linear_out, vp_stage=0),
+    )
+    return prefix, task, weight
+
+
+def _stream_packed_expert_adapter(monkeypatch, linear_in, linear_out, **kwargs):
+    """Stream one grouped-expert adapter whose HF base name is a packed expert tensor (GPT-OSS style)."""
+    bridge = DummyBridge()
+    bridge.hf_pretrained = SimpleNamespace()
+    bridge.hf_config = bridge.hf_pretrained
+    prefix, adapter_task, adapter_weight = _shared_grouped_expert_adapter(linear_in, linear_out)
+    monkeypatch.setattr(bridge, "build_adapter_conversion_tasks", lambda *_a, **_k: {prefix: [adapter_task]})
+    monkeypatch.setattr(bridge, "materialize_adapter_weights", lambda *_: [adapter_weight])
+    # A packed HF expert name (no ``experts.N.``) routes the export through the packed-expert path.
+    monkeypatch.setattr(
+        bridge,
+        "_get_base_hf_param_names_for_adapter",
+        lambda *_a, **_k: ["model.layers.0.mlp.experts.gate_up_proj"],
+    )
+    monkeypatch.setattr(bridge, "_get_fused_adapter_linear_out_slices", lambda *_a, **_k: None)
+    megatron_model = [SimpleNamespace(config=SimpleNamespace(num_moe_experts=8))]
+    return list(bridge.stream_adapter_weights_megatron_to_hf(megatron_model, cpu=False, show_progress=False, **kwargs))
+
+
+def test_stream_adapter_weights_megatron_to_hf_replicates_shared_expert_adapter_by_default(monkeypatch):
+    weights = _stream_packed_expert_adapter(monkeypatch, torch.ones(4, 2), 2 * torch.ones(2, 4))
+
+    assert [w.param_name for w in weights] == [
+        "model.layers.0.mlp.experts.gate_up_proj.lora_A.weight",
+        "model.layers.0.mlp.experts.gate_up_proj.lora_B.weight",
+    ]
+    assert weights[0].weight.shape == (8, 4, 2)
+    assert weights[1].weight.shape == (8, 2, 4)
+
+
+def test_stream_adapter_weights_megatron_to_hf_collapse_shared_experts(monkeypatch):
+    weights = _stream_packed_expert_adapter(
+        monkeypatch, torch.ones(4, 2), 2 * torch.ones(2, 4), collapse_shared_experts=True
+    )
+
+    assert [w.param_name for w in weights] == [
+        "model.layers.0.mlp.experts.gate_up_proj.lora_A.weight",
+        "model.layers.0.mlp.experts.gate_up_proj.lora_B.weight",
+    ]
+    assert weights[0].weight.shape == (1, 4, 2)
+    assert weights[1].weight.shape == (1, 2, 4)
+    torch.testing.assert_close(weights[0].weight[0], torch.ones(4, 2))
+    torch.testing.assert_close(weights[1].weight[0], 2 * torch.ones(2, 4))
+
+
+def test_stream_adapter_weights_megatron_to_hf_collapse_ignores_per_expert_adapters(monkeypatch):
+    # Per-expert (3D) adapters are not shared, so the flag must leave them alone.
+    weights = _stream_packed_expert_adapter(
+        monkeypatch, torch.ones(8, 4, 2), 2 * torch.ones(8, 2, 4), collapse_shared_experts=True
+    )
+
+    assert weights[0].weight.shape == (8, 4, 2)
+    assert weights[1].weight.shape == (8, 2, 4)
+
+
 def test_stream_adapter_weights_megatron_to_hf_qkv(monkeypatch):
     bridge = DummyBridge()
     bridge.hf_pretrained = SimpleNamespace()


### PR DESCRIPTION
# What does this PR do ?

Adds an opt-in `collapse_shared_experts` flag to the adapter export so a grouped-expert LoRA shared by every expert is emitted once as a `[1, ...]` tensor instead of being replicated `num_moe_experts` times.

# Changelog

- `stream_adapter_weights_megatron_to_hf(..., collapse_shared_experts=False)`: in the packed-expert path, when both lora_A and lora_B are 2D (i.e. `share_expert_adapters=True`), emit `linear_in.unsqueeze(0)` and the single-expert `linear_out` (still split per HF projection for fused gate/up) under the packed HF expert name (e.g. GPT-OSS `model.layers.N.mlp.experts.gate_up_proj.lora_{A,B}.weight`). Per-expert (3D) and shared-outer adapters are untouched.
- `AutoBridge.export_adapter_weights` forwards the flag.
- Tests: default replication is pinned (`(E, r, in)` / `(E, out, r)`), the collapsed layout is `(1, ...)`, and per-expert adapters ignore the flag.

This is the fully-shared analogue of the `[1, ...]` layout the shared-outer exporter already produces for SGLang.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? — no

# Additional Information

- Re-implements the GPT-OSS export hooks from radixark/Megatron-Bridge commit `f710f8120` as a flag on the current export path.

# Validation

- `test_model_bridge.py` + `test_model_bridge_lora.py` + `test_adapter_export.py`: **184 passed** (baseline 181). New tests PASSED: `test_stream_adapter_weights_megatron_to_hf_replicates_shared_expert_adapter_by_default`, `test_stream_adapter_weights_megatron_to_hf_collapse_shared_experts`, `test_stream_adapter_weights_megatron_to_hf_collapse_ignores_per_expert_adapters`.
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. Baseline `upstream/main@2eae3c971` on the same box: `tests/unit_tests/peft` 443 passed / 7 skipped, the three model-bridge export files 181 passed, `test_qwen3_next_bridge.py` 23 passed. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
