### PR TITLE
[model] fix: Preserve token classification AutoBridge dispatch

### DIFF
--- a/src/megatron/bridge/models/conversion/auto_bridge.py
+++ b/src/megatron/bridge/models/conversion/auto_bridge.py
@@ -276,6 +276,14 @@ def _resolve_pretrained_wrapper_cls(
     return PreTrainedCausalLM
 
 
+def _get_architecture_class_name_via_auto_map(config: Any, architecture: str) -> str | None:
+    """Return the model class from a Hugging Face ``auto_map`` when applicable."""
+    if architecture.endswith("ForTokenClassification"):
+        return None
+
+    return get_causal_lm_class_name_via_auto_map(config=config)
+
+
 def _drop_readonly_config_properties(
     config_dict: dict[str, object], config_type: Type[PretrainedConfig]
 ) -> dict[str, object]:
@@ -2274,7 +2282,7 @@ class AutoBridge(Generic[MegatronModelT]):
             )
 
         # Try auto_map first (returns class name string if available)
-        cls_name = get_causal_lm_class_name_via_auto_map(config=config)
+        cls_name = _get_architecture_class_name_via_auto_map(config, causal_lm_arch)
         if cls_name is not None:
             # For auto_map models, return the class name as a string
             return cls_name
@@ -2314,7 +2322,7 @@ class AutoBridge(Generic[MegatronModelT]):
 
         if architecture:
             # Try auto_map first; returns a class-name string if available
-            arch_name = get_causal_lm_class_name_via_auto_map(config=config)
+            arch_name = _get_architecture_class_name_via_auto_map(config, architecture)
             if arch_name is not None:
                 # For auto_map models, use class-name string
                 arch_key = arch_name

--- a/tests/unit_tests/models/test_auto_bridge.py
+++ b/tests/unit_tests/models/test_auto_bridge.py
@@ -555,6 +555,20 @@ class TestAutoBridge:
         assert provider.classifier_dropout == 0.2
         assert {"score.weight", "score.bias"} <= hf_params
 
+    def test_token_classification_config_with_multitask_auto_map_uses_task_bridge(self):
+        config = PretrainedConfig()
+        config.architectures = ["Qwen3_5ForTokenClassification"]
+        config.auto_map = {
+            "AutoModelForCausalLM": "custom.Qwen3_5ForCausalLM",
+            "AutoModelForTokenClassification": "custom.Qwen3_5ForTokenClassification",
+        }
+
+        bridge = AutoBridge.from_hf_config(config)
+        hf_params = {str(mapping.hf_param) for mapping in bridge._model_bridge.mapping_registry().mappings}
+
+        assert bridge._pretrained_wrapper_cls is PreTrainedTokenClassification
+        assert {"score.weight", "score.bias"} <= hf_params
+
     def test_qwen35_token_classification_runtime_preflight_does_not_block_config_only(self):
         config = PretrainedConfig()
         config.architectures = ["Qwen3_5ForTokenClassification"]


### PR DESCRIPTION
## Summary

Token-classification configs can validly advertise both `AutoModelForTokenClassification` and `AutoModelForCausalLM` remote implementations. AutoBridge selected the token-classification Hugging Face wrapper, but its validation and bridge lookup unconditionally preferred the causal `auto_map` entry. That paired the token wrapper with the causal bridge and `lm_head` mappings instead of the registered token-classification bridge and `score` mappings.

This change keeps token-classification dispatch on its declared, registered architecture while preserving the existing causal `auto_map` behavior for other architectures. Both validation and runtime bridge selection use the same narrow guard. Related task-head support context: #5211.

## User impact

A supported trusted-remote token classifier with both task entries could fail conversion/provider construction or use the wrong head mappings. The fix preserves `score.weight` and `score.bias` mapping for that configuration.

## Validation

Fail-before on the unmodified base:

```text
uv run python -m pytest tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_token_classification_config_with_multitask_auto_map_uses_task_bridge -q
1 failed: score.weight and score.bias were absent; lm_head.weight was selected
```

Pass-after with the unchanged regression:

```text
uv run python -m pytest tests/unit_tests/models/test_auto_bridge.py::TestAutoBridge::test_token_classification_config_with_multitask_auto_map_uses_task_bridge -q
1 passed
```

Focused and adjacent validation in the locked dependency environment:

```text
uv run python -m pytest tests/unit_tests/models/test_auto_bridge.py -q
101 passed

uv run pre-commit run --all-files
Passed
```

## Scope

No public API, dependency, workflow, model-family support, or causal-model behavior is changed.
