### PR TITLE
[data] fix: Stop forwarding packed chat templates

### DIFF
--- a/src/megatron/bridge/data/builders/gpt_sft.py
+++ b/src/megatron/bridge/data/builders/gpt_sft.py
@@ -681,6 +681,8 @@ def build_gpt_sft_split(
             effective_metadata_path = pack_metadata_path
 
     options = dict(dataset_kwargs or {})
+    if not is_not_packing:
+        options.pop("chat_template", None)
     chat = options.pop("chat", False)
     use_hf_tokenizer_chat_template = options.pop("use_hf_tokenizer_chat_template", True)
     chat_loss_mode = options.pop("chat_loss_mode", "assistant")

--- a/tests/unit_tests/data/builders/test_gpt_sft_builder.py
+++ b/tests/unit_tests/data/builders/test_gpt_sft_builder.py
@@ -220,6 +220,47 @@ def test_offline_packing_consumes_one_blended_raw_dataset(tmp_path, monkeypatch)
     assert blend.weights == (3.0, 1.0)
 
 
+def test_cached_offline_packing_does_not_forward_chat_template(tmp_path, monkeypatch):
+    """Preparation-only chat templates must not reach the packed dataset constructor."""
+    monkeypatch.setattr(builder_mod, "get_dataset_root", lambda name: tmp_path / "cache" / name)
+    train_a = tmp_path / "train-a.jsonl"
+    train_b = tmp_path / "train-b.jsonl"
+    for path in (train_a, train_b):
+        path.write_text('{"messages": []}\n')
+    args_path = tmp_path / "per-split.json"
+    args_path.write_text(json.dumps({"train": [str(train_a), str(train_b)]}))
+
+    builder = GPTSFTDatasetBuilder(
+        config=GPTSFTDatasetConfig(
+            seq_length=128,
+            per_split_data_source_manifest_path=args_path,
+            preprocessing=ChatSFTPreprocessingConfig(),
+            enable_offline_packing=True,
+            offline_packing_specs=PackedSequenceSpecs(
+                packed_sequence_size=128,
+                tokenizer_model_name="mock-tokenizer",
+            ),
+            dataset_kwargs={"chat_template": "{{ messages }}"},
+            do_validation=False,
+            do_test=False,
+        ),
+        tokenizer=MagicMock(),
+    )
+    builder.train_path_packed.touch()
+    packed_dataset = object()
+
+    def build_packed_dataset(**kwargs):
+        assert "chat_template" not in kwargs
+        return packed_dataset
+
+    monkeypatch.setattr(
+        "megatron.bridge.data.packing.parquet.GPTSFTPackedParquetDataset",
+        build_packed_dataset,
+    )
+
+    assert builder.build() == [packed_dataset, None, None]
+
+
 def test_offline_packing_materializes_one_weighted_blend_parquet(tmp_path, monkeypatch):
     monkeypatch.setattr(builder_mod, "get_dataset_root", lambda name: tmp_path / "cache" / name)
 


### PR DESCRIPTION
## What changed

Offline-packed chat datasets now consume the preparation-only `chat_template` option before constructing the runtime packed dataset.

## Supported trigger and impact

A GPT SFT configuration using offline packing with a custom `dataset_kwargs["chat_template"]` fails when reusing an existing packed cache. The same failure affects non-producer ranks during a distributed first build, because only rank zero runs tokenization.

The surviving option is forwarded through `build_gpt_sft_split` and the packed Parquet/packed dataset constructors into `GPTSFTDataset.__init__`, whose closed signature rejects it with `TypeError`. This can prevent training from starting after packing has already completed.

## Root cause and fix

`tokenize_dataset` consumes `chat_template` during preparation, but cache-hit builders and non-producer ranks do not execute that mutation. `build_gpt_sft_split` now removes the option specifically when constructing an offline-packed dataset. Raw dataset behavior is unchanged.

The regression test creates a supported multi-source chat configuration, simulates an existing builder-managed packed artifact, and asserts that the final packed constructor does not receive the preparation-only key.

## Validation

The CPU-only workstation required a private import bootstrap to bypass unrelated eager imports of optional GPU packages; it did not mock the builder, packing path, or option handling. Commands below use sanitized environment variables for that bootstrap and source environment.

Fail before, unchanged regression:

```text
uv run --project "$SOURCE_ENV" --no-sync python "$CPU_PYTEST_BOOTSTRAP" tests/unit_tests/data/builders/test_gpt_sft_builder.py -q --confcutdir=tests/unit_tests/data/builders -k cached_offline_packing_does_not_forward_chat_template
1 failed: packed constructor kwargs still contained chat_template
```

Pass after:

```text
uv run --project "$SOURCE_ENV" --no-sync python "$CPU_PYTEST_BOOTSTRAP" tests/unit_tests/data/builders/test_gpt_sft_builder.py -q --confcutdir=tests/unit_tests/data/builders -k cached_offline_packing_does_not_forward_chat_template
1 passed, 9 deselected
```

Adjacent tests:

```text
uv run --project "$SOURCE_ENV" --no-sync python "$CPU_PYTEST_BOOTSTRAP" tests/unit_tests/data/builders/test_gpt_sft_builder.py tests/unit_tests/data/packing/test_offline.py -q --confcutdir=tests/unit_tests/data
23 passed
```

Additional gates:

```text
git diff --check
uv run --project "$SOURCE_ENV" --no-sync pre-commit run --all-files
```

Both passed.

## Scope

This change covers the offline-packed Parquet and legacy NPY construction boundary. It does not change chat-template rendering, raw dataset semantics, packing formats, distributed synchronization, or public APIs.
