### PR TITLE
[peft] fix: Support parameterless Multi-LoRA base layers

### DIFF
--- a/src/megatron/bridge/peft/multi_lora_layers.py
+++ b/src/megatron/bridge/peft/multi_lora_layers.py
@@ -212,8 +212,11 @@ class MultiLoRALinear(AdapterWrapper):
         # forward never synchronizes each layer to recover split sizes.
         self.tokens_per_adapter_splits: Optional[Tuple[int, ...]] = None
         self.tokens_per_adapter_total: Optional[int] = None
-        device = next(to_wrap.parameters()).device
-        dtype = next(to_wrap.parameters()).dtype
+        reference = next(to_wrap.parameters(), None)
+        if reference is None:
+            reference = next(self.adapters.parameters())
+        device = reference.device
+        dtype = reference.dtype
         # Non-persistent: slot lifecycle is externally managed, not checkpointed.
         self.register_buffer("alpha_values", torch.ones(n_adapters, dtype=dtype, device=device), persistent=False)
         self.register_buffer(

--- a/tests/unit_tests/peft/test_multi_lora_layers.py
+++ b/tests/unit_tests/peft/test_multi_lora_layers.py
@@ -306,6 +306,21 @@ class TestMultiLoRALinearSlots:
             assert adapter.extra_kwargs["disable_tensor_parallel_comm"] is False
             assert adapter.extra_kwargs["base_linear_is_parallel"] is True
 
+    def test_constructor_accepts_parameterless_wrapped_module(self) -> None:
+        """Tied output layers receive their shared weight at forward time."""
+        base = nn.Module()
+        base.in_features = 16
+        base.out_features = 32
+        base.config = object()
+
+        layer = MultiLoRALinear(to_wrap=base, n_adapters=2, dim=8, alpha=16, full_name="output_layer")
+
+        adapter_reference = next(layer.adapters.parameters())
+        assert layer.alpha_values.device == adapter_reference.device
+        assert layer.alpha_values.dtype == adapter_reference.dtype
+        assert layer.rank_values.device == adapter_reference.device
+        assert layer.rank_values.dtype == adapter_reference.dtype
+
     def test_slot_metadata_registered_as_buffers(self) -> None:
         layer = _build_multi_lora_linear(n_adapters=2, dim=8)
 


### PR DESCRIPTION
## What does this PR do?

Allows `MultiLoRALinear` to wrap a supported parameterless Megatron linear, such as a tied `output_layer` whose shared embedding weight is supplied at forward time.

## Supported trigger and impact

The Multi-LoRA transform already accepts Megatron parallel linear targets. A tied output layer is one such target, but it allocates no local parameter. Construction currently calls `next(to_wrap.parameters())` only to place two slot-metadata buffers, so targeting that layer raises `StopIteration` before training starts.

The direct downstream fork carries this contract in [radixark/Megatron-Bridge#38](https://github.com/radixark/Megatron-Bridge/pull/38), and its merged output-layer training path [radixark/miles#3210](https://github.com/radixark/miles/pull/3210) demonstrates the reachable user need. This implementation was derived from the contract and does not copy the downstream implementation.

## Minimal scope

When the wrapped module has no parameter, use the already-created Bridge adapter parameters as the device/dtype reference for the metadata buffers. Parameter-backed modules keep the existing path.

Non-goals:

- Changing target-module selection or model recipes.
- Changing tied-weight forward behavior.
- Adding a CUDA/config-specific placement path.
- Broadening Multi-LoRA lifecycle or export behavior.

## Validation

Recorded base: [`60b91488afc05e8dc70b999b5f89382b1dfcbe58`](https://github.com/NVIDIA-NeMo/Megatron-Bridge/commit/60b91488afc05e8dc70b999b5f89382b1dfcbe58)

Fail-before and pass-after used the identical focused command:

```bash
uv run --no-project python -m pytest --confcutdir=tests/unit_tests/peft tests/unit_tests/peft/test_multi_lora_layers.py::TestMultiLoRALinearSlots::test_constructor_accepts_parameterless_wrapped_module -q
```

- Before: failed with `StopIteration` at the wrapped-module parameter lookup.
- After: 1 passed.

Adjacent constructor/buffer contracts:

```bash
uv run --no-project python -m pytest --confcutdir=tests/unit_tests/peft \
  tests/unit_tests/peft/test_multi_lora_layers.py::TestMultiLoRALinearSlots::test_slot_defaults_after_construction \
  tests/unit_tests/peft/test_multi_lora_layers.py::TestMultiLoRALinearSlots::test_constructor_forwards_wrapped_module_runtime_config \
  tests/unit_tests/peft/test_multi_lora_layers.py::TestMultiLoRALinearSlots::test_constructor_accepts_parameterless_wrapped_module \
  tests/unit_tests/peft/test_multi_lora_layers.py::TestMultiLoRALinearSlots::test_slot_metadata_registered_as_buffers -q
```

Result: 4 passed.

- `git diff --check`: passed.
- `uv run --no-sync pre-commit run --all-files`: passed.
- Separate read-only review checked duplicate status, supported ownership, minimal scope, red/green evidence, and public sanitization; no blocking findings.
