### PR TITLE
feat(training): add DPO training with offline-scored reference model

### DIFF
--- a/scripts/dpo/README.md
+++ b/scripts/dpo/README.md
@@ -139,10 +139,10 @@ scored source and artifact with trailing overrides, and at the reference
 weights with a local HF model directory:
 
 ```bash
-uv run python -m torch.distributed.run --nproc_per_node=1 \
+uv run python -m torch.distributed.run --nproc_per_node=8 \
     scripts/training/run_recipe.py \
-    --model qwen25_500m --mode dpo \
-    --pretrained_checkpoint /checkpoints/qwen2.5-0.5b-instruct \
+    --model qwen3_30b_a3b --mode dpo \
+    --pretrained_checkpoint /checkpoints/qwen3-30b-a3b \
     dataset.source.path_or_dataset=argilla/distilabel-capybara-dpo-7k-binarized \
     dataset.source.split=train \
     dataset.ref_artifact=msc://profile/bucket/capybara_ref_logprobs \
@@ -156,10 +156,9 @@ metadata, then delegates to the stock `finetune` loop with the `dpo_step`
 forward step from the shared registry.
 
 Multi-GPU: `--nproc_per_node = tp × dp`. Pass `-tp` matching the scoring
-run; the remaining ranks form the data-parallel group. At TP ≥ 2 the model's
-activations and weights are sharded, which relaxes the full-recompute
-requirement that 7B-class models need at `tp=1` (recipes carry their model's
-recompute settings; override via `model.recompute_granularity` if needed).
+run; the remaining ranks form the data-parallel group. Recipes carry their
+model's recompute settings; override via `model.recompute_granularity` if the
+measured headroom allows.
 
 ### Multinode
 
@@ -171,8 +170,8 @@ existing ref artifacts stay valid.
 
 Launch with any standard torchrun rendezvous (same command on every node,
 varying `--node_rank`). Every node needs the same code tree, the run-critical
-env (`CUDA_DEVICE_MAX_CONNECTIONS=1`, the allocator conf, model-specific vars
-like `QWEN35_CONVERSION_MODE`), the HF cache/token, the pretrained-checkpoint
+env (`CUDA_DEVICE_MAX_CONNECTIONS=1`, the allocator conf, any model-specific
+vars), the HF cache/token, the pretrained-checkpoint
 directory, and the ref artifacts readable at the same path. Batch math:
 `train.global_batch_size % (train.micro_batch_size × dp) == 0` — checked at
 startup.

--- a/scripts/dpo/README.md
+++ b/scripts/dpo/README.md
@@ -1,0 +1,250 @@
+# DPO Training
+
+Direct Preference Optimization on Megatron Bridge, with reference logprobs
+scored **offline** — the trainer never loads reference weights.
+
+## Input format
+
+Expected input: rows with two chat-format message-list fields (default field
+names `chosen` / `rejected`, override with `--chosen-key` / `--rejected-key`).
+Both sides must share the same context (all messages except the last) and end
+with an assistant turn.
+
+Rows that keep the shared prompt in its own field, with `chosen` / `rejected`
+holding only the completion turns (TRL's *explicit-prompt conversational*
+format), are read by naming that field with `--prompt-key`:
+
+```jsonc
+{"messages":  [{"role": "system", ...}, {"role": "user", ...}],
+ "chosen":    [{"role": "assistant", "content": "..."}],
+ "rejected":  [{"role": "assistant", "content": "..."}]}
+```
+
+Each side is assembled into a full conversation before tokenization, so the
+context match holds by construction and everything downstream is unchanged.
+Extra row fields (`preference_margin`, `pairs_metadata`, …) are ignored.
+The scorer's `--prompt-key` and the trainer's `dataset.prompt_key` must agree;
+the trainer refuses to start when it disagrees with the value recorded in the
+artifact.
+
+Any of the three fields may be a plain string instead of a message list (TRL's
+*standard* format, the shape most public preference sets ship in) — the prompt
+becomes one user turn and a completion one assistant turn, matching how NeMo-RL's
+`BinaryPreferenceDataset` reads the same row. String and message-list fields mix
+freely within a row:
+
+```jsonc
+{"prompt": "What is 2+2?", "chosen": "4", "rejected": "5"}
+```
+
+A pair is unusable when either side fails: `context_mismatch`,
+`no_assistant_completion`, `empty_completion`, `over_length`. Pairs are never
+dropped (the sampler needs a fixed dataset length) — they become zero-loss stubs.
+The scorer logs one warning per stub, and training reports the live share as the
+`live fraction` metric; check both before letting a run continue.
+
+> Reading explicit-prompt rows **without** `--prompt-key` does not crash — every
+> pair becomes a `no_assistant_completion` stub and training gets zero signal.
+> A `live fraction` of 0 at step 0 is the tell.
+
+## Workflow
+
+Two steps, in order. Step 1 runs once per (dataset, tokenizer, max-seq-length,
+reference model); step 2 can then sweep beta, LR, etc. without re-scoring — the
+ref-logprob artifact is beta-free.
+
+### 1. Score reference logprobs (offline, one-time)
+
+```bash
+python scripts/dpo/score_reference_logprobs.py \
+    --model Qwen/Qwen2.5-0.5B-Instruct \
+    --dataset argilla/distilabel-capybara-dpo-7k-binarized \
+    --output msc://profile/bucket/capybara_ref_logprobs --num-pairs 1024
+```
+
+Forwards the reference model (the checkpoint the policy will initialize from)
+over the same dataset and writes the artifact to `--output` — a local
+directory or an `msc://` URL, written in place:
+
+- `ref_logprobs.jsonl` — one record per pair, keyed by `pair_id` (= source row
+  index): completion logprob sums + token counts for both sides.
+- `scoring_metadata.json` — the inputs this artifact is only valid for
+  (see invariants below). Training refuses artifacts that don't match.
+
+The scorer applies the trainer's default `bf16_mixed` precision recipe and disables
+any MTP head, and records the recipe name; `--tp` and
+`--sequence-parallel` are recorded and must match training (MoE models at
+TP > 1 need `--sequence-parallel` — MCore refuses MoE + TP without it in
+train mode).
+
+For models that don't fit on one GPU, score with tensor parallelism — launch
+exactly `--tp` processes; every rank computes identical sums (vocab-parallel
+CE all-reduces across the TP group) and rank 0 writes the artifact:
+
+```bash
+python -m torch.distributed.run --nproc_per_node=2 \
+    scripts/dpo/score_reference_logprobs.py --tp 2 \
+    --model Qwen/Qwen2.5-7B-Instruct \
+    --dataset HuggingFaceH4/ultrafeedback_binarized --split train_prefs \
+    --output /data/uf_ref_logprobs
+```
+
+Training must then run with the same `--tp` (recorded in the artifact's
+metadata and checked at startup): TP changes the vocab-parallel CE reduction
+order, so a mismatch would shift step 0 off ln 2 and hide a real mismatch
+behind it. Pipeline parallelism is not supported.
+
+MoE models can additionally shard experts with `--ep` (experts split *between*
+ranks) and `--etp` (each expert's GEMMs split *within* a rank group). `--etp`
+defaults to `--tp`, so dense models need neither flag. The expert mesh must
+also cover the world exactly, so `--ep > 1` requires `--etp 1`:
+
+```bash
+python -m torch.distributed.run --nproc_per_node=8 \
+    scripts/dpo/score_reference_logprobs.py --tp 8 --ep 8 --etp 1 \
+    --model <moe-model> \
+    --dataset HuggingFaceH4/ultrafeedback_binarized --split train_prefs \
+    --output /data/uf_ref_logprobs
+```
+
+`(EP, ETP)` is recorded only when it differs from the implied `EP=1 / ETP=TP`.
+Unlike TP, an expert-layout mismatch against the trainer warns rather than
+fails: it perturbs expert-GEMM numerics without mis-anchoring margins.
+
+By default batches are a fixed pair count (`--micro-batch-size`), padded to
+the longest pair in the batch — at long `--max-seq-length` a batch of long
+pairs can OOM. `--token-budget N` replaces it with length-sorted batches
+capped at `N` *padded* tokens (`2 rows × pairs × batch-max length`): peak
+memory is bounded by construction, short pairs pack densely instead of being
+padded to a long neighbor (typically several times faster). Batching perturbs
+the scored values on MoE models by a few nats per pair (the router amplifies
+batch-shape numerics; dense models are insensitive) — measured to have no
+training effect, so pick whatever fits the hardware. `--micro-batch-size 1`
+only matters if you want step 0 to read ln 2 to the third decimal:
+
+```bash
+python -m torch.distributed.run --nproc_per_node=8 \
+    scripts/dpo/score_reference_logprobs.py --tp 8 --token-budget 16384 \
+    --model <moe-model> --max-seq-length 4096 \
+    --dataset HuggingFaceH4/ultrafeedback_binarized --split train_prefs \
+    --output /data/uf_ref_logprobs
+```
+
+### 2. Train
+
+Training runs through the shared recipe launcher with `--mode dpo`
+(see `scripts/training/README.md` for the full launcher docs). `--mode dpo`
+selects the model's `<model>_dpo_config` library recipe; point the run at the
+scored source and artifact with trailing overrides, and at the reference
+weights with a local HF model directory:
+
+```bash
+uv run python -m torch.distributed.run --nproc_per_node=1 \
+    scripts/training/run_recipe.py \
+    --model qwen25_500m --mode dpo \
+    --pretrained_checkpoint /checkpoints/qwen2.5-0.5b-instruct \
+    dataset.source.path_or_dataset=argilla/distilabel-capybara-dpo-7k-binarized \
+    dataset.source.split=train \
+    dataset.ref_artifact=msc://profile/bucket/capybara_ref_logprobs \
+    dataset.num_pairs=1024
+```
+
+The launcher routes `--mode dpo` through `dpo_train()`
+(`megatron.bridge.training.dpo_train`), the API entry for programmatic
+callers. `dpo_train` fail-fast validates the run config and the artifact
+metadata, then delegates to the stock `finetune` loop with the `dpo_step`
+forward step from the shared registry.
+
+Multi-GPU: `--nproc_per_node = tp × dp`. Pass `-tp` matching the scoring
+run; the remaining ranks form the data-parallel group. At TP ≥ 2 the model's
+activations and weights are sharded, which relaxes the full-recompute
+requirement that 7B-class models need at `tp=1` (recipes carry their model's
+recompute settings; override via `model.recompute_granularity` if needed).
+
+### Multinode
+
+`world_size = nnodes × nproc_per_node = tp × dp`. DP > 1 is what a second
+node buys: the distributed optimizer (already enabled) shards the fp32 Adam
+state — the largest per-GPU resident at TP=8 — across the DP replicas. DP is
+parity-neutral: it only deals different *pairs* to different replicas, so
+existing ref artifacts stay valid.
+
+Launch with any standard torchrun rendezvous (same command on every node,
+varying `--node_rank`). Every node needs the same code tree, the run-critical
+env (`CUDA_DEVICE_MAX_CONNECTIONS=1`, the allocator conf, model-specific vars
+like `QWEN35_CONVERSION_MODE`), the HF cache/token, the pretrained-checkpoint
+directory, and the ref artifacts readable at the same path. Batch math:
+`train.global_batch_size % (train.micro_batch_size × dp) == 0` — checked at
+startup.
+
+**World size and step 0:** step 0 reads exactly `ln 2` only when the
+trainer's world size equals the scoring run's — NCCL reduction order shifts
+with topology, and MoE routers amplify it into a fixed, reproducible offset
+(measured on gemma-4 26B: world 8 → 0.6931; world 16, same artifact →
+0.8507). Same noise class as batching, same verdict: harmless. For multinode
+runs against a single-node-scored artifact, the step-0 health signal is a
+*stable* opening value, not ln 2 itself.
+
+### Optional: validation
+
+Validation runs the same DPO metrics (`dpo loss`, `margin`, `accuracy`,
+`rewards chosen/rejected`, `live fraction`) over a held-out split at every
+`eval_interval` steps. The validation split needs its **own** scored artifact —
+repeat step 1 over the validation rows (same model, tokenizer, and
+`--max-seq-length` as the train scoring run).
+
+Enable it by setting `dataset.validation_source` (an `HFDatasetSourceConfig`
+or a `PreferenceJSONLSource`) plus `dataset.validation_ref_artifact` — in the
+model's DPO recipe or from a programmatic caller — and turn it on with
+`validation.eval_interval` / `validation.eval_iters`. `eval_global_batch_size` /
+`eval_micro_batch_size` default to the train sizes and are row-denominated
+(even) like everything else. All invariants below apply to the validation
+artifact too, checked against the validation source. Semantics match the SFT
+dataset configs: eval settings without a validation split are rejected at
+startup, while a configured validation split with `eval_iters=0` is simply not
+built — validation toggles via `validation.eval_iters` alone.
+
+**Step-0 sanity check (read the log):** at step 0 the policy equals the
+reference, so every pair's margin should be 0 and the first logged iteration
+shows `preference loss ≈ ln 2 ≈ 0.6931`, `margin ≈ 0`, `rewards ≈ 0`. Kernel
+and layout noise moves these by hundredths; a wrong artifact, wrong pretrained
+checkpoint, or tokenization mismatch moves them by whole units. There is no
+automatic gate on this — the same posture as TRL's precomputed reference
+logprobs — so look at iteration 1 before letting a long run continue.
+
+## Invariants: scorer run == training run
+
+The margins are only meaningful if both jobs compute logprobs over the exact
+same token streams. These must match between the scoring run and the training run:
+
+| Invariant | Enforced by |
+|---|---|
+| Dataset source + split | `scoring_metadata.json` check at startup |
+| Tokenizer | `scoring_metadata.json` check at startup |
+| Sequence length (`dataset.seq_length`, stored as `max_seq_length` in the artifact) | `scoring_metadata.json` check at startup |
+| Row layout (`dataset.prompt_key` / `--prompt-key`) | `scoring_metadata.json` check at startup |
+| TP / PP sizes | `scoring_metadata.json` check at startup |
+| `num_pairs` (same rows, same order) | artifact coverage check: ref logprobs must cover `pair_id 0..N-1` exactly |
+| Reference model == `pretrained_checkpoint` | not checked — visible as step-0 `preference loss` ≠ ln 2 in the log |
+| No MTP head | `validate_dpo_run_config` |
+| bf16 forward | not checked; the scorer pins it and the recipes default to `bf16_mixed` |
+
+A mismatch in any of these silently mis-anchors every margin, which is why
+each one is either rejected at startup or worth a glance at the step-0 log.
+
+## Batch sizes are rows, not pairs
+
+`micro_batch_size` / `global_batch_size` / consumed-sample counters are
+denominated in **rows** everywhere (config, train state, logs), and one pair
+is two rows — chosen at even row indices, rejected at odd. Both batch sizes
+must therefore be even. The row→pair halving happens in exactly one place
+(`build_preference_data_loader`) so the shared training loop, LR scheduler
+increments, and checkpoint resume accounting all stay row-denominated and
+unmodified.
+
+
+## Verification tools
+
+- Unit tests: `tests/unit_tests/training/test_dpo*.py`,
+  `tests/unit_tests/data/datasets/test_preference*.py` (includes a NeMo-RL
+  reference-implementation parity test for the loss).

--- a/scripts/dpo/score_reference_logprobs.py
+++ b/scripts/dpo/score_reference_logprobs.py
@@ -145,7 +145,7 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def dpo_source(args: argparse.Namespace) -> Prefere
+def dpo_source(args: argparse.Namespace) -> PreferenceSource:
     """The preference source these CLI args select; a path-shaped --dataset is routed to JSONL by the config."""
     if args.jsonl:
         return PreferenceJSONLSource(paths=list(args.jsonl), index_mapping_dir=args.index_mapping_dir)

--- a/scripts/dpo/score_reference_logprobs.py
+++ b/scripts/dpo/score_reference_logprobs.py
@@ -1,0 +1,344 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Score reference-model logprobs for every DPO preference pair (offline, one-time).
+
+Runs the reference model forward over the trainer's own pair dataset and writes a
+``pair_id``-keyed artifact the trainer loads instead of the reference weights. Data, tokenizer, ``--max-seq-length`` and
+the parallel layout (``--tp``, ``--sequence-parallel``) must equal the training run's;
+``scoring_metadata.json`` records them and the trainer checks it.
+
+Example:
+    python scripts/dpo/score_reference_logprobs.py \\
+        --model Qwen/Qwen2.5-0.5B-Instruct \\
+        --output /tmp/capybara_ref_logprobs --num-pairs 1024
+
+With tensor parallelism (launch exactly ``--tp`` processes; rank 0 writes the artifact):
+    python -m torch.distributed.run --nproc_per_node=2 \\
+        scripts/dpo/score_reference_logprobs.py --tp 2 \\
+        --model Qwen/Qwen2.5-7B-Instruct --output /tmp/uf_ref_logprobs
+"""
+
+import argparse
+import os
+from dataclasses import asdict
+
+import torch
+from megatron.core.msc_utils import MultiStorageClientFeature
+from megatron.core.pipeline_parallel import get_forward_backward_func
+from torch.utils.data import BatchSampler, DataLoader, SequentialSampler
+
+from megatron.bridge import AutoBridge
+from megatron.bridge.data.builders.dpo import DPODatasetConfig, PreferenceSource, build_preference_split
+from megatron.bridge.data.datasets.preference import (
+    ScoringFingerprint,
+    pack_pairs_by_token_budget,
+    pair_token_lengths,
+    write_ref_logprobs,
+    write_scoring_metadata,
+)
+from megatron.bridge.data.datasets.preference_lazy import LazyChatPreferencePairDataset
+from megatron.bridge.data.sources.hf import HFDatasetSourceConfig
+from megatron.bridge.data.sources.jsonl import PreferenceJSONLSource
+from megatron.bridge.models import GPTModelProvider
+from megatron.bridge.training.dpo import sequence_logprob_sums, split_pair_rows
+from megatron.bridge.training.mixed_precision import get_mixed_precision_config
+from megatron.bridge.utils.common_utils import (
+    get_rank_safe,
+    get_world_size_safe,
+    maybe_initialize_distributed,
+    print_rank_0,
+)
+
+
+# The trainer's default recipe; applied here too so the reference forward runs the policy's numerics
+# whatever precision the checkpoint declares.
+MIXED_PRECISION_RECIPE = "bf16_mixed"
+
+
+def parse_args() -> argparse.Namespace:
+    """CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument(
+        "--dataset",
+        help="HF hub id, local path, or a single JSONL file (local or msc://); must match training",
+    )
+    parser.add_argument("--split", default="train")
+    source_group.add_argument(
+        "--jsonl",
+        nargs="+",
+        default=None,
+        help="JSONL preference rows (local or msc://) read in place, instead of --dataset",
+    )
+    parser.add_argument(
+        "--index-mapping-dir",
+        default=os.path.expanduser("~/.cache/megatron_bridge/dpo_index"),
+        help="Where JSONL memmap index sidecars go; required for msc:// paths",
+    )
+    parser.add_argument("--chosen-key", default="chosen")
+    parser.add_argument("--rejected-key", default="rejected")
+    parser.add_argument(
+        "--prompt-key",
+        default=None,
+        help="Field holding the shared prompt when chosen/rejected hold only the completion turns; "
+        "must match training",
+    )
+    parser.add_argument("--model", required=True, help="Reference model (HF path/id the policy initializes from)")
+    parser.add_argument("--tokenizer", default=None, help="Defaults to --model; must match training")
+    parser.add_argument("--output", required=True, help="msc:// URL or local directory for the artifact")
+    parser.add_argument("--max-seq-length", type=int, default=2048, help="Must match training")
+    parser.add_argument("--num-pairs", type=int, default=0, help="Score only the first N source rows (0 = all)")
+    batch_group = parser.add_mutually_exclusive_group()
+    batch_group.add_argument(
+        "--micro-batch-size",
+        type=int,
+        default=None,
+        help="Pairs per forward pass, each pair is 2 rows (default 8 when --token-budget is unset)",
+    )
+    batch_group.add_argument(
+        "--token-budget",
+        type=int,
+        default=None,
+        help="Length-sorted batches capped at this many padded tokens instead of a fixed pair count",
+    )
+    parser.add_argument(
+        "--max-pairs-per-batch",
+        type=int,
+        default=64,
+        help="Pair cap per --token-budget batch; ignored otherwise",
+    )
+    parser.add_argument(
+        "--tp",
+        type=int,
+        default=1,
+        help="Tensor parallel size; launch exactly this many processes. Must match training",
+    )
+    parser.add_argument(
+        "--sequence-parallel",
+        action="store_true",
+        help="Shard activations along the sequence across the TP group (required for MoE at TP > 1); "
+        "must match training",
+    )
+    parser.add_argument("--ep", type=int, default=1, help="Expert parallel size (MoE only)")
+    parser.add_argument("--etp", type=int, default=None, help="Expert tensor parallel size (default: --tp)")
+    parser.add_argument("--seed", type=int, default=0)
+
+    args = parser.parse_args()
+    if args.ep < 1 or (args.etp is not None and args.etp < 1):
+        parser.error(f"--ep and --etp must be >= 1; got --ep {args.ep} --etp {args.etp}.")
+    if args.etp is None:
+        args.etp = args.tp
+    if args.micro_batch_size is None and args.token_budget is None:
+        args.micro_batch_size = 8
+    return args
+
+
+def dpo_source(args: argparse.Namespace) -> Prefere
+    """The preference source these CLI args select; a path-shaped --dataset is routed to JSONL by the config."""
+    if args.jsonl:
+        return PreferenceJSONLSource(paths=list(args.jsonl), index_mapping_dir=args.index_mapping_dir)
+    return HFDatasetSourceConfig(path_or_dataset=args.dataset, split=args.split)
+
+
+class ReferenceLogprobScorer:
+    """Forward the reference model over every pair and write the ref-logprob artifact."""
+
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.tokenizer_name: str = args.tokenizer or args.model
+        self.dataset_config = DPODatasetConfig(
+            tokenizer_name=self.tokenizer_name,
+            seq_length=args.max_seq_length,
+            source=dpo_source(args),
+            index_mapping_dir=args.index_mapping_dir,
+            ref_artifact=args.output,
+            num_pairs=args.num_pairs,
+            chosen_key=args.chosen_key,
+            rejected_key=args.rejected_key,
+            prompt_key=args.prompt_key,
+            pad_seq_length_to_mult=args.tp if args.sequence_parallel else 1,
+        )
+
+    def run(self) -> None:
+        """Load data + model, score all pairs, write the artifact."""
+        maybe_initialize_distributed()
+        source_key, _ = self.dataset_config.source_identity(self.dataset_config.source)
+        print_rank_0(f"loading {source_key} and tokenizer {self.tokenizer_name}...")
+
+        # The trainer's own builder, so both sides see identical rows, token streams, and pair_ids.
+        dataset = build_preference_split(self.dataset_config, "train", self.dataset_config.load_tokenizer())
+        model = self._build_model()
+        records = self._score_all(model, dataset)
+
+        if get_rank_safe() == 0:
+            write_ref_logprobs(records, self.args.output)
+            self._commit_artifact(num_pairs=len(dataset))
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()  # don't tear down the process group under the writer
+
+    def _score_all(
+        self, model: list[torch.nn.Module], dataset: LazyChatPreferencePairDataset
+    ) -> list[dict[str, float | int]]:
+        """Forward every batch and collect one record per pair, logging progress about ten times."""
+        loader = self._pair_loader(dataset)
+        log_every = max(1, len(loader) // 10)
+        records: list[dict[str, float | int]] = []
+        for step, batch in enumerate(loader):
+            records.extend(self._score_batch(model, batch))
+            if step % log_every == 0 or step == len(loader) - 1:
+                print_rank_0(f"scored {len(records)}/{len(dataset)} pairs")
+        return records
+
+    def _build_model(self) -> list[torch.nn.Module]:
+        """Forward-only Megatron bring-up (no ConfigContainer/optimizer)."""
+        world_size = get_world_size_safe()
+        expert_mesh = self.args.ep * self.args.etp
+        if world_size != self.args.tp or world_size != expert_mesh:
+            raise SystemExit(
+                f"World size {world_size} must equal both --tp {self.args.tp} and EP x ETP "
+                f"{self.args.ep} x {self.args.etp} = {expert_mesh}: the scorer runs "
+                "without data parallelism on either mesh."
+            )
+        bridge = AutoBridge.from_hf_pretrained(self.args.model, torch_dtype=torch.bfloat16)
+        provider = bridge.to_megatron_provider(load_weights=True)
+        self._configure_provider(provider)
+        provider.finalize()
+        provider.initialize_model_parallel(seed=self.args.seed)
+        model = provider.provide_distributed_model(wrap_with_ddp=False)
+        model = [m.cuda() for m in model]
+        for m in model:
+            m.eval()
+        return model
+
+    def _configure_provider(self, provider: GPTModelProvider) -> None:
+        """Apply the trainer's precision recipe, the scorer's parallel layout, and the no-MTP pin."""
+        get_mixed_precision_config(MIXED_PRECISION_RECIPE).setup(provider)
+        overrides = {
+            "tensor_model_parallel_size": self.args.tp,
+            "pipeline_model_parallel_size": 1,
+            "expert_model_parallel_size": self.args.ep,
+            "expert_tensor_parallel_size": self.args.etp,
+            "sequence_parallel": self.args.sequence_parallel,
+            "seq_length": self.args.max_seq_length,
+            "mtp_num_layers": None,  # an MTP head would add its own next-token loss on top of the DPO loss
+        }
+        for name, value in overrides.items():
+            if not hasattr(provider, name):
+                raise ValueError(f"Model provider {type(provider).__name__} has no '{name}' to pin.")
+            setattr(provider, name, value)
+
+    def _pair_loader(self, dataset: LazyChatPreferencePairDataset) -> DataLoader:
+        """Deterministic full-coverage batches: records carry pair_id, so order is free."""
+        if self.args.token_budget:
+            print_rank_0(f"token-budget batching: measuring {len(dataset)} pair lengths (one CPU pass)...")
+            batch_plan = pack_pairs_by_token_budget(
+                pair_token_lengths(dataset),
+                budget_tokens=self.args.token_budget,
+                max_pairs_per_batch=self.args.max_pairs_per_batch,
+            )
+            print_rank_0(
+                f"token-budget batching: {len(batch_plan)} batches under {self.args.token_budget} padded tokens"
+            )
+            return DataLoader(dataset, batch_sampler=batch_plan, collate_fn=dataset.collate_fn, pin_memory=True)
+        sampler = BatchSampler(SequentialSampler(dataset), batch_size=self.args.micro_batch_size, drop_last=False)
+        return DataLoader(dataset, batch_sampler=sampler, collate_fn=dataset.collate_fn, pin_memory=True)
+
+    @staticmethod
+    def _score_batch(model: list[torch.nn.Module], batch: dict[str, torch.Tensor]) -> list[dict[str, float | int]]:
+        """One forward pass; returns one record per pair via the shared DPO sum math."""
+        rows = {key: batch[key].cuda() for key in ("tokens", "labels", "loss_mask", "position_ids")}
+
+        def forward_step(data_iterator, megatron_model):
+            data = next(data_iterator)
+
+            def collect(per_token_nll, non_loss_data=True):
+                sums, counts = sequence_logprob_sums(per_token_nll, data["loss_mask"])
+                return sums.cpu(), counts.cpu()
+
+            output = megatron_model(
+                input_ids=data["tokens"],
+                position_ids=data["position_ids"],
+                attention_mask=None,
+                labels=data["labels"],
+            )
+            return output, collect
+
+        with torch.no_grad():
+            collected = get_forward_backward_func()(
+                forward_step_func=forward_step,
+                data_iterator=iter([rows]),
+                model=model,
+                num_microbatches=1,
+                forward_only=True,
+                collect_non_loss_data=True,
+                seq_length=rows["tokens"].size(1),
+                micro_batch_size=rows["tokens"].size(0),
+            )
+
+        sums, counts = collected[0]
+        chosen_sums, rejected_sums = split_pair_rows(sums)
+        chosen_counts, rejected_counts = split_pair_rows(counts)
+        pair_ids = batch["pair_id"][::2]
+        return [
+            {
+                "pair_id": int(pair_ids[i]),
+                "ref_chosen_logprob_sum": float(chosen_sums[i]),
+                "ref_chosen_num_tokens": int(chosen_counts[i]),
+                "ref_rejected_logprob_sum": float(rejected_sums[i]),
+                "ref_rejected_num_tokens": int(rejected_counts[i]),
+            }
+            for i in range(len(pair_ids))
+        ]
+
+    def _expert_layout_metadata(self) -> dict[str, int]:
+        """The (EP, ETP) keys, omitted when they match the implied EP=1 / ETP=TP layout."""
+        if self.args.ep == 1 and self.args.etp == self.args.tp:
+            return {}
+        return {"expert_model_parallel_size": self.args.ep, "expert_tensor_parallel_size": self.args.etp}
+
+    def _commit_artifact(self, num_pairs: int) -> None:
+        """Publish the scoring metadata; the trainer refuses a table without it."""
+        dataset_key, split = self.dataset_config.source_identity(self.dataset_config.source)
+        fingerprint = ScoringFingerprint(
+            dataset=dataset_key,
+            split=split,
+            tokenizer=self.tokenizer_name,
+            max_seq_length=self.args.max_seq_length,
+            prompt_key=self.args.prompt_key,
+            tensor_model_parallel_size=self.args.tp,
+            sequence_parallel=bool(self.args.sequence_parallel),
+            pipeline_model_parallel_size=1,
+        )
+        write_scoring_metadata(
+            {
+                **asdict(fingerprint),
+                **self._expert_layout_metadata(),
+                "model": self.args.model,
+                "num_pairs": num_pairs,
+                "mixed_precision": MIXED_PRECISION_RECIPE,
+            },
+            self.args.output,
+        )
+        print_rank_0(f"artifact committed to {self.args.output} ({num_pairs} pairs)")
+
+
+def main() -> None:
+    """Score the reference model over the preference dataset and publish the artifact."""
+    MultiStorageClientFeature.enable()
+    ReferenceLogprobScorer(parse_args()).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -18,8 +18,8 @@ resolving the full GPU training dependency set on the login node.
 
 Choose exactly one of a complete recipe or a model selector. `--recipe` and `--model` are mutually exclusive. A complete
 recipe is discovered automatically from its exported function name, whether it is a library or benchmark recipe;
-there is no separate source flag. A model selector requires one of `--mode pretrain`, `--mode sft`, `--mode lora`, or
-`--mode dora`; a conventional complete recipe name infers its mode when `--mode` is omitted.
+there is no separate source flag. A model selector requires one of `--mode pretrain`, `--mode sft`, `--mode lora`,
+`--mode dora`, or `--mode dpo`; a conventional complete recipe name infers its mode when `--mode` is omitted.
 
 ### Library recipe
 
@@ -38,7 +38,8 @@ A complete recipe already identifies the model and default training configuratio
 
 The model selector combines the model stem and mode to load the corresponding library recipe. For example,
 `--model gpt_oss_20b --mode sft` loads `gpt_oss_20b_sft_config`; LoRA and DoRA load the model's PEFT recipe and set the
-requested adapter scheme.
+requested adapter scheme. `--mode dpo` loads `<model>_dpo_config`; a DPO recipe owns its preference dataset and
+scored reference artifact, so `--dataset` presets do not apply and the forward step is always `dpo_step`.
 
 ```bash
 ./scripts/training/train.sh \

--- a/scripts/training/recipe_metadata.py
+++ b/scripts/training/recipe_metadata.py
@@ -72,7 +72,7 @@ LIBRARY_RECIPE_PRECEDENCE_COLLISIONS: frozenset[str] = frozenset(
     }
 )
 
-PUBLIC_MODES = frozenset({"pretrain", "sft", "lora", "dora"})
+PUBLIC_MODES = frozenset({"pretrain", "sft", "lora", "dora", "dpo"})
 TEXT_FORWARD_STEPS = frozenset({"dsv4_step", "gpt_step", "llm_step"})
 
 # Exact source-specific overrides take precedence over family defaults. The
@@ -201,6 +201,9 @@ def recipe_step(recipe_name: str, *, native_energon_packing: bool = False) -> st
         return "vlm_step"
     if recipe_name in RECIPE_FORWARD_STEPS:
         return RECIPE_FORWARD_STEPS[recipe_name]
+    # DPO computes its pair loss inside the forward step, so DPO recipes never use a modality step.
+    if infer_recipe_mode(recipe_name) == "dpo":
+        return "dpo_step"
     for prefix, step_name in RECIPE_FORWARD_STEP_PREFIXES:
         if recipe_name.startswith(prefix):
             return step_name
@@ -226,6 +229,8 @@ def infer_recipe_mode(recipe_name: str) -> str | None:
         return "pretrain"
     if "_sft_" in normalized_name or "_finetune_" in normalized_name:
         return "sft"
+    if "_dpo_" in normalized_name:
+        return "dpo"
     if "_dora_" in normalized_name:
         return "dora"
     if "_peft_" in normalized_name or "_lora_" in normalized_name:

--- a/scripts/training/recipe_runner.py
+++ b/scripts/training/recipe_runner.py
@@ -52,6 +52,7 @@ TrainFunctionEntry = Callable | tuple[str, str]
 
 STEP_FUNCTIONS: dict[str, StepFunctionEntry] = {
     "audio_lm_step": ("megatron.bridge.training.audio_lm_step", "forward_step"),
+    "dpo_step": ("megatron.bridge.training.dpo_step", "dpo_forward_step"),
     "dsv4_step": ("megatron.bridge.models.deepseek.deepseek_v4_step", "forward_step"),
     "gpt_step": ("megatron.bridge.training.gpt_step", "forward_step"),
     "llm_step": ("megatron.bridge.training.gpt_step", "forward_step"),
@@ -67,6 +68,7 @@ STEP_FUNCTIONS: dict[str, StepFunctionEntry] = {
 
 STEP_MODALITIES = {
     "audio_lm_step": "audio",
+    "dpo_step": "text",
     "dsv4_step": "text",
     "gpt_step": "text",
     "llm_step": "text",
@@ -83,6 +85,7 @@ STEP_MODALITIES = {
 TRAIN_FUNCTIONS: dict[str, TrainFunctionEntry] = {
     "pretrain": ("megatron.bridge.training.pretrain", "pretrain"),
     "finetune": ("megatron.bridge.training.finetune", "finetune"),
+    "dpo": ("megatron.bridge.training.dpo_train", "dpo_train"),
 }
 
 ERR_UNKNOWN_STEP = "Unknown step type: {step_type}. Choose from: {choices}"

--- a/scripts/training/run_recipe.py
+++ b/scripts/training/run_recipe.py
@@ -128,8 +128,8 @@ if TYPE_CHECKING:
     from megatron.bridge.training.config import ConfigContainer
 
 
-PublicMode = Literal["pretrain", "sft", "lora", "dora"]
-TrainMode = Literal["pretrain", "finetune"]
+PublicMode = Literal["pretrain", "sft", "lora", "dora", "dpo"]
+TrainMode = Literal["pretrain", "finetune", "dpo"]
 
 
 IMPORT_TIME_RECIPE_ENV_VARS = frozenset({"NVTE_CPU_OFFLOAD_V1"})
@@ -174,7 +174,7 @@ def _build_parser() -> argparse.ArgumentParser:
     recipe_selection.add_argument("--recipe", help="Complete recipe function name.")
     selection.add_argument(
         "--mode",
-        choices=["pretrain", "sft", "lora", "dora"],
+        choices=["pretrain", "sft", "lora", "dora", "dpo"],
         help="Training mode; inferred from a conventional --recipe name when omitted.",
     )
     selection.add_argument(
@@ -289,7 +289,9 @@ def _common_config_overrides(args: argparse.Namespace) -> list[str]:
 
 def _train_mode(mode: PublicMode) -> TrainMode:
     """Map the public mode to a training loop."""
-    return "pretrain" if mode == "pretrain" else "finetune"
+    if mode in {"pretrain", "dpo"}:
+        return mode
+    return "finetune"
 
 
 def _infer_mode(args: argparse.Namespace) -> None:
@@ -298,6 +300,20 @@ def _infer_mode(args: argparse.Namespace) -> None:
         args.mode = infer_recipe_mode(args.recipe)
     if args.mode is None:
         raise ValueError("Unable to infer training mode; pass --mode or use a conventional --recipe name.")
+
+
+def _resolve_step_for_mode(step_name: str, mode: PublicMode) -> str:
+    """Pair dpo_step with DPO mode: the DPO loss lives in its forward step, so no other step fits."""
+    step = step_name.lower()
+    if mode == "dpo":
+        if step == "llm_step":
+            return "dpo_step"
+        if step != "dpo_step":
+            raise ValueError(f"--step-func {step_name} is incompatible with --mode dpo: DPO trains with dpo_step.")
+        return step
+    if step == "dpo_step":
+        raise ValueError(f"--step-func dpo_step is incompatible with --mode {mode}: dpo_step requires --mode dpo.")
+    return step_name
 
 
 def _validate_recipe_mode(recipe_name: str, mode: PublicMode) -> None:
@@ -442,6 +458,10 @@ def _apply_dataset(recipe: ConfigContainer, args: argparse.Namespace) -> ConfigC
     """Apply a public dataset selection to a recipe config."""
     if args.dataset is None:
         return recipe
+    if args.mode == "dpo":
+        raise ValueError(
+            f"Mode 'dpo' is incompatible with dataset '{args.dataset}': DPO recipes own their preference dataset."
+        )
 
     recipe.dataset = build_dataset_config(recipe, args.dataset)
     requested_train_mode = _train_mode(args.mode)
@@ -530,6 +550,7 @@ def main(argv: list[str] | None = None) -> None:
         recipe_name,
         native_energon_packing=native_energon_packing,
     )
+    step_func_name = _resolve_step_for_mode(step_func_name, args.mode)
     forward_step = load_forward_step(step_func_name, mode=step_mode)
     run_config(
         config=recipe,

--- a/src/megatron/bridge/data/builders/__init__.py
+++ b/src/megatron/bridge/data/builders/__init__.py
@@ -6,6 +6,11 @@ from megatron.bridge.data.builders.direct_hf_sft import (
     DirectHFSFTDatasetConfig,
     direct_hf_sft_train_valid_test_datasets_provider,
 )
+from megatron.bridge.data.builders.dpo import (
+    DPODatasetBuilder,
+    DPODatasetConfig,
+    dpo_train_valid_test_datasets_provider,
+)
 from megatron.bridge.data.builders.energon import (
     EnergonDatasetBuilder,
     EnergonDatasetConfig,
@@ -40,6 +45,8 @@ FinetuningDatasetConfig = _gpt_sft.FinetuningDatasetConfig
 
 
 __all__ = [
+    "DPODatasetBuilder",
+    "DPODatasetConfig",
     "GPTSFTDatasetBuilder",
     "GPTSFTDatasetConfig",
     "ChatSFTPreprocessingConfig",
@@ -55,6 +62,7 @@ __all__ = [
     "MockVLMSFTDatasetConfig",
     "PromptCompletionSFTPreprocessingConfig",
     "SFTPreprocessingConfig",
+    "dpo_train_valid_test_datasets_provider",
     "gpt_sft_train_valid_test_datasets_provider",
     "direct_hf_sft_train_valid_test_datasets_provider",
     "energon_train_valid_test_datasets_provider",

--- a/src/megatron/bridge/data/builders/dpo.py
+++ b/src/megatron/bridge/data/builders/dpo.py
@@ -97,7 +97,7 @@ class DPODatasetConfig(DataloaderConfig):
     TP | seq_len; ``dpo_train`` derives it from the model config, the scorer from its flags."""
     shuffle: bool = True
 
-    def _resolve_source(self, source: PreferenceSource, *, field: str) -> PreferenceSource:
+    def resolve_source(self, source: PreferenceSource, *, field: str) -> PreferenceSource:
         """Route a JSONL path to the memmap reader, then validate whichever source type results."""
         source = _as_source(source)
         if isinstance(source, HFDatasetSourceConfig) and (source.path_or_dataset or "").endswith(_JSONL_SUFFIXES):
@@ -115,11 +115,11 @@ class DPODatasetConfig(DataloaderConfig):
         if self.seq_length <= 0:
             raise ValueError("seq_length must be greater than 0.")
 
-        source = self._resolve_source(self.source, field="source")
+        source = self.resolve_source(self.source, field="source")
         validation_source = None
 
         if self.validation_source is not None:
-            validation_source = self._resolve_source(self.validation_source, field="validation_source")
+            validation_source = self.resolve_source(self.validation_source, field="validation_source")
             if not self.validation_ref_artifact:
                 raise ValueError(
                     "validation_ref_artifact must be set with a validation split: validation needs its own "

--- a/src/megatron/bridge/data/builders/dpo.py
+++ b/src/megatron/bridge/data/builders/dpo.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``ConfigContainer.dataset`` entry for DPO preference training.
+
+``DPODatasetConfig`` + ``DPODatasetBuilder`` + the registered
+``dpo_train_valid_test_datasets_provider`` follow the config-and-builder dataset
+architecture (registered in ``data/utils.py``); loader construction is the DPO
+branch of ``data/loaders.py``.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from torch.utils.data import Subset
+from transformers import AutoTokenizer
+
+from megatron.bridge.data.base import DataloaderConfig, DatasetBuildContext
+from megatron.bridge.data.datasets.preference import load_ref_logprobs
+from megatron.bridge.data.datasets.preference_lazy import LazyChatPreferencePairDataset
+from megatron.bridge.data.datasets.utils import _JSONLMemMapDataset
+from megatron.bridge.data.sources.hf import HFDatasetSourceConfig, load_hf_dataset_source, prepare_hf_dataset_sources
+from megatron.bridge.data.sources.jsonl import PreferenceJSONLSource
+from megatron.bridge.models.hf_pretrained.utils import is_safe_repo
+
+
+if TYPE_CHECKING:
+    from megatron.core.process_groups_config import ProcessGroupCollection
+
+    from megatron.bridge.training.tokenizers.tokenizer import MegatronTokenizer
+
+
+PreferenceSource = HFDatasetSourceConfig | PreferenceJSONLSource
+
+_JSONL_SUFFIXES = (".jsonl", ".json")
+
+
+def _as_source(entry: "PreferenceSource | Mapping[str, Any]") -> Any:
+    """Rebuild a source that an override round trip flattened into a mapping."""
+    if not isinstance(entry, Mapping):
+        return entry
+    return PreferenceJSONLSource(**dict(entry)) if "paths" in entry else HFDatasetSourceConfig(**dict(entry))
+
+
+@dataclass(kw_only=True)
+class DPODatasetConfig(DataloaderConfig):
+    """Chat-format preference dataset plus its offline-scored ref-logprob artifact.
+
+    ``source`` is an ``HFDatasetSourceConfig`` for anything HuggingFace ``datasets``
+    can read, or a ``PreferenceJSONLSource`` for JSONL that may live in object storage.
+    The source identity, ``tokenizer_name``, and ``seq_length`` must equal the
+    scoring run's values, which ``dpo_train`` checks against ``scoring_metadata.json``
+    (where the length is recorded under its dataset-level name, ``max_seq_length``).
+
+    A validation split is optional and mirrors the train shape: one ``validation_source``
+    plus its own scored ``validation_ref_artifact`` (``tokenizer_name`` and
+    ``seq_length`` are shared with training, so the validation split must be
+    scored with the same values). Like the SFT dataset configs, a configured
+    validation split is built only when the run actually validates
+    (``validation.eval_iters``/``eval_interval`` > 0).
+
+    Batch sizes stay row-denominated; pair halving happens only in the loader builder.
+    """
+
+    tokenizer_name: str
+    seq_length: int
+    """Truncation ceiling for tokenized pairs."""
+    source: PreferenceSource
+    ref_artifact: str | None = None
+    """Scorer artifact directory or URL. Required to build datasets; only
+    source-only helpers (``load_source``) may leave it unset."""
+    validation_ref_artifact: str | None = None
+    """Scorer artifact for the validation split. Required when a validation source is set."""
+    validation_source: PreferenceSource | None = None
+    validation_num_pairs: int = 0
+    chosen_key: str = "chosen"
+    rejected_key: str = "rejected"
+    prompt_key: str | None = None
+    index_mapping_dir: str | None = None
+    num_pairs: int = 0
+    dataloader_type: Literal["batch"] | None = "batch"
+    """Pinned: the batch sampler's cyclic wrap provides epochs beyond one dataset pass."""
+    pad_seq_length_to_mult: int = 1
+    """Round each batch's padded row length up to this multiple. Sequence parallelism needs
+    TP | seq_len; ``dpo_train`` derives it from the model config, the scorer from its flags."""
+    shuffle: bool = True
+
+    def _resolve_source(self, source: PreferenceSource, *, field: str) -> PreferenceSource:
+        """Route a JSONL path to the memmap reader, then validate whichever source type results."""
+        source = _as_source(source)
+        if isinstance(source, HFDatasetSourceConfig) and (source.path_or_dataset or "").endswith(_JSONL_SUFFIXES):
+            source = PreferenceJSONLSource(paths=[source.path_or_dataset], index_mapping_dir=self.index_mapping_dir)
+        if not isinstance(source, (HFDatasetSourceConfig, PreferenceJSONLSource)):
+            raise TypeError(f"{field} must be an HFDatasetSourceConfig or PreferenceJSONLSource; got {source!r}.")
+
+        source.validate()
+        return source
+
+    def validate(self) -> None:
+        """Resolve and validate the sources; pin the dataloader type."""
+        if self.dataloader_type != "batch":
+            raise ValueError(f"DPO supports only dataloader_type='batch'; got {self.dataloader_type!r}.")
+        if self.seq_length <= 0:
+            raise ValueError("seq_length must be greater than 0.")
+
+        source = self._resolve_source(self.source, field="source")
+        validation_source = None
+
+        if self.validation_source is not None:
+            validation_source = self._resolve_source(self.validation_source, field="validation_source")
+            if not self.validation_ref_artifact:
+                raise ValueError(
+                    "validation_ref_artifact must be set with a validation split: validation needs its own "
+                    "offline-scored artifact."
+                )
+        elif self.validation_ref_artifact:
+            raise ValueError("validation_ref_artifact is set but no validation split is: set validation_source.")
+
+        self.source, self.validation_source = source, validation_source
+
+    def finalize(self) -> None:
+        """Finalize dataloader settings and validate. ``ref_artifact`` may be local or msc://."""
+        super().finalize()
+        self.validate()
+
+    @property
+    def has_validation_split(self) -> bool:
+        """Whether a validation source is configured."""
+        return self.validation_source is not None
+
+    @staticmethod
+    def source_identity(source: PreferenceSource) -> tuple[str, str | None]:
+        """``(dataset, split)`` as recorded in and checked against ``scoring_metadata.json``.
+
+        JSONL sources have no split: their paths name the rows directly.
+        """
+        if isinstance(source, PreferenceJSONLSource):
+            return ",".join(source.paths), None
+        return source.dataset_name or source.path_or_dataset, source.split
+
+    def load_tokenizer(self):
+        """The HF tokenizer both the scorer and the trainer tokenize pairs with."""
+        trust_remote_code = is_safe_repo(hf_path=self.tokenizer_name, trust_remote_code=self.trust_remote_code)
+        return AutoTokenizer.from_pretrained(self.tokenizer_name, trust_remote_code=trust_remote_code)
+
+    def load_source(self, split: Literal["train", "validation"] = "train"):
+        """Load the raw preference rows of ``split``, truncated to that split's ``num_pairs``.
+
+        The offline scorer calls this too: both jobs must see the same rows in the same
+        order for ``pair_id`` to line up between the artifact and training.
+        """
+        self.validate()
+        if split == "validation":
+            if self.validation_source is None:
+                raise ValueError("No validation split is configured: set validation_source.")
+            return self._load_rows(self.validation_source, self.validation_num_pairs)
+        return self._load_rows(self.source, self.num_pairs)
+
+    @staticmethod
+    def _load_rows(source: PreferenceSource, num_pairs: int):
+        if isinstance(source, PreferenceJSONLSource):
+            rows = _JSONLMemMapDataset(
+                dataset_paths=source.paths,
+                tokenizer=None,
+                header_lines=0,
+                index_mapping_dir=source.index_mapping_dir,
+            )
+        else:
+            # Rank 0 materializes the HuggingFace cache first: concurrent builders on a
+            # shared filesystem are not safe. No-op for single-process callers.
+            prepare_hf_dataset_sources([source])
+            rows = load_hf_dataset_source(source)
+
+        if num_pairs and num_pairs < len(rows):
+            # Truncate by position so row index == pair_id survives.
+            rows = rows.select(range(num_pairs)) if hasattr(rows, "select") else Subset(rows, range(num_pairs))
+        return rows
+
+
+def build_preference_split(
+    config: DPODatasetConfig,
+    split: Literal["train", "validation"],
+    tokenizer,
+    ref_artifact: str | None = None,
+) -> LazyChatPreferencePairDataset:
+    """Load one split's rows and wrap them as a pair dataset.
+
+    The scorer builds without ``ref_artifact``; the trainer supplies the split's artifact,
+    which must cover every loaded pair.
+    """
+    rows = config.load_source(split)
+    ref_logprobs = load_ref_logprobs(ref_artifact, expected_num_pairs=len(rows)) if ref_artifact else None
+    return LazyChatPreferencePairDataset(
+        rows,
+        tokenizer,
+        max_seq_length=config.seq_length,
+        pad_seq_length_to_mult=config.pad_seq_length_to_mult,
+        chosen_key=config.chosen_key,
+        rejected_key=config.rejected_key,
+        prompt_key=config.prompt_key,
+        ref_logprobs=ref_logprobs,
+    )
+
+
+class DPODatasetBuilder:
+    """Build the runtime preference-pair dataset with reference logprobs attached."""
+
+    def __init__(self, config: DPODatasetConfig) -> None:
+        config.validate()
+        if not config.ref_artifact:
+            raise ValueError(
+                "ref_artifact is not set: training needs the offline scorer's artifact "
+                "(score_reference_logprobs.py --output) to anchor the margins."
+            )
+        self.config = config
+
+    def build(
+        self,
+        context: DatasetBuildContext,
+    ) -> tuple[LazyChatPreferencePairDataset, LazyChatPreferencePairDataset | None, None]:
+        tokenizer = self.config.load_tokenizer()
+        train_dataset = build_preference_split(self.config, "train", tokenizer, self.config.ref_artifact)
+        valid_dataset = (
+            build_preference_split(self.config, "validation", tokenizer, self.config.validation_ref_artifact)
+            if self.config.has_validation_split and context.valid_samples > 0
+            else None
+        )
+        return train_dataset, valid_dataset, None
+
+
+def dpo_train_valid_test_datasets_provider(
+    train_val_test_num_samples: list[int],
+    dataset_config: DPODatasetConfig,
+    tokenizer: "MegatronTokenizer | None" = None,
+    pg_collection: "ProcessGroupCollection | None" = None,
+) -> tuple[LazyChatPreferencePairDataset, LazyChatPreferencePairDataset | None, None]:
+    """Build DPO preference datasets through the canonical runtime builder."""
+    context = DatasetBuildContext(
+        train_samples=train_val_test_num_samples[0],
+        valid_samples=train_val_test_num_samples[1],
+        test_samples=train_val_test_num_samples[2],
+        tokenizer=tokenizer,
+        pg_collection=pg_collection,
+    )
+    return DPODatasetBuilder(dataset_config).build(context)

--- a/src/megatron/bridge/data/conversation_processing.py
+++ b/src/megatron/bridge/data/conversation_processing.py
@@ -796,6 +796,7 @@ def tokenize_chat_example(
     warn_on_all_masked: bool = True,
     loss_mode: Literal["assistant", "last_turn", "full"] = "assistant",
     return_final_assistant_start: bool = False,
+    final_assistant_span: Literal["content", "turn"] = "content",
 ) -> TokenizedConversation:
     """Render, tokenize, and construct the assistant mask for one chat row.
 
@@ -807,6 +808,8 @@ def tokenize_chat_example(
     """
     if loss_mode not in {"assistant", "last_turn", "full"}:
         raise ValueError("Chat SFT loss_mode must be assistant, last_turn, or full.")
+    if final_assistant_span not in {"content", "turn"}:
+        raise ValueError("final_assistant_span must be content or turn.")
     conversation = normalize_chat_conversation(example_or_conversation)
     template_kwargs = chat_template_kwargs_from_example(example_or_conversation)
     if not template_kwargs.get("tools") and tool_schemas is not None:
@@ -847,12 +850,21 @@ def tokenize_chat_example(
     generation_assistant_start = None
     last_turn_start = None
     if return_final_assistant_start and selected_template_owner is not None and selected_tokenize_kwargs is not None:
-        generation_assistant_start = _infer_terminal_assistant_content_start(
-            selected_template_owner,
-            conversation,
-            selected_tokenize_kwargs,
-            input_ids.tolist(),
-        )
+        if final_assistant_span == "turn":
+            generation_assistant_start = _infer_final_assistant_start(
+                selected_template_owner,
+                conversation,
+                selected_tokenize_kwargs,
+                input_ids.tolist(),
+                terminal_only=True,
+            )
+        else:
+            generation_assistant_start = _infer_terminal_assistant_content_start(
+                selected_template_owner,
+                conversation,
+                selected_tokenize_kwargs,
+                input_ids.tolist(),
+            )
     if loss_mode == "last_turn" and selected_template_owner is not None and selected_tokenize_kwargs is not None:
         last_turn_start = _infer_final_assistant_start(
             selected_template_owner,

--- a/src/megatron/bridge/data/datasets/preference.py
+++ b/src/megatron/bridge/data/datasets/preference.py
@@ -14,6 +14,7 @@
 
 import json
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,20 @@ from megatron.bridge.data.samplers import build_pretraining_data_loader
 SCORING_METADATA_FILENAME = "scoring_metadata.json"
 
 REF_LOGPROBS_FILENAME = "ref_logprobs.jsonl"
+
+
+@dataclass(frozen=True)
+class ScoringFingerprint:
+    """Scoring-run inputs a training run must reproduce; written to and checked against ``scoring_metadata.json``."""
+
+    dataset: str
+    split: str | None
+    tokenizer: str
+    max_seq_length: int
+    prompt_key: str | None
+    tensor_model_parallel_size: int
+    sequence_parallel: bool
+    pipeline_model_parallel_size: int
 
 
 def _open_path(path: str, mode: str):
@@ -111,16 +126,19 @@ def read_scoring_metadata(artifact_dir: str) -> dict[str, Any]:
         ) from None
 
 
-def validate_scoring_metadata(artifact_dir: str, expected: Mapping[str, Any]) -> None:
-    """Raise if the artifact was scored under different inputs than ``expected``."""
+def validate_scoring_metadata(artifact_dir: str, expected: ScoringFingerprint) -> dict[str, Any]:
+    """Raise if the artifact was scored under different inputs than ``expected``; return its metadata."""
     metadata = read_scoring_metadata(artifact_dir)
-    mismatched = {key: (metadata.get(key), value) for key, value in expected.items() if metadata.get(key) != value}
+    mismatched = {
+        key: (metadata.get(key), value) for key, value in asdict(expected).items() if metadata.get(key) != value
+    }
     if mismatched:
         raise ValueError(
             f"scoring_metadata.json mismatch, artifact vs this run: {mismatched}. "
             "Re-score the reference logprobs or fix the training config — training against a "
             "differently-scored artifact silently corrupts every margin."
         )
+    return metadata
 
 
 def pair_token_lengths(dataset: Dataset) -> list[int]:

--- a/src/megatron/bridge/data/datasets/preference.py
+++ b/src/megatron/bridge/data/datasets/preference.py
@@ -234,6 +234,7 @@ def build_preference_data_loader(
     pin_memory: bool = True,
     worker_init_fn: Callable[[int], None] | None = None,
     shuffle: bool = True,
+    seed: int | None = None,
 ) -> DataLoader:
     """Build a DPO loader from row-denominated sizes (one pair == two rows), halved here for the stock loader."""
     if micro_batch_size % 2 != 0 or global_batch_size % 2 != 0:
@@ -267,4 +268,5 @@ def build_preference_data_loader(
         data_parallel_size=data_parallel_size,
         drop_last=True,
         shuffle=shuffle,
+        seed=seed,
     )

--- a/src/megatron/bridge/data/datasets/preference.py
+++ b/src/megatron/bridge/data/datasets/preference.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import torch
+from megatron.core.msc_utils import MultiStorageClientFeature
+from torch.utils.data import DataLoader, Dataset
+
+from megatron.bridge.data.collators.sequence_padding import _ceil_to_multiple
+from megatron.bridge.data.samplers import build_pretraining_data_loader
+
+
+SCORING_METADATA_FILENAME = "scoring_metadata.json"
+
+REF_LOGPROBS_FILENAME = "ref_logprobs.jsonl"
+
+
+def _open_path(path: str, mode: str):
+    if MultiStorageClientFeature.is_enabled():
+        msc = MultiStorageClientFeature.import_package()
+        return msc.open(path, mode)
+    if "w" in mode:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+    return open(path, mode)
+
+
+REF_LOGPROB_COLUMNS: tuple[str, ...] = (
+    "ref_chosen_logprob_sum",
+    "ref_chosen_num_tokens",
+    "ref_rejected_logprob_sum",
+    "ref_rejected_num_tokens",
+)
+
+
+def ref_logprobs_from_rows(rows: Iterable[Mapping[str, Any]], expected_num_pairs: int) -> dict[int, dict[str, Any]]:
+    """Validate offline-scorer output rows and key them by ``pair_id``."""
+    mapping: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        missing = [col for col in ("pair_id",) + REF_LOGPROB_COLUMNS if col not in row]
+        if missing:
+            raise ValueError(f"Ref-logprob row is missing columns {missing}; present keys: {sorted(row)}.")
+        pair_id = int(row["pair_id"])
+        if pair_id in mapping:
+            raise ValueError(f"Ref-logprob artifact has duplicate pair_id={pair_id}.")
+        mapping[pair_id] = {col: row[col] for col in REF_LOGPROB_COLUMNS}
+
+    expected_ids = set(range(expected_num_pairs))
+    if mapping.keys() != expected_ids:
+        missing_ids = sorted(expected_ids - mapping.keys())
+        unexpected_ids = sorted(mapping.keys() - expected_ids)
+        raise ValueError(
+            f"Ref-logprob artifact must cover pair_id 0..{expected_num_pairs - 1} exactly; "
+            f"missing {missing_ids[:10]}{'...' if len(missing_ids) > 10 else ''}, "
+            f"unexpected {unexpected_ids[:10]}{'...' if len(unexpected_ids) > 10 else ''}. "
+            "Was the artifact scored against this dataset?"
+        )
+    return mapping
+
+
+def _artifact_path(artifact_dir: str, filename: str) -> str:
+    return f"{artifact_dir.rstrip('/')}/{filename}"
+
+
+def write_ref_logprobs(records: Sequence[Mapping[str, Any]], artifact_dir: str) -> None:
+    """Write the ref-logprob rows as JSONL to ``artifact_dir`` (local or msc://)."""
+    path = _artifact_path(artifact_dir, REF_LOGPROBS_FILENAME)
+    with _open_path(path, "w") as f:
+        for record in records:
+            f.write(json.dumps(dict(record)) + "\n")
+
+
+def load_ref_logprobs(path: str, expected_num_pairs: int) -> dict[int, dict[str, Any]]:
+    """Load and validate a ref-scorer artifact from ``path`` (local or msc://)."""
+    with _open_path(_artifact_path(path, REF_LOGPROBS_FILENAME), "r") as f:
+        rows = [json.loads(line) for line in f if line.strip()]
+    return ref_logprobs_from_rows(rows, expected_num_pairs)
+
+
+def write_scoring_metadata(metadata: Mapping[str, Any], artifact_dir: str) -> None:
+    """Write ``scoring_metadata.json`` to ``artifact_dir`` (local or msc://)."""
+    path = _artifact_path(artifact_dir, SCORING_METADATA_FILENAME)
+    with _open_path(path, "w") as f:
+        json.dump(dict(metadata), f, indent=2)
+
+
+def read_scoring_metadata(artifact_dir: str) -> dict[str, Any]:
+    """Load the artifact's ``scoring_metadata.json`` (local or msc://)."""
+    path = _artifact_path(artifact_dir, SCORING_METADATA_FILENAME)
+    try:
+        with _open_path(path, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise ValueError(
+            f"No {SCORING_METADATA_FILENAME} in {artifact_dir} — is this a scorer artifact "
+            "(written by score_reference_logprobs.py)?"
+        ) from None
+
+
+def validate_scoring_metadata(artifact_dir: str, expected: Mapping[str, Any]) -> None:
+    """Raise if the artifact was scored under different inputs than ``expected``."""
+    metadata = read_scoring_metadata(artifact_dir)
+    mismatched = {key: (metadata.get(key), value) for key, value in expected.items() if metadata.get(key) != value}
+    if mismatched:
+        raise ValueError(
+            f"scoring_metadata.json mismatch, artifact vs this run: {mismatched}. "
+            "Re-score the reference logprobs or fix the training config — training against a "
+            "differently-scored artifact silently corrupts every margin."
+        )
+
+
+def pair_token_lengths(dataset: Dataset) -> list[int]:
+    """Per-pair padded row length (max of the two sides), one full pass over ``dataset``."""
+    return [
+        max(len(item["chosen_input_ids"]), len(item["rejected_input_ids"]))
+        for item in (dataset[i] for i in range(len(dataset)))
+    ]
+
+
+def pack_pairs_by_token_budget(
+    lengths: Sequence[int],
+    *,
+    budget_tokens: int,
+    max_pairs_per_batch: int = 64,
+) -> list[list[int]]:
+    """Deterministic longest-first batches under ``budget_tokens``; an over-budget pair gets a singleton."""
+    if budget_tokens < 1:
+        raise ValueError(f"budget_tokens must be positive, got {budget_tokens}.")
+    if max_pairs_per_batch < 1:
+        raise ValueError(f"max_pairs_per_batch must be positive, got {max_pairs_per_batch}.")
+
+    order = sorted(range(len(lengths)), key=lambda i: (-lengths[i], i))
+    batches: list[list[int]] = []
+    batch: list[int] = []
+    for idx in order:
+        # Descending order makes the first item the batch max.
+        batch_max = lengths[batch[0]] if batch else lengths[idx]
+        if batch and (len(batch) == max_pairs_per_batch or 2 * (len(batch) + 1) * batch_max > budget_tokens):
+            batches.append(batch)
+            batch = []
+        batch.append(idx)
+    if batch:
+        batches.append(batch)
+    return batches
+
+
+def preference_collate_fn(
+    batch: list[Mapping[str, Any]],
+    pad_token_id: int,
+    pad_seq_length_to_mult: int = 1,
+    require_ref_logprobs: bool = True,
+) -> dict[str, Any]:
+    """Collate pair records into an interleaved row batch (chosen@even, rejected@odd)."""
+    input_ids: list[Sequence[int]] = []
+    context_lens: list[int] = []
+    pair_ids: list[int] = []
+    loss_multipliers: list[float] = []
+    ref_sums: list[float] = []
+    ref_counts: list[int] = []
+
+    for record in batch:
+        input_ids.append(record["chosen_input_ids"])
+        input_ids.append(record["rejected_input_ids"])
+        context_lens.append(int(record["chosen_context_len"]))
+        context_lens.append(int(record["rejected_context_len"]))
+        pair_ids.extend([int(record["pair_id"])] * 2)
+        loss_multipliers.extend([float(record.get("loss_multiplier", 1.0))] * 2)
+        if require_ref_logprobs:
+            ref_sums.append(float(record["ref_chosen_logprob_sum"]))
+            ref_sums.append(float(record["ref_rejected_logprob_sum"]))
+            ref_counts.append(int(record["ref_chosen_num_tokens"]))
+            ref_counts.append(int(record["ref_rejected_num_tokens"]))
+
+    for ids, ctx_len, pair_id in zip(input_ids, context_lens, pair_ids):
+        if not 1 <= ctx_len < len(ids):
+            raise ValueError(
+                f"Pair {pair_id}: context_len={ctx_len} must leave at least one completion "
+                f"token in a sequence of length {len(ids)}. The prep script should have "
+                "dropped this pair."
+            )
+
+    num_rows = len(input_ids)
+    # Row length after the tokens/labels shift.
+    seq_lens = torch.tensor([len(ids) - 1 for ids in input_ids], dtype=torch.long)
+    max_length = _ceil_to_multiple(int(seq_lens.max()), pad_seq_length_to_mult)
+
+    # One padded id tensor; tokens and labels are its two shifted views.
+    full = torch.full((num_rows, max_length + 1), pad_token_id, dtype=torch.long)
+    for i, ids in enumerate(input_ids):
+        full[i, : len(ids)] = torch.as_tensor(ids, dtype=torch.long)
+
+    positions = torch.arange(max_length, dtype=torch.long)
+    valid = positions < seq_lens.unsqueeze(1)
+    # Label position j predicts original token j+1, so completion labels start at ctx_len - 1.
+    completion_start = (torch.tensor(context_lens, dtype=torch.long) - 1).unsqueeze(1)
+
+    collated: dict[str, Any] = {
+        "tokens": full[:, :-1].masked_fill(~valid, pad_token_id),
+        "labels": full[:, 1:],
+        "loss_mask": (valid & (positions >= completion_start)).long(),
+        "position_ids": positions.unsqueeze(0).expand(num_rows, -1).contiguous(),
+        "attention_mask": None,
+        "pair_id": torch.tensor(pair_ids, dtype=torch.long),
+        "loss_multiplier": torch.tensor(loss_multipliers, dtype=torch.float32),
+    }
+    if require_ref_logprobs:
+        collated["ref_logprob_sum"] = torch.tensor(ref_sums, dtype=torch.float32)
+        collated["ref_num_tokens"] = torch.tensor(ref_counts, dtype=torch.long)
+    return collated
+
+
+def build_preference_data_loader(
+    dataset: Dataset,
+    micro_batch_size: int,
+    global_batch_size: int,
+    data_parallel_rank: int,
+    data_parallel_size: int,
+    consumed_samples: int,
+    num_workers: int = 0,
+    pin_memory: bool = True,
+    worker_init_fn: Callable[[int], None] | None = None,
+    shuffle: bool = True,
+) -> DataLoader:
+    """Build a DPO loader from row-denominated sizes (one pair == two rows), halved here for the stock loader."""
+    if micro_batch_size % 2 != 0 or global_batch_size % 2 != 0:
+        raise ValueError(
+            f"DPO batch sizes are row-denominated and must be even (one pair == two rows); "
+            f"got micro_batch_size={micro_batch_size}, global_batch_size={global_batch_size}."
+        )
+    if consumed_samples % 2 != 0:
+        raise ValueError(f"consumed_samples must be even for DPO, got {consumed_samples}.")
+    # The sampler checks this too, but reports the halved pair counts, which do not
+    # match the row-denominated numbers the user configured.
+    if global_batch_size % (micro_batch_size * data_parallel_size) != 0:
+        raise ValueError(
+            f"global_batch_size={global_batch_size} must be divisible by "
+            f"micro_batch_size*data_parallel_size={micro_batch_size * data_parallel_size}."
+        )
+
+    return build_pretraining_data_loader(
+        dataset,
+        consumed_samples=consumed_samples // 2,
+        dataloader_type="batch",
+        micro_batch_size=micro_batch_size // 2,
+        global_batch_size=global_batch_size // 2,
+        num_workers=num_workers,
+        data_sharding=False,  # unused by the 'batch' sampler
+        worker_init_fn=worker_init_fn,
+        collate_fn=dataset.collate_fn,
+        pin_memory=pin_memory,
+        persistent_workers=num_workers > 0,
+        data_parallel_rank=data_parallel_rank,
+        data_parallel_size=data_parallel_size,
+        drop_last=True,
+        shuffle=shuffle,
+    )

--- a/src/megatron/bridge/data/datasets/preference_lazy.py
+++ b/src/megatron/bridge/data/datasets/preference_lazy.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections.abc import Mapping, Sequence
+from functools import partial
+from typing import Any
+
+from torch.utils.data import Dataset
+
+from megatron.bridge.data.datasets.preference import REF_LOGPROB_COLUMNS, preference_collate_fn
+from megatron.bridge.data.datasets.preference_tokenization import build_pair_conversations, tokenize_conversation
+
+
+logger = logging.getLogger(__name__)
+
+
+class LazyChatPreferencePairDataset(Dataset):
+    """Preference-pair dataset that tokenizes chat-format rows on fetch.
+
+    Nothing is tokenized at init; each ``__getitem__`` runs the chat template on
+    that pair. ``__len__`` must stay fixed for the sampler, so invalid pairs are
+    not dropped - they are emitted as two-token stubs with ``loss_multiplier=0.0``
+    and contribute nothing to the loss. ``pair_id`` is the source row index, which
+    is what ``ref_logprobs`` (the scorer's output) is keyed by.
+    """
+
+    def __init__(
+        self,
+        source: Sequence[Mapping[str, Any]],
+        tokenizer,
+        max_seq_length: int,
+        pad_token_id: int | None = None,
+        pad_seq_length_to_mult: int = 1,
+        chosen_key: str = "chosen",
+        rejected_key: str = "rejected",
+        prompt_key: str | None = None,
+        ref_logprobs: Mapping[int, Mapping[str, Any]] | None = None,
+    ) -> None:
+        if len(source) == 0:
+            raise ValueError("Preference dataset is empty.")
+        self.source = source
+        self.tokenizer = tokenizer
+        self.max_seq_length = max_seq_length
+        self.chosen_key = chosen_key
+        self.rejected_key = rejected_key
+        self.prompt_key = prompt_key
+        self.ref_logprobs = ref_logprobs
+        self.require_ref_logprobs = ref_logprobs is not None
+
+        if pad_token_id is None:
+            pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+
+        self.pad_token_id = pad_token_id
+
+        self.collate_fn = partial(
+            preference_collate_fn,
+            pad_token_id=pad_token_id,
+            pad_seq_length_to_mult=pad_seq_length_to_mult,
+            require_ref_logprobs=self.require_ref_logprobs,
+        )
+
+    def __len__(self) -> int:
+        return len(self.source)
+
+    def _stub_record(self, idx: int, reason: str) -> dict[str, Any]:
+        logger.warning("Pair %d unusable (%s); emitting a zero-loss stub.", idx, reason)
+        stub_ids = [self.pad_token_id, self.pad_token_id]
+
+        return {
+            "pair_id": idx,
+            "chosen_input_ids": stub_ids,
+            "chosen_context_len": 1,
+            "rejected_input_ids": stub_ids,
+            "rejected_context_len": 1,
+            "loss_multiplier": 0.0,
+        }
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        row = self.source[idx]
+        pair = build_pair_conversations(
+            row, chosen_key=self.chosen_key, rejected_key=self.rejected_key, prompt_key=self.prompt_key
+        )
+        if isinstance(pair, str):
+            record = self._stub_record(idx, pair)
+        else:
+            side_c = tokenize_conversation(self.tokenizer, pair[0], self.max_seq_length)
+            side_r = tokenize_conversation(self.tokenizer, pair[1], self.max_seq_length)
+            if isinstance(side_c, str) or isinstance(side_r, str):
+                record = self._stub_record(idx, side_c if isinstance(side_c, str) else side_r)
+            else:
+                record = {
+                    "pair_id": idx,
+                    "chosen_input_ids": side_c[0],
+                    "chosen_context_len": side_c[1],
+                    "rejected_input_ids": side_r[0],
+                    "rejected_context_len": side_r[1],
+                    "loss_multiplier": 1.0,
+                }
+        if self.ref_logprobs is not None:
+            try:
+                ref = self.ref_logprobs[idx]
+            except KeyError:
+                raise ValueError(f"ref_logprobs has no entry for pair_id={idx}.") from None
+            record.update({col: ref[col] for col in REF_LOGPROB_COLUMNS})
+        return record

--- a/src/megatron/bridge/data/datasets/preference_tokenization.py
+++ b/src/megatron/bridge/data/datasets/preference_tokenization.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Mapping
+
+from megatron.bridge.data.conversation_processing import tokenize_chat_example
+
+
+def tokenize_conversation(tokenizer, messages: list[dict], max_seq_length: int) -> tuple[list[int], int] | str:
+    """Tokenize one conversation into ``(input_ids, context_len)``, or return a drop reason."""
+    if len(messages) < 2 or messages[-1].get("role") != "assistant":
+        return "no_assistant_completion"
+    if not str(messages[-1].get("content") or "").strip():
+        return "empty_completion"
+
+    tokenized = tokenize_chat_example(
+        messages,
+        tokenizer,
+        loss_mode="full",
+        return_final_assistant_start=True,
+        final_assistant_span="turn",
+    )
+    input_ids = tokenized.input_ids.tolist()
+    context_len = tokenized.final_assistant_start
+
+    eos_token_id = tokenizer.eos_token_id
+    if eos_token_id is not None and input_ids and input_ids[-1] != eos_token_id:
+        input_ids.append(eos_token_id)
+
+    if context_len is None or not 1 <= context_len < len(input_ids):
+        return "empty_completion"
+
+    if len(input_ids) > max_seq_length:
+        return "over_length"
+
+    return input_ids, context_len
+
+
+def _as_messages(value: str | list[dict], role: str) -> list[dict]:
+    if isinstance(value, str):
+        return [{"role": role, "content": value}]
+    return list(value)
+
+
+def build_pair_conversations(
+    row: Mapping[str, Any],
+    *,
+    chosen_key: str = "chosen",
+    rejected_key: str = "rejected",
+    prompt_key: str | None = None,
+) -> tuple[list[dict], list[dict]] | str:
+    """Build the chosen/rejected conversations for one row, or return a drop reason."""
+    chosen = _as_messages(row[chosen_key], "assistant")
+    rejected = _as_messages(row[rejected_key], "assistant")
+
+    if prompt_key is not None:
+        prompt = _as_messages(row[prompt_key], "user")
+        return prompt + chosen, prompt + rejected
+
+    if chosen[:-1] != rejected[:-1]:
+        return "context_mismatch"
+
+    return chosen, rejected

--- a/src/megatron/bridge/data/loaders.py
+++ b/src/megatron/bridge/data/loaders.py
@@ -20,7 +20,8 @@ from megatron.core.datasets.utils import get_blend_from_list
 from megatron.core.rerun_state_machine import RerunDataIterator
 from torch.utils.data import DataLoader
 
-from megatron.bridge.data.builders import GPTSFTDatasetConfig
+from megatron.bridge.data.builders import DPODatasetConfig, GPTSFTDatasetConfig
+from megatron.bridge.data.datasets.preference import build_preference_data_loader
 from megatron.bridge.data.samplers import build_pretraining_data_loader
 from megatron.bridge.training.config import ConfigContainer, GPTDatasetConfig
 from megatron.bridge.training.state import TrainState
@@ -199,6 +200,72 @@ def build_train_valid_test_datasets_for_num_epochs(
     return train_ds, valid_ds, test_ds
 
 
+def build_dpo_data_loaders(
+    cfg: ConfigContainer,
+    train_state: TrainState,
+    datasets_provider: Callable,
+    dp_group: torch.distributed.ProcessGroup,
+) -> tuple[DataLoader, DataLoader | None, None]:
+    """DPO branch of ``build_train_valid_test_data_loaders``: row→pair-halved train/valid loaders."""
+    train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
+        cfg=cfg, build_train_valid_test_datasets_provider=datasets_provider
+    )
+    if test_ds is not None:
+        raise ValueError("DPO does not support a test split; the provider must not return a test dataset.")
+    if len(train_ds) < cfg.train.global_batch_size // 2:
+        raise RuntimeError(
+            f"Not enough preference pairs for a single global batch: {len(train_ds)} pairs "
+            f"< {cfg.train.global_batch_size // 2} (global_batch_size {cfg.train.global_batch_size} rows)."
+        )
+
+    dp_rank = torch.distributed.get_rank(group=dp_group)
+    dp_size = torch.distributed.get_world_size(group=dp_group)
+    train_dataloader = build_preference_data_loader(
+        train_ds,
+        micro_batch_size=cfg.train.micro_batch_size,
+        global_batch_size=cfg.train.global_batch_size,
+        data_parallel_rank=dp_rank,
+        data_parallel_size=dp_size,
+        consumed_samples=train_state.consumed_train_samples,
+        num_workers=cfg.dataset.num_workers,
+        pin_memory=cfg.dataset.pin_memory,
+        shuffle=cfg.dataset.shuffle,
+        seed=cfg.rng.seed,
+    )
+
+    valid_dataloader = None
+    eval_iters = cfg.validation.eval_iters or 0
+    if valid_ds is not None and eval_iters > 0:
+        eval_gbs = cfg.validation.eval_global_batch_size or cfg.train.global_batch_size
+        eval_mbs = cfg.validation.eval_micro_batch_size or cfg.train.micro_batch_size
+        if len(valid_ds) < eval_gbs // 2:
+            raise RuntimeError(
+                f"Not enough validation preference pairs for a single eval global batch: {len(valid_ds)} "
+                f"pairs < {eval_gbs // 2} (eval_global_batch_size {eval_gbs} rows)."
+            )
+        valid_dataloader = build_preference_data_loader(
+            valid_ds,
+            micro_batch_size=eval_mbs,
+            global_batch_size=eval_gbs,
+            data_parallel_rank=dp_rank,
+            data_parallel_size=dp_size,
+            consumed_samples=0 if cfg.validation.skip_train else train_state.consumed_valid_samples,
+            num_workers=cfg.dataset.num_workers,
+            pin_memory=cfg.dataset.pin_memory,
+            shuffle=cfg.dataset.shuffle,
+            seed=cfg.rng.seed,
+        )
+
+    flags = torch.tensor(
+        [int(cfg.train.train_iters > 0), int(valid_dataloader is not None), 0], dtype=torch.long, device="cuda"
+    )
+    torch.distributed.broadcast(flags, 0)
+    train_state.do_train = flags[0].item()
+    train_state.do_valid = flags[1].item()
+    train_state.do_test = False
+    return train_dataloader, valid_dataloader, None
+
+
 def build_train_valid_test_data_loaders(
     cfg: ConfigContainer,
     train_state: TrainState,
@@ -226,6 +293,9 @@ def build_train_valid_test_data_loaders(
     # Check for MegatronMIMO path
     from megatron.bridge.data.megatron_mimo.base_provider import MegatronMIMODatasetProvider
     from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import MegatronMIMOProvider
+
+    if isinstance(cfg.dataset, DPODatasetConfig):
+        return build_dpo_data_loaders(cfg, train_state, build_train_valid_test_datasets_provider, dp_group)
 
     eval_iters = cfg.validation.eval_iters or 0
     if isinstance(cfg.model, MegatronMIMOProvider):

--- a/src/megatron/bridge/data/samplers.py
+++ b/src/megatron/bridge/data/samplers.py
@@ -47,6 +47,7 @@ def build_pretraining_data_loader(
     drop_last: Optional[bool] = True,
     global_batch_size: Optional[int] = None,
     seed: int | None = None,
+    shuffle: bool = True,
 ) -> Optional[DataLoader]:
     """Build a dataloader for pretraining.
 
@@ -74,6 +75,8 @@ def build_pretraining_data_loader(
         seed: Explicit shuffle seed for the global-batch sampler. Supplying the
               dataset seed keeps pipeline stages on the same sample order even
               though their model RNG seeds differ.
+        shuffle: Whether the 'batch' sampler reshuffles each epoch (seeded, deterministic).
+                 False yields dataset order; other sampler types ignore this.
 
     Returns:
         A PyTorch DataLoader instance, or the dataset itself if dataloader_type is
@@ -123,6 +126,7 @@ def build_pretraining_data_loader(
             drop_last=drop_last,
             pad_samples_to_global_batch_size=not drop_last,
             seed=seed,
+            shuffle=shuffle,
         )
     elif dataloader_type == "external":
         # External dataloaders are passed through. User is expected to provide a

--- a/src/megatron/bridge/data/sources/__init__.py
+++ b/src/megatron/bridge/data/sources/__init__.py
@@ -15,6 +15,7 @@
 """Declarative dataset source APIs."""
 
 from megatron.bridge.data.sources.hf import HFDatasetSourceConfig
+from megatron.bridge.data.sources.jsonl import PreferenceJSONLSource
 
 
-__all__ = ["HFDatasetSourceConfig"]
+__all__ = ["HFDatasetSourceConfig", "PreferenceJSONLSource"]

--- a/src/megatron/bridge/data/sources/jsonl.py
+++ b/src/megatron/bridge/data/sources/jsonl.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declarative JSONL source read in place through the memmap reader."""
+
+from dataclasses import dataclass
+
+
+def _is_object_store_url(path: str) -> bool:
+    """Whether ``path`` carries a URL scheme (``msc://``, ``s3://``, ...) rather than naming a local file."""
+    return "://" in path
+
+
+@dataclass(kw_only=True)
+class PreferenceJSONLSource:
+    """JSONL preference rows read in place through the memmap reader.
+
+    The only source type that reads object storage (``msc://`` paths); anything
+    HuggingFace ``datasets`` can read goes through ``HFDatasetSourceConfig`` instead.
+    """
+
+    paths: list[str]
+    index_mapping_dir: str | None = None
+    """Where the memmap ``.idx`` sidecars go. Required for object-store ``paths``,
+    whose buckets may be read-only."""
+
+    def validate(self) -> None:
+        """Validate the paths against the memmap reader's constraints."""
+        if not self.paths:
+            raise ValueError("PreferenceJSONLSource.paths must contain at least one path.")
+        bad = [path for path in self.paths if not path.endswith((".jsonl", ".json"))]
+        if bad:
+            raise ValueError(
+                f"PreferenceJSONLSource accepts only .jsonl/.json files (the memmap reader's formats); got {bad}. "
+                "Other formats must go through HFDatasetSourceConfig, which cannot read msc://."
+            )
+        if any(_is_object_store_url(path) for path in self.paths) and self.index_mapping_dir is None:
+            raise ValueError(
+                "index_mapping_dir is required for object-store paths: the memmap index "
+                "sidecars cannot be written beside data in a read-only bucket."
+            )

--- a/src/megatron/bridge/data/utils.py
+++ b/src/megatron/bridge/data/utils.py
@@ -25,6 +25,7 @@ from megatron.bridge.data.builders.direct_hf_sft import (
     DirectHFSFTDatasetConfig,
     direct_hf_sft_train_valid_test_datasets_provider,
 )
+from megatron.bridge.data.builders.dpo import DPODatasetConfig, dpo_train_valid_test_datasets_provider
 from megatron.bridge.data.builders.energon import EnergonDatasetConfig, energon_train_valid_test_datasets_provider
 from megatron.bridge.data.builders.gpt_sft import (
     GPTSFTDatasetConfig,
@@ -97,6 +98,7 @@ _REGISTRY: dict[type[Any], Callable[..., Any]] = {
     DirectHFSFTDatasetConfig: direct_hf_sft_train_valid_test_datasets_provider,
     EnergonDatasetConfig: energon_train_valid_test_datasets_provider,
     MockVLMSFTDatasetConfig: mock_vlm_sft_train_valid_test_datasets_provider,
+    DPODatasetConfig: dpo_train_valid_test_datasets_provider,
 }
 
 
@@ -107,6 +109,7 @@ def get_dataset_provider(
         | DirectHFSFTDatasetConfig
         | EnergonDatasetConfig
         | MockVLMSFTDatasetConfig
+        | DPODatasetConfig
         | DatasetProvider
     ),
 ) -> Callable[..., Any]:

--- a/src/megatron/bridge/recipes/common.py
+++ b/src/megatron/bridge/recipes/common.py
@@ -14,9 +14,16 @@
 
 import os
 
+import torch
 from megatron.core.distributed import DistributedDataParallelConfig
 
-from megatron.bridge.data.builders import ChatSFTPreprocessingConfig, DirectHFSFTDatasetConfig, HFDatasetSourceConfig
+from megatron.bridge import AutoBridge
+from megatron.bridge.data.builders import (
+    ChatSFTPreprocessingConfig,
+    DirectHFSFTDatasetConfig,
+    DPODatasetConfig,
+    HFDatasetSourceConfig,
+)
 from megatron.bridge.peft.lora import LoRA
 from megatron.bridge.recipes.utils.dataset_utils import default_squad_config
 from megatron.bridge.recipes.utils.optimizer_utils import distributed_fused_adam_with_cosine_annealing
@@ -32,6 +39,7 @@ from megatron.bridge.training.config import (
     TrainingConfig,
     ValidationConfig,
 )
+from megatron.bridge.training.dpo import DPOLossConfig
 
 
 def _pretrain_common() -> ConfigContainer:
@@ -232,6 +240,65 @@ def _sft_common() -> ConfigContainer:
         peft=None,
     )
 
+    return cfg
+
+
+def _dpo_common(hf_path: str, *, seq_length: int = 4096, revision: str | None = None) -> ConfigContainer:
+    """Create a base DPO ConfigContainer for one HF reference model.
+
+    Builds on ``_sft_common`` and applies the loss contract that
+    ``validate_dpo_run_config`` enforces (per-token loss, no collective
+    averaging, fp32 CE, PP=CP=1). The dataset is a preference-pair
+    skeleton over ``hf_path``'s tokenizer; every run must still point at its
+    scored reference artifact and reference weights, typically via
+    ``dataset.ref_artifact=...`` and ``--pretrained_checkpoint``.
+
+    Args:
+        hf_path: HF id or local path of the reference model; also the tokenizer.
+        seq_length: Pair sequence length; must match the scoring run.
+        revision: HF revision to pin the model config and tokenizer to.
+
+    Returns:
+        ConfigContainer: Base configuration for DPO training.
+    """
+    cfg = _sft_common()
+    hf_kwargs = {"revision": revision} if revision else {}
+    cfg.model = AutoBridge.from_hf_pretrained(hf_path, torch_dtype=torch.bfloat16, **hf_kwargs).to_megatron_provider(
+        load_weights=False
+    )
+    cfg.tokenizer.tokenizer_model = hf_path
+    cfg.tokenizer.hf_tokenizer_kwargs = hf_kwargs
+
+    cfg.model.tensor_model_parallel_size = 1
+    cfg.model.pipeline_model_parallel_size = 1
+    cfg.model.pipeline_dtype = None
+    cfg.model.context_parallel_size = 1
+    cfg.model.sequence_parallel = False
+    cfg.model.seq_length = seq_length
+    cfg.model.mtp_num_layers = None
+
+    # DPO loss contract (validate_dpo_run_config enforces all but the CE-fusion
+    # knob, which stays off to match the scorer's unfused CE rounding).
+    cfg.model.calculate_per_token_loss = True
+    cfg.model.cross_entropy_loss_fusion = False
+    cfg.ddp.average_in_collective = False
+
+    cfg.dataset = DPODatasetConfig(
+        tokenizer_name=hf_path,
+        seq_length=seq_length,
+        source=HFDatasetSourceConfig(path_or_dataset="HuggingFaceH4/ultrafeedback_binarized", split="train_prefs"),
+        ref_artifact=None,  # required per run: the offline scorer's artifact for this source
+    )
+    cfg.dpo = DPOLossConfig()
+
+    # Batch sizes are row-denominated (one pair == two rows) and must be even.
+    cfg.train.global_batch_size = 32
+    cfg.train.micro_batch_size = 4
+    cfg.validation.eval_iters = 0  # enable via dataset.validation_* + validation.eval_*
+
+    cfg.optimizer.lr = 1e-6
+    cfg.optimizer.min_lr = 0.0
+    cfg.scheduler.lr_warmup_iters = 0
     return cfg
 
 

--- a/src/megatron/bridge/recipes/qwen/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/__init__.py
@@ -84,6 +84,7 @@ from .qwen3 import (
 
 # Qwen3 MoE models
 from .qwen3_moe import (
+    qwen3_30b_a3b_dpo_config,
     qwen3_30b_a3b_peft_config,
     qwen3_30b_a3b_pretrain_config,
     qwen3_30b_a3b_sft_config,
@@ -163,6 +164,7 @@ __all__ = [
     "qwen3_30b_a3b_pretrain_8gpu_gb200_fp8mx_config",
     "qwen3_30b_a3b_sft_config",
     "qwen3_30b_a3b_peft_config",
+    "qwen3_30b_a3b_dpo_config",
     "qwen3_235b_a22b_pretrain_config",
     "qwen3_235b_a22b_sft_config",
     "qwen3_235b_a22b_peft_config",

--- a/src/megatron/bridge/recipes/qwen/h100/__init__.py
+++ b/src/megatron/bridge/recipes/qwen/h100/__init__.py
@@ -58,6 +58,7 @@ __all__ = [
     "qwen3_235b_a22b_peft_16gpu_h100_bf16_config",
     "qwen3_235b_a22b_pretrain_256gpu_h100_bf16_config",  # pragma: allowlist secret
     "qwen3_235b_a22b_sft_64gpu_h100_bf16_config",
+    "qwen3_30b_a3b_dpo_8gpu_h100_bf16_config",
     "qwen3_30b_a3b_peft_4gpu_h100_bf16_config",
     "qwen3_30b_a3b_pretrain_16gpu_h100_bf16_config",
     "qwen3_30b_a3b_pretrain_8gpu_h100_bf16_config",

--- a/src/megatron/bridge/recipes/qwen/h100/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/h100/qwen3_moe.py
@@ -16,7 +16,7 @@ import torch
 
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.base import PEFT
-from megatron.bridge.recipes.common import _peft_common, _pretrain_common, _sft_common
+from megatron.bridge.recipes.common import _dpo_common, _peft_common, _pretrain_common, _sft_common
 from megatron.bridge.recipes.utils.dataset_utils import default_peft_config
 from megatron.bridge.recipes.utils.environment_utils import COMMON_RECIPE_ENV_VARS
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
@@ -997,7 +997,50 @@ def qwen3_235b_a22b_peft_16gpu_h100_bf16_config(peft_scheme: str | PEFT = "lora"
     return cfg
 
 
+def qwen3_30b_a3b_dpo_8gpu_h100_bf16_config() -> ConfigContainer:
+    """Return a DPO config for Qwen3-30B-A3B MoE.
+
+    Recommended parallelism: TP=8, EP=8, ETP=1, SP=True (1 node, 8 GPUs); score the
+    reference with the same layout. Runs must set ``--pretrained_checkpoint`` to a local
+    HF model directory and ``dataset.ref_artifact`` to the scored artifact.
+    """
+    cfg = _dpo_common(_QWEN3_30B_A3B_MODEL_ID, seq_length=4096, revision=_QWEN3_30B_A3B_MODEL_REVISION)
+
+    cfg.model.tensor_model_parallel_size = 8
+    cfg.model.expert_model_parallel_size = 8
+    cfg.model.expert_tensor_parallel_size = 1
+    cfg.model.sequence_parallel = True
+
+    # Row-denominated (one pair == two rows, so mbs must be even): gbs 128 rows = 64 pairs
+    # = DP1 x mbs2 x accum64.
+    cfg.train.global_batch_size = 128
+    cfg.train.micro_batch_size = 2
+
+    # MoE kernels and dispatcher, as in the SFT recipes. Routing must stay natural: forced
+    # load balancing would change the policy's logprobs relative to the scored reference.
+    cfg.model.moe_token_dispatcher_type = "alltoall"
+    cfg.model.moe_flex_dispatcher_backend = "deepep"
+    cfg.model.moe_grouped_gemm = True
+    cfg.model.moe_permute_fusion = True
+    cfg.model.moe_router_fusion = False
+    cfg.model.moe_shared_expert_overlap = False
+    cfg.model.moe_router_force_load_balancing = False
+
+    cfg.model.recompute_granularity = "full"
+    cfg.model.recompute_method = "uniform"
+    cfg.model.recompute_num_layers = 1
+
+    # A no-op at DP=1; shards the Adam state as soon as the run adds nodes.
+    cfg.ddp.use_distributed_optimizer = True
+
+    cfg.optimizer.lr = 5e-7
+
+    apply_flex_dispatcher_backend(cfg.model, cfg.model.moe_flex_dispatcher_backend)
+    return cfg
+
+
 __all__ = [
+    "qwen3_30b_a3b_dpo_8gpu_h100_bf16_config",
     "qwen3_235b_a22b_peft_16gpu_h100_bf16_config",
     "qwen3_235b_a22b_pretrain_256gpu_h100_bf16_config",  # pragma: allowlist secret
     "qwen3_235b_a22b_sft_64gpu_h100_bf16_config",

--- a/src/megatron/bridge/recipes/qwen/qwen3_moe.py
+++ b/src/megatron/bridge/recipes/qwen/qwen3_moe.py
@@ -17,6 +17,9 @@
 from __future__ import annotations
 
 from megatron.bridge.recipes.qwen.h100.qwen3_moe import (
+    qwen3_30b_a3b_dpo_8gpu_h100_bf16_config as qwen3_30b_a3b_dpo_config,
+)
+from megatron.bridge.recipes.qwen.h100.qwen3_moe import (
     qwen3_30b_a3b_peft_4gpu_h100_bf16_config as qwen3_30b_a3b_peft_config,
 )
 from megatron.bridge.recipes.qwen.h100.qwen3_moe import (
@@ -40,6 +43,7 @@ __all__ = [
     "qwen3_235b_a22b_peft_config",
     "qwen3_235b_a22b_pretrain_config",
     "qwen3_235b_a22b_sft_config",
+    "qwen3_30b_a3b_dpo_config",
     "qwen3_30b_a3b_peft_config",
     "qwen3_30b_a3b_pretrain_config",
     "qwen3_30b_a3b_sft_config",

--- a/src/megatron/bridge/training/config.py
+++ b/src/megatron/bridge/training/config.py
@@ -50,6 +50,7 @@ from megatron.bridge.data.base import (
     DatasetBuildContext as DatasetBuildContext,
 )
 from megatron.bridge.data.builders.direct_hf_sft import DirectHFSFTDatasetConfig
+from megatron.bridge.data.builders.dpo import DPODatasetConfig
 from megatron.bridge.data.builders.energon import EnergonDatasetConfig
 
 # Deprecated training.config import compatibility. New code imports dataset
@@ -70,6 +71,7 @@ from megatron.bridge.models.megatron_mimo.megatron_mimo_provider import Megatron
 from megatron.bridge.models.transformer_config import _enable_safe_hybridep_dispatch
 from megatron.bridge.peft.base import PEFT
 from megatron.bridge.training.comm_overlap import CommOverlapConfig
+from megatron.bridge.training.dpo import DPOLossConfig
 from megatron.bridge.training.flex_dispatcher_backend import validate_flex_dispatcher_backend
 from megatron.bridge.training.fsdp_compat import MCORE_HAS_MEGATRON_FSDP_V2
 from megatron.bridge.training.mixed_precision import MixedPrecisionConfig, get_mixed_precision_config
@@ -1012,6 +1014,7 @@ class ConfigContainer(Container):
         | DirectHFSFTDatasetConfig
         | EnergonDatasetConfig
         | MockVLMSFTDatasetConfig
+        | DPODatasetConfig
         | DatasetProvider
     )
     logger: LoggerConfig
@@ -1023,6 +1026,7 @@ class ConfigContainer(Container):
     nvrx_straggler: Optional[NVRxStragglerDetectionConfig] = None
     profiling: ProfilingConfig = field(default_factory=ProfilingConfig)
     peft: Optional[PEFT] = None
+    dpo: Optional[DPOLossConfig] = None
     comm_overlap: Optional[CommOverlapConfig] = None
     mixed_precision: Optional[Union[MixedPrecisionConfig, str]] = None
     tensor_inspect: TensorInspectConfig | None = None
@@ -1381,7 +1385,7 @@ class ConfigContainer(Container):
         if (
             isinstance(
                 self.dataset,
-                (DirectHFSFTDatasetConfig, EnergonDatasetConfig, MockVLMSFTDatasetConfig),
+                (DirectHFSFTDatasetConfig, EnergonDatasetConfig, MockVLMSFTDatasetConfig, DPODatasetConfig),
             )
             or (isinstance(self.dataset, GPTSFTDatasetConfig) and enable_in_batch_packing)
         ) and self.dataset.seq_length % collate_padding_multiple != 0:
@@ -1405,6 +1409,8 @@ class ConfigContainer(Container):
                 self.dataset.pad_to_multiple_of,
                 collate_padding_multiple,
             )
+        elif isinstance(self.dataset, DPODatasetConfig):
+            self.dataset.pad_seq_length_to_mult = collate_padding_multiple
 
         _enable_safe_hybridep_dispatch(transformer_config, uses_thd=uses_thd)
 

--- a/src/megatron/bridge/training/dpo.py
+++ b/src/megatron/bridge/training/dpo.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DPO pair loss and the logprob reduction it shares with the offline reference scorer.
+
+Both jobs reduce per-token NLL to per-sequence sums through the same function, so a
+step-0 margin can only come from the models or the tokens, never from the reduction.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+
+def sequence_logprob_sums(per_token_nll: torch.Tensor, loss_mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reduce per-token NLL to per-row completion logprob sums and token counts.
+
+    Args:
+        per_token_nll: ``[rows, seq]`` next-token negative log-likelihood, as returned
+            by ``model(..., labels=...)``.
+        loss_mask: ``[rows, seq]``; nonzero marks completion-label positions.
+
+    Returns:
+        ``(logprob_sums, num_tokens)``, both ``[rows]``: float32 ``-sum(nll * mask)``
+        per row and the number of counted positions.
+    """
+    if per_token_nll.shape != loss_mask.shape:
+        raise ValueError(
+            f"per_token_nll and loss_mask must have the same shape; got {per_token_nll.shape} vs {loss_mask.shape}."
+        )
+    mask = loss_mask.float()
+    logprob_sums = -(per_token_nll.float() * mask).sum(dim=-1)
+    num_tokens = mask.sum(dim=-1).long()
+    return logprob_sums, num_tokens
+
+
+def split_pair_rows(rows: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split a row-interleaved tensor into its (chosen, rejected) halves."""
+    if rows.shape[0] % 2 != 0:
+        raise ValueError(f"Interleaved pair rows must come in an even count; got {rows.shape[0]}.")
+    return rows[0::2], rows[1::2]
+
+
+@dataclass
+class DPOLossConfig:
+    """DPO loss hyperparameters.
+
+    Field names and defaults deliberately mirror NeMo-RL's ``DPOLossConfig``
+    (``nemo_rl/algorithms/loss/loss_functions.py``) so runs are 1:1 comparable.
+
+    Attributes:
+        reference_policy_kl_penalty: The DPO beta: temperature on the margin inside the
+            sigmoid, i.e. the strength of the implicit KL leash to the reference policy.
+        preference_loss_weight: Weight of the preference (``-logsigmoid``) term.
+        sft_loss_weight: Weight of the auxiliary NLL term on the chosen response;
+            0 disables it.
+        preference_average_log_probs: Average (instead of sum) per-token logprobs
+            over completion tokens in the preference margins.
+        sft_average_log_probs: Same, for the auxiliary SFT term.
+    """
+
+    reference_policy_kl_penalty: float = 0.05
+    preference_loss_weight: float = 1.0
+    sft_loss_weight: float = 0.0
+    preference_average_log_probs: bool = False
+    sft_average_log_probs: bool = False
+
+
+def dpo_loss(
+    config: DPOLossConfig, batch: dict[str, torch.Tensor], output_tensor: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor]]:
+    """DPO pair loss over one row-interleaved microbatch.
+
+    ``loss = sum over pairs of loss_multiplier * (w_p * -logsigmoid(beta * margin) + w_s * sft_nll)``
+    where ``margin = (pi_chosen - pi_rejected) - (ref_chosen - ref_rejected)``.
+
+    Stub pairs (``loss_multiplier == 0``) contribute nothing to the loss, the count, or any metric.
+
+    Args:
+        config: Loss hyperparameters (see ``DPOLossConfig``).
+        batch: Collate output; uses ``loss_mask``, ``pair_id``, ``loss_multiplier``,
+            ``ref_logprob_sum`` and (in average mode) ``ref_num_tokens``, all
+            row-aligned, chosen@even/rejected@odd.
+        output_tensor: ``[rows, seq]`` per-token NLL from ``model(..., labels=...)``.
+
+    Returns:
+        ``(loss_sum, num_live_pairs, metrics)`` for ``calculate_per_token_loss=True``. Every
+        metric is a detached ``[sum, count]`` 2-tensor with count = live pairs, except
+        ``live fraction`` whose count is all pairs. Per-pair metrics are reported unweighted.
+    """
+    chosen_ids, rejected_ids = split_pair_rows(batch["pair_id"])
+    if not torch.equal(chosen_ids, rejected_ids):
+        raise ValueError(
+            "Rows are not interleaved (chosen, rejected) pairs: pair_id[0::2] != pair_id[1::2]. "
+            "The batch must come from preference_collate_fn without reordering."
+        )
+
+    policy_sums, token_counts = sequence_logprob_sums(output_tensor, batch["loss_mask"])
+    policy, ref = policy_sums, batch["ref_logprob_sum"].float()
+    if config.preference_average_log_probs:
+        policy = policy_sums / token_counts.clamp(min=1)
+        ref = ref / batch["ref_num_tokens"].clamp(min=1)
+
+    policy_chosen, policy_rejected = split_pair_rows(policy)
+    ref_chosen, ref_rejected = split_pair_rows(ref)
+    rewards_chosen = policy_chosen - ref_chosen
+    rewards_rejected = policy_rejected - ref_rejected
+    margin = rewards_chosen - rewards_rejected
+
+    preference = -torch.nn.functional.logsigmoid(config.reference_policy_kl_penalty * margin)
+    per_pair = config.preference_loss_weight * preference
+
+    sft = torch.zeros_like(preference)
+    if config.sft_loss_weight > 0:
+        sft = -split_pair_rows(policy_sums)[0]
+        if config.sft_average_log_probs:
+            sft = sft / split_pair_rows(token_counts)[0].clamp(min=1)
+        per_pair = per_pair + config.sft_loss_weight * sft
+
+    multiplier = split_pair_rows(batch["loss_multiplier"])[0].float()
+    loss = (per_pair * multiplier).sum()
+    live_mask = (multiplier > 0).float()
+    num_live_pairs = live_mask.sum().to(torch.int)
+
+    def report(per_pair_values: torch.Tensor) -> torch.Tensor:
+        live_sum = (per_pair_values.detach().float() * live_mask).sum()
+        return torch.cat([live_sum.view(1), num_live_pairs.view(1)])
+
+    metrics = {
+        "dpo loss": torch.cat([loss.detach().view(1), num_live_pairs.view(1)]),
+        "preference loss": report(preference),
+        "sft loss": report(sft),
+        "margin": report(margin),
+        "accuracy": report((margin > 0).float()),
+        "rewards chosen": report(rewards_chosen),
+        "rewards rejected": report(rewards_rejected),
+        "live fraction": torch.cat([num_live_pairs.view(1), num_live_pairs.new_full((1,), live_mask.numel())]),
+    }
+    return loss, num_live_pairs, metrics

--- a/src/megatron/bridge/training/dpo_step.py
+++ b/src/megatron/bridge/training/dpo_step.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DPO forward step: pair-batch fetch, the model call, and the checked loss closure."""
+
+from collections.abc import Iterator
+from functools import partial
+from typing import TYPE_CHECKING
+
+import torch
+
+from megatron.bridge.data.collators.sequence_padding import _ceil_to_multiple
+from megatron.bridge.training.dpo import DPOLossConfig, dpo_loss
+from megatron.bridge.training.losses import validate_local_loss
+
+
+if TYPE_CHECKING:
+    from megatron.core.models.gpt import GPTModel
+
+    from megatron.bridge.training.state import GlobalState
+
+
+# The generic SFT batch fetch keeps only the first four; the loss needs the rest too.
+DPO_BATCH_KEYS = (
+    "tokens",
+    "labels",
+    "loss_mask",
+    "position_ids",
+    "pair_id",
+    "loss_multiplier",
+    "ref_logprob_sum",
+    "ref_num_tokens",
+)
+
+
+def validate_dpo_batch(batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Fail loudly if a batch is missing DPO keys (e.g. built without ref logprobs)."""
+    missing = [key for key in DPO_BATCH_KEYS if batch.get(key) is None]
+    if missing:
+        raise ValueError(
+            f"DPO batch is missing {missing}. The loader must be built by "
+            "build_preference_data_loader over a dataset with ref_logprobs attached "
+            "(load_ref_logprobs over the offline scorer's artifact)."
+        )
+    return batch
+
+
+_SEQ_DIM_KEYS = ("tokens", "labels", "loss_mask", "position_ids")
+
+
+def trim_dpo_batch_padding(batch: dict[str, torch.Tensor], pad_to_multiple: int = 1) -> dict[str, torch.Tensor]:
+    """Drop all-pad tail columns so the microbatch width matches a standalone collate of its own pairs.
+
+    ``pad_to_multiple`` must equal the collate's ``pad_seq_length_to_mult``.
+    """
+    live = batch["loss_mask"].any(dim=0)
+    if not bool(live.any()):
+        return batch  # all-stub microbatch: nothing anchors the width, keep as-is
+    width = _ceil_to_multiple(max(int(live.nonzero().max().item()) + 1, 2), pad_to_multiple)
+    if width < batch["tokens"].size(1):
+        for key in _SEQ_DIM_KEYS:
+            batch[key] = batch[key][:, :width].contiguous()
+    return batch
+
+
+def get_dpo_batch(
+    data_iterator: Iterator[dict[str, torch.Tensor]], pad_to_multiple: int = 1
+) -> dict[str, torch.Tensor]:
+    """Fetch one row-interleaved pair batch, move it to device, and trim pad tails."""
+    batch = validate_dpo_batch(next(data_iterator))
+    return trim_dpo_batch_padding({key: batch[key].cuda(non_blocking=True) for key in DPO_BATCH_KEYS}, pad_to_multiple)
+
+
+def dpo_loss_with_checks(
+    loss_config: DPOLossConfig,
+    batch: dict[str, torch.Tensor],
+    output_tensor: torch.Tensor,
+    *,
+    check_for_nan_in_loss: bool,
+    check_for_spiky_loss: bool,
+) -> tuple[torch.Tensor, torch.Tensor, dict[str, torch.Tensor]]:
+    """``dpo_loss`` followed by the rerun-state-machine loss checks."""
+    loss, num_live_pairs, metrics = dpo_loss(loss_config, batch, output_tensor)
+    validate_local_loss(loss, check_for_nan_in_loss=check_for_nan_in_loss, check_for_spiky_loss=check_for_spiky_loss)
+    return loss, num_live_pairs, metrics
+
+
+def dpo_forward_step(
+    state: "GlobalState",
+    data_iterator: Iterator[dict[str, torch.Tensor]],
+    model: "GPTModel",
+) -> tuple[torch.Tensor, partial]:
+    """DPO forward training step.
+
+    Args:
+        state: Global state for the run; ``state.cfg.dpo`` holds the ``DPOLossConfig``.
+        data_iterator: Yields preference_collate_fn batches (rows: chosen@even/rejected@odd).
+        model: The GPT model chunk.
+
+    Returns:
+        The ``[rows, seq]`` per-token NLL tensor and the loss closure.
+    """
+    loss_config: DPOLossConfig = state.cfg.dpo
+    timers = state.timers
+    straggler_timer = state.straggler_timer
+
+    timers("batch-generator", log_level=2).start()
+    with straggler_timer(bdata=True):
+        batch = get_dpo_batch(data_iterator, state.cfg.dataset.pad_seq_length_to_mult)
+    timers("batch-generator").stop()
+
+    with straggler_timer:
+        output_tensor = model(
+            input_ids=batch["tokens"],
+            position_ids=batch["position_ids"],
+            attention_mask=None,
+            labels=batch["labels"],
+        )
+
+    return output_tensor, partial(
+        dpo_loss_with_checks,
+        loss_config,
+        batch,
+        check_for_nan_in_loss=state.cfg.rerun_state_machine.check_for_nan_in_loss,
+        check_for_spiky_loss=state.cfg.rerun_state_machine.check_for_spiky_loss,
+    )

--- a/src/megatron/bridge/training/dpo_train.py
+++ b/src/megatron/bridge/training/dpo_train.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DPO training entry point: run-config guardrails, artifact validation, loop hand-off."""
+
+import logging
+from typing import Any, Literal
+
+from megatron.bridge.data.builders.dpo import DPODatasetConfig
+from megatron.bridge.data.datasets.preference import ScoringFingerprint, validate_scoring_metadata
+from megatron.bridge.training.callbacks import Callback, CallbackManager
+from megatron.bridge.training.config import ConfigContainer
+from megatron.bridge.training.finetune import finetune
+from megatron.bridge.training.forward_step_func_types import ForwardStepCallable
+
+
+logger = logging.getLogger(__name__)
+
+
+def dpo_train(
+    config: ConfigContainer,
+    forward_step_func: ForwardStepCallable,
+    callbacks: list[Callback] | CallbackManager | None = None,
+) -> None:
+    """Run DPO training over a scored preference dataset."""
+    validate_dpo_run_config(config)
+    finetune(config, forward_step_func, callbacks=callbacks)
+
+
+def validate_dpo_run_config(config: ConfigContainer) -> None:
+    """Fail fast, listing every violation, if the run would train incorrectly."""
+    problems: list[str] = []
+    dataset_is_dpo = isinstance(config.dataset, DPODatasetConfig)
+    if config.dpo is None:
+        problems.append("config.dpo must be a DPOLossConfig; the DPO forward step binds it into the loss.")
+    if not dataset_is_dpo:
+        problems.append(
+            f"config.dataset must be a DPODatasetConfig, got {type(config.dataset).__name__}: DPO needs "
+            "the pair-granular dataset and loader."
+        )
+    elif not config.dataset.ref_artifact:
+        problems.append(
+            "dataset.ref_artifact must be set: training needs the offline scorer's artifact "
+            "(score_reference_logprobs.py --output) to anchor the margins."
+        )
+    if not config.model.calculate_per_token_loss:
+        problems.append(
+            "model.calculate_per_token_loss must be True: the DPO loss returns a raw (loss_sum, "
+            "num_live_pairs) that finalize_model_grads normalizes by the global live-pair count."
+        )
+    if config.ddp.average_in_collective:
+        problems.append(
+            "ddp.average_in_collective must be False: gradients are normalized by the global live-pair "
+            "count, not averaged over DP ranks."
+        )
+    if config.model.pipeline_model_parallel_size != 1:
+        problems.append("pipeline_model_parallel_size > 1 is not supported for DPO.")
+    if config.model.context_parallel_size != 1:
+        problems.append("context_parallel_size > 1 is not supported for DPO.")
+    if config.model.mtp_num_layers:
+        problems.append(
+            "model.mtp_num_layers must be None for DPO: an MTP head would backpropagate its own "
+            "next-token CE on top of the DPO loss."
+        )
+    if config.train.micro_batch_size % 2 != 0 or config.train.global_batch_size % 2 != 0:
+        problems.append(
+            f"Batch sizes are row-denominated and must be even (one pair == two rows); got "
+            f"micro_batch_size={config.train.micro_batch_size}, "
+            f"global_batch_size={config.train.global_batch_size}."
+        )
+
+    validation_enabled = (config.validation.eval_iters or 0) > 0
+    if validation_enabled:
+        if not (dataset_is_dpo and config.dataset.has_validation_split):
+            problems.append(
+                "validation.eval_iters > 0 needs a scored validation split: set dataset.validation_source "
+                "plus dataset.validation_ref_artifact."
+            )
+        if not config.validation.eval_interval:
+            problems.append(
+                "validation.eval_interval must be set when eval_iters > 0: the loop only evaluates "
+                "every eval_interval steps."
+            )
+        if config.dist.eval_context_parallel_size is not None:
+            problems.append("dist.eval_context_parallel_size is not supported for DPO.")
+        for name in ("eval_global_batch_size", "eval_micro_batch_size"):
+            value = getattr(config.validation, name)
+            if value is not None and value % 2 != 0:
+                problems.append(
+                    f"validation.{name} is row-denominated and must be even (one pair == two rows); got {value}."
+                )
+    if problems:
+        raise ValueError("DPO run config is invalid:\n- " + "\n- ".join(problems))
+
+    _validate_artifact(config, config.dataset.ref_artifact, "train")
+    if validation_enabled:
+        _validate_artifact(config, config.dataset.validation_ref_artifact, "validation")
+
+
+def _validate_artifact(config: ConfigContainer, artifact_dir: str, split: Literal["train", "validation"]) -> None:
+    metadata = validate_scoring_metadata(artifact_dir, expected_scoring_metadata(config, split))
+    _warn_on_expert_layout_mismatch(config, artifact_dir, metadata)
+
+
+def _warn_on_expert_layout_mismatch(config: ConfigContainer, artifact_dir: str, metadata: dict[str, Any]) -> None:
+    """Warn, never fail, when the trainer's expert layout (EP, ETP) differs from the scoring run's."""
+    scorer_tp = metadata.get("tensor_model_parallel_size", 1)
+    scored = (
+        metadata.get("expert_model_parallel_size", 1),
+        metadata.get("expert_tensor_parallel_size", scorer_tp),
+    )
+    trainer = (
+        config.model.expert_model_parallel_size,
+        config.model.expert_tensor_parallel_size or config.model.tensor_model_parallel_size,
+    )
+    if scored != trainer:
+        logger.warning(
+            "Expert layout differs from the scoring run: %s was scored at (EP, ETP)=%s, this run "
+            "trains at %s. Expect a small step-0 shift, not margin corruption.",
+            artifact_dir,
+            scored,
+            trainer,
+        )
+
+
+def expected_scoring_metadata(
+    config: ConfigContainer, split: Literal["train", "validation"] = "train"
+) -> ScoringFingerprint:
+    """The scoring fingerprint the artifact for ``split`` must match."""
+    source = config.dataset.validation_source if split == "validation" else config.dataset.source
+    dataset_key, source_split = config.dataset.source_identity(source)
+    return ScoringFingerprint(
+        dataset=dataset_key,
+        split=source_split,
+        tokenizer=config.dataset.tokenizer_name,
+        max_seq_length=config.dataset.seq_length,
+        prompt_key=config.dataset.prompt_key,
+        tensor_model_parallel_size=config.model.tensor_model_parallel_size,
+        sequence_parallel=bool(config.model.sequence_parallel),
+        pipeline_model_parallel_size=config.model.pipeline_model_parallel_size,
+    )

--- a/src/megatron/bridge/training/dpo_train.py
+++ b/src/megatron/bridge/training/dpo_train.py
@@ -137,7 +137,6 @@ def _warn_on_expert_layout_mismatch(config: ConfigContainer, artifact_dir: str, 
 def expected_scoring_metadata(
     config: ConfigContainer, split: Literal["train", "validation"] = "train"
 ) -> ScoringFingerprint:
-    """The scoring fingerprint the artifact for ``split`` must match."""
     source = config.dataset.validation_source if split == "validation" else config.dataset.source
     dataset_key, source_split = config.dataset.source_identity(source)
     return ScoringFingerprint(

--- a/src/megatron/bridge/training/dpo_train.py
+++ b/src/megatron/bridge/training/dpo_train.py
@@ -137,7 +137,8 @@ def _warn_on_expert_layout_mismatch(config: ConfigContainer, artifact_dir: str, 
 def expected_scoring_metadata(
     config: ConfigContainer, split: Literal["train", "validation"] = "train"
 ) -> ScoringFingerprint:
-    source = config.dataset.validation_source if split == "validation" else config.dataset.source
+    field = "validation_source" if split == "validation" else "source"
+    source = config.dataset.resolve_source(getattr(config.dataset, field), field=field)
     dataset_key, source_split = config.dataset.source_identity(source)
     return ScoringFingerprint(
         dataset=dataset_key,

--- a/src/megatron/bridge/training/losses.py
+++ b/src/megatron/bridge/training/losses.py
@@ -22,6 +22,39 @@ from megatron.core.rerun_state_machine import get_rerun_state_machine
 _DEFAULT_SPIKY_LOSS_FACTOR: float = 10.0
 
 
+def validate_local_loss(loss: torch.Tensor, *, check_for_nan_in_loss: bool, check_for_spiky_loss: bool) -> None:
+    """Run the rerun-state-machine NaN/Inf and spiky-loss checks on one rank's loss before the DP all-reduce."""
+    rerun_state_machine = get_rerun_state_machine()
+    if check_for_nan_in_loss:
+        rerun_state_machine.validate_result(
+            result=loss,
+            rejection_func=torch.isnan,
+            message="found NaN in local forward loss calculation",
+            tolerance=0.0,  # forward pass calculations are deterministic
+            fatal=True,
+        )
+        rerun_state_machine.validate_result(
+            result=loss,
+            rejection_func=torch.isinf,
+            message="found Inf in local forward loss calculation",
+            tolerance=0.0,  # forward pass calculations are deterministic
+            fatal=True,
+        )
+    if check_for_spiky_loss:
+        spiky_loss_factor = getattr(rerun_state_machine, "spiky_loss_factor", _DEFAULT_SPIKY_LOSS_FACTOR)
+        rerun_state_machine.validate_result(
+            result=loss,
+            rejection_func=partial(
+                rerun_state_machine.is_unexpectedly_large,
+                threshold=spiky_loss_factor,
+                context="loss",
+            ),
+            message="Spiky loss",
+            tolerance=0.0,  # forward pass calculations are deterministic
+            fatal=False,
+        )
+
+
 def create_masked_next_token_loss_function(
     loss_mask: torch.Tensor, check_for_nan_in_loss: bool, check_for_spiky_loss: bool
 ) -> partial:
@@ -66,38 +99,7 @@ def masked_next_token_loss(
         losses = output_tensor.view(-1).float()
     loss_mask = loss_mask.view(-1).float()
     loss = torch.sum(losses * loss_mask)
-
-    # Check individual rank losses are not NaN prior to DP all-reduce.
-    rerun_state_machine = get_rerun_state_machine()
-    if check_for_nan_in_loss:
-        rerun_state_machine.validate_result(
-            result=loss,
-            rejection_func=torch.isnan,
-            message="found NaN in local forward loss calculation",
-            tolerance=0.0,  # forward pass calculations are determinisic
-            fatal=True,
-        )
-        rerun_state_machine.validate_result(
-            result=loss,
-            rejection_func=torch.isinf,
-            message="found Inf in local forward loss calculation",
-            tolerance=0.0,  # forward pass calculations are determinisic
-            fatal=True,
-        )
-    # Check for spiky loss
-    if check_for_spiky_loss:
-        spiky_loss_factor = getattr(rerun_state_machine, "spiky_loss_factor", _DEFAULT_SPIKY_LOSS_FACTOR)
-        rerun_state_machine.validate_result(
-            result=loss,
-            rejection_func=partial(
-                rerun_state_machine.is_unexpectedly_large,
-                threshold=spiky_loss_factor,
-                context="loss",
-            ),
-            message="Spiky loss",
-            tolerance=0.0,  # forward pass calculations are determinisic
-            fatal=False,
-        )
+    validate_local_loss(loss, check_for_nan_in_loss=check_for_nan_in_loss, check_for_spiky_loss=check_for_spiky_loss)
 
     num_tokens = loss_mask.sum().clone().detach().to(torch.int)
     reporting_loss = torch.cat([loss.clone().detach().view(1), num_tokens.view(1)])

--- a/tests/unit_tests/data/builders/test_dpo.py
+++ b/tests/unit_tests/data/builders/test_dpo.py
@@ -1,0 +1,386 @@
+"""Unit tests for DPODatasetConfig (the ConfigContainer.dataset entry for DPO)."""
+
+import json
+
+import pytest
+import torch
+
+from megatron.bridge.data.builders.dpo import (
+    DPODatasetBuilder,
+    DPODatasetConfig,
+    build_preference_split,
+    dpo_train_valid_test_datasets_provider,
+)
+from megatron.bridge.data.sources.hf import HFDatasetSourceConfig
+from megatron.bridge.data.sources.jsonl import PreferenceJSONLSource
+from tests.unit_tests.data.preference_fakes import FakeChatTokenizer
+
+
+class FakeSource:
+    """datasets.Dataset stand-in: sized, indexable, selectable."""
+
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def __len__(self):
+        return len(self.rows)
+
+    def __getitem__(self, index):
+        return self.rows[index]
+
+    def select(self, indices):
+        return FakeSource([self.rows[i] for i in indices])
+
+
+def chat_row(pair_id: int) -> dict:
+    conversation = [
+        {"role": "user", "content": f"prompt {pair_id}"},
+        {"role": "assistant", "content": "an answer"},
+    ]
+    worse = conversation[:-1] + [{"role": "assistant", "content": "worse"}]
+    return {"chosen": conversation, "rejected": worse}
+
+
+def ref_mapping(num_pairs: int) -> dict:
+    return {
+        pair_id: {
+            "ref_chosen_logprob_sum": -1.0,
+            "ref_chosen_num_tokens": 3,
+            "ref_rejected_logprob_sum": -2.0,
+            "ref_rejected_num_tokens": 3,
+        }
+        for pair_id in range(num_pairs)
+    }
+
+
+def make_config(**overrides) -> DPODatasetConfig:
+    fields = dict(
+        tokenizer_name="org/some-model",
+        seq_length=64,
+        ref_artifact="/tmp/ref_artifact",
+        source=HFDatasetSourceConfig(path_or_dataset="org/some-preference-set", split="train"),
+    )
+    fields.update(overrides)
+    return DPODatasetConfig(**fields)
+
+
+def make_validation_config(**overrides) -> DPODatasetConfig:
+    fields = dict(
+        validation_ref_artifact="/tmp/validation_ref_artifact",
+        validation_source=HFDatasetSourceConfig(path_or_dataset="org/some-preference-set", split="validation"),
+    )
+    fields.update(overrides)
+    return make_config(**fields)
+
+
+def test_dataloader_type_is_pinned_to_batch():
+    config = make_config()
+    config.finalize()
+    assert config.dataloader_type == "batch"
+    with pytest.raises(ValueError, match="dataloader_type"):
+        make_config(dataloader_type="single").finalize()
+
+
+def test_source_must_be_a_supported_source_type():
+    """The source type selects the mode, so anything else fails loudly."""
+    with pytest.raises(TypeError, match="HFDatasetSourceConfig or PreferenceJSONLSource"):
+        make_config(source=None).finalize()
+    with pytest.raises(TypeError, match="HFDatasetSourceConfig or PreferenceJSONLSource"):
+        make_config(source=["/tmp/pairs.jsonl"]).finalize()
+
+
+def test_mapping_shaped_sources_are_rebuilt_after_an_override_round_trip():
+    """OmegaConf overrides hand nested dataclasses back as plain mappings; validate must rebuild them."""
+    config = make_config(
+        source={"path_or_dataset": "org/some-preference-set", "split": "train"},
+        validation_source={"paths": ["/tmp/v.jsonl"]},
+        validation_ref_artifact="/tmp/validation_ref_artifact",
+    )
+    config.finalize()
+    assert isinstance(config.source, HFDatasetSourceConfig)
+    assert isinstance(config.validation_source, PreferenceJSONLSource)
+    assert config.source_identity(config.source) == ("org/some-preference-set", "train")
+    assert config.source_identity(config.validation_source) == ("/tmp/v.jsonl", None)
+
+
+def test_seq_length_must_be_positive():
+    with pytest.raises(ValueError, match="seq_length"):
+        make_config(seq_length=0).finalize()
+
+
+def test_jsonl_sources_reject_formats_the_memmap_reader_cannot_parse():
+    config = make_config(source=PreferenceJSONLSource(paths=["/tmp/pairs.parquet"]))
+    with pytest.raises(ValueError, match="accepts only"):
+        config.finalize()
+
+
+def test_remote_jsonl_requires_an_index_mapping_dir():
+    """The .idx sidecars cannot be written beside data in a read-only bucket."""
+    config = make_config(source=PreferenceJSONLSource(paths=["msc://bucket/pairs.jsonl"]))
+    with pytest.raises(ValueError, match="index_mapping_dir"):
+        config.finalize()
+
+    ok = make_config(source=PreferenceJSONLSource(paths=["msc://bucket/pairs.jsonl"], index_mapping_dir="/tmp/idx"))
+    ok.finalize()
+
+
+def test_source_identity_covers_each_source_mode():
+    """These land in scoring_metadata.json, so both modes need a stable identity."""
+    hf = make_config()
+    assert hf.source_identity(hf.source) == ("org/some-preference-set", "train")
+
+    jsonl = make_config(source=PreferenceJSONLSource(paths=["/tmp/a.jsonl", "/tmp/b.jsonl"]))
+    assert jsonl.source_identity(jsonl.source) == ("/tmp/a.jsonl,/tmp/b.jsonl", None)
+
+
+def test_validate_resolves_a_jsonl_path_on_the_hf_source_in_place(tmp_path):
+    """After validation the config holds one source type, and its identity has no split."""
+    config = make_config(
+        source=HFDatasetSourceConfig(path_or_dataset="/tmp/pairs.jsonl", split="train"),
+        index_mapping_dir=str(tmp_path / "index"),
+    )
+    config.finalize()
+    assert isinstance(config.source, PreferenceJSONLSource)
+    assert config.source.index_mapping_dir == str(tmp_path / "index")
+    assert config.source_identity(config.source) == ("/tmp/pairs.jsonl", None)
+
+
+def test_load_tokenizer_routes_trust_remote_code_through_the_repo_guard(monkeypatch):
+    import megatron.bridge.data.builders.dpo as dpo_module
+
+    seen = {}
+
+    class FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(name, **kwargs):
+            seen.update(name=name, **kwargs)
+            return FakeChatTokenizer()
+
+    monkeypatch.setattr(dpo_module, "AutoTokenizer", FakeAutoTokenizer)
+    make_config().load_tokenizer()
+    assert seen == {"name": "org/some-model", "trust_remote_code": False}
+    make_config(trust_remote_code=True).load_tokenizer()
+    assert seen["trust_remote_code"] is True
+
+
+def test_build_preference_split_without_an_artifact_is_the_scorer_shape(monkeypatch):
+    """The scorer builds through the same helper as the trainer, so token streams match by construction."""
+    monkeypatch.setattr(DPODatasetConfig, "load_source", lambda self, split="train": [chat_row(0), chat_row(1)])
+    config = make_config(pad_seq_length_to_mult=4, prompt_key=None)
+    dataset = build_preference_split(config, "train", FakeChatTokenizer())
+    assert len(dataset) == 2
+    assert dataset.require_ref_logprobs is False
+    assert dataset.max_seq_length == config.seq_length
+    batch = dataset.collate_fn([dataset[0], dataset[1]])
+    assert batch["tokens"].shape[1] % 4 == 0
+    assert "ref_logprob_sum" not in batch
+
+
+def test_validation_split_requires_its_own_artifact():
+    config = make_validation_config(validation_ref_artifact=None)
+    with pytest.raises(ValueError, match="validation_ref_artifact"):
+        config.finalize()
+
+
+def test_validation_artifact_without_a_validation_source_is_rejected():
+    config = make_config(validation_ref_artifact="/tmp/validation_ref_artifact")
+    with pytest.raises(ValueError, match="set validation_source"):
+        config.finalize()
+
+
+def test_load_source_validation_split_requires_a_validation_source():
+    with pytest.raises(ValueError, match="No validation split"):
+        make_config().load_source("validation")
+
+
+def test_num_pairs_truncates_by_position_and_zero_or_oversized_is_a_no_op():
+    rows = [{"i": i} for i in range(5)]
+    import megatron.bridge.data.builders.dpo as dpo_module
+
+    seen = []
+    for num_pairs, expected in [(0, 5), (9, 5), (2, 2)]:
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(dpo_module, "prepare_hf_dataset_sources", lambda sources: seen.append(sources))
+            mp.setattr(dpo_module, "load_hf_dataset_source", lambda source: rows)
+            out = DPODatasetConfig._load_rows(HFDatasetSourceConfig(path_or_dataset="org/x", split="train"), num_pairs)
+        assert len(out) == expected
+        assert [out[i]["i"] for i in range(len(out))] == list(range(expected))
+
+
+def write_jsonl(path, rows):
+    path.write_text("\n".join(json.dumps(r) for r in rows))
+
+
+def test_a_jsonl_path_on_the_hf_source_routes_to_the_memmap_reader(tmp_path):
+    """The launcher channel: run_recipe can only override existing scalar fields, so a
+    JSONL path arrives as ``source.path_or_dataset`` and must still reach the memmap reader."""
+    rows = [chat_row(0), chat_row(1)]
+    write_jsonl(tmp_path / "pairs.jsonl", rows)
+
+    config = make_config(
+        source=HFDatasetSourceConfig(path_or_dataset=str(tmp_path / "pairs.jsonl"), split="train"),
+        index_mapping_dir=str(tmp_path / "index"),
+    )
+    source = config.load_source()
+
+    assert [dict(source[i]) for i in range(len(source))] == rows
+    assert (tmp_path / "index").is_dir()
+
+
+def test_a_hub_id_on_the_hf_source_still_loads_through_hf_datasets(monkeypatch, tmp_path):
+    """Only path-shaped sources switch readers; a hub id must keep the HF loader."""
+    seen = []
+    monkeypatch.setattr(
+        "megatron.bridge.data.builders.dpo.prepare_hf_dataset_sources",
+        lambda sources: seen.append(sources),
+    )
+    monkeypatch.setattr(
+        "megatron.bridge.data.builders.dpo.load_hf_dataset_source",
+        lambda source: FakeSource([chat_row(0)]),
+    )
+    source = make_config().load_source()
+
+    assert len(source) == 1
+    assert seen and seen[0][0].path_or_dataset == "org/some-preference-set"
+
+
+def test_load_source_concatenates_files_in_order_and_truncates_to_num_pairs(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    write_jsonl(data_dir / "a.jsonl", [{"x": 0}])
+    write_jsonl(data_dir / "b.jsonl", [{"x": 1}, {"x": 2}])
+
+    config = make_config(
+        source=PreferenceJSONLSource(
+            paths=[str(data_dir / "a.jsonl"), str(data_dir / "b.jsonl")],
+            index_mapping_dir=str(tmp_path / "index"),
+        ),
+        num_pairs=2,
+    )
+    source = config.load_source()
+
+    assert [source[i]["x"] for i in range(len(source))] == [0, 1]
+
+
+@pytest.fixture
+def patched_build_deps(monkeypatch):
+    """Route source loading, artifact loading, and the HF tokenizer to fakes."""
+    source = FakeSource([chat_row(i) for i in range(6)])
+    validation_source = FakeSource([chat_row(i) for i in range(4)])
+    loaded_artifacts = []
+
+    def fake_load_source(self, split="train"):
+        rows, num_pairs = (
+            (validation_source, self.validation_num_pairs) if split == "validation" else (source, self.num_pairs)
+        )
+        return rows.select(range(num_pairs)) if num_pairs else rows
+
+    def fake_load_ref_logprobs(path, expected_num_pairs):
+        loaded_artifacts.append((path, expected_num_pairs))
+        return ref_mapping(expected_num_pairs)
+
+    import megatron.bridge.data.builders.dpo as provider_module
+
+    fake_auto_tokenizer = type(
+        "AutoTokenizer", (), {"from_pretrained": staticmethod(lambda name, **kwargs: FakeChatTokenizer())}
+    )
+    monkeypatch.setattr(provider_module, "AutoTokenizer", fake_auto_tokenizer)
+    monkeypatch.setattr(DPODatasetConfig, "load_source", fake_load_source)
+    monkeypatch.setattr(provider_module, "load_ref_logprobs", fake_load_ref_logprobs)
+    return loaded_artifacts
+
+
+def build_datasets(config: DPODatasetConfig, valid_samples: int = 0):
+    """Invoke the registry provider the way ``build_train_valid_test_datasets`` does."""
+    return dpo_train_valid_test_datasets_provider([0, valid_samples, 0], config)
+
+
+def test_provider_requires_a_ref_artifact():
+    with pytest.raises(ValueError, match="ref_artifact"):
+        build_datasets(make_config(ref_artifact=None))
+
+
+def test_builder_validates_at_construction():
+    """Bad configs fail when the builder is created, before any data is touched."""
+    with pytest.raises(ValueError, match="ref_artifact"):
+        DPODatasetBuilder(make_config(ref_artifact=None))
+    with pytest.raises(TypeError, match="HFDatasetSourceConfig or PreferenceJSONLSource"):
+        DPODatasetBuilder(make_config(source=None))
+
+
+def test_provider_returns_train_only_without_a_validation_split(patched_build_deps):
+    train_ds, valid_ds, test_ds = build_datasets(make_config(), valid_samples=8)
+    assert valid_ds is None and test_ds is None
+    assert len(train_ds) == 6
+    assert train_ds.require_ref_logprobs
+    assert patched_build_deps == [("/tmp/ref_artifact", 6)]
+
+
+def test_provider_builds_the_validation_dataset_from_its_own_artifact(patched_build_deps):
+    train_ds, valid_ds, test_ds = build_datasets(make_validation_config(), valid_samples=8)
+    assert test_ds is None
+    assert len(train_ds) == 6
+    assert len(valid_ds) == 4
+    assert valid_ds.require_ref_logprobs
+    assert patched_build_deps == [("/tmp/ref_artifact", 6), ("/tmp/validation_ref_artifact", 4)]
+
+
+def test_provider_skips_the_validation_split_when_the_run_never_validates(patched_build_deps):
+    """SFT-builder behavior: a configured validation split with valid_samples == 0 is not built."""
+    _, valid_ds, _ = build_datasets(make_validation_config(), valid_samples=0)
+    assert valid_ds is None
+    assert patched_build_deps == [("/tmp/ref_artifact", 6)]
+
+
+def test_provider_selects_validation_num_pairs(patched_build_deps):
+    _, valid_ds, _ = build_datasets(make_validation_config(validation_num_pairs=2), valid_samples=8)
+    assert len(valid_ds) == 2
+    assert patched_build_deps == [("/tmp/ref_artifact", 6), ("/tmp/validation_ref_artifact", 2)]
+
+
+def test_registry_resolves_dpo_config_to_the_provider():
+    pytest.importorskip("megatron.core.datasets.blended_megatron_dataset_builder")
+    from megatron.bridge.data.utils import get_dataset_provider
+
+    assert get_dataset_provider(make_config()) is dpo_train_valid_test_datasets_provider
+
+
+def test_built_dataset_collates_dpo_batch_keys(patched_build_deps):
+    train_ds, _, _ = build_datasets(make_config())
+    batch = train_ds.collate_fn([train_ds[0], train_ds[1]])
+    for key in ("tokens", "labels", "loss_mask", "pair_id", "loss_multiplier", "ref_logprob_sum", "ref_num_tokens"):
+        assert key in batch, key
+    assert batch["tokens"].shape[0] == 4  # 2 pairs -> 4 interleaved rows
+
+
+def explicit_chat_row(pair_id: int) -> dict:
+    """``chat_row`` in TRL's explicit-prompt layout: shared prompt, completion-only sides."""
+    return {
+        "messages": [{"role": "user", "content": f"prompt {pair_id}"}],
+        "chosen": [{"role": "assistant", "content": "an answer"}],
+        "rejected": [{"role": "assistant", "content": "worse"}],
+    }
+
+
+def test_explicit_prompt_rows_build_the_same_batch_as_implicit_rows(monkeypatch, patched_build_deps):
+    """Config plumbing proven end-to-end: the provider's batch is format-independent."""
+    implicit_batch = _collated_first_batch(make_config())
+
+    monkeypatch.setattr(
+        DPODatasetConfig,
+        "load_source",
+        lambda self, split="train": FakeSource([explicit_chat_row(i) for i in range(6)]),
+    )
+    explicit_batch = _collated_first_batch(make_config(prompt_key="messages"))
+
+    assert implicit_batch.keys() == explicit_batch.keys()
+    for key, value in implicit_batch.items():
+        if isinstance(value, torch.Tensor):
+            assert torch.equal(value, explicit_batch[key]), key
+        else:
+            assert value == explicit_batch[key], key
+
+
+def _collated_first_batch(config: DPODatasetConfig):
+    train_ds, _, _ = build_datasets(config)
+    return train_ds.collate_fn([train_ds[0], train_ds[1]])

--- a/tests/unit_tests/data/datasets/conftest.py
+++ b/tests/unit_tests/data/datasets/conftest.py
@@ -1,0 +1,49 @@
+import io
+
+import pytest
+from megatron.core.msc_utils import MultiStorageClientFeature
+
+
+class _RecordingWriter(io.BytesIO):
+    """Write-mode handle: commits its bytes into the fake's blob store on close."""
+
+    def __init__(self, msc: "RecordingMsc", path: str, binary: bool) -> None:
+        super().__init__()
+        self._msc = msc
+        self._path = path
+        self._binary = binary
+
+    def write(self, data) -> int:
+        if not self._binary and isinstance(data, str):
+            data = data.encode()
+        return super().write(data)
+
+    def close(self) -> None:
+        self._msc.blobs[self._path] = self.getvalue()
+        super().close()
+
+
+class RecordingMsc:
+    """Fake multistorageclient package: an in-memory blob store behind ``msc.open``."""
+
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+
+    def open(self, path: str, mode: str = "r"):  # noqa: A003 — mirrors msc.open
+        binary = "b" in mode
+        if "r" in mode:
+            if path not in self.blobs:
+                raise FileNotFoundError(path)
+            data = self.blobs[path]
+            return io.BytesIO(data) if binary else io.StringIO(data.decode())
+        return _RecordingWriter(self, path, binary)
+
+
+@pytest.fixture
+def fake_msc(monkeypatch):
+    """Turn the MSC feature flag on and back it with an in-memory package fake."""
+    msc = RecordingMsc()
+    # MultiStorageClientFeature is a module-level instance, so plain callables replace its bound methods.
+    monkeypatch.setattr(MultiStorageClientFeature, "is_enabled", lambda: True)
+    monkeypatch.setattr(MultiStorageClientFeature, "import_package", lambda: msc)
+    return msc

--- a/tests/unit_tests/data/datasets/test_preference.py
+++ b/tests/unit_tests/data/datasets/test_preference.py
@@ -109,6 +109,21 @@ def test_pair_adjacency_and_epoch_coverage(dp_size, mbs_rows):
         assert len(step_pairs) == len(set(step_pairs)), "ranks must not overlap within a step"
 
 
+def test_seed_reaches_the_batch_sampler():
+    """Every DP rank must shuffle with the config seed, not its rank-local torch seed."""
+    loader = build_preference_data_loader(
+        dataset=RecordsDataset(make_records(8)),
+        micro_batch_size=2,
+        global_batch_size=4,
+        data_parallel_rank=0,
+        data_parallel_size=1,
+        consumed_samples=0,
+        pin_memory=False,
+        seed=4321,
+    )
+    assert loader.batch_sampler.seed == 4321
+
+
 def test_shuffle_false_consumes_pairs_in_source_row_order():
     """shuffle=False must yield pair ids exactly in dataset order — the contract
     step-synchronized parity runs against an external trainer rely on."""

--- a/tests/unit_tests/data/datasets/test_preference.py
+++ b/tests/unit_tests/data/datasets/test_preference.py
@@ -1,0 +1,371 @@
+import json
+from functools import partial
+
+import pytest
+import torch
+from torch.utils.data import Dataset
+
+from megatron.bridge.data.batch_utils import split_batch_into_microbatches
+from megatron.bridge.data.datasets.preference import (
+    REF_LOGPROB_COLUMNS,
+    build_preference_data_loader,
+    load_ref_logprobs,
+    pack_pairs_by_token_budget,
+    pair_token_lengths,
+    preference_collate_fn,
+    ref_logprobs_from_rows,
+    validate_scoring_metadata,
+    write_ref_logprobs,
+    write_scoring_metadata,
+)
+
+
+PAD_ID = 0
+
+
+class RecordsDataset(Dataset):
+    """Serves ready-made pair records, so collate and sampler tests skip tokenization."""
+
+    def __init__(self, records: list[dict]) -> None:
+        self.records = records
+        self.collate_fn = partial(preference_collate_fn, pad_token_id=PAD_ID)
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __getitem__(self, idx: int) -> dict:
+        return dict(self.records[idx])
+
+
+def make_records(num_pairs: int) -> list[dict]:
+    """Synthetic records; token ids encode (pair, side): chosen 1000+p/2000+p (ctx/completion),
+    rejected 3000+p/4000+p, ref sums p+0.25 (chosen) / p+0.75 (rejected)."""
+    records = []
+    for p in range(num_pairs):
+        ctx_c, comp_c = 2 + p % 3, 1 + p % 4
+        ctx_r, comp_r = 2 + (p + 1) % 3, 2 + (p + 2) % 3
+        records.append(
+            {
+                "pair_id": p,
+                "chosen_input_ids": [1000 + p] * ctx_c + [2000 + p] * comp_c,
+                "chosen_context_len": ctx_c,
+                "rejected_input_ids": [3000 + p] * ctx_r + [4000 + p] * comp_r,
+                "rejected_context_len": ctx_r,
+                "ref_chosen_logprob_sum": p + 0.25,
+                "ref_chosen_num_tokens": comp_c,
+                "ref_rejected_logprob_sum": p + 0.75,
+                "ref_rejected_num_tokens": comp_r,
+            }
+        )
+    return records
+
+
+def iter_rank_microbatches(records, dp_size, gbs_rows, mbs_rows, consumed_rows=0, shuffle=True):
+    """Yield (rank, step, microbatch) through the real loader + microbatch split."""
+    num_microbatches = gbs_rows // (mbs_rows * dp_size)
+    for rank in range(dp_size):
+        loader = build_preference_data_loader(
+            dataset=RecordsDataset(records),
+            micro_batch_size=mbs_rows,
+            global_batch_size=gbs_rows,
+            data_parallel_rank=rank,
+            data_parallel_size=dp_size,
+            consumed_samples=consumed_rows,
+            # sampler shuffles by default; adjacency must hold under shuffle
+            pin_memory=False,
+            shuffle=shuffle,
+        )
+        for step, global_batch in enumerate(loader):
+            for microbatch in split_batch_into_microbatches(global_batch, num_microbatches):
+                yield rank, step, microbatch
+
+
+@pytest.mark.parametrize("dp_size", [1, 2, 4])
+@pytest.mark.parametrize("mbs_rows", [2, 4])
+def test_pair_adjacency_and_epoch_coverage(dp_size, mbs_rows):
+    """Every microbatch on every rank holds whole, adjacent pairs; one epoch covers
+    each pair exactly once with no overlap across ranks."""
+    num_pairs, gbs_rows = 16, 8
+    if gbs_rows % (mbs_rows * dp_size) != 0:
+        pytest.skip("incompatible grid point")
+
+    seen: dict[tuple[int, int], list[int]] = {}
+    for rank, step, mb in iter_rank_microbatches(make_records(num_pairs), dp_size, gbs_rows, mbs_rows):
+        assert mb["tokens"].shape[0] == mbs_rows
+        pair_id = mb["pair_id"]
+        # THE invariant: even row and its odd neighbor belong to the same pair.
+        assert torch.equal(pair_id[::2], pair_id[1::2]), f"pair split across rows: {pair_id.tolist()}"
+        # chosen@even / rejected@odd: token ids encode the side.
+        assert (mb["tokens"][::2, 0] < 3000).all(), "even rows must be chosen"
+        assert (mb["tokens"][1::2, 0] >= 3000).all(), "odd rows must be rejected"
+        seen.setdefault((step, rank), []).extend(pair_id[::2].tolist())
+
+    steps = {step for step, _ in seen}
+    assert len(steps) == num_pairs // (gbs_rows // 2)
+    all_pairs = [p for pairs in seen.values() for p in pairs]
+    assert sorted(all_pairs) == list(range(num_pairs)), "epoch must cover every pair exactly once"
+    for step in steps:
+        step_pairs = [p for (s, r), pairs in seen.items() if s == step for p in pairs]
+        assert len(step_pairs) == len(set(step_pairs)), "ranks must not overlap within a step"
+
+
+def test_shuffle_false_consumes_pairs_in_source_row_order():
+    """shuffle=False must yield pair ids exactly in dataset order — the contract
+    step-synchronized parity runs against an external trainer rely on."""
+    num_pairs, gbs_rows = 16, 8
+    ordered = [
+        pid
+        for _, _, mb in iter_rank_microbatches(
+            make_records(num_pairs), dp_size=1, gbs_rows=gbs_rows, mbs_rows=2, shuffle=False
+        )
+        for pid in mb["pair_id"][::2].tolist()
+    ]
+    assert ordered == list(range(num_pairs))
+
+
+def test_ref_columns_ride_in_lockstep_with_rows():
+    """Aux tensors must stay row-aligned through collate + microbatch split."""
+    for _, _, mb in iter_rank_microbatches(make_records(8), dp_size=2, gbs_rows=4, mbs_rows=2):
+        pair_id = mb["pair_id"].float()
+        assert torch.equal(mb["ref_logprob_sum"][::2], pair_id[::2] + 0.25)
+        assert torch.equal(mb["ref_logprob_sum"][1::2], pair_id[1::2] + 0.75)
+        assert (mb["ref_num_tokens"] > 0).all()
+
+
+def test_resume_matches_uninterrupted_run():
+    """Rebuilding the loader with row-denominated consumed_samples continues
+    the exact pair sequence (exercises the rows→pairs //2 translation)."""
+    records, dp_size, gbs_rows, mbs_rows = make_records(24), 2, 8, 2
+
+    def pair_sequence(consumed_rows):
+        return [
+            (rank, step, mb["pair_id"][::2].tolist())
+            for rank, step, mb in iter_rank_microbatches(records, dp_size, gbs_rows, mbs_rows, consumed_rows)
+        ]
+
+    full = pair_sequence(consumed_rows=0)
+    resumed = pair_sequence(consumed_rows=2 * gbs_rows)  # 2 completed steps
+    steps_done = 2
+    remaining = [(rank, step - steps_done, pairs) for rank, step, pairs in full if step >= steps_done]
+    assert resumed == remaining
+
+
+def test_collate_shift_mask_and_padding():
+    """Hand-checked shift/mask/padding for one pair, incl. TP/SP divisibility."""
+    record = {
+        "pair_id": 7,
+        "chosen_input_ids": [11, 12, 13, 21, 22],  # ctx=[11,12,13], completion=[21,22]
+        "chosen_context_len": 3,
+        "rejected_input_ids": [11, 12, 13, 31],  # ctx same, completion=[31]
+        "rejected_context_len": 3,
+        "ref_chosen_logprob_sum": -1.0,
+        "ref_chosen_num_tokens": 2,
+        "ref_rejected_logprob_sum": -2.0,
+        "ref_rejected_num_tokens": 1,
+    }
+    out = preference_collate_fn([record], pad_token_id=PAD_ID, pad_seq_length_to_mult=8)
+
+    assert out["tokens"].shape == (2, 8)  # max real length 4, ceiled to 8
+    assert out["tokens"][0].tolist() == [11, 12, 13, 21, 0, 0, 0, 0]
+    assert out["labels"][0].tolist() == [12, 13, 21, 22, 0, 0, 0, 0]
+    # completion labels start at ctx_len-1=2: labels [21, 22] are trained on.
+    assert out["loss_mask"][0].tolist() == [0, 0, 1, 1, 0, 0, 0, 0]
+    assert out["tokens"][1].tolist() == [11, 12, 13, 0, 0, 0, 0, 0]
+    assert out["labels"][1].tolist() == [12, 13, 31, 0, 0, 0, 0, 0]
+    assert out["loss_mask"][1].tolist() == [0, 0, 1, 0, 0, 0, 0, 0]
+    assert out["position_ids"].shape == (2, 8)
+    assert out["attention_mask"] is None
+
+
+def test_collate_tensors_are_pinnable():
+    """No collated tensor may alias memory across rows (stride 0): pin_memory
+    allocates with identical strides and copy_s, which rejects overlapping writes —
+    position_ids via bare expand() crashed every pin_memory=True consumer."""
+    batch = preference_collate_fn(make_records(3), pad_token_id=PAD_ID)
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor):
+            assert 0 not in value.stride(), f"{key} aliases memory across rows: strides {value.stride()}"
+            # The exact copy pin_memory performs must succeed.
+            torch.empty_strided(value.shape, value.stride(), dtype=value.dtype).copy_(value)
+
+
+def test_loader_rejects_odd_row_batch_sizes():
+    common = dict(
+        dataset=RecordsDataset(make_records(8)),
+        data_parallel_rank=0,
+        data_parallel_size=1,
+    )
+    with pytest.raises(ValueError, match="row-denominated and must be even"):
+        build_preference_data_loader(micro_batch_size=3, global_batch_size=6, consumed_samples=0, **common)
+    with pytest.raises(ValueError, match="row-denominated and must be even"):
+        build_preference_data_loader(micro_batch_size=2, global_batch_size=5, consumed_samples=0, **common)
+    with pytest.raises(ValueError, match="must be divisible"):
+        build_preference_data_loader(micro_batch_size=4, global_batch_size=10, consumed_samples=0, **common)
+    with pytest.raises(ValueError, match="consumed_samples must be even"):
+        build_preference_data_loader(micro_batch_size=2, global_batch_size=4, consumed_samples=3, **common)
+
+
+def test_collate_rejects_context_only_sequences():
+    record = make_records(1)[0]
+    record["chosen_context_len"] = len(record["chosen_input_ids"])  # no completion tokens
+    with pytest.raises(ValueError, match="at least one completion"):
+        preference_collate_fn([record], pad_token_id=PAD_ID)
+
+
+def make_ref_rows(num_pairs: int) -> list[dict]:
+    """Scorer-output rows; values encode the pair id so mixups are detectable."""
+    return [
+        {
+            "pair_id": p,
+            "ref_chosen_logprob_sum": p + 0.25,
+            "ref_chosen_num_tokens": 2,
+            "ref_rejected_logprob_sum": p + 0.75,
+            "ref_rejected_num_tokens": 3,
+        }
+        for p in range(num_pairs)
+    ]
+
+
+def test_ref_logprobs_from_rows_keys_by_pair_id():
+    mapping = ref_logprobs_from_rows(make_ref_rows(4), expected_num_pairs=4)
+    assert sorted(mapping) == [0, 1, 2, 3]
+    for p, ref in mapping.items():
+        assert set(ref) == set(REF_LOGPROB_COLUMNS)
+        assert ref["ref_chosen_logprob_sum"] == p + 0.25
+        assert ref["ref_rejected_logprob_sum"] == p + 0.75
+
+
+def test_ref_logprobs_from_rows_rejects_bad_artifacts():
+    rows = make_ref_rows(4)
+
+    with pytest.raises(ValueError, match="missing columns"):
+        ref_logprobs_from_rows([{k: v for k, v in rows[0].items() if k != "ref_chosen_num_tokens"}], 1)
+    with pytest.raises(ValueError, match="duplicate pair_id"):
+        ref_logprobs_from_rows(rows + [rows[0]], 4)
+    # A gap in coverage: pair 2 unscored — training would silently mis-anchor it.
+    with pytest.raises(ValueError, match="cover pair_id"):
+        ref_logprobs_from_rows([r for r in rows if r["pair_id"] != 2], 4)
+    # Artifact from a different (larger) dataset.
+    with pytest.raises(ValueError, match="cover pair_id"):
+        ref_logprobs_from_rows(rows, 3)
+    # Artifact from a smaller dataset.
+    with pytest.raises(ValueError, match="cover pair_id"):
+        ref_logprobs_from_rows(rows, 5)
+
+
+def test_load_ref_logprobs_from_disk(tmp_path):
+    rows = make_ref_rows(3)
+    write_ref_logprobs(rows, str(tmp_path))
+
+    mapping = load_ref_logprobs(str(tmp_path), expected_num_pairs=3)
+    assert mapping == ref_logprobs_from_rows(rows, 3)
+    with pytest.raises(ValueError, match="cover pair_id"):
+        load_ref_logprobs(str(tmp_path), expected_num_pairs=4)
+
+
+def write_metadata(tmp_path, **overrides) -> str:
+    metadata = {"dataset": "d", "split": "train", "max_seq_length": 2048}
+    metadata.update(overrides)
+    (tmp_path / "scoring_metadata.json").write_text(json.dumps(metadata))
+    return str(tmp_path)
+
+
+def test_validate_scoring_metadata_passes_on_match(tmp_path):
+    artifact = write_metadata(tmp_path)
+    validate_scoring_metadata(artifact, {"dataset": "d", "max_seq_length": 2048})
+
+
+def test_validate_scoring_metadata_reports_every_mismatched_key(tmp_path):
+    artifact = write_metadata(tmp_path)
+    with pytest.raises(ValueError) as exc_info:
+        validate_scoring_metadata(artifact, {"dataset": "other", "max_seq_length": 4096})
+    message = str(exc_info.value)
+    assert "dataset" in message and "max_seq_length" in message
+    assert "'d'" in message and "'other'" in message  # artifact vs expected values shown
+
+
+def test_validate_scoring_metadata_missing_key_counts_as_mismatch(tmp_path):
+    artifact = write_metadata(tmp_path)
+    with pytest.raises(ValueError, match="tokenizer"):
+        validate_scoring_metadata(artifact, {"tokenizer": "org/model"})
+
+
+def test_validate_scoring_metadata_missing_file_names_the_artifact(tmp_path):
+    with pytest.raises(ValueError, match="scoring_metadata.json"):
+        validate_scoring_metadata(str(tmp_path), {"dataset": "d"})
+
+
+def test_write_and_load_ref_logprobs_round_trip_through_msc_with_no_staging(fake_msc):
+    url = "msc://bucket/dpo/artifact"
+    rows = make_ref_rows(3)
+
+    write_ref_logprobs(rows, url)
+    write_scoring_metadata({"dataset": "d"}, url)
+
+    assert set(fake_msc.blobs) == {f"{url}/ref_logprobs.jsonl", f"{url}/scoring_metadata.json"}
+
+    mapping = load_ref_logprobs(url, expected_num_pairs=3)
+    assert mapping == ref_logprobs_from_rows(rows, 3)
+    validate_scoring_metadata(url, {"dataset": "d"})
+
+
+class _FakeLengthDataset:
+    """Minimal dataset stub: items expose the two token-id lists the length sweep reads."""
+
+    def __init__(self, lengths: list[tuple[int, int]]):
+        self._lengths = lengths
+
+    def __len__(self) -> int:
+        return len(self._lengths)
+
+    def __getitem__(self, idx: int) -> dict:
+        chosen_len, rejected_len = self._lengths[idx]
+        return {"chosen_input_ids": [1] * chosen_len, "rejected_input_ids": [2] * rejected_len}
+
+
+def test_pair_token_lengths_takes_max_of_sides():
+    dataset = _FakeLengthDataset([(5, 3), (2, 8), (4, 4)])
+    assert pair_token_lengths(dataset) == [5, 8, 4]
+
+
+def test_token_budget_batches_cover_every_pair_exactly_once():
+    lengths = [7, 2, 4096, 130, 2, 512, 512, 3000, 64, 2]
+    batches = pack_pairs_by_token_budget(lengths, budget_tokens=8192)
+    flat = sorted(idx for batch in batches for idx in batch)
+    assert flat == list(range(len(lengths)))
+
+
+def test_token_budget_padded_cost_invariant_holds_for_multi_pair_batches():
+    lengths = [7, 2, 4096, 130, 2, 512, 512, 3000, 64, 2, 900, 900, 901]
+    budget = 8192
+    for batch in pack_pairs_by_token_budget(lengths, budget_tokens=budget):
+        padded_cost = 2 * len(batch) * max(lengths[i] for i in batch)
+        if len(batch) > 1:
+            assert padded_cost <= budget
+
+
+def test_token_budget_oversize_pair_gets_its_own_batch():
+    lengths = [10, 5000, 10]
+    batches = pack_pairs_by_token_budget(lengths, budget_tokens=4096)
+    assert [1] in batches  # 2 * 5000 > 4096, still scored
+
+
+def test_token_budget_batches_are_sorted_longest_first_and_deterministic():
+    lengths = [3, 100, 3, 50, 100, 7]
+    first = pack_pairs_by_token_budget(lengths, budget_tokens=1000)
+    second = pack_pairs_by_token_budget(lengths, budget_tokens=1000)
+    assert first == second
+    assert first[0][0] == 1  # longest length wins; equal lengths tie-break by index
+
+
+def test_token_budget_stub_flood_respects_max_pairs_cap():
+    batches = pack_pairs_by_token_budget([2] * 300, budget_tokens=100_000, max_pairs_per_batch=64)
+    assert max(len(batch) for batch in batches) == 64
+    assert sum(len(batch) for batch in batches) == 300
+
+
+def test_token_budget_rejects_non_positive_knobs():
+    with pytest.raises(ValueError, match="budget_tokens"):
+        pack_pairs_by_token_budget([4], budget_tokens=0)
+    with pytest.raises(ValueError, match="max_pairs_per_batch"):
+        pack_pairs_by_token_budget([4], budget_tokens=8, max_pairs_per_batch=0)

--- a/tests/unit_tests/data/datasets/test_preference.py
+++ b/tests/unit_tests/data/datasets/test_preference.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import asdict
 from functools import partial
 
 import pytest
@@ -8,6 +9,7 @@ from torch.utils.data import Dataset
 from megatron.bridge.data.batch_utils import split_batch_into_microbatches
 from megatron.bridge.data.datasets.preference import (
     REF_LOGPROB_COLUMNS,
+    ScoringFingerprint,
     build_preference_data_loader,
     load_ref_logprobs,
     pack_pairs_by_token_budget,
@@ -278,36 +280,50 @@ def test_load_ref_logprobs_from_disk(tmp_path):
         load_ref_logprobs(str(tmp_path), expected_num_pairs=4)
 
 
-def write_metadata(tmp_path, **overrides) -> str:
-    metadata = {"dataset": "d", "split": "train", "max_seq_length": 2048}
-    metadata.update(overrides)
+def fingerprint(**overrides) -> ScoringFingerprint:
+    fields = {
+        "dataset": "d",
+        "split": "train",
+        "tokenizer": "org/model",
+        "max_seq_length": 2048,
+        "prompt_key": None,
+        "tensor_model_parallel_size": 1,
+        "sequence_parallel": False,
+        "pipeline_model_parallel_size": 1,
+    }
+    fields.update(overrides)
+    return ScoringFingerprint(**fields)
+
+
+def write_metadata(tmp_path, drop: tuple[str, ...] = ()) -> str:
+    metadata = {key: value for key, value in asdict(fingerprint()).items() if key not in drop}
     (tmp_path / "scoring_metadata.json").write_text(json.dumps(metadata))
     return str(tmp_path)
 
 
-def test_validate_scoring_metadata_passes_on_match(tmp_path):
+def test_validate_scoring_metadata_passes_on_match_and_returns_the_metadata(tmp_path):
     artifact = write_metadata(tmp_path)
-    validate_scoring_metadata(artifact, {"dataset": "d", "max_seq_length": 2048})
+    assert validate_scoring_metadata(artifact, fingerprint()) == asdict(fingerprint())
 
 
 def test_validate_scoring_metadata_reports_every_mismatched_key(tmp_path):
     artifact = write_metadata(tmp_path)
     with pytest.raises(ValueError) as exc_info:
-        validate_scoring_metadata(artifact, {"dataset": "other", "max_seq_length": 4096})
+        validate_scoring_metadata(artifact, fingerprint(dataset="other", max_seq_length=4096))
     message = str(exc_info.value)
     assert "dataset" in message and "max_seq_length" in message
     assert "'d'" in message and "'other'" in message  # artifact vs expected values shown
 
 
 def test_validate_scoring_metadata_missing_key_counts_as_mismatch(tmp_path):
-    artifact = write_metadata(tmp_path)
+    artifact = write_metadata(tmp_path, drop=("tokenizer",))
     with pytest.raises(ValueError, match="tokenizer"):
-        validate_scoring_metadata(artifact, {"tokenizer": "org/model"})
+        validate_scoring_metadata(artifact, fingerprint())
 
 
 def test_validate_scoring_metadata_missing_file_names_the_artifact(tmp_path):
     with pytest.raises(ValueError, match="scoring_metadata.json"):
-        validate_scoring_metadata(str(tmp_path), {"dataset": "d"})
+        validate_scoring_metadata(str(tmp_path), fingerprint())
 
 
 def test_write_and_load_ref_logprobs_round_trip_through_msc_with_no_staging(fake_msc):
@@ -315,13 +331,13 @@ def test_write_and_load_ref_logprobs_round_trip_through_msc_with_no_staging(fake
     rows = make_ref_rows(3)
 
     write_ref_logprobs(rows, url)
-    write_scoring_metadata({"dataset": "d"}, url)
+    write_scoring_metadata(asdict(fingerprint()), url)
 
     assert set(fake_msc.blobs) == {f"{url}/ref_logprobs.jsonl", f"{url}/scoring_metadata.json"}
 
     mapping = load_ref_logprobs(url, expected_num_pairs=3)
     assert mapping == ref_logprobs_from_rows(rows, 3)
-    validate_scoring_metadata(url, {"dataset": "d"})
+    validate_scoring_metadata(url, fingerprint())
 
 
 class _FakeLengthDataset:

--- a/tests/unit_tests/data/datasets/test_preference_tokenization.py
+++ b/tests/unit_tests/data/datasets/test_preference_tokenization.py
@@ -9,26 +9,7 @@ from megatron.bridge.data.batch_utils import split_batch_into_microbatches
 from megatron.bridge.data.datasets.preference import build_preference_data_loader
 from megatron.bridge.data.datasets.preference_lazy import LazyChatPreferencePairDataset
 from megatron.bridge.data.datasets.preference_tokenization import build_pair_conversations, tokenize_conversation
-
-
-USER_HEADER, ASSISTANT_HEADER = 1, 2
-
-
-class FakeChatTokenizer:
-    """Chat-template stub (header token per message, token per word) with the prefix
-    property by construction: add_generation_prompt appends the assistant header."""
-
-    pad_token_id = 0
-    eos_token_id = 9
-
-    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False):
-        ids = []
-        for message in messages:
-            ids.append(ASSISTANT_HEADER if message["role"] == "assistant" else USER_HEADER)
-            ids.extend(100 + len(word) for word in message["content"].split())
-        if add_generation_prompt:
-            ids.append(ASSISTANT_HEADER)
-        return ids
+from tests.unit_tests.data.preference_fakes import ASSISTANT_HEADER, USER_HEADER, FakeChatTokenizer
 
 
 class BatchEncodingChatTokenizer(FakeChatTokenizer):

--- a/tests/unit_tests/data/datasets/test_preference_tokenization.py
+++ b/tests/unit_tests/data/datasets/test_preference_tokenization.py
@@ -1,0 +1,421 @@
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import pytest
+import torch
+
+from megatron.bridge.data.batch_utils import split_batch_into_microbatches
+from megatron.bridge.data.datasets.preference import build_preference_data_loader
+from megatron.bridge.data.datasets.preference_lazy import LazyChatPreferencePairDataset
+from megatron.bridge.data.datasets.preference_tokenization import build_pair_conversations, tokenize_conversation
+
+
+USER_HEADER, ASSISTANT_HEADER = 1, 2
+
+
+class FakeChatTokenizer:
+    """Chat-template stub (header token per message, token per word) with the prefix
+    property by construction: add_generation_prompt appends the assistant header."""
+
+    pad_token_id = 0
+    eos_token_id = 9
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False):
+        ids = []
+        for message in messages:
+            ids.append(ASSISTANT_HEADER if message["role"] == "assistant" else USER_HEADER)
+            ids.extend(100 + len(word) for word in message["content"].split())
+        if add_generation_prompt:
+            ids.append(ASSISTANT_HEADER)
+        return ids
+
+
+class BatchEncodingChatTokenizer(FakeChatTokenizer):
+    """transformers>=5 shape: dict-like return, single conversation batched as [[ids]]."""
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False):
+        ids = super().apply_chat_template(messages, tokenize, add_generation_prompt)
+        return {"input_ids": [ids]}
+
+
+def conversation(prompt="hello there", completion="general kenobi"):
+    return [
+        {"role": "user", "content": prompt},
+        {"role": "assistant", "content": completion},
+    ]
+
+
+def chat_source(num_pairs):
+    return [
+        {"chosen": conversation(f"prompt {p}"), "rejected": conversation(f"prompt {p}", f"worse answer {p}")}
+        for p in range(num_pairs)
+    ]
+
+
+def explicit_chat_source(num_pairs, with_system=False):
+    """The same pairs as ``chat_source`` in TRL's explicit-prompt layout:
+    a shared ``messages`` prompt plus completion-only chosen/rejected."""
+    return [
+        {
+            "messages": ([{"role": "system", "content": "be terse"}] if with_system else [])
+            + [{"role": "user", "content": f"prompt {p}"}],
+            "chosen": [{"role": "assistant", "content": "general kenobi"}],
+            "rejected": [{"role": "assistant", "content": f"worse answer {p}"}],
+            # Rows may carry extra fields the dataset must ignore.
+            "preference_margin": 0.5,
+            "pairs_metadata": {"quality_score": {"chosen": 0.0}},
+        }
+        for p in range(num_pairs)
+    ]
+
+
+def build_chat_preference_records(
+    source: Iterable[Mapping[str, Any]],
+    tokenizer,
+    max_seq_length: int,
+    chosen_key: str = "chosen",
+    rejected_key: str = "rejected",
+    prompt_key: str | None = None,
+    num_pairs: int = 0,
+) -> tuple[list[dict], Counter]:
+    """Eager twin of the lazy dataset: drops bad pairs whole and counts the reasons."""
+    records: list[dict] = []
+    drops: Counter = Counter()
+    for example in source:
+        if num_pairs and len(records) >= num_pairs:
+            break
+        pair = build_pair_conversations(
+            example, chosen_key=chosen_key, rejected_key=rejected_key, prompt_key=prompt_key
+        )
+        if isinstance(pair, str):
+            drops[pair] += 1
+            continue
+        side_c = tokenize_conversation(tokenizer, pair[0], max_seq_length)
+        side_r = tokenize_conversation(tokenizer, pair[1], max_seq_length)
+        if isinstance(side_c, str) or isinstance(side_r, str):
+            drops[side_c if isinstance(side_c, str) else side_r] += 1
+            continue
+        records.append(
+            {
+                "pair_id": len(records),
+                "chosen_input_ids": side_c[0],
+                "chosen_context_len": side_c[1],
+                "rejected_input_ids": side_r[0],
+                "rejected_context_len": side_r[1],
+            }
+        )
+    return records, drops
+
+
+def test_tokenize_conversation_returns_ids_with_context_prefix():
+    result = tokenize_conversation(FakeChatTokenizer(), conversation(), max_seq_length=100)
+    assert not isinstance(result, str), f"unexpected drop: {result}"
+    input_ids, context_len = result
+    # Context = user header + 2 prompt words; the assistant header belongs to the completion.
+    assert context_len == 3
+    assert input_ids[:context_len] == [USER_HEADER, 105, 105]
+    # Completion = assistant header + two words + appended EOS.
+    assert input_ids[context_len:] == [ASSISTANT_HEADER, 107, 106, FakeChatTokenizer.eos_token_id]
+
+
+def test_context_len_is_a_true_prefix_of_the_single_full_render():
+    """The boundary comes from one render, so it cannot disagree with input_ids."""
+    multi_turn = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "second question"},
+        {"role": "assistant", "content": "final answer here"},
+    ]
+    input_ids, context_len = tokenize_conversation(FakeChatTokenizer(), multi_turn, max_seq_length=100)
+
+    # Only the last assistant turn is completion; earlier assistant turns stay in context.
+    assert input_ids[context_len] == ASSISTANT_HEADER
+    assert len(input_ids) - context_len == 5  # header + three words + EOS
+
+
+@pytest.mark.parametrize(
+    ("messages", "max_seq_length", "reason"),
+    [
+        ([{"role": "user", "content": "no reply"}], 100, "no_assistant_completion"),
+        (conversation(completion=""), 100, "empty_completion"),
+        (conversation(), 3, "over_length"),
+    ],
+)
+def test_tokenize_conversation_drop_reasons(messages, max_seq_length, reason):
+    assert tokenize_conversation(FakeChatTokenizer(), messages, max_seq_length) == reason
+
+
+class ChatMLTokenizer:
+    """Character-level stand-in that renders exactly like the Qwen2.5 ChatML template."""
+
+    pad_token_id = 0
+    eos_token_id = 1
+    extra_generation_newline = False
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False):
+        text = "".join(f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages)
+        if add_generation_prompt:
+            text += "<|im_start|>assistant\n" + ("\n" if self.extra_generation_newline else "")
+        return [ord(c) for c in text]
+
+
+class TrailingNewlineChatMLTokenizer(ChatMLTokenizer):
+    """Generation prompt ends with a newline the full render does not contain."""
+
+    extra_generation_newline = True
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        conversation(),
+        [{"role": "system", "content": "be terse"}, *conversation()],
+        [*conversation("q1", "a1"), *conversation("q2", "a2")],
+        conversation("line one\nline two", "reply\nwith\nnewlines"),
+    ],
+    ids=["single_turn", "with_system", "multi_turn", "multiline_content"],
+)
+def test_context_len_equals_the_prior_turns_render_length_for_chatml(messages):
+    """The boundary sits at the start of the final assistant turn, header included."""
+    tokenizer = ChatMLTokenizer()
+    input_ids, context_len = tokenize_conversation(tokenizer, messages, max_seq_length=10_000)
+
+    prior_turns = tokenizer.apply_chat_template(messages[:-1])
+    assert context_len == len(prior_turns)
+    assert input_ids[:context_len] == prior_turns
+
+
+def test_completion_span_covers_the_whole_final_assistant_turn_plus_eos():
+    """NeMo-RL alignment: the scored span is header + content + terminator + EOS."""
+    tokenizer = ChatMLTokenizer()
+    input_ids, context_len = tokenize_conversation(tokenizer, conversation(), max_seq_length=10_000)
+    completion = "".join(map(chr, input_ids[context_len:]))
+    assert completion == "<|im_start|>assistant\ngeneral kenobi<|im_end|>\n" + chr(tokenizer.eos_token_id)
+
+
+class EosTerminatedChatTokenizer(FakeChatTokenizer):
+    """Render already ends with EOS, as instruct-tuned chat templates do."""
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False):
+        ids = super().apply_chat_template(messages, tokenize, add_generation_prompt)
+        if not add_generation_prompt:
+            ids.append(self.eos_token_id)
+        return ids
+
+
+def test_eos_is_not_appended_when_the_render_already_ends_with_it():
+    input_ids, _ = tokenize_conversation(EosTerminatedChatTokenizer(), conversation(), max_seq_length=100)
+    assert input_ids[-1] == FakeChatTokenizer.eos_token_id
+    assert input_ids[-2] != FakeChatTokenizer.eos_token_id
+
+
+def test_a_generation_prompt_that_is_not_a_prefix_no_longer_costs_the_pair():
+    """Previously dropped as template_prefix_mismatch; the boundary is now derived in-render."""
+    input_ids, context_len = tokenize_conversation(
+        TrailingNewlineChatMLTokenizer(), conversation(), max_seq_length=10_000
+    )
+    assert "".join(map(chr, input_ids)).startswith("".join(map(chr, input_ids[:context_len])))
+    assert "".join(map(chr, input_ids[context_len:])) == "<|im_start|>assistant\ngeneral kenobi<|im_end|>\n" + chr(
+        ChatMLTokenizer.eos_token_id
+    )
+
+
+class CountingChatTokenizer(FakeChatTokenizer):
+    def __init__(self):
+        self.calls = 0
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False):
+        self.calls += 1
+        return super().apply_chat_template(messages, tokenize, add_generation_prompt)
+
+
+def test_lazy_dataset_tokenizes_on_fetch_and_stubs_invalid_pairs():
+    source = chat_source(3) + [{"chosen": conversation("one prompt"), "rejected": conversation("another prompt")}]
+    tokenizer = CountingChatTokenizer()
+    dataset = LazyChatPreferencePairDataset(source, tokenizer, max_seq_length=100)
+
+    assert len(dataset) == 4  # invalid pair kept, not dropped
+    assert tokenizer.calls == 0  # nothing tokenized at init
+
+    record = dataset[0]
+    assert tokenizer.calls == 4  # 2 sides x (full render + boundary render) — tokenized on fetch
+    assert record["loss_multiplier"] == 1.0
+    assert record["pair_id"] == 0
+
+    stub = dataset[3]
+    assert stub["loss_multiplier"] == 0.0
+    assert stub["chosen_context_len"] == 1
+    assert len(stub["chosen_input_ids"]) == 2  # two-token stub, valid for the collate
+
+
+def test_lazy_dataset_loss_multiplier_rides_row_aligned_through_the_loader():
+    over_length_pair = {"chosen": conversation(completion="x " * 50), "rejected": conversation()}
+    source = chat_source(7) + [over_length_pair]
+    # BatchEncodingChatTokenizer also covers the transformers>=5 return shape end-to-end.
+    dataset = LazyChatPreferencePairDataset(source, BatchEncodingChatTokenizer(), max_seq_length=20)
+    loader = build_preference_data_loader(
+        dataset=dataset,
+        micro_batch_size=4,
+        global_batch_size=8,
+        data_parallel_rank=0,
+        data_parallel_size=1,
+        consumed_samples=0,
+        pin_memory=False,
+    )
+    for global_batch in loader:
+        for mb in split_batch_into_microbatches(global_batch, 2):
+            assert torch.equal(mb["pair_id"][::2], mb["pair_id"][1::2])
+            # Both rows of a stubbed pair are zeroed together.
+            assert torch.equal(mb["loss_multiplier"][::2], mb["loss_multiplier"][1::2])
+            dead = mb["loss_multiplier"] == 0.0
+            assert torch.equal(dead, mb["pair_id"] == 7), "only the over-length pair is dead"
+
+
+def test_lazy_dataset_joins_ref_logprobs_by_source_index():
+    # The collate asserts each row's completion-token count matches the artifact's, so the
+    # ref entries must carry the counts this tokenization actually produces
+    # (completion tokens == len(input_ids) - context_len).
+    probe = LazyChatPreferencePairDataset(chat_source(4), FakeChatTokenizer(), max_seq_length=100)
+    ref = {
+        p: {
+            "ref_chosen_logprob_sum": p + 0.25,
+            "ref_chosen_num_tokens": len(probe[p]["chosen_input_ids"]) - probe[p]["chosen_context_len"],
+            "ref_rejected_logprob_sum": p + 0.75,
+            "ref_rejected_num_tokens": len(probe[p]["rejected_input_ids"]) - probe[p]["rejected_context_len"],
+        }
+        for p in range(4)
+    }
+    dataset = LazyChatPreferencePairDataset(chat_source(4), FakeChatTokenizer(), max_seq_length=100, ref_logprobs=ref)
+    assert dataset.require_ref_logprobs
+    batch = dataset.collate_fn([dataset[i] for i in range(4)])
+    assert torch.equal(batch["ref_logprob_sum"][::2], batch["pair_id"][::2].float() + 0.25)
+
+    incomplete = LazyChatPreferencePairDataset(
+        chat_source(4), FakeChatTokenizer(), max_seq_length=100, ref_logprobs={0: ref[0]}
+    )
+    with pytest.raises(ValueError, match="no entry for pair_id"):
+        incomplete[1]
+
+
+@pytest.mark.parametrize("tokenizer_cls", [FakeChatTokenizer, ChatMLTokenizer], ids=["fake", "chatml"])
+def test_explicit_prompt_rows_tokenize_identically_to_implicit_rows(tokenizer_cls):
+    """Load-bearing: the new mode reduces to the already-validated implicit path."""
+    implicit, _ = build_chat_preference_records(chat_source(3), tokenizer_cls(), max_seq_length=1000)
+    explicit, drops = build_chat_preference_records(
+        explicit_chat_source(3), tokenizer_cls(), max_seq_length=1000, prompt_key="messages"
+    )
+    assert not drops
+    assert explicit == implicit
+
+
+def test_explicit_prompt_carries_multi_message_prompts():
+    """A leading system turn belongs to the shared context, not to either completion."""
+    records, drops = build_chat_preference_records(
+        explicit_chat_source(1, with_system=True), ChatMLTokenizer(), max_seq_length=1000, prompt_key="messages"
+    )
+    assert not drops
+    record = records[0]
+    context = "".join(map(chr, record["chosen_input_ids"][: record["chosen_context_len"]]))
+    assert context == "<|im_start|>system\nbe terse<|im_end|>\n<|im_start|>user\nprompt 0<|im_end|>\n"
+
+
+def test_explicit_prompt_mode_keeps_pairs_whose_completions_share_no_prefix():
+    """The shared prefix is shared by construction, so the mismatch check does not apply."""
+    row = {
+        "messages": [{"role": "user", "content": "a question"}],
+        "chosen": [{"role": "assistant", "content": "yes"}],
+        "rejected": [{"role": "assistant", "content": "no"}],
+    }
+    records, drops = build_chat_preference_records(
+        [row], FakeChatTokenizer(), max_seq_length=100, prompt_key="messages"
+    )
+    assert not drops and len(records) == 1
+
+
+def test_explicit_prompt_rows_read_without_prompt_key_are_all_dead():
+    """Documents the misconfiguration: no crash, just zero training signal."""
+    dataset = LazyChatPreferencePairDataset(explicit_chat_source(3), FakeChatTokenizer(), max_seq_length=100)
+    assert [dataset[i]["loss_multiplier"] for i in range(3)] == [0.0, 0.0, 0.0]
+
+
+@pytest.mark.parametrize(
+    ("completion", "max_seq_length", "reason"),
+    [
+        ([], 100, "no_assistant_completion"),
+        ([{"role": "user", "content": "not a completion"}], 100, "no_assistant_completion"),
+        ([{"role": "assistant", "content": ""}], 100, "empty_completion"),
+        ([{"role": "assistant", "content": "x " * 50}], 20, "over_length"),
+    ],
+    ids=["empty_list", "wrong_role", "empty_content", "over_length"],
+)
+def test_explicit_prompt_malformed_rows_drop_by_reason(completion, max_seq_length, reason):
+    row = {"messages": [{"role": "user", "content": "a question"}], "chosen": completion, "rejected": completion}
+    _, drops = build_chat_preference_records(
+        [row], FakeChatTokenizer(), max_seq_length=max_seq_length, prompt_key="messages"
+    )
+    assert dict(drops) == {reason: 1}
+
+
+def test_lazy_dataset_stubs_malformed_explicit_rows_without_shrinking():
+    source = explicit_chat_source(2) + [
+        {"messages": [{"role": "user", "content": "q"}], "chosen": [], "rejected": []},
+    ]
+    dataset = LazyChatPreferencePairDataset(source, FakeChatTokenizer(), max_seq_length=100, prompt_key="messages")
+    assert len(dataset) == 3
+    assert [dataset[i]["loss_multiplier"] for i in range(3)] == [1.0, 1.0, 0.0]
+    assert dataset[2]["chosen_input_ids"] == [0, 0]
+
+
+def standard_source(num_pairs):
+    """The same pairs as ``chat_source`` in TRL's *standard* layout: every field a plain
+    string, the shape most public preference sets on the hub ship in."""
+    return [
+        {"prompt": f"prompt {p}", "chosen": "general kenobi", "rejected": f"worse answer {p}"}
+        for p in range(num_pairs)
+    ]
+
+
+@pytest.mark.parametrize("tokenizer_cls", [FakeChatTokenizer, ChatMLTokenizer], ids=["fake", "chatml"])
+def test_standard_string_rows_tokenize_identically_to_conversational_rows(tokenizer_cls):
+    """Load-bearing: strings reduce to the already-validated message-list path."""
+    conversational, _ = build_chat_preference_records(chat_source(3), tokenizer_cls(), max_seq_length=1000)
+    standard, drops = build_chat_preference_records(
+        standard_source(3), tokenizer_cls(), max_seq_length=1000, prompt_key="prompt"
+    )
+    assert not drops
+    assert standard == conversational
+
+
+def test_string_prompt_becomes_a_user_turn_and_string_completion_an_assistant_turn():
+    """Wrapping roles match NeMo-RL's BinaryPreferenceDataset, so the same row reads the same in both."""
+    records, drops = build_chat_preference_records(
+        standard_source(1), ChatMLTokenizer(), max_seq_length=1000, prompt_key="prompt"
+    )
+    assert not drops
+    record = records[0]
+    rendered = "".join(map(chr, record["chosen_input_ids"]))
+    assert rendered.startswith("<|im_start|>user\nprompt 0<|im_end|>\n")
+    assert rendered.endswith("<|im_start|>assistant\ngeneral kenobi<|im_end|>\n" + chr(ChatMLTokenizer.eos_token_id))
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {"prompt": "a question", "chosen": [{"role": "assistant", "content": "yes"}], "rejected": "no"},
+        {"prompt": [{"role": "user", "content": "a question"}], "chosen": "yes", "rejected": "no"},
+    ],
+    ids=["string_prompt_list_completions", "list_prompt_string_completions"],
+)
+def test_string_and_message_list_fields_mix_freely(row):
+    records, drops = build_chat_preference_records([row], FakeChatTokenizer(), max_seq_length=100, prompt_key="prompt")
+    assert not drops and len(records) == 1
+
+
+def test_string_completions_without_a_prompt_key_drop_instead_of_crashing():
+    """Strings are only meaningful alongside a prompt field; the misconfiguration must
+    report a drop reason, not raise out of the tokenizer."""
+    _, drops = build_chat_preference_records(
+        [{"chosen": "yes", "rejected": "no"}], FakeChatTokenizer(), max_seq_length=100
+    )
+    assert dict(drops) == {"no_assistant_completion": 1}

--- a/tests/unit_tests/data/preference_fakes.py
+++ b/tests/unit_tests/data/preference_fakes.py
@@ -1,0 +1,19 @@
+"""Chat-template stand-ins shared by the preference dataset and DPO builder tests."""
+
+USER_HEADER, ASSISTANT_HEADER = 1, 2
+
+
+class FakeChatTokenizer:
+    """Header token per message and one token per word; ``add_generation_prompt`` appends the assistant header."""
+
+    pad_token_id = 0
+    eos_token_id = 9
+
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=False):
+        ids = []
+        for message in messages:
+            ids.append(ASSISTANT_HEADER if message["role"] == "assistant" else USER_HEADER)
+            ids.extend(100 + len(word) for word in message["content"].split())
+        if add_generation_prompt:
+            ids.append(ASSISTANT_HEADER)
+        return ids

--- a/tests/unit_tests/recipes/qwen/test_qwen3_recipes.py
+++ b/tests/unit_tests/recipes/qwen/test_qwen3_recipes.py
@@ -2,8 +2,9 @@
 
 import pytest
 
-from megatron.bridge.data.builders import GPTSFTDatasetConfig
-from megatron.bridge.recipes.qwen.h100 import qwen3
+from megatron.bridge.data.builders import DPODatasetConfig, GPTSFTDatasetConfig
+from megatron.bridge.recipes import common
+from megatron.bridge.recipes.qwen.h100 import qwen3, qwen3_moe
 
 
 pytestmark = pytest.mark.unit
@@ -33,3 +34,37 @@ def test_yarn_128k_recipe_uses_disjoint_train_and_validation_slices(monkeypatch)
     assert config.dataset.hf_dataset.path_or_dataset == config.dataset.hf_validation_dataset.path_or_dataset
     assert config.dataset.hf_dataset.subset == config.dataset.hf_validation_dataset.subset == "math"
     assert config.dataset.hf_dataset.load_kwargs == config.dataset.hf_validation_dataset.load_kwargs
+
+
+def test_qwen3_30b_a3b_dpo_config_applies_the_dpo_contract(monkeypatch):
+    monkeypatch.setattr(common, "AutoBridge", _FakeBridge)
+
+    cfg = qwen3_moe.qwen3_30b_a3b_dpo_8gpu_h100_bf16_config()
+
+    assert isinstance(cfg.dataset, DPODatasetConfig)
+    assert cfg.dataset.tokenizer_name == cfg.tokenizer.tokenizer_model == qwen3_moe._QWEN3_30B_A3B_MODEL_ID
+    assert cfg.tokenizer.hf_tokenizer_kwargs == {"revision": qwen3_moe._QWEN3_30B_A3B_MODEL_REVISION}
+    assert cfg.dataset.seq_length == cfg.model.seq_length == 4096
+    assert cfg.dataset.ref_artifact is None  # every run must point at its scored artifact
+    assert cfg.dpo is not None
+
+    # What validate_dpo_run_config enforces at startup.
+    assert cfg.model.calculate_per_token_loss is True
+    assert cfg.model.cross_entropy_loss_fusion is False
+    assert cfg.ddp.average_in_collective is False
+    assert cfg.model.pipeline_model_parallel_size == 1
+    assert cfg.model.context_parallel_size == 1
+    assert cfg.model.mtp_num_layers is None
+
+    # One node fills both meshes, matching a --tp 8 --sequence-parallel --ep 8 --etp 1 scoring run.
+    assert cfg.model.tensor_model_parallel_size == 8
+    assert cfg.model.sequence_parallel is True
+    assert cfg.model.expert_model_parallel_size == 8
+    assert cfg.model.expert_tensor_parallel_size == 1
+    assert cfg.model.moe_router_force_load_balancing is False
+    assert cfg.model.recompute_granularity == "full"
+
+    # Row-denominated batch sizes must be even (one pair == two rows).
+    assert cfg.train.global_batch_size % 2 == 0
+    assert cfg.train.micro_batch_size % 2 == 0
+    assert cfg.validation.eval_iters == 0

--- a/tests/unit_tests/scripts/training/test_recipe_metadata.py
+++ b/tests/unit_tests/scripts/training/test_recipe_metadata.py
@@ -138,6 +138,8 @@ def test_benchmark_recipe_metadata_selects_task_and_step(recipe_name, task, step
         ("step37_sft_flickr8k_config", "step37_flickr8k_step"),
         ("flux_12b_pretrain_config", "flux_step"),
         ("wan_14b_pretrain_config", "wan_step"),
+        ("qwen3_30b_a3b_dpo_config", "dpo_step"),
+        ("qwen3_30b_a3b_dpo_8gpu_h100_bf16_config", "dpo_step"),
     ],
 )
 def test_recipe_step_is_source_agnostic(recipe_name, step_name):

--- a/tests/unit_tests/scripts/training/test_recipe_runner.py
+++ b/tests/unit_tests/scripts/training/test_recipe_runner.py
@@ -593,6 +593,7 @@ def test_training_stack_is_registered_for_lazy_import(recipe_runner: ModuleType)
     assert recipe_runner.TRAIN_FUNCTIONS == {
         "pretrain": ("megatron.bridge.training.pretrain", "pretrain"),
         "finetune": ("megatron.bridge.training.finetune", "finetune"),
+        "dpo": ("megatron.bridge.training.dpo_train", "dpo_train"),
     }
 
 

--- a/tests/unit_tests/scripts/training/test_run_recipe.py
+++ b/tests/unit_tests/scripts/training/test_run_recipe.py
@@ -194,6 +194,7 @@ def test_model_selection_requires_mode_when_it_cannot_be_inferred():
         ("gpt_oss_20b_pretrain_config", "pretrain"),
         ("llama3_8b_sft_8gpu_gb200_bf16_config", "sft"),
         ("llama3_70b_peft_8gpu_gb200_bf16_config", "lora"),
+        ("qwen3_30b_a3b_dpo_8gpu_h100_bf16_config", "dpo"),
     ],
 )
 def test_conventional_recipe_name_infers_mode(recipe_name, mode):
@@ -1478,3 +1479,60 @@ def test_config_container_overrides_are_forwarded_directly():
     )
     handles.recipe_runner.apply_runtime_environment.assert_called_once_with(config)
     handles.recipe_runner.bootstrap_recipe_environment.assert_not_called()
+
+
+def test_dpo_mode_selects_dpo_recipe_step_and_train_loop():
+    module, handles = _load_module()
+    config = SimpleNamespace()
+    handles.recipe_runner.load_recipe.return_value = config
+
+    module.main(["--model", "qwen3_30b_a3b", "--mode", "dpo"])
+
+    handles.recipe_runner.load_recipe.assert_called_once_with("qwen3_30b_a3b_dpo_config", peft_scheme=None)
+    handles.recipe_runner.load_forward_step.assert_called_once_with("dpo_step", mode="dpo")
+    assert handles.recipe_runner.run_config.call_args.kwargs["mode"] == "dpo"
+
+
+def test_dpo_mode_maps_seq_length_like_every_other_mode():
+    module, _ = _load_module()
+
+    _, overrides = module.parse_args(["--model", "qwen3_30b_a3b", "--mode", "dpo", "-sl", "4096"])
+
+    assert overrides == ["dataset.seq_length=4096"]
+
+
+def test_dpo_mode_swaps_the_default_llm_step_for_dpo_step():
+    module, handles = _load_module()
+    handles.recipe_runner.load_recipe.return_value = SimpleNamespace()
+
+    module.main(["--model", "qwen3_30b_a3b", "--mode", "dpo", "--step-func", "llm_step"])
+
+    handles.recipe_runner.load_forward_step.assert_called_once_with("dpo_step", mode="dpo")
+
+
+@pytest.mark.parametrize(
+    ("mode", "step_func"),
+    [("dpo", "vlm_step"), ("sft", "dpo_step"), ("pretrain", "dpo_step")],
+)
+def test_dpo_step_and_other_steps_do_not_cross_modes(mode, step_func):
+    module, handles = _load_module()
+    handles.recipe_runner.load_recipe.return_value = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="is incompatible with --mode"):
+        module.main(["--model", "qwen3_30b_a3b", "--mode", mode, "--step-func", step_func])
+
+
+def test_dpo_mode_rejects_dataset_presets():
+    module, handles = _load_module()
+    handles.recipe_runner.load_recipe.return_value = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="incompatible with dataset"):
+        module.main(["--model", "qwen3_30b_a3b", "--mode", "dpo", "--dataset", "squad"])
+
+
+def test_dpo_mode_rejects_contradicting_recipe_name():
+    module, handles = _load_module()
+    handles.recipe_runner.load_recipe.return_value = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="incompatible with recipe"):
+        module.main(["--recipe", "qwen3_30b_a3b_sft_config", "--mode", "dpo"])

--- a/tests/unit_tests/training/test_config.py
+++ b/tests/unit_tests/training/test_config.py
@@ -25,6 +25,7 @@ import torch
 
 from megatron.bridge.data.builders import (
     DirectHFSFTDatasetConfig,
+    DPODatasetConfig,
     EnergonDatasetConfig,
     GPTSFTDatasetConfig,
     HFDatasetSourceConfig,
@@ -1437,6 +1438,34 @@ class TestConfigContainerValidation:
         try:
             container.validate()
             assert dataset_cfg.pad_to_multiple_of == 24
+        finally:
+            restore_get_world_size_safe(og_ws, cfg_mod)
+
+    def test_dpo_dataset_pads_to_the_sequence_parallel_multiple(self):
+        """DPO batches are padded dynamically, so SP needs the collate width to be a TP multiple."""
+        gpt_model_cfg = create_test_gpt_config(
+            tensor_model_parallel_size=4,
+            sequence_parallel=True,
+            calculate_per_token_loss=True,
+        )
+        train_cfg = create_test_training_config(micro_batch_size=2, global_batch_size=8)
+        dataset_cfg = DPODatasetConfig(
+            tokenizer_name="org/some-model",
+            seq_length=512,
+            source=HFDatasetSourceConfig(path_or_dataset="org/some-preference-set", split="train"),
+        )
+
+        container, og_ws, cfg_mod = create_test_config_container(
+            world_size_override=4,
+            model_config=gpt_model_cfg,
+            train_config=train_cfg,
+            dataset_config_override=dataset_cfg,
+        )
+        container.ddp.average_in_collective = False
+
+        try:
+            container.validate()
+            assert dataset_cfg.pad_seq_length_to_mult == 4
         finally:
             restore_get_world_size_safe(og_ws, cfg_mod)
 

--- a/tests/unit_tests/training/test_dpo.py
+++ b/tests/unit_tests/training/test_dpo.py
@@ -1,0 +1,241 @@
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.bridge.data.datasets.preference import preference_collate_fn
+from megatron.bridge.training.dpo import DPOLossConfig, dpo_loss, sequence_logprob_sums, split_pair_rows
+
+
+def test_sequence_logprob_sums_hand_computed():
+    """Masked sums per row, accumulated in float32 from bf16 model output; a fully masked stub row yields (0.0, 0)."""
+    nll = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=torch.bfloat16)
+    mask = torch.tensor([[0, 1, 1], [1, 0, 0], [0, 0, 0]], dtype=torch.long)
+    sums, counts = sequence_logprob_sums(nll, mask)
+    assert sums.dtype == torch.float32
+    assert counts.dtype == torch.long
+    assert sums.tolist() == [-5.0, -4.0, 0.0]
+    assert counts.tolist() == [2, 1, 0]
+
+
+def test_sums_through_real_collate_land_per_side():
+    """Drive the actual training collate, fabricate per-token NLL from the labels,
+    and check chosen/rejected sums come out on the right side of the split."""
+    records = [
+        {
+            "pair_id": p,
+            "chosen_input_ids": [11, 12, 13, 21 + p, 22 + p],  # ctx len 3, completion [21+p, 22+p]
+            "chosen_context_len": 3,
+            "rejected_input_ids": [11, 12, 13, 31 + p],  # ctx len 3, completion [31+p]
+            "rejected_context_len": 3,
+        }
+        for p in range(2)
+    ]
+    batch = preference_collate_fn(records, pad_token_id=0, require_ref_logprobs=False)
+
+    # NLL encodes the label id, so masked sums are predictable per side.
+    nll = batch["labels"].float() * 0.01
+    sums, counts = sequence_logprob_sums(nll, batch["loss_mask"])
+    chosen_sums, rejected_sums = split_pair_rows(sums)
+    chosen_counts, rejected_counts = split_pair_rows(counts)
+
+    for p in range(2):
+        assert chosen_sums[p].item() == pytest.approx(-0.01 * (21 + p + 22 + p))
+        assert rejected_sums[p].item() == pytest.approx(-0.01 * (31 + p))
+    assert chosen_counts.tolist() == [2, 2]
+    assert rejected_counts.tolist() == [1, 1]
+
+
+# --- dpo_loss -----------------------------------------------------------------
+
+
+def make_loss_batch(
+    per_row_nll: list[list[float]],
+    loss_mask: list[list[float]],
+    ref_sums: list[float],
+    ref_counts: list[int] | None = None,
+    multipliers: list[float] | None = None,
+    pair_ids: list[int] | None = None,
+    requires_grad: bool = False,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Row-interleaved (chosen@even, rejected@odd) loss inputs from plain lists."""
+    num_rows = len(per_row_nll)
+    output_tensor = torch.tensor(per_row_nll, dtype=torch.float32, requires_grad=requires_grad)
+    if pair_ids is None:
+        pair_ids = [p for p in range(num_rows // 2) for _ in range(2)]
+    if multipliers is None:
+        multipliers = [1.0] * num_rows
+    if ref_counts is None:
+        ref_counts = [int(sum(row)) for row in loss_mask]
+    batch = {
+        "loss_mask": torch.tensor(loss_mask, dtype=torch.long),
+        "pair_id": torch.tensor(pair_ids, dtype=torch.long),
+        "loss_multiplier": torch.tensor(multipliers, dtype=torch.float32),
+        "ref_logprob_sum": torch.tensor(ref_sums, dtype=torch.float32),
+        "ref_num_tokens": torch.tensor(ref_counts, dtype=torch.long),
+    }
+    return output_tensor, batch
+
+
+def nemo_rl_dpo_reference(output_tensor: torch.Tensor, batch: dict[str, torch.Tensor], config: DPOLossConfig) -> float:
+    """NeMo-RL DPOLossFn semantics (RL/nemo_rl/algorithms/loss/loss_functions.py),
+    restated at pair granularity: the global per-live-pair mean of the total loss."""
+    policy_sums, token_counts = sequence_logprob_sums(output_tensor, batch["loss_mask"])
+    policy, ref = policy_sums, batch["ref_logprob_sum"].float()
+    if config.preference_average_log_probs:
+        policy = policy / token_counts.clamp(min=1)
+        ref = ref / batch["ref_num_tokens"].clamp(min=1)
+    rewards = policy - ref
+    delta = rewards[0::2] - rewards[1::2]
+    sample_mask = (batch["loss_multiplier"][0::2] > 0).float()
+    live = sample_mask.sum()
+
+    preference = (-F.logsigmoid(config.reference_policy_kl_penalty * delta) * sample_mask).sum() / live
+    total = config.preference_loss_weight * preference
+    if config.sft_loss_weight > 0:
+        sft = -policy_sums[0::2]
+        if config.sft_average_log_probs:
+            sft = sft / token_counts[0::2].clamp(min=1)
+        total = total + config.sft_loss_weight * (sft * sample_mask).sum() / live
+    return total.item()
+
+
+def neg_logsigmoid(x: float) -> float:
+    return -math.log(1 / (1 + math.exp(-x)))
+
+
+@pytest.mark.parametrize("beta", [0.05, 0.5])
+def test_dpo_loss_golden_hand_computed(beta):
+    """Two pairs, hand-computed margins 4 and -2; beta must scale the margin inside the sigmoid."""
+    output_tensor, batch = make_loss_batch(
+        per_row_nll=[[5.0, 5.0], [10.0, 10.0], [15.0, 15.0], [12.5, 12.5]],
+        loss_mask=[[1, 1]] * 4,
+        ref_sums=[-12.0, -18.0, -29.0, -26.0],
+    )
+    loss, num_live_pairs, metrics = dpo_loss(DPOLossConfig(reference_policy_kl_penalty=beta), batch, output_tensor)
+
+    # margins: (-10 - -20) - (-12 - -18) = 4;  (-30 - -25) - (-29 - -26) = -2
+    expected = neg_logsigmoid(beta * 4) + neg_logsigmoid(beta * -2)
+    assert loss.item() == pytest.approx(expected, rel=1e-6)
+    assert num_live_pairs.item() == 2
+    assert metrics["margin"].tolist() == pytest.approx([2.0, 2.0])
+    assert metrics["accuracy"].tolist() == pytest.approx([1.0, 2.0])
+    assert metrics["rewards chosen"].tolist() == pytest.approx([1.0, 2.0])  # 2 + (-1)
+    assert metrics["rewards rejected"].tolist() == pytest.approx([-1.0, 2.0])  # -2 + 1
+    assert metrics["dpo loss"].tolist() == pytest.approx([expected, 2.0], rel=1e-6)
+
+
+def test_dpo_loss_stub_pair_excluded_from_loss_count_and_metrics():
+    """A loss_multiplier=0 stub pair contributes nothing anywhere. Every metric is a detached
+    [sum, live_pairs] pair, except live fraction whose denominator counts ALL pairs."""
+    live_rows_nll = [[5.0, 5.0], [10.0, 10.0]]
+    live_mask = [[1, 1], [1, 1]]
+    output_live, batch_live = make_loss_batch(live_rows_nll, live_mask, ref_sums=[-12.0, -18.0])
+    loss_live, count_live, metrics_live = dpo_loss(DPOLossConfig(), batch_live, output_live)
+
+    output_tensor, batch = make_loss_batch(
+        per_row_nll=live_rows_nll + [[99.0, 99.0], [99.0, 99.0]],
+        loss_mask=live_mask + [[0, 0], [0, 0]],  # stub rows are fully masked
+        ref_sums=[-12.0, -18.0, 0.0, 0.0],
+        multipliers=[1.0, 1.0, 0.0, 0.0],
+    )
+    loss, num_live_pairs, metrics = dpo_loss(DPOLossConfig(), batch, output_tensor)
+
+    assert loss.item() == pytest.approx(loss_live.item(), rel=1e-6)
+    assert num_live_pairs.item() == count_live.item() == 1
+    assert set(metrics) == {
+        "dpo loss",
+        "preference loss",
+        "sft loss",
+        "margin",
+        "accuracy",
+        "rewards chosen",
+        "rewards rejected",
+        "live fraction",
+    }
+    for key, value in metrics.items():
+        assert value.shape == (2,), key
+        if key == "live fraction":
+            continue
+        assert value[1].item() == 1, key
+        assert value.tolist() == pytest.approx(metrics_live[key].tolist(), rel=1e-6), key
+    assert metrics_live["live fraction"].tolist() == [1, 1]
+    assert metrics["live fraction"].tolist() == [1, 2]  # 1 live of 2 pairs -> 0.5 live share
+
+
+def test_dpo_loss_adjacency_tripwire():
+    output_tensor, batch = make_loss_batch(
+        per_row_nll=[[1.0, 1.0]] * 4,
+        loss_mask=[[1, 1]] * 4,
+        ref_sums=[0.0] * 4,
+        pair_ids=[0, 1, 1, 0],  # rows are not (chosen, rejected) adjacent
+    )
+    with pytest.raises(ValueError, match="pair_id"):
+        dpo_loss(DPOLossConfig(), batch, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        DPOLossConfig(),
+        DPOLossConfig(preference_average_log_probs=True),
+        DPOLossConfig(sft_loss_weight=0.3),
+        DPOLossConfig(sft_loss_weight=0.3, sft_average_log_probs=True),
+        DPOLossConfig(preference_loss_weight=2.0, sft_loss_weight=0.1, preference_average_log_probs=True),
+    ],
+    ids=["sum", "avg-pref", "sft", "sft-avg", "weights-mixed"],
+)
+def test_dpo_loss_matches_nemo_rl_reference(config):
+    """(loss_sum / live_pairs) must equal NeMo-RL DPOLossFn's global per-pair mean,
+    across sum/average modes and SFT mixing — including a stub pair in the batch."""
+    torch.manual_seed(7)
+    num_pairs, seq = 4, 6
+    nll = torch.rand(2 * num_pairs, seq) * 3
+    mask = (torch.rand(2 * num_pairs, seq) > 0.3).long()
+    mask[:, 0] = 1  # no accidentally-empty live completion
+    mask[4:6] = 0  # pair 2 is a stub: fully masked, multiplier 0
+    ref_counts = mask.sum(-1).tolist()
+    output_tensor, batch = make_loss_batch(
+        per_row_nll=nll.tolist(),
+        loss_mask=mask.tolist(),
+        ref_sums=(torch.randn(2 * num_pairs) * 5 - 10).tolist(),
+        ref_counts=ref_counts,
+        multipliers=[1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0],
+    )
+    loss, num_live_pairs, _ = dpo_loss(config, batch, output_tensor)
+    ours = loss.item() / num_live_pairs.item()
+    assert ours == pytest.approx(nemo_rl_dpo_reference(output_tensor, batch, config), rel=1e-5)
+
+
+def test_dpo_loss_sft_term_golden():
+    """sft_loss_weight adds w_s * chosen NLL sum on top of the preference term."""
+    output_tensor, batch = make_loss_batch(
+        per_row_nll=[[5.0, 5.0], [10.0, 10.0]],
+        loss_mask=[[1, 1]] * 2,
+        ref_sums=[-12.0, -18.0],
+    )
+    base, _, base_metrics = dpo_loss(DPOLossConfig(), batch, output_tensor)
+    loss, _, metrics = dpo_loss(DPOLossConfig(sft_loss_weight=0.1), batch, output_tensor)
+    assert loss.item() == pytest.approx(base.item() + 0.1 * 10.0, rel=1e-6)  # chosen NLL sum = 10
+    assert metrics["sft loss"].tolist() == pytest.approx([10.0, 1.0])  # reported unweighted, NeMo-RL style
+    assert base_metrics["sft loss"].tolist() == pytest.approx([0.0, 1.0])
+
+
+def test_dpo_loss_gradient_flow():
+    """Gradients reach live masked positions only; stub rows and metrics stay detached."""
+    output_tensor, batch = make_loss_batch(
+        per_row_nll=[[5.0, 5.0], [10.0, 10.0], [99.0, 99.0], [99.0, 99.0]],
+        loss_mask=[[1, 0], [1, 1], [0, 0], [0, 0]],
+        ref_sums=[-12.0, -18.0, 0.0, 0.0],
+        multipliers=[1.0, 1.0, 0.0, 0.0],
+        requires_grad=True,
+    )
+    loss, _, metrics = dpo_loss(DPOLossConfig(), batch, output_tensor)
+    assert loss.requires_grad
+    assert all(not value.requires_grad for value in metrics.values())
+    loss.backward()
+    grad = output_tensor.grad
+    assert grad[0, 0].item() != 0.0
+    assert grad[0, 1].item() == 0.0  # masked-out position
+    assert torch.all(grad[2:] == 0)  # stub rows

--- a/tests/unit_tests/training/test_dpo_step.py
+++ b/tests/unit_tests/training/test_dpo_step.py
@@ -1,0 +1,198 @@
+import types
+
+import pytest
+import torch
+
+from megatron.bridge.data.batch_utils import split_batch_into_microbatches
+from megatron.bridge.data.datasets.preference import preference_collate_fn
+from megatron.bridge.training.dpo import DPOLossConfig
+from megatron.bridge.training.dpo_step import (
+    _SEQ_DIM_KEYS,
+    DPO_BATCH_KEYS,
+    dpo_forward_step,
+    trim_dpo_batch_padding,
+    validate_dpo_batch,
+)
+
+
+def make_batch() -> dict[str, torch.Tensor]:
+    return {
+        "tokens": torch.zeros(2, 3, dtype=torch.long),
+        "labels": torch.zeros(2, 3, dtype=torch.long),
+        "loss_mask": torch.ones(2, 3, dtype=torch.long),
+        "position_ids": torch.zeros(2, 3, dtype=torch.long),
+        "pair_id": torch.tensor([0, 0]),
+        "loss_multiplier": torch.ones(2),
+        "ref_logprob_sum": torch.tensor([-1.0, -2.0]),
+        "ref_num_tokens": torch.tensor([3, 3]),
+    }
+
+
+class FakeRerunStateMachine:
+    def __init__(self):
+        self.validated = []
+
+    def validate_result(self, *, result, rejection_func, message, tolerance, fatal):
+        self.validated.append(message)
+        if rejection_func(result):
+            raise AssertionError(message)
+
+
+@pytest.fixture
+def fake_rerun_state_machine(monkeypatch):
+    machine = FakeRerunStateMachine()
+    monkeypatch.setattr("megatron.bridge.training.losses.get_rerun_state_machine", lambda: machine)
+    return machine
+
+
+@pytest.mark.parametrize("missing_key", ["ref_logprob_sum", "loss_multiplier", "pair_id"])
+def test_validate_dpo_batch_rejects_missing_or_none_key(missing_key):
+    batch = make_batch()
+    del batch[missing_key]
+    with pytest.raises(ValueError, match=missing_key):
+        validate_dpo_batch(batch)
+    batch = make_batch()
+    batch[missing_key] = None  # get_batch-style key dropping
+    with pytest.raises(ValueError, match=missing_key):
+        validate_dpo_batch(batch)
+
+
+def make_pair_record(pair_id: int, ctx_len: int, chosen_comp: int, rejected_comp: int) -> dict:
+    return {
+        "pair_id": pair_id,
+        "chosen_input_ids": list(range(10, 10 + ctx_len + chosen_comp)),
+        "chosen_context_len": ctx_len,
+        "rejected_input_ids": list(range(50, 50 + ctx_len + rejected_comp)),
+        "rejected_context_len": ctx_len,
+        "ref_chosen_logprob_sum": -1.0,
+        "ref_chosen_num_tokens": chosen_comp,
+        "ref_rejected_logprob_sum": -2.0,
+        "ref_rejected_num_tokens": rejected_comp,
+    }
+
+
+def make_stub_record(pair_id: int) -> dict:
+    """A zero-loss stub: two-token sides, loss_multiplier 0, live loss_mask only at column 0."""
+    return {
+        "pair_id": pair_id,
+        "chosen_input_ids": [0, 0],
+        "chosen_context_len": 1,
+        "rejected_input_ids": [0, 0],
+        "rejected_context_len": 1,
+        "loss_multiplier": 0.0,
+        "ref_chosen_logprob_sum": 0.0,
+        "ref_chosen_num_tokens": 0,
+        "ref_rejected_logprob_sum": 0.0,
+        "ref_rejected_num_tokens": 0,
+    }
+
+
+def split_global_batch(records: list[dict], pad_to_multiple: int) -> list[dict[str, torch.Tensor]]:
+    global_batch = preference_collate_fn(records, pad_token_id=0, pad_seq_length_to_mult=pad_to_multiple)
+    global_batch.pop("attention_mask")  # None, not a tensor — split handles tensors
+    return split_batch_into_microbatches(global_batch, num_microbatches=len(records))
+
+
+@pytest.mark.parametrize("pad_to_multiple", [1, 8])
+def test_trim_recovers_standalone_collate_shapes_and_content(pad_to_multiple):
+    """A pair collated inside a wider global batch, split and trimmed, must be tensor-identical
+    to the same pair collated alone (the mbs-1 scorer's shape), at the collate's multiple."""
+    short = make_pair_record(0, ctx_len=2, chosen_comp=2, rejected_comp=1)
+    long = make_pair_record(1, ctx_len=9, chosen_comp=40, rejected_comp=30)
+
+    for record, microbatch in zip((short, long), split_global_batch([short, long], pad_to_multiple)):
+        trimmed = trim_dpo_batch_padding(dict(microbatch), pad_to_multiple=pad_to_multiple)
+        standalone = preference_collate_fn([record], pad_token_id=0, pad_seq_length_to_mult=pad_to_multiple)
+        for key in _SEQ_DIM_KEYS:
+            assert trimmed[key].shape[1] % pad_to_multiple == 0, key
+            assert torch.equal(trimmed[key], standalone[key]), key
+        # Row-aligned keys are untouched by the trim.
+        assert torch.equal(trimmed["pair_id"], standalone["pair_id"])
+        assert torch.equal(trimmed["ref_logprob_sum"], standalone["ref_logprob_sum"])
+
+
+@pytest.mark.parametrize(("pad_to_multiple", "expected_width"), [(1, 2), (8, 8)])
+def test_trim_floors_stub_pair_microbatch(pad_to_multiple, expected_width):
+    """A stub-pair microbatch trims to width 2, not 1 (TE's fused-attention backward rejects
+    seq length 1), rounded up to the collate multiple so SP's TP-divides-seq assert holds."""
+    stub = make_stub_record(0)
+    wide = make_pair_record(1, ctx_len=9, chosen_comp=40, rejected_comp=30)
+    stub_microbatch, _ = split_global_batch([stub, wide], pad_to_multiple)
+
+    assert bool(stub_microbatch["loss_mask"].any()), "stub rows carry a live mask at column 0"
+    trimmed = trim_dpo_batch_padding(dict(stub_microbatch), pad_to_multiple=pad_to_multiple)
+    for key in _SEQ_DIM_KEYS:
+        assert trimmed[key].shape[1] == expected_width, key
+
+
+def test_trim_keeps_all_stub_microbatch_unchanged():
+    batch = make_batch()
+    batch["loss_mask"] = torch.zeros(2, 3, dtype=torch.long)
+    trimmed = trim_dpo_batch_padding(dict(batch))
+    for key in _SEQ_DIM_KEYS:
+        assert trimmed[key].shape == batch[key].shape
+
+
+class FakeTimer:
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+class FakeStragglerTimer:
+    def __call__(self, bdata=False):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+class FakeState:
+    def __init__(self):
+        self.timers = lambda *args, **kwargs: FakeTimer()
+        self.straggler_timer = FakeStragglerTimer()
+        self.cfg = types.SimpleNamespace(
+            dpo=DPOLossConfig(),
+            dataset=types.SimpleNamespace(pad_seq_length_to_mult=1),
+            rerun_state_machine=types.SimpleNamespace(check_for_nan_in_loss=True, check_for_spiky_loss=False),
+        )
+
+
+def test_dpo_forward_step_wires_forward_and_loss_closure(monkeypatch, fake_rerun_state_machine):
+    """The step must forward (tokens, position_ids, None mask, labels) and bind the
+    full batch plus the rerun flags into the loss closure."""
+    import megatron.bridge.training.dpo_step as dpo_step_module
+
+    batch = make_batch()
+    monkeypatch.setattr(dpo_step_module, "get_dpo_batch", lambda it, _mult=1: validate_dpo_batch(next(it)))
+
+    forward_calls = []
+
+    def fake_model(*, input_ids, position_ids, attention_mask, labels):
+        forward_calls.append((input_ids, position_ids, attention_mask, labels))
+        return torch.full(labels.shape, 0.5)
+
+    output_tensor, loss_closure = dpo_forward_step(FakeState(), iter([batch]), fake_model)
+
+    assert len(forward_calls) == 1
+    input_ids, position_ids, attention_mask, labels = forward_calls[0]
+    assert input_ids is batch["tokens"]
+    assert position_ids is batch["position_ids"]
+    assert attention_mask is None
+    assert labels is batch["labels"]
+
+    loss, num_live_pairs, metrics = loss_closure(output_tensor)
+    assert torch.isfinite(loss)
+    assert num_live_pairs.item() == 1
+    assert "dpo loss" in metrics
+    assert set(DPO_BATCH_KEYS) <= set(batch)
+    # check_for_nan_in_loss=True, check_for_spiky_loss=False per FakeState.cfg
+    assert fake_rerun_state_machine.validated == [
+        "found NaN in local forward loss calculation",
+        "found Inf in local forward loss calculation",
+    ]

--- a/tests/unit_tests/training/test_dpo_train.py
+++ b/tests/unit_tests/training/test_dpo_train.py
@@ -1,0 +1,198 @@
+"""Unit tests for the DPO entry point's run-config guardrails and artifact validation."""
+
+import json
+from dataclasses import asdict
+from types import SimpleNamespace
+
+import pytest
+
+import megatron.bridge.training.dpo_train as dpo_train_module
+from megatron.bridge.data.builders.dpo import DPODatasetConfig
+from megatron.bridge.data.datasets.preference import ScoringFingerprint
+from megatron.bridge.data.sources.hf import HFDatasetSourceConfig
+from megatron.bridge.training.dpo import DPOLossConfig
+from megatron.bridge.training.dpo_train import dpo_train, expected_scoring_metadata, validate_dpo_run_config
+
+
+SCORED_FINGERPRINT = ScoringFingerprint(
+    dataset="org/some-preference-set",
+    split="train",
+    tokenizer="org/some-model",
+    max_seq_length=64,
+    prompt_key=None,
+    tensor_model_parallel_size=1,
+    sequence_parallel=False,
+    pipeline_model_parallel_size=1,
+)
+
+
+def write_artifact_metadata(artifact_dir, **overrides) -> str:
+    metadata = asdict(SCORED_FINGERPRINT)
+    metadata.update(overrides)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / "scoring_metadata.json").write_text(json.dumps(metadata))
+    return str(artifact_dir)
+
+
+def make_config(tmp_path) -> SimpleNamespace:
+    dataset = DPODatasetConfig(
+        tokenizer_name="org/some-model",
+        seq_length=64,
+        ref_artifact=write_artifact_metadata(tmp_path / "train_ref"),
+        source=HFDatasetSourceConfig(path_or_dataset="org/some-preference-set", split="train"),
+    )
+    return SimpleNamespace(
+        dpo=DPOLossConfig(),
+        dataset=dataset,
+        model=SimpleNamespace(
+            calculate_per_token_loss=True,
+            mtp_num_layers=None,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            context_parallel_size=1,
+            sequence_parallel=False,
+        ),
+        ddp=SimpleNamespace(average_in_collective=False),
+        train=SimpleNamespace(micro_batch_size=4, global_batch_size=8),
+        validation=SimpleNamespace(
+            eval_iters=0, eval_interval=None, eval_global_batch_size=None, eval_micro_batch_size=None
+        ),
+        dist=SimpleNamespace(eval_context_parallel_size=None),
+    )
+
+
+def add_validation_split(config, tmp_path, **metadata_overrides) -> SimpleNamespace:
+    config.dataset.validation_source = HFDatasetSourceConfig(
+        path_or_dataset="org/some-preference-set", split="validation"
+    )
+    config.dataset.validation_ref_artifact = write_artifact_metadata(
+        tmp_path / "validation_ref", split="validation", **metadata_overrides
+    )
+    config.validation.eval_iters = 2
+    config.validation.eval_interval = 10
+    return config
+
+
+def test_valid_configs_pass(tmp_path):
+    validate_dpo_run_config(make_config(tmp_path))
+    validate_dpo_run_config(add_validation_split(make_config(tmp_path), tmp_path))
+
+
+def with_validation(mutate):
+    def apply(config, tmp_path):
+        add_validation_split(config, tmp_path)
+        mutate(config)
+
+    return apply
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda c, _: setattr(c, "dpo", None), "config.dpo"),
+        (lambda c, _: setattr(c, "dataset", SimpleNamespace()), "DPODatasetConfig"),
+        (lambda c, _: setattr(c.dataset, "ref_artifact", None), "ref_artifact"),
+        (lambda c, _: setattr(c.model, "calculate_per_token_loss", False), "calculate_per_token_loss"),
+        (lambda c, _: setattr(c.ddp, "average_in_collective", True), "average_in_collective"),
+        (lambda c, _: setattr(c.model, "pipeline_model_parallel_size", 2), "pipeline"),
+        (lambda c, _: setattr(c.model, "context_parallel_size", 2), "context"),
+        (lambda c, _: setattr(c.model, "mtp_num_layers", 1), "mtp_num_layers"),
+        (lambda c, _: setattr(c.train, "micro_batch_size", 3), "even"),
+        (lambda c, _: setattr(c.train, "global_batch_size", 7), "even"),
+        (lambda c, _: setattr(c.validation, "eval_iters", 2), "validation split"),
+        (with_validation(lambda c: setattr(c.validation, "eval_interval", None)), "eval_interval"),
+        (with_validation(lambda c: setattr(c.validation, "eval_global_batch_size", 7)), "eval_global_batch_size"),
+        (with_validation(lambda c: setattr(c.validation, "eval_micro_batch_size", 7)), "eval_micro_batch_size"),
+        (with_validation(lambda c: setattr(c.dist, "eval_context_parallel_size", 2)), "eval_context_parallel_size"),
+    ],
+)
+def test_invalid_config_raises_naming_the_knob(tmp_path, mutate, match):
+    config = make_config(tmp_path)
+    mutate(config, tmp_path)
+    with pytest.raises(ValueError, match=match):
+        validate_dpo_run_config(config)
+
+
+def test_all_violations_reported_at_once(tmp_path):
+    config = make_config(tmp_path)
+    config.model.calculate_per_token_loss = False
+    config.ddp.average_in_collective = True
+    with pytest.raises(ValueError) as exc_info:
+        validate_dpo_run_config(config)
+    assert "calculate_per_token_loss" in str(exc_info.value)
+    assert "average_in_collective" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("split", ["train", "validation"])
+def test_artifact_metadata_mismatch_fails_validation(tmp_path, split):
+    config = add_validation_split(make_config(tmp_path), tmp_path)
+    write_artifact_metadata(tmp_path / f"{split}_ref", split=split, max_seq_length=4096)
+    with pytest.raises(ValueError, match="max_seq_length"):
+        validate_dpo_run_config(config)
+
+
+def test_validation_artifact_is_not_checked_when_eval_is_disabled(tmp_path):
+    """SFT behavior: eval_iters=0 turns validation off without touching the dataset config."""
+    config = add_validation_split(make_config(tmp_path), tmp_path, max_seq_length=4096)
+    config.validation.eval_iters = 0
+    validate_dpo_run_config(config)
+
+
+@pytest.mark.parametrize("split", ["train", "validation"])
+def test_expected_scoring_metadata_reads_the_split_source_and_model_config(tmp_path, split):
+    config = add_validation_split(make_config(tmp_path), tmp_path)
+    assert expected_scoring_metadata(config, split) == ScoringFingerprint(
+        **{**asdict(SCORED_FINGERPRINT), "split": split}
+    )
+
+
+def test_expert_layout_mismatch_warns_but_passes(tmp_path, caplog):
+    config = make_config(tmp_path)
+    config.model.expert_model_parallel_size = 8
+    config.model.expert_tensor_parallel_size = 1
+    with caplog.at_level("WARNING", logger="megatron.bridge.training.dpo_train"):
+        validate_dpo_run_config(config)
+    assert "Expert layout" in caplog.text
+    assert "(8, 1)" in caplog.text
+
+
+def test_matching_expert_layout_does_not_warn(tmp_path, caplog):
+    config = make_config(tmp_path)
+    config.model.expert_model_parallel_size = 8
+    config.model.expert_tensor_parallel_size = 1
+    write_artifact_metadata(tmp_path / "train_ref", expert_model_parallel_size=8, expert_tensor_parallel_size=1)
+    with caplog.at_level("WARNING", logger="megatron.bridge.training.dpo_train"):
+        validate_dpo_run_config(config)
+    assert "Expert layout" not in caplog.text
+
+
+def test_artifact_without_expert_keys_implies_scorer_layout(tmp_path, caplog):
+    """Pre-MoE artifacts carry no expert keys: EP defaults to 1 and ETP to the scorer's TP."""
+    config = make_config(tmp_path)
+    config.model.tensor_model_parallel_size = 2
+    config.model.expert_tensor_parallel_size = 2
+    write_artifact_metadata(tmp_path / "train_ref", tensor_model_parallel_size=2)
+    with caplog.at_level("WARNING", logger="megatron.bridge.training.dpo_train"):
+        validate_dpo_run_config(config)
+    assert "Expert layout" not in caplog.text
+
+
+def step_stub(state, data_iterator, model):
+    raise AssertionError("the forward step is never called in these tests")
+
+
+def test_dpo_train_validates_then_hands_off_to_finetune(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(dpo_train_module, "finetune", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    config = make_config(tmp_path)
+    user_callback = object()
+    dpo_train(config, step_stub, callbacks=[user_callback])
+    assert calls == [((config, step_stub), {"callbacks": [user_callback]})]
+
+    config.validation.eval_iters = 5  # invalid: no validation split
+    with pytest.raises(ValueError, match="validation split"):
+        dpo_train(config, step_stub)
+    assert len(calls) == 1


### PR DESCRIPTION
# What does this PR do ?

Adds DPO (Direct Preference Optimization) as a training mode. The reference model's log-probabilities are scored once, offline, and read back during training, so the trainer holds one model and runs at SFT memory and step time.

# Changelog

- `--mode dpo` in `scripts/training/run_recipe.py`, backed by `dpo_train()` in `training/dpo_train.py`: validates the run config and the reference artifact, then hands off to the existing `finetune` loop.
- Preference-pair dataset, config and loader under `data/datasets/preference*.py` and `data/builders/dpo.py`. Rows are TRL-style chat pairs from an HF dataset or a JSONL file. Chosen and rejected rows of a pair always land in the same micro batch, next to each other.
- DPO loss and forward step in `training/dpo.py` and `training/dpo_step.py`: sigmoid preference loss, optional SFT term, metrics for preference loss, accuracy, margin and chosen/rejected rewards.
- `scripts/dpo/score_reference_logprobs.py`, the offline scorer. You run it with the same TP, EP and ETP you'll train with. Extra GPUs beyond that become data-parallel replicas, and rank 0 collects the results and writes the artifact.
- Recipe `qwen3_30b_a3b_dpo_config` (TP=4, PP=2, EP=4, ETP=1, SP).
- Docs: `scripts/dpo/README.md` and a DPO section in `scripts/training/README.md`.

# Why the reference is scored offline

The usual DPO trainer keeps a frozen copy of the reference model and runs it every step - a second set of resident weights, an extra forward per step, and the reference is stuck with the policy's parallel layout

Instead, the scorer runs the reference over the dataset once and writes `ref_logprobs.jsonl` (chosen and rejected completion logprob sums per row) and `scoring_metadata.json` (dataset, split, tokenizer, sequence length, Parallelism type, prompt key). At startup the trainer compares that metadata against its own config and refuses to run on a mismatch. Without the check a stale or mis-scored artifact does not crash anything, the margins could possibly be wrong.

Pipeline parallelism is not recorded: it only decides which rank runs a layer. Scoring at PP=2 and PP=1 gave the same results over sums on all 8,320 pairs; TP=4 vs TP=8 differed on every pair, so TP is recorded.

The artifact stores plain logprob sums with no beta applied, so one scoring run covers every learning rate and beta you try afterwards.

```mermaid
flowchart LR
    DS[("preference pairs<br/>HF dataset or JSONL")]

    subgraph once["scorer, run once"]
        REF["reference model"]
        ART[/"ref_logprobs.jsonl<br/>chosen / rejected logprob sums per row"/]
        META[/"scoring_metadata.json<br/>dataset, split, tokenizer,<br/>seq len, TP / SP"/]
        REF --> ART
        REF --> META
    end

    subgraph train["trainer, every run"]
        CHK{"metadata matches<br/>run config?"}
        LOADER["pair loader<br/>chosen + rejected adjacent"]
        POL["policy model"]
        LOSS["DPO loss<br/>preference loss, accuracy,<br/>margin, rewards"]
        STEP["backward + optimizer step<br/>finetune loop"]
        CHK -->|"yes"| LOADER
        CHK -->|"no"| STOP["error at startup"]
        LOADER --> POL --> LOSS --> STEP
        LOADER -->|"reference sums"| LOSS
    end

    DS --> REF
    DS -->|"same rows, same order"| LOADER
    ART -->|"joined by row index"| LOADER
    META --> CHK
```

# Usage

```bash
# score the reference once
uv run python -m torch.distributed.run --nproc_per_node=8 scripts/dpo/score_reference_logprobs.py \
    --model Qwen/Qwen3-30B-A3B --dataset HuggingFaceH4/ultrafeedback_binarized --split train_prefs \
    --num-pairs 8192 --max-seq-length 4096 --tp 4 --ep 4 --etp 1 --sequence-parallel \
    --output /data/uf_ref_logprobs

# train
uv run python -m torch.distributed.run --nproc_per_node=8 scripts/training/run_recipe.py \
    --model qwen3_30b_a3b --mode dpo --pretrained_checkpoint /checkpoints/qwen3-30b-a3b \
    dataset.source.path_or_dataset=HuggingFaceH4/ultrafeedback_binarized dataset.source.split=train_prefs \
    dataset.ref_artifact=/data/uf_ref_logprobs dataset.num_pairs=8192
```

# Results

Qwen/Qwen3-30B-A3B with `qwen3_30b_a3b_dpo_config` at its defaults, 2 nodes x 8 H100 80GB.

| | |
|---|---|
| Data | `HuggingFaceH4/ultrafeedback_binarized` `train_prefs`, 8,192 pairs, one epoch. Validation on 128 pairs of `test_prefs` every 32 steps |
| Parallelism | TP=4, PP=2, EP=4, ETP=1, SP, DP=2, distributed optimizer |
| Batch | 64 pairs per step: micro batch 1 pair (2 rows) × 32 accumulation × DP 2; seq length 4096 |
| DPO | beta 0.05, lr 5e-7 |
| Speed | 20 s / step mean, 19 s median after warmup (16-34 s range) |

Step 1 preference loss is 0.691, i.e. ln 2, as it should be when the policy starts from the reference.

W&B curves from the run above, validation split. The model learns to prefer chosen over rejected

<img width="512" height="304" alt="image" src="https://github.com/user-attachments/assets/baa5347e-597d-4aef-a69c-b38e10b61f14" />
<img width="512" height="306" alt="image" src="https://github.com/user-attachments/assets/06443b93-39d1-4937-b5fb-3dcc8c17c3b4" />
<img width="515" height="299" alt="image" src="https://github.com/user-attachments/assets/0691f048-5c5f-41dc-a2c9-5b86f1f8df24" />


Training preference loss per 32-step window: 0.681, 0.652, 0.636, 0.634. 

Accuracy plateaus at 0.68-0.70, in line with published DPO results on UltraFeedback.

# Tests

Unit tests, no GPU: `tests/unit_tests/data/builders/test_dpo.py`, `data/datasets/test_preference.py`, `data/datasets/test_preference_tokenization.py`, `training/test_dpo.py`, `training/test_dpo_step.py`, `training/test_dpo_train.py`, `scripts/dpo/test_score_reference_logprobs.py`, plus cases in `training/test_config.py`, `training/utils/test_pg_utils.py`, `recipes/qwen/test_qwen3_recipes.py` and the `scripts/training` runner tests.