### PR TITLE
fix(model): register both MTP sub-layer spellings in Qwen3-Next and Qwen3.5 MoE bridges

### DIFF
--- a/src/megatron/bridge/models/qwen/qwen35_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen35_bridge.py
@@ -327,70 +327,81 @@ class Qwen35MoEBridge(MegatronModelBridge):
             f"{megatron_prefix}mtp.layers.0.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
             f"{megatron_prefix}mtp.layers.0.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
             f"{megatron_prefix}mtp.layers.0.final_layernorm.weight": "mtp.norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.mlp.router.weight": "mtp.layers.0.mlp.gate.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.pre_mlp_layernorm.weight": "mtp.layers.0.post_attention_layernorm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
-            f"{megatron_prefix}mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
         }
-
         for megatron_param, hf_param in mtp_param_mappings.items():
             mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
 
-        mapping_list.extend(
-            [
-                QKVMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
-                    q="mtp.layers.*.self_attn.q_proj.weight",
-                    k="mtp.layers.*.self_attn.k_proj.weight",
-                    v="mtp.layers.*.self_attn.v_proj.weight",
-                ),
-                GatedMLPMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc1.weight",
-                    gate="mtp.layers.*.mlp.shared_expert.gate_proj.weight",
-                    up="mtp.layers.*.mlp.shared_expert.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc2.weight",
-                    hf_param="mtp.layers.*.mlp.shared_expert.down_proj.weight",
-                ),
-                ReplicatedMapping(
-                    megatron_param=f"{megatron_prefix}mtp.layers.0.mtp_model_layer.mlp.shared_experts.gate_weight",
-                    hf_param="mtp.layers.0.mlp.shared_expert_gate.weight",
-                ),
-            ]
-        )
+        # Megatron-Core has exposed the MTP transformer sub-layer as both
+        # ``mtp_model_layer`` and ``transformer_layer`` depending on version, so
+        # register every sub-layer mapping under both spellings (as glm45_bridge
+        # and glm5_bridge do) and checkpoints from either version convert.
+        for mtp_layer_attr in ("mtp_model_layer", "transformer_layer"):
+            layer0 = f"{megatron_prefix}mtp.layers.0.{mtp_layer_attr}"
+            layer = f"{megatron_prefix}mtp.layers.*.{mtp_layer_attr}"
+            sublayer_param_mappings = {
+                f"{layer0}.mlp.router.weight": "mtp.layers.0.mlp.gate.weight",
+                f"{layer0}.pre_mlp_layernorm.weight": "mtp.layers.0.post_attention_layernorm.weight",
+                f"{layer0}.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
+                f"{layer0}.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
+                f"{layer0}.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
+                f"{layer0}.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
+            }
+            for megatron_param, hf_param in sublayer_param_mappings.items():
+                mapping_list.append(AutoMapping(megatron_param=megatron_param, hf_param=hf_param))
 
-        if mtp_experts_packed:
-            # Qwen3.6: packed format (same as main decoder)
             mapping_list.extend(
                 [
-                    FusedGatedExpertMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc1.weight*",
-                        hf_param="mtp.layers.*.mlp.experts.gate_up_proj",
+                    QKVMapping(
+                        megatron_param=f"{layer}.self_attention.linear_qkv.weight",
+                        q="mtp.layers.*.self_attn.q_proj.weight",
+                        k="mtp.layers.*.self_attn.k_proj.weight",
+                        v="mtp.layers.*.self_attn.v_proj.weight",
                     ),
-                    FusedExpertMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc2.weight*",
-                        hf_param="mtp.layers.*.mlp.experts.down_proj",
-                    ),
-                ]
-            )
-        else:
-            # Qwen3.5: per-expert format (current behavior)
-            mapping_list.extend(
-                [
                     GatedMLPMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc1.weight*",
-                        gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
-                        up="mtp.layers.*.mlp.experts.*.up_proj.weight",
+                        megatron_param=f"{layer}.mlp.shared_experts.linear_fc1.weight",
+                        gate="mtp.layers.*.mlp.shared_expert.gate_proj.weight",
+                        up="mtp.layers.*.mlp.shared_expert.up_proj.weight",
                     ),
                     AutoMapping(
-                        megatron_param=f"{megatron_prefix}mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc2.weight*",
-                        hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
+                        megatron_param=f"{layer}.mlp.shared_experts.linear_fc2.weight",
+                        hf_param="mtp.layers.*.mlp.shared_expert.down_proj.weight",
+                    ),
+                    ReplicatedMapping(
+                        megatron_param=f"{layer0}.mlp.shared_experts.gate_weight",
+                        hf_param="mtp.layers.0.mlp.shared_expert_gate.weight",
                     ),
                 ]
             )
+
+            if mtp_experts_packed:
+                # Qwen3.6: packed format (same as main decoder)
+                mapping_list.extend(
+                    [
+                        FusedGatedExpertMapping(
+                            megatron_param=f"{layer}.mlp.experts.linear_fc1.weight*",
+                            hf_param="mtp.layers.*.mlp.experts.gate_up_proj",
+                        ),
+                        FusedExpertMapping(
+                            megatron_param=f"{layer}.mlp.experts.linear_fc2.weight*",
+                            hf_param="mtp.layers.*.mlp.experts.down_proj",
+                        ),
+                    ]
+                )
+            else:
+                # Qwen3.5: per-expert format (current behavior)
+                mapping_list.extend(
+                    [
+                        GatedMLPMapping(
+                            megatron_param=f"{layer}.mlp.experts.linear_fc1.weight*",
+                            gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
+                            up="mtp.layers.*.mlp.experts.*.up_proj.weight",
+                        ),
+                        AutoMapping(
+                            megatron_param=f"{layer}.mlp.experts.linear_fc2.weight*",
+                            hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
+                        ),
+                    ]
+                )
 
         return mapping_list
 

--- a/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
+++ b/src/megatron/bridge/models/qwen/qwen3_next_bridge.py
@@ -124,14 +124,6 @@ class Qwen3NextBridge(MegatronModelBridge):
             "mtp.layers.0.enorm.weight": "mtp.pre_fc_norm_embedding.weight",
             "mtp.layers.0.hnorm.weight": "mtp.pre_fc_norm_hidden.weight",
             "mtp.layers.0.final_layernorm.weight": "mtp.norm.weight",
-            # MTP MoE
-            "mtp.layers.0.mtp_model_layer.mlp.router.weight": "mtp.layers.0.mlp.gate.weight",
-            "mtp.layers.0.mtp_model_layer.pre_mlp_layernorm.weight": "mtp.layers.0.post_attention_layernorm.weight",
-            # MTP standard attention
-            "mtp.layers.0.mtp_model_layer.self_attention.linear_qkv.layer_norm_weight": "mtp.layers.0.input_layernorm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.q_layernorm.weight": "mtp.layers.0.self_attn.q_norm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.k_layernorm.weight": "mtp.layers.0.self_attn.k_norm.weight",
-            "mtp.layers.0.mtp_model_layer.self_attention.linear_proj.weight": "mtp.layers.0.self_attn.o_proj.weight",
         }
 
         mapping_list = []
@@ -151,12 +143,6 @@ class Qwen3NextBridge(MegatronModelBridge):
                     q="model.layers.*.self_attn.q_proj.weight",
                     k="model.layers.*.self_attn.k_proj.weight",
                     v="model.layers.*.self_attn.v_proj.weight",
-                ),
-                QKVMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.self_attention.linear_qkv.weight",
-                    q="mtp.layers.*.self_attn.q_proj.weight",
-                    k="mtp.layers.*.self_attn.k_proj.weight",
-                    v="mtp.layers.*.self_attn.v_proj.weight",
                 ),
                 # GDNLinear: Combine separate QKVZ_proj and BA_proj into single in_proj for GDN
                 # Note: Qwen3-Next does NOT have bias in the input linear projections
@@ -189,25 +175,6 @@ class Qwen3NextBridge(MegatronModelBridge):
                     megatron_param="decoder.layers.*.mlp.experts.local_experts.*.linear_fc2.weight",
                     hf_param="model.layers.*.mlp.experts.*.down_proj.weight",
                 ),
-                GatedMLPMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc1.weight*",
-                    gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="mtp.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.linear_fc2.weight*",
-                    hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
-                ),
-                # Sequential (non-grouped) MTP experts (e.g. ModelOpt pruning).
-                GatedMLPMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.local_experts.*.linear_fc1.weight",
-                    gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
-                    up="mtp.layers.*.mlp.experts.*.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.experts.local_experts.*.linear_fc2.weight",
-                    hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
-                ),
                 # Gated MLP of shared expert
                 GatedMLPMapping(
                     megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc1.weight",
@@ -218,23 +185,10 @@ class Qwen3NextBridge(MegatronModelBridge):
                     megatron_param="decoder.layers.*.mlp.shared_experts.linear_fc2.weight",
                     hf_param="model.layers.*.mlp.shared_expert.down_proj.weight",
                 ),
-                GatedMLPMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc1.weight",
-                    gate="mtp.layers.*.mlp.shared_expert.gate_proj.weight",
-                    up="mtp.layers.*.mlp.shared_expert.up_proj.weight",
-                ),
-                AutoMapping(
-                    megatron_param="mtp.layers.*.mtp_model_layer.mlp.shared_experts.linear_fc2.weight",
-                    hf_param="mtp.layers.*.mlp.shared_expert.down_proj.weight",
-                ),
                 # Shared expert gate
                 ReplicatedMapping(
                     megatron_param="decoder.layers.*.mlp.shared_experts.gate_weight",
                     hf_param="model.layers.*.mlp.shared_expert_gate.weight",
-                ),
-                ReplicatedMapping(
-                    megatron_param="mtp.layers.0.mtp_model_layer.mlp.shared_experts.gate_weight",
-                    hf_param="mtp.layers.0.mlp.shared_expert_gate.weight",
                 ),
                 # Qwen3-Next implements the output norm as a standard RMSNorm while initializing weight to ones,
                 # while other norms are regular zero-centered RMSNorms.
@@ -245,5 +199,81 @@ class Qwen3NextBridge(MegatronModelBridge):
                 ),
             ]
         )
+
+        # Megatron-Core has exposed the MTP transformer sub-layer as both
+        # ``mtp_model_layer`` and ``transformer_layer`` depending on version, so
+        # register every MTP mapping under both spellings (as glm45_bridge does)
+        # and checkpoints from either version convert.
+        for mtp_layer_attr in ("mtp_model_layer", "transformer_layer"):
+            mapping_list.extend(
+                [
+                    # MTP MoE
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.0.{mtp_layer_attr}.mlp.router.weight",
+                        hf_param="mtp.layers.0.mlp.gate.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.0.{mtp_layer_attr}.pre_mlp_layernorm.weight",
+                        hf_param="mtp.layers.0.post_attention_layernorm.weight",
+                    ),
+                    # MTP standard attention
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.0.{mtp_layer_attr}.self_attention.linear_qkv.layer_norm_weight",
+                        hf_param="mtp.layers.0.input_layernorm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.0.{mtp_layer_attr}.self_attention.q_layernorm.weight",
+                        hf_param="mtp.layers.0.self_attn.q_norm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.0.{mtp_layer_attr}.self_attention.k_layernorm.weight",
+                        hf_param="mtp.layers.0.self_attn.k_norm.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.0.{mtp_layer_attr}.self_attention.linear_proj.weight",
+                        hf_param="mtp.layers.0.self_attn.o_proj.weight",
+                    ),
+                    QKVMapping(
+                        megatron_param=f"mtp.layers.*.{mtp_layer_attr}.self_attention.linear_qkv.weight",
+                        q="mtp.layers.*.self_attn.q_proj.weight",
+                        k="mtp.layers.*.self_attn.k_proj.weight",
+                        v="mtp.layers.*.self_attn.v_proj.weight",
+                    ),
+                    # Grouped MTP experts
+                    GatedMLPMapping(
+                        megatron_param=f"mtp.layers.*.{mtp_layer_attr}.mlp.experts.linear_fc1.weight*",
+                        gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
+                        up="mtp.layers.*.mlp.experts.*.up_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.*.{mtp_layer_attr}.mlp.experts.linear_fc2.weight*",
+                        hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
+                    ),
+                    # Sequential (non-grouped) MTP experts (e.g. ModelOpt pruning).
+                    GatedMLPMapping(
+                        megatron_param=f"mtp.layers.*.{mtp_layer_attr}.mlp.experts.local_experts.*.linear_fc1.weight",
+                        gate="mtp.layers.*.mlp.experts.*.gate_proj.weight",
+                        up="mtp.layers.*.mlp.experts.*.up_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.*.{mtp_layer_attr}.mlp.experts.local_experts.*.linear_fc2.weight",
+                        hf_param="mtp.layers.*.mlp.experts.*.down_proj.weight",
+                    ),
+                    # MTP shared expert + gate
+                    GatedMLPMapping(
+                        megatron_param=f"mtp.layers.*.{mtp_layer_attr}.mlp.shared_experts.linear_fc1.weight",
+                        gate="mtp.layers.*.mlp.shared_expert.gate_proj.weight",
+                        up="mtp.layers.*.mlp.shared_expert.up_proj.weight",
+                    ),
+                    AutoMapping(
+                        megatron_param=f"mtp.layers.*.{mtp_layer_attr}.mlp.shared_experts.linear_fc2.weight",
+                        hf_param="mtp.layers.*.mlp.shared_expert.down_proj.weight",
+                    ),
+                    ReplicatedMapping(
+                        megatron_param=f"mtp.layers.0.{mtp_layer_attr}.mlp.shared_experts.gate_weight",
+                        hf_param="mtp.layers.0.mlp.shared_expert_gate.weight",
+                    ),
+                ]
+            )
 
         return MegatronMappingRegistry(*mapping_list)

--- a/tests/unit_tests/models/qwen/test_qwen35_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen35_bridge.py
@@ -683,6 +683,33 @@ class TestQwen35MoEBridge:
         assert "mtp.norm.weight" in hf_params
         assert "mtp.layers.0.final_layernorm.weight" in megatron_params
 
+    def test_mapping_registry_mtp_layer_spellings(self):
+        """Every MTP sub-layer mapping is registered under both Megatron-Core spellings."""
+        bridge = Qwen35MoEBridge()
+
+        registry = bridge.mapping_registry()
+
+        megatron_params = [mapping.megatron_param for mapping in registry.mappings]
+        for layer_attr in ("mtp_model_layer", "transformer_layer"):
+            for suffix in (
+                "mlp.router.weight",
+                "pre_mlp_layernorm.weight",
+                "self_attention.linear_qkv.layer_norm_weight",
+                "self_attention.q_layernorm.weight",
+                "self_attention.k_layernorm.weight",
+                "self_attention.linear_proj.weight",
+                "mlp.shared_experts.gate_weight",
+            ):
+                assert f"mtp.layers.0.{layer_attr}.{suffix}" in megatron_params
+            for suffix in (
+                "self_attention.linear_qkv.weight",
+                "mlp.shared_experts.linear_fc1.weight",
+                "mlp.shared_experts.linear_fc2.weight",
+                "mlp.experts.linear_fc1.weight*",
+                "mlp.experts.linear_fc2.weight*",
+            ):
+                assert f"mtp.layers.*.{layer_attr}.{suffix}" in megatron_params
+
     def test_mapping_registry_qkv_mapping(self):
         """Test that mapping_registry contains QKV mapping."""
         bridge = Qwen35MoEBridge()

--- a/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
+++ b/tests/unit_tests/models/qwen/test_qwen3_next_bridge.py
@@ -433,6 +433,35 @@ class TestQwen3NextBridge:
         assert "mtp.norm.weight" in hf_params
         assert "mtp.layers.0.final_layernorm.weight" in megatron_params
 
+    def test_mapping_registry_mtp_layer_spellings(self):
+        """Every MTP sub-layer mapping is registered under both Megatron-Core spellings."""
+        bridge = Qwen3NextBridge()
+
+        registry = bridge.mapping_registry()
+
+        megatron_params = [mapping.megatron_param for mapping in registry.mappings]
+        for layer_attr in ("mtp_model_layer", "transformer_layer"):
+            for suffix in (
+                "mlp.router.weight",
+                "pre_mlp_layernorm.weight",
+                "self_attention.linear_qkv.layer_norm_weight",
+                "self_attention.q_layernorm.weight",
+                "self_attention.k_layernorm.weight",
+                "self_attention.linear_proj.weight",
+                "mlp.shared_experts.gate_weight",
+            ):
+                assert f"mtp.layers.0.{layer_attr}.{suffix}" in megatron_params
+            for suffix in (
+                "self_attention.linear_qkv.weight",
+                "mlp.experts.linear_fc1.weight*",
+                "mlp.experts.linear_fc2.weight*",
+                "mlp.experts.local_experts.*.linear_fc1.weight",
+                "mlp.experts.local_experts.*.linear_fc2.weight",
+                "mlp.shared_experts.linear_fc1.weight",
+                "mlp.shared_experts.linear_fc2.weight",
+            ):
+                assert f"mtp.layers.*.{layer_attr}.{suffix}" in megatron_params
+
     def test_mapping_registry_qkv_mapping(self):
         """Test that mapping_registry contains QKV mapping."""
         bridge = Qwen3NextBridge()


### PR DESCRIPTION
# What does this PR do ?

Registers the Qwen3-Next and Qwen3.5/3.6 MoE MTP sub-layer mappings under both spellings Megatron-Core has used for the MTP transformer sub-layer (`mtp_model_layer` and `transformer_layer`), matching what `glm45_bridge`, `glm5_bridge`, `bailing_moe2_bridge`, `mimo_*_bridge` and `step35/37_bridge` already do.

# Changelog

- `Qwen3NextBridge.mapping_registry`: move the MTP router/norm/attention/expert/shared-expert mappings into a loop over `("mtp_model_layer", "transformer_layer")`; the emitted mappings for `mtp_model_layer` are unchanged.
- `Qwen35MoEBridge._get_moe_mtp_mappings` (shared by the Qwen3.5 text and VL MoE bridges, packed and per-expert experts): same dual registration.
- Tests: every MTP sub-layer mapping is present under both spellings, for Qwen3-Next and Qwen3.5 MoE.

# GitHub Actions CI

See the [CI section](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md#-running-github-ci) in the Contributing doc for how to trigger the CI. A Nvidia developer will need to approve and trigger the CI for external contributors.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? — no

# Additional Information

- Ported from radixark/Megatron-Bridge#11 (author: @Zhichenzzz) and radixark/Megatron-Bridge#2 (author: @artem-osmosis). Needed to convert checkpoints produced by Megatron-Core versions that expose the MTP sub-layer as `transformer_layer`.


# Validation

- `test_qwen3_next_bridge.py` + `test_qwen35_bridge.py` + `test_qwen35_vl_bridge.py`: **107 passed** (baseline 105). New tests PASSED by name: `TestQwen3NextBridge::test_mapping_registry_mtp_layer_spellings`, `TestQwen35MoEBridge::test_mapping_registry_mtp_layer_spellings`.
- GPU: `rx devbox` 2× H200 (h200-sci-k8s), image `nvcr.io/nvidia/pytorch:26.08-py3` (the upstream CI base image), TE 2.18.0+27486e03 (matches upstream `uv.lock`), Megatron-Core at `.main.commit` `c9b53d0a8`, Megatron-Bridge editable. Command mirrors CI's `Launch_Unit_Tests_Core.sh`: `CUDA_VISIBLE_DEVICES=0,1 pytest -m "not pleasefixme"`. `ruff check`, `ruff check --select I`, `ruff format --check` (ruff 0.9.9) pass on the changed files.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
